### PR TITLE
Scalar fixes

### DIFF
--- a/rocsolver/library/src/auxiliary/rocauxiliary_lacgv.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_lacgv.hpp
@@ -70,8 +70,8 @@ rocblas_status rocsolver_lacgv_template(rocblas_handle handle, const rocblas_int
     rocblas_int offset = incx < 0 ? shiftx - (n-1)*incx : shiftx;
 
     // conjugate x
-    rocblas_int blocks = (n - 1)/1024 + 1;
-    hipLaunchKernelGGL(conj_in_place<T>, dim3(1,blocks,batch_count), dim3(1,1024,1), 0, stream,
+    rocblas_int blocks = (n - 1)/64 + 1;
+    hipLaunchKernelGGL(conj_in_place<T>, dim3(1,blocks,batch_count), dim3(1,64,1), 0, stream,
                        1, n, x, offset, incx, stridex);
 
     return rocblas_status_success;

--- a/rocsolver/library/src/auxiliary/rocauxiliary_larf.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_larf.cpp
@@ -38,13 +38,10 @@ rocblas_status rocsolver_larf_impl(rocblas_handle handle, const rocblas_side sid
     if (!scalars || (size_2 && !work) || (size_3 && !workArr))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =

--- a/rocsolver/library/src/auxiliary/rocauxiliary_larft.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_larft.cpp
@@ -39,13 +39,10 @@ rocblas_status rocsolver_larft_impl(rocblas_handle handle, const rocblas_direct 
     if (!scalars || (size_2 && !work) || (size_3 && !workArr))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status = 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_org2r_ung2r.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_org2r_ung2r.cpp
@@ -36,13 +36,10 @@ rocblas_status rocsolver_org2r_ung2r_impl(rocblas_handle handle, const rocblas_i
     if (!scalars || (size_2 && !work) || (size_3 && !workArr))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =    

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgbr_ungbr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgbr_ungbr.cpp
@@ -39,13 +39,10 @@ rocblas_status rocsolver_orgbr_ungbr_impl(rocblas_handle handle, const rocblas_s
     if (!scalars || (size_2 && !work) || (size_3 && !workArr) || (size_4 && !trfact))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status = 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgl2_ungl2.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgl2_ungl2.cpp
@@ -36,13 +36,10 @@ rocblas_status rocsolver_orgl2_ungl2_impl(rocblas_handle handle, const rocblas_i
     if (!scalars || (size_2 && !work) || (size_3 && !workArr))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orglq_unglq.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orglq_unglq.cpp
@@ -38,13 +38,10 @@ rocblas_status rocsolver_orglq_unglq_impl(rocblas_handle handle, const rocblas_i
     if (!scalars || (size_2 && !work) || (size_3 && !workArr) || (size_4 && !trfact))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
     
     // execution
     rocblas_status status = 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgqr_ungqr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgqr_ungqr.cpp
@@ -38,13 +38,10 @@ rocblas_status rocsolver_orgqr_ungqr_impl(rocblas_handle handle, const rocblas_i
     if (!scalars || (size_2 && !work) || (size_3 && !workArr) || (size_4 && !trfact))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
     
     // execution
     rocblas_status status = 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orm2r_unm2r.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orm2r_unm2r.cpp
@@ -40,13 +40,10 @@ rocblas_status rocsolver_orm2r_unm2r_impl(rocblas_handle handle, const rocblas_s
     if (!scalars || (size_2 && !work) || (size_3 && !workArr) || (size_4 && !diag))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =

--- a/rocsolver/library/src/auxiliary/rocauxiliary_ormbr_unmbr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_ormbr_unmbr.cpp
@@ -40,13 +40,10 @@ rocblas_status rocsolver_ormbr_unmbr_impl(rocblas_handle handle, const rocblas_s
     if (!scalars || (size_2 && !work) || (size_3 && !workArr) || (size_4 && !trfact))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status = 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orml2_unml2.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orml2_unml2.cpp
@@ -40,13 +40,10 @@ rocblas_status rocsolver_orml2_unml2_impl(rocblas_handle handle, const rocblas_s
     if (!scalars || (size_2 && !work) || (size_3 && !workArr) || (size_4 && !diag))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status = 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_ormlq_unmlq.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_ormlq_unmlq.cpp
@@ -40,13 +40,10 @@ rocblas_status rocsolver_ormlq_unmlq_impl(rocblas_handle handle, const rocblas_s
     if (!scalars || (size_2 && !work) || (size_3 && !workArr) || (size_4 && !trfact))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status = 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_ormqr_unmqr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_ormqr_unmqr.cpp
@@ -40,13 +40,10 @@ rocblas_status rocsolver_ormqr_unmqr_impl(rocblas_handle handle, const rocblas_s
     if (!scalars || (size_2 && !work) || (size_3 && !workArr) || (size_4 && !trfact))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status = 

--- a/rocsolver/library/src/lapack/roclapack_gelq2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelq2.cpp
@@ -39,13 +39,10 @@ rocblas_status rocsolver_gelq2_impl(rocblas_handle handle, const rocblas_int m,
     if (!scalars || (size_2 && !work) || (size_3 && !workArr) || (size_4 && !diag))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =

--- a/rocsolver/library/src/lapack/roclapack_gelq2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelq2_batched.cpp
@@ -38,13 +38,10 @@ rocblas_status rocsolver_gelq2_batched_impl(rocblas_handle handle, const rocblas
     if (!scalars || (size_2 && !work) || (size_3 && !workArr) || (size_4 && !diag))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =

--- a/rocsolver/library/src/lapack/roclapack_gelq2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelq2_strided_batched.cpp
@@ -35,13 +35,10 @@ rocblas_status rocsolver_gelq2_strided_batched_impl(rocblas_handle handle, const
     if (!scalars || (size_2 && !work) || (size_3 && !workArr) || (size_4 && !diag))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =

--- a/rocsolver/library/src/lapack/roclapack_gelqf.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelqf.cpp
@@ -41,13 +41,10 @@ rocblas_status rocsolver_gelqf_impl(rocblas_handle handle, const rocblas_int m,
     if (!scalars || (size_2 && !work) || (size_3 && !workArr) || (size_4 && !diag) || (size_5 && !trfact))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =

--- a/rocsolver/library/src/lapack/roclapack_gelqf_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelqf_batched.cpp
@@ -40,13 +40,10 @@ rocblas_status rocsolver_gelqf_batched_impl(rocblas_handle handle, const rocblas
     if (!scalars || (size_2 && !work) || (size_3 && !workArr) || (size_4 && !diag) || (size_5 && !trfact))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =

--- a/rocsolver/library/src/lapack/roclapack_gelqf_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelqf_strided_batched.cpp
@@ -37,13 +37,10 @@ rocblas_status rocsolver_gelqf_strided_batched_impl(rocblas_handle handle, const
     if (!scalars || (size_2 && !work) || (size_3 && !workArr) || (size_4 && !diag) || (size_5 && !trfact))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =

--- a/rocsolver/library/src/lapack/roclapack_geqr2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqr2.cpp
@@ -39,13 +39,10 @@ rocblas_status rocsolver_geqr2_impl(rocblas_handle handle, const rocblas_int m,
     if (!scalars || (size_2 && !work) || (size_3 && !workArr) || (size_4 && !diag))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =

--- a/rocsolver/library/src/lapack/roclapack_geqr2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqr2_batched.cpp
@@ -38,13 +38,10 @@ rocblas_status rocsolver_geqr2_batched_impl(rocblas_handle handle, const rocblas
     if (!scalars || (size_2 && !work) || (size_3 && !workArr) || (size_4 && !diag))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =

--- a/rocsolver/library/src/lapack/roclapack_geqr2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqr2_strided_batched.cpp
@@ -35,13 +35,10 @@ rocblas_status rocsolver_geqr2_strided_batched_impl(rocblas_handle handle, const
     if (!scalars || (size_2 && !work) || (size_3 && !workArr) || (size_4 && !diag))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =

--- a/rocsolver/library/src/lapack/roclapack_geqrf.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqrf.cpp
@@ -41,13 +41,10 @@ rocblas_status rocsolver_geqrf_impl(rocblas_handle handle, const rocblas_int m,
     if (!scalars || (size_2 && !work) || (size_3 && !workArr) || (size_4 && !diag) || (size_5 && !trfact))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =

--- a/rocsolver/library/src/lapack/roclapack_geqrf_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqrf_batched.cpp
@@ -40,13 +40,10 @@ rocblas_status rocsolver_geqrf_batched_impl(rocblas_handle handle, const rocblas
     if (!scalars || (size_2 && !work) || (size_3 && !workArr) || (size_4 && !diag) || (size_5 && !trfact))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =

--- a/rocsolver/library/src/lapack/roclapack_geqrf_ptr_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqrf_ptr_batched.cpp
@@ -65,13 +65,10 @@ rocblas_status rocsolver_geqrf_ptr_batched_impl(rocblas_handle handle, const roc
     if (!scalars || (size_2 && !work) || (size_3 && !workArr) || (size_4 && !diag) || (size_5 && !trfact) || (size_6 && !ipiv))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =

--- a/rocsolver/library/src/lapack/roclapack_geqrf_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqrf_strided_batched.cpp
@@ -37,13 +37,10 @@ rocblas_status rocsolver_geqrf_strided_batched_impl(rocblas_handle handle, const
     if (!scalars || (size_2 && !work) || (size_3 && !workArr) || (size_4 && !diag) || (size_5 && !trfact))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =

--- a/rocsolver/library/src/lapack/roclapack_getf2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getf2.cpp
@@ -35,13 +35,10 @@ rocblas_status rocsolver_getf2_impl(rocblas_handle handle, const rocblas_int m,
     if (!scalars || (size_2 && !pivotGPU))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =

--- a/rocsolver/library/src/lapack/roclapack_getf2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getf2_batched.cpp
@@ -35,13 +35,10 @@ rocblas_status rocsolver_getf2_batched_impl(rocblas_handle handle, const rocblas
     if (!scalars || (size_2 && !pivotGPU))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =

--- a/rocsolver/library/src/lapack/roclapack_getf2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getf2_strided_batched.cpp
@@ -32,13 +32,10 @@ rocblas_status rocsolver_getf2_strided_batched_impl(rocblas_handle handle, const
     if (!scalars || (size_2 && !pivotGPU))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status = 

--- a/rocsolver/library/src/lapack/roclapack_getrf.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getrf.cpp
@@ -36,13 +36,10 @@ rocblas_status rocsolver_getrf_impl(rocblas_handle handle, const rocblas_int m,
     if (!scalars || (size_2 && !pivotGPU) || (size_3 && !iinfo))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =

--- a/rocsolver/library/src/lapack/roclapack_getrf_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getrf_batched.cpp
@@ -35,13 +35,10 @@ rocblas_status rocsolver_getrf_batched_impl(rocblas_handle handle, rocblas_int m
     if (!scalars || (size_2 && !pivotGPU) || (size_3 && !iinfo))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =

--- a/rocsolver/library/src/lapack/roclapack_getrf_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getrf_strided_batched.cpp
@@ -32,13 +32,10 @@ rocblas_status rocsolver_getrf_strided_batched_impl(rocblas_handle handle, const
     if (!scalars || (size_2 && !pivotGPU) || (size_3 && !iinfo))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =

--- a/rocsolver/library/src/lapack/roclapack_potf2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potf2.cpp
@@ -35,13 +35,10 @@ rocblas_status rocsolver_potf2_impl(rocblas_handle handle, const rocblas_fill up
     if (!scalars || (size_2 && !work) || (size_3 && !pivotGPU))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls 
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status = 

--- a/rocsolver/library/src/lapack/roclapack_potf2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potf2_batched.cpp
@@ -36,13 +36,10 @@ rocblas_status rocsolver_potf2_batched_impl(rocblas_handle handle, const rocblas
     if (!scalars || (size_2 && !work) || (size_3 && !pivotGPU))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls 
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status = 

--- a/rocsolver/library/src/lapack/roclapack_potf2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potf2_strided_batched.cpp
@@ -33,13 +33,10 @@ rocblas_status rocsolver_potf2_strided_batched_impl(rocblas_handle handle, const
     if (!scalars || (size_2 && !work) || (size_3 && !pivotGPU))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls 
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
     
     // execution
     rocblas_status status = 

--- a/rocsolver/library/src/lapack/roclapack_potrf.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potrf.cpp
@@ -37,13 +37,10 @@ rocblas_status rocsolver_potrf_impl(rocblas_handle handle, const rocblas_fill up
     if (!scalars || (size_2 && !work) || (size_3 && !pivotGPU) || (size_4 && !iinfo))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =

--- a/rocsolver/library/src/lapack/roclapack_potrf_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potrf_batched.cpp
@@ -38,13 +38,10 @@ rocblas_status rocsolver_potrf_batched_impl(rocblas_handle handle, const rocblas
     if (!scalars || (size_2 && !work) || (size_3 && !pivotGPU) || (size_4 && !iinfo))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =

--- a/rocsolver/library/src/lapack/roclapack_potrf_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potrf_strided_batched.cpp
@@ -35,13 +35,10 @@ rocblas_status rocsolver_potrf_strided_batched_impl(rocblas_handle handle, const
     if (!scalars || (size_2 && !work) || (size_3 && !pivotGPU) || (size_4 && !iinfo))
         return rocblas_status_memory_error;
 
-    // scalars constants for rocblas functions calls
-    // (to standarize and enable re-use, size_1 always equals 3)
-    std::vector<T> sca(size_1);
-    sca[0] = -1;
-    sca[1] = 0;
-    sca[2] = 1;
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca.data(), sizeof(T)*size_1, hipMemcpyHostToDevice));
+    // scalar constants for rocblas functions calls
+    // (to standarize and enable re-use, size_1 always equals 3*sizeof(T))
+    T sca[] = { -1, 0, 1 };
+    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_1, hipMemcpyHostToDevice));
 
     // execution
     rocblas_status status =


### PR DESCRIPTION
Fixed initialization of device scalar arrays.

size_1 is set to be 3*sizeof(T) in .hpp files, but is considered to be 3 in .cpp files. Sizes for host arrays and hipMemcpys are now correct.