### PR TITLE
Minor cleanup for docs, scripts and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,39 @@
 # rocSOLVER
 
-rocSOLVER is a work-in-progress implementation of a subset of [LAPACK](http://www.netlib.org/lapack/explore-html/index.html) 
-functionality on the [ROCm platform](https://rocm.github.io). 
+rocSOLVER is a work-in-progress implementation of a subset of [LAPACK][1]
+functionality on the [ROCm platform][2].
 
 # Documentation
 
-For a detailed description of the rocSOLVER library, its implemented routines, the installation process and user guide, see the
-[rocSOLVER documentation](https://rocsolver.readthedocs.io/en/latest).
+For a detailed description of the rocSOLVER library, its implemented routines,
+the installation process and user guide, see the [rocSOLVER documentation][3].
 
 # Quick start
 
-To download rocSOLVER source code, clone this repository with the command
+To download rocSOLVER source code, clone this repository with the command:
 
-```bash
-git clone https://github.com/ROCmSoftwarePlatform/rocSOLVER.git
-```
-rocSOLVER requires rocBLAS as a companion GPU BLAS implementation. For more information about rocBLAS and how to
-install it, see the [rocBLAS documentation](https://rocblas.readthedocs.io/en/latest).
+    git clone https://github.com/ROCmSoftwarePlatform/rocSOLVER.git
 
-After a standard installation of rocBLAS, the following commands will build and install rocSOLVER at the standard location
-/opt/rocm/rocsolver    
+rocSOLVER requires rocBLAS as a companion GPU BLAS implementation. For
+more information about rocBLAS and how to install it, see the
+[rocBLAS documentation][4].
 
-```bash
-cd rocsolver 
-./install.sh -i
-````
+After a standard installation of rocBLAS, the following commands will build
+rocSOLVER and install to `/opt/rocm/rocsolver`:
 
-Once installed, rocSOLVER can be used just like any other library with a C API. 
-The header file will need to be included in the user code, and both the rocBLAS and rocSOLVER shared libraries 
-will become link-time and run-time dependencies for the user applciation.
+    cd rocsolver
+    ./install.sh -i
+
+Once installed, rocSOLVER can be used just like any other library with a C API.
+The header file will need to be included in the user code, and both the rocBLAS
+and rocSOLVER shared libraries will become link-time and run-time dependencies
+for the user application.
 
 # Using rocSOLVER example
 
-The following code snippet uses rocSOLVER to compute the QR factorization of a general m-by-n real matrix in double precsision. 
-For a description of function rocsolver_dgeqrf see the API documentation [here](https://rocsolver.readthedocs.io/en/latest/userguide_api.html#rocsolver-type-geqrf).
+The following code snippet uses rocSOLVER to compute the QR factorization of a
+general m-by-n real matrix in double precision. For a description of the
+function `rocsolver_dgeqrf`, see the [API documentation][5].
 
 ```cpp
 /////////////////////////////
@@ -85,8 +85,16 @@ int main() {
   rocsolver_destroy_handle(handle);   // destroy handle
 }
 ```
-Compile command may vary depending on the system and session environment. Here is an example of a common use case
 
-```bash
->> hipcc -I/opt/rocm/include -L/opt/rocm/lib -lrocsolver -lrocblas example.cpp -o example_executable
-```
+The exact command used to compile the example above may vary depending on the
+system environment, but here is a typical example:
+
+    /opt/rocm/bin/hipcc -I/opt/rocm/include -c example.cpp
+    /opt/rocm/bin/hipcc -o example -L/opt/rocm/lib -lrocsolver -lrocblas example.o
+
+
+[1]: https://www.netlib.org/lapack/explore-html/index.html
+[2]: https://rocm.github.io
+[3]: https://rocsolver.readthedocs.io/en/latest
+[4]: https://rocblas.readthedocs.io/en/latest
+[5]: https://rocsolver.readthedocs.io/en/latest/userguide_api.html#rocsolver-type-geqrf

--- a/install.sh
+++ b/install.sh
@@ -32,9 +32,9 @@ Options:
   --rocblas_dir <blasdir>     Specify path to the companion rocBLAS-library root directory. 
                               Use only absolute paths.
                               (Default is /opt/rocm/rocblas)
-    
+
   --hcc                       Pass this flag to build library using deprecated hcc compiler.
-  
+
   -g | --debug                Pass this flag to build in Debug mode (equivalent to set CMAKE_BUILD_TYPE=Debug).
                               (Default build type is Release)
 
@@ -253,12 +253,12 @@ install_packages( )
       ;;
 
     sles|opensuse-leap)
-       install_zypper_packages "${client_dependencies_sles[@]}"
+      install_zypper_packages "${client_dependencies_sles[@]}"
 
-        if [[ "${build_clients}" == true ]]; then
-            install_zypper_packages "${client_dependencies_sles[@]}"
-        fi
-        ;;
+      if [[ "${build_clients}" == true ]]; then
+        install_zypper_packages "${client_dependencies_sles[@]}"
+      fi
+      ;;
     *)
       echo "This script is currently supported on Ubuntu, CentOS, RHEL, SLES, OpenSUSE-Leap, and Fedora"
       exit 2
@@ -310,7 +310,7 @@ optimal=true
 
 rocm_path=/opt/rocm
 if ! [ -z ${ROCM_PATH+x} ]; then
-    rocm_path=${ROCM_PATH}
+  rocm_path=${ROCM_PATH}
 fi
 
 # #################################################
@@ -397,7 +397,7 @@ printf "\033[32mCreating project build directory in: \033[33m${build_dir}\033[0m
 # prep
 # #################################################
 # ensure a clean build environment
-rm -rf ${build_dir}
+rm -rf "${build_dir}"
 
 # Default cmake executable is called cmake
 cmake_executable=cmake
@@ -408,7 +408,7 @@ case "${ID}" in
   ;;
 esac
 
-main=`pwd`
+main=$(pwd)
 
 # #################################################
 # dependencies
@@ -420,8 +420,8 @@ if [[ "${install_dependencies}" == true ]]; then
     # The following builds googletest & lapack from source, installs into cmake default /usr/local
     pushd .
     printf "\033[32mBuilding \033[33mgoogletest & lapack\033[32m from source; installing into \033[33m/usr/local\033[0m\n"
-    mkdir -p ${build_dir}/deps && cd ${build_dir}/deps
-    ${cmake_executable} -lpthread -DBUILD_BOOST=OFF ${main}/rocblascommon/deps
+    mkdir -p "${build_dir}/deps" && cd "${build_dir}/deps"
+    ${cmake_executable} -lpthread -DBUILD_BOOST=OFF "${main}/rocblascommon/deps"
     make -j$(nproc)
     elevate_if_not_root make install
     popd
@@ -443,7 +443,7 @@ pushd .
 cmake_common_options=""
 cmake_client_options=""
 
-mkdir -p ${build_dir} && cd ${build_dir}
+mkdir -p "${build_dir}" && cd "${build_dir}"
 
 if [[ "${build_type}" == Debug ]]; then
   mkdir -p debug && cd debug
@@ -513,7 +513,7 @@ if [[ "${build_package}" == true ]]; then
         elevate_if_not_root dnf install rocsolver-*.rpm
         ;;
       sles|opensuse-leap)
-	elevate_if_not_root zypper -n --no-gpg-checks install rocsolver-*.rpm
+        elevate_if_not_root zypper -n --no-gpg-checks install rocsolver-*.rpm
         ;;
     esac
   fi

--- a/rocsolver/clients/gtest/rocsolver_gtest_main.cpp
+++ b/rocsolver/clients/gtest/rocsolver_gtest_main.cpp
@@ -3,30 +3,45 @@
  * ************************************************************************ */
 
 #include "clientcommon.hpp"
+#include "rocblas-version.h"
+#include "rocsolver-version.h"
 #include <gtest/gtest.h>
 #include <stdexcept>
 
-/* =====================================================================
-      Main function:
-=================================================================== */
+#define STRINGIFY(s) STRINGIFY_HELPER(s)
+#define STRINGIFY_HELPER(s) #s
 
-int main(int argc, char **argv) {
+static void print_version_info()
+{
+    rocblas_cout << "rocSOLVER version "
+        STRINGIFY(ROCSOLVER_VERSION_MAJOR) "."
+        STRINGIFY(ROCSOLVER_VERSION_MINOR) "."
+        STRINGIFY(ROCSOLVER_VERSION_PATCH) "."
+        STRINGIFY(ROCSOLVER_VERSION_TWEAK)
+        " (with rocBLAS "
+        STRINGIFY(ROCBLAS_VERSION_MAJOR) "."
+        STRINGIFY(ROCBLAS_VERSION_MINOR) "."
+        STRINGIFY(ROCBLAS_VERSION_PATCH) "."
+        STRINGIFY(ROCBLAS_VERSION_TWEAK) ")"
+        << std::endl;
+}
 
-  // Device Query
+int main(int argc, char **argv)
+{
+    print_version_info();
 
-  int device_id = 0;
-
-  int device_count = query_device_property();
-
-  if (device_count <= device_id) {
-    //printf("Error: invalid device ID. There may not be such device ID. Will exit \n");
-    rocblas_cout << "Error: invalid device ID. There may not be such device ID. Will exit \n";
-    return -1;
-  } else {
+    // Device Query
+    int device_id = 0;
+    int device_count = query_device_property();
+    if (device_count <= device_id) {
+        rocblas_cerr << "Error: invalid device ID. There may not be such device ID." << std::endl;
+        return -1;
+    }
     set_device(device_id);
-  }
 
-  ::testing::InitGoogleTest(&argc, argv);
+    ::testing::InitGoogleTest(&argc, argv);
 
-  return RUN_ALL_TESTS();
+    int status = RUN_ALL_TESTS();
+    print_version_info(); // redundant, but convenient when tests fail
+    return status;
 }


### PR DESCRIPTION
These are a collection of minor improvements to the docs, scripts and tests that I made while familiarizing myself with the rocSOLVER library and associated tooling.

- Used [shellcheck](https://www.shellcheck.net/) to lint the install script and addressed a subset of the warnings it listed. I also fixed some inconsistent indenting. The most important change was to quote the `$build_dir` when removing the old build directory.

- Fixed the example code in the README, which didn't build as specified prior to this change. It appears the example was originally C code. I fixed all errors I encountered, and reformatted it to be a little more compact. Sprawl is fine for most code, but a README is often read in more limited environments (like Notepad or a mobile browser).

- Added a version header and footer to the `rocsolver-test` utility to help make that information more obvious in our logs.