### PR TITLE
Added requirements.txt file for Read The Docs integration.

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,0 +1,2 @@
+
+breathe


### PR DESCRIPTION
A requirements.txt file is needed for the Read The Docs build to succeed.