### PR TITLE
Use complex accessor/setter instead of accessing internal members

### DIFF
--- a/rocsolver/clients/common/near.cpp
+++ b/rocsolver/clients/common/near.cpp
@@ -57,8 +57,8 @@ void near_check_general(rocblas_int M, rocblas_int N, rocblas_int lda,
 #pragma unroll
     for (rocblas_int i = 0; i < M; i++) {
 #ifdef GOOGLE_TEST
-      ASSERT_NEAR(hCPU[i + j * lda].x, hGPU[i + j * lda].x, abs_error);
-      ASSERT_NEAR(hCPU[i + j * lda].y, hGPU[i + j * lda].y, abs_error);
+      ASSERT_NEAR(hCPU[i + j * lda].real(), hGPU[i + j * lda].real(), abs_error);
+      ASSERT_NEAR(hCPU[i + j * lda].imag(), hGPU[i + j * lda].imag(), abs_error);
 #endif
     }
   }
@@ -73,8 +73,8 @@ void near_check_general(rocblas_int M, rocblas_int N, rocblas_int lda,
 #pragma unroll
     for (rocblas_int i = 0; i < M; i++) {
 #ifdef GOOGLE_TEST
-      ASSERT_NEAR(hCPU[i + j * lda].x, hGPU[i + j * lda].x, abs_error);
-      ASSERT_NEAR(hCPU[i + j * lda].y, hGPU[i + j * lda].y, abs_error);
+      ASSERT_NEAR(hCPU[i + j * lda].real(), hGPU[i + j * lda].real(), abs_error);
+      ASSERT_NEAR(hCPU[i + j * lda].imag(), hGPU[i + j * lda].imag(), abs_error);
 #endif
     }
   }

--- a/rocsolver/clients/common/unit.cpp
+++ b/rocsolver/clients/common/unit.cpp
@@ -99,8 +99,8 @@ void unit_check_general(rocblas_int M, rocblas_int N, rocblas_int lda,
 #pragma unroll
     for (rocblas_int i = 0; i < M; i++) {
 #ifdef GOOGLE_TEST
-      ASSERT_FLOAT_EQ(hCPU[i + j * lda].x, hGPU[i + j * lda].x);
-      ASSERT_FLOAT_EQ(hCPU[i + j * lda].y, hGPU[i + j * lda].y);
+      ASSERT_FLOAT_EQ(hCPU[i + j * lda].real(), hGPU[i + j * lda].real());
+      ASSERT_FLOAT_EQ(hCPU[i + j * lda].imag(), hGPU[i + j * lda].imag());
 #endif
     }
   }
@@ -115,8 +115,8 @@ void unit_check_general(rocblas_int M, rocblas_int N, rocblas_int lda,
 #pragma unroll
     for (rocblas_int i = 0; i < M; i++) {
 #ifdef GOOGLE_TEST
-      ASSERT_DOUBLE_EQ(hCPU[i + j * lda].x, hGPU[i + j * lda].x);
-      ASSERT_DOUBLE_EQ(hCPU[i + j * lda].y, hGPU[i + j * lda].y);
+      ASSERT_DOUBLE_EQ(hCPU[i + j * lda].real(), hGPU[i + j * lda].real());
+      ASSERT_DOUBLE_EQ(hCPU[i + j * lda].imag(), hGPU[i + j * lda].imag());
 #endif
     }
   }

--- a/rocsolver/clients/include/utility.h
+++ b/rocsolver/clients/include/utility.h
@@ -184,7 +184,9 @@ template <typename T>
 void rocblas_init_symmetric(vector<T> &A, rocblas_int N, rocblas_int lda) {
   for (rocblas_int i = 0; i < N; ++i) {
     for (rocblas_int j = 0; j <= i; ++j) {
-      A[j + i * lda] = A[i + j * lda] = random_generator<T>();
+      auto r = random_generator<T>();
+      A[j + i * lda] = r;
+      A[i + j * lda] = r;
     }
   }
 };
@@ -196,9 +198,11 @@ template <typename T>
 void rocblas_init_hermitian(vector<T> &A, rocblas_int N, rocblas_int lda) {
   for (rocblas_int i = 0; i < N; ++i) {
     for (rocblas_int j = 0; j <= i; ++j) {
-      A[j + i * lda] = A[i + j * lda] = random_generator<T>();
+      auto r = random_generator<T>();
+      A[j + i * lda] = r;
+      A[i + j * lda] = r;
       if (i == j)
-        A[j + i * lda].y = 0.0;
+        A[j + i * lda].imag(0);
     }
   }
 };


### PR DESCRIPTION
The internal members `x` and `y` in `rocblas_{float,double}_complex` were recently changed to private, and accessors/setters `real()` and `imag()` were added.

This changes rocSOLVER to use the accessors/setters instead of directly accessing internal members.

Also, like in hipBLAS, the undefined behavior of assigning to the same array element twice in the same statement without a sequence point in-between assignments, is fixed. It happens with symmetric/hermitian matrices being initialized with random numbers: When `i==j`, it is setting a diagonal element, and if `a[i * lda + j] = a[j* lda  +i] = ...` is used, it is undefined behavior because the same element is assigned twice without a sequence-point in-between.

Finally, in `rocauxiliary_larfg.hpp`, `is_complex<>` is used as a better test than `std::is_floating_point<>` to differentiate real and complex, and in the `set_taubeta` routine, the norm `n` is treated as a real instead of as a complex with imaginary part `0`, to simplify and speed up the arithmetic, since `rocblas_{float,double}_complex` allows arithmetic between real and complex numbers.