### PR TITLE
Add C sample program

### DIFF
--- a/rocsolver/clients/CMakeLists.txt
+++ b/rocsolver/clients/CMakeLists.txt
@@ -12,7 +12,7 @@ if( NOT DEFINED CMAKE_CONFIGURATION_TYPES AND NOT DEFINED CMAKE_BUILD_TYPE )
 endif()
 
 # This project may compile dependencies for clients
-project( rocsolver-clients LANGUAGES CXX Fortran )
+project( rocsolver-clients LANGUAGES C CXX Fortran )
 
 if(OS_ID_rhel OR OS_ID_centos OR OS_ID_sles)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp=libgomp -pthread")

--- a/rocsolver/clients/samples/CMakeLists.txt
+++ b/rocsolver/clients/samples/CMakeLists.txt
@@ -7,7 +7,11 @@ add_library( rocblas_module OBJECT
   "${ROCBLAS_INCLUDE_DIR}/rocblas_module.f90"
 )
 
-add_executable( example-basic
+# declare sample programs
+add_executable( example-c-basic
+  example_basic.c
+)
+add_executable( example-cpp-basic
   example_basic.cpp
 )
 add_executable( example-fortran-basic
@@ -15,21 +19,23 @@ add_executable( example-fortran-basic
   $<TARGET_OBJECTS:rocblas_module>
 )
 
+# group sample programs by language
 set( c_samples
+  example-c-basic
 )
 set( cpp_samples
-  example-basic
+  example-cpp-basic
 )
 set( fortran_samples
   example-fortran-basic
 )
 
+# set flags for building the sample programs
 foreach( exe ${c_samples} ${cpp_samples} ${fortran_samples} )
   target_link_libraries( ${exe} PRIVATE roc::rocsolver roc::rocblas )
 
   set_target_properties( ${exe} PROPERTIES CXX_EXTENSIONS NO )
   set_target_properties( ${exe} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
-  target_compile_definitions( ${exe} PRIVATE ROCM_USE_FLOAT16 )
 
   target_include_directories( ${exe}
     PRIVATE
@@ -72,10 +78,18 @@ foreach( exe ${c_samples} ${cpp_samples} ${fortran_samples} )
   endif()
 endforeach( )
 
-foreach( exe ${c_samples} ${cpp_samples} )
+foreach( exe ${cpp_samples} )
   if( NOT CUDA_FOUND )
     target_link_libraries( ${exe} PRIVATE hip::device )
   endif()
+endforeach( )
+
+foreach( exe ${c_samples} )
+  set_target_properties( ${exe} PROPERTIES
+    C_STANDARD 11
+    C_STANDARD_REQUIRED ON
+    C_EXTENSIONS OFF
+  )
 endforeach( )
 
 if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )

--- a/rocsolver/docs/source/userguide_examples.rst
+++ b/rocsolver/docs/source/userguide_examples.rst
@@ -36,9 +36,9 @@ For a full description of the used rocSOLVER routine, see the API documentation 
                             rocblas_int& N,
                             rocblas_int& lda) {
       // a *very* small example input; not a very efficient use of the API
-      double A[3][3] = { {  12, -51,   4},
-                         {   6, 167, -68},
-                         {  -4,  24, -41} };
+      const double A[3][3] = { {  12, -51,   4},
+                               {   6, 167, -68},
+                               {  -4,  24, -41} };
       M = 3;
       N = 3;
       lda = 3;


### PR DESCRIPTION
Removed ROCM_USE_FLOAT16 and the linking against hip::device, from
the C samples as the default compiler may not support them (e.g. GCC on
x86_64), and our samples don't need them anyway.

Updated the C++ sample to match the C sample's improved use of const.