### PR TITLE
Disable test when building msgpack from source

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -159,7 +159,7 @@ install_msgpack_from_source( )
       cd "${build_dir}/deps"
       git clone -b cpp-3.0.1 https://github.com/msgpack/msgpack-c.git
       cd msgpack-c
-      ${cmake_executable} .
+      ${cmake_executable} -DMSGPACK_BUILD_TESTS=OFF .
       make
       elevate_if_not_root make install
       popd


### PR DESCRIPTION
This prevents errors when building rocsolver with dependencies (install.sh -d) and msgpack/gtest are already installed. 