### PR TITLE
getri fixes 2

### DIFF
--- a/rocsolver/clients/gtest/getri_gtest.cpp
+++ b/rocsolver/clients/gtest/getri_gtest.cpp
@@ -28,7 +28,7 @@ const vector<vector<int>> matrix_size_range = {
 
 // for daily_lapack tests
 const vector<vector<int>> large_matrix_size_range = {
-    {192, 192}, {640, 640}, {1000, 1024}, {1200, 1230} 
+    {192, 192}, {500, 600}, {640, 640}, {1000, 1024}, {1200, 1230} 
 };
 
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_trtri.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_trtri.hpp
@@ -89,7 +89,7 @@ __global__ void trtri_kernel(const rocblas_diagonal diag, const rocblas_int n,
 {
     int b = hipBlockIdx_x;
 
-    rocblas_stride strideW = (n <= TRTRI_SWITCHSIZE_MID ? n : TRTRI_BLOCKSIZE);
+    rocblas_stride strideW = n;
     T* a = load_ptr_batch<T>(A,b,shiftA,strideA);
     T* w = load_ptr_batch<T>(work,b,0,strideW);
 
@@ -170,10 +170,8 @@ void rocsolver_trtri_getMemorySize(const rocblas_int n, const rocblas_int batch_
     *size_1 = sizeof(T)*3;
 
     // for workspace
-    if (n <= TRTRI_SWITCHSIZE_MID)
+    if (n <= TRTRI_SWITCHSIZE_LARGE)
         *size_2 = n;
-    else if (n <= TRTRI_SWITCHSIZE_LARGE)
-        *size_2 = TRTRI_BLOCKSIZE;
     else
         *size_2 = n * TRTRI_BLOCKSIZE + 2 * ROCBLAS_TRMM_NB * ROCBLAS_TRMM_NB;
     *size_2 *= sizeof(T)*batch_count;
@@ -267,4 +265,4 @@ rocblas_status rocsolver_trtri_template(rocblas_handle handle, const rocblas_fil
     return rocblas_status_success;
 }
 
-#endif /* ROCLAPACK_GETRI_H */
+#endif /* ROCLAPACK_TRTRI_H */

--- a/rocsolver/library/src/lapack/roclapack_getri.hpp
+++ b/rocsolver/library/src/lapack/roclapack_getri.hpp
@@ -450,7 +450,7 @@ rocblas_status rocsolver_getri_template(rocblas_handle handle, const rocblas_int
 
     #endif
 
-    rocblas_int threads = min(((n - 1)/64 + 1) * 64, GETRI_BLOCKSIZE);
+    rocblas_int threads = min(((n - 1)/64 + 1) * 64, BLOCKSIZE);
 
     // compute inv(U)
     rocsolver_trtri_template<BATCHED,STRIDED,T>(handle, rocblas_fill_upper, rocblas_diagonal_non_unit, n,

--- a/rocsolver/library/src/lapack/roclapack_getri.hpp
+++ b/rocsolver/library/src/lapack/roclapack_getri.hpp
@@ -450,7 +450,7 @@ rocblas_status rocsolver_getri_template(rocblas_handle handle, const rocblas_int
 
     #endif
 
-    rocblas_int threads = min(((n - 1)/64 + 1) * 64, BLOCKSIZE);
+    rocblas_int threads = min(((n - 1)/64 + 1) * 64, TRTRI_BLOCKSIZE);
 
     // compute inv(U)
     rocsolver_trtri_template<BATCHED,STRIDED,T>(handle, rocblas_fill_upper, rocblas_diagonal_non_unit, n,

--- a/rocsolver/library/src/lapack/roclapack_getri.hpp
+++ b/rocsolver/library/src/lapack/roclapack_getri.hpp
@@ -450,7 +450,7 @@ rocblas_status rocsolver_getri_template(rocblas_handle handle, const rocblas_int
 
     #endif
 
-    rocblas_int threads = min(((n - 1)/64 + 1) * 64, TRTRI_BLOCKSIZE);
+    rocblas_int threads = min(((n - 1)/64 + 1) * 64, GETRI_BLOCKSIZE);
 
     // compute inv(U)
     rocsolver_trtri_template<BATCHED,STRIDED,T>(handle, rocblas_fill_upper, rocblas_diagonal_non_unit, n,


### PR DESCRIPTION
Size 500 matrix with lda = 600 is giving test errors. Likely cause is incorrect behaviour in the internal trmm device function. Pending a fix, this PR removes the use of the internal trmm device function.

EDIT: Cause of the bug has been identified as incorrect workspace handling. I started using the workspace within the trmm function to fix a different bug, and forgot to update the workspace allocation and strides.