### PR TITLE
Add -DROCM_USE_FLOAT16 so that it can build after upcoming rocBLAS changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,3 +188,5 @@ add_subdirectory( rocsolver/library )
 if( BUILD_CLIENTS_TESTS OR BUILD_CLIENTS_BENCHMARKS )
   add_subdirectory( rocsolver/clients )
 endif( )
+
+target_compile_definitions( rocsolver PRIVATE ROCM_USE_FLOAT16 )

--- a/rocsolver/clients/benchmarks/CMakeLists.txt
+++ b/rocsolver/clients/benchmarks/CMakeLists.txt
@@ -167,3 +167,4 @@ endif( )
 
 set_target_properties( rocsolver-bench PROPERTIES CXX_EXTENSIONS NO )
 set_target_properties( rocsolver-bench PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/../../clients/staging" )
+target_compile_definitions( rocsolver-bench PRIVATE ROCM_USE_FLOAT16 )

--- a/rocsolver/clients/gtest/CMakeLists.txt
+++ b/rocsolver/clients/gtest/CMakeLists.txt
@@ -203,3 +203,4 @@ endif( )
 
 set_target_properties( rocsolver-test PROPERTIES CXX_EXTENSIONS NO )
 set_target_properties( rocsolver-test PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/../../clients/staging" )
+target_compile_definitions( rocsolver-test PRIVATE ROCM_USE_FLOAT16 )


### PR DESCRIPTION
This change needs to go in before the upcoming rocBLAS hotfix, so that `_Float16` is still used by rocBLAS when it's included by rocSOLVER.
