### PR TITLE
Changing dependency package name (#33)

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -122,8 +122,8 @@ add_subdirectory( src )
 # endif( )
 
 # Package specific CPACK vars
-set( CPACK_DEBIAN_PACKAGE_DEPENDS "hip_hcc (>= 1.3)" )
-set( CPACK_RPM_PACKAGE_REQUIRES "hip_hcc >= 1.3" )
+set( CPACK_DEBIAN_PACKAGE_DEPENDS "rocm-dev (>= 2.5.27)" )
+set( CPACK_RPM_PACKAGE_REQUIRES "rocm-dev >= 2.5.27" )
 set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE.md" )
 
 if( NOT CPACK_PACKAGING_INSTALL_PREFIX )


### PR DESCRIPTION
The staging branch is missing this change, and the ROCm CI is tracking staging branch. We need this fix for our builds.