### PR TITLE
Enable QR Factorization and CentOS fix (#21)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ rocSOLVERCI:
 
     def rocsolver = new rocProject('rocSOLVER')
     
-    def nodes = new dockerNodes(['internal && gfx900 && ubuntu', 'internal && gfx906 && ubuntu'], rocsolver)
+    def nodes = new dockerNodes(['internal && gfx900 && ubuntu', 'internal && gfx906 && ubuntu', 'internal && gfx906 && centos7', 'internal && gfx900 && centos7'], rocsolver)
 
     boolean formatCheck = false
 

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -64,10 +64,25 @@ target_include_directories( rocsolver-bench
 #set( BLIS_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/build/deps/blis/include/blis )
 #set( BLIS_LIBRARY ${CMAKE_SOURCE_DIR}/build/deps/blis/lib/libblis.so )
 
-if( EXISTS /etc/redhat-release)
-    set( OPENMP_INCLUDE_DIR /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/include )
-    set( OPENMP_LIBRARY /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/libgomp.so ) 
-    set( CLANG_INCLUDE_DIR /opt/rocm/hcc/lib/clang/9.0.0/include ) 
+if( OS_ID_rhel OR OS_ID_centos OR OS_ID_sles)
+    if( OS_ID_rhel OR OS_ID_centos)
+        # defer OpenMP include as search order must come after clang
+        set( XXX_OPENMP_INCLUDE_DIR /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/include )
+        set( OPENMP_LIBRARY /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/libgomp.so )
+    else()
+    #SLES
+        set( OPENMP_INCLUDE_DIR /usr/lib64/gcc/x86_64-suse-linux/7/include/ )
+        set( OPENMP_LIBRARY /usr/lib64/gcc/x86_64-suse-linux/7/libgomp.so )
+    endif()
+
+    if(EXISTS /opt/rocm/hcc/lib/clang/10.0.0/include/immintrin.h)
+        set( CLANG_INCLUDE_DIR /opt/rocm/hcc/lib/clang/10.0.0/include )
+    elseif (EXISTS /opt/rocm/hcc/lib/clang/9.0.0/include/immintrin.h)
+        set( CLANG_INCLUDE_DIR /opt/rocm/hcc/lib/clang/9.0.0/include )
+    else()
+        error("cannot find immintrin.h")
+    endif()
+
 
     # External header includes included as system files
     target_include_directories( rocsolver-bench
@@ -124,6 +139,11 @@ elseif( CMAKE_COMPILER_IS_GNUCXX OR CXX_VERSION_STRING MATCHES "clang")
   # GCC or hip-clang needs specific flags to turn on f16c intrinsics
   target_compile_options( rocsolver-bench PRIVATE -mf16c )
 endif( )
+
+if( OS_ID_rhel OR OS_ID_centos)
+    # force clang includes to take precedence over devtoolset-7 which we only want for OpenMP
+    set(CMAKE_CXX_FLAGS "-isystem ${CLANG_INCLUDE_DIR} -isystem ${XXX_OPENMP_INCLUDE_DIR} ${CMAKE_CXX_FLAGS}")
+endif()
 
 set_target_properties( rocsolver-bench PROPERTIES CXX_EXTENSIONS NO )
 set_target_properties( rocsolver-bench PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -77,10 +77,24 @@ target_include_directories( rocsolver-test
 #set( BLIS_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/build/deps/blis/include/blis )
 #set( BLIS_LIBRARY ${CMAKE_SOURCE_DIR}/build/deps/blis/lib/libblis.so )
 
-if( EXISTS /etc/redhat-release)
-    set( OPENMP_INCLUDE_DIR /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/include )
-    set( OPENMP_LIBRARY /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/libgomp.so ) 
-    set( CLANG_INCLUDE_DIR /opt/rocm/hcc/lib/clang/9.0.0/include ) 
+if( OS_ID_rhel OR OS_ID_centos OR OS_ID_sles)
+    if( OS_ID_rhel OR OS_ID_centos)
+        # defer OpenMP include as search order must come after clang
+        set( XXX_OPENMP_INCLUDE_DIR /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/include )
+        set( OPENMP_LIBRARY /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/libgomp.so )
+    else()
+    #SLES
+        set( OPENMP_INCLUDE_DIR /usr/lib64/gcc/x86_64-suse-linux/7/include/ )
+        set( OPENMP_LIBRARY /usr/lib64/gcc/x86_64-suse-linux/7/libgomp.so )
+    endif()
+
+    if(EXISTS /opt/rocm/hcc/lib/clang/10.0.0/include/immintrin.h)
+        set( CLANG_INCLUDE_DIR /opt/rocm/hcc/lib/clang/10.0.0/include )
+    elseif (EXISTS /opt/rocm/hcc/lib/clang/9.0.0/include/immintrin.h)
+        set( CLANG_INCLUDE_DIR /opt/rocm/hcc/lib/clang/9.0.0/include )
+    else()
+        error("cannot find immintrin.h")
+    endif()
 
     # External header includes included as system files
     target_include_directories( rocsolver-test
@@ -139,6 +153,11 @@ elseif( CMAKE_COMPILER_IS_GNUCXX OR CXX_VERSION_STRING MATCHES "clang" )
   # GCC or hip-clang needs specific flag to turn on f16c intrinsics
   target_compile_options( rocsolver-test PRIVATE -mf16c )
 endif( )
+
+if( OS_ID_rhel OR OS_ID_centos)
+    # force clang includes to take precedence over devtoolset-7 which we only want for OpenMP
+    set(CMAKE_CXX_FLAGS "-isystem ${CLANG_INCLUDE_DIR} -isystem ${XXX_OPENMP_INCLUDE_DIR} ${CMAKE_CXX_FLAGS}")
+endif()
 
 if( CXX_VERSION_STRING MATCHES "clang" )
   target_link_libraries( rocsolver-test PRIVATE -lpthread -lm )


### PR DESCRIPTION
* Enable batched and strided batched LU factorization

- Correct getf2 and getrf to handle singularities as in LAPACK
- Correct getf2 and getrf APIs
- Add getf2_batched and getf2_strided_batched
- Add getrf_batched and getrf_strided_batched
- Correct laswp to work as in LAPACK
- Add correct laswp API
- Create specific folder for auxiliary functions codes

* Change ideal sizes

* Building with updated CMake files

* Add tests for corrected functions getrf and getf2

* Add tests for functions: getf2_batched, getf2_strided_batched, getrf_batched and getrf_strided_bacthed

* Add Householder reflection generator (larfg)

- minor changes to LU factorization code
- add larfg and its unit-test

* Add application of householder matrix (larf) and corresponding unit tests

* Add unblocked version of QR factorization

Add functions geqr2, geqr2_batched and geqr2_strided_bacthed
with their corresponding unit tests

Restore Centos build