### PR TITLE
rocSOLVER - Changes to support multiple ROCM installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ get_os_id(OS_ID)
 message (STATUS "OS detected is ${OS_ID}")
 
 # Versioning via rocm-cmake
-set ( VERSION_STRING "2.7.0" )
+set ( VERSION_STRING "2.7" )
 rocm_setup_version( VERSION ${VERSION_STRING} )
 
 # Append our library helper cmake path and the cmake path for hip (for convenience)

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -95,6 +95,7 @@ target_include_directories( rocsolver
 
 set_target_properties( rocsolver PROPERTIES VERSION ${rocsolver_VERSION} SOVERSION ${rocsolver_SOVERSION} CXX_EXTENSIONS NO )
 set_target_properties( rocsolver PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
+rocm_set_soversion(rocsolver ${VERSION_STRING})
 
 # Package that helps me set visibility for function names exported from shared library
 include( GenerateExportHeader )


### PR DESCRIPTION
- Adding rocm_set_soversion to set versioning to the lib so file.

Signed-off-by: Pruthvi Madugundu <mpruthvi@gmail.com>