### PR TITLE
Fix CI for static builds with noOptimizations

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -10,6 +10,7 @@ def runCompileCommand(platform, project, jobName, boolean sameOrg=false)
     String sles = platform.jenkinsLabel.contains('sles') ? '/usr/bin/sudo --preserve-env' : ''
     String debug = project.buildName.contains('Debug') ? '-g' : ''   
     String centos = platform.jenkinsLabel.contains('centos') ? 'source scl_source enable devtoolset-7' : ''
+    String noOptimizations = ''
 
     if (env.BRANCH_NAME ==~ /PR-\d+/)
     {
@@ -17,7 +18,7 @@ def runCompileCommand(platform, project, jobName, boolean sameOrg=false)
         {
             if (it == "noOptimizations")
             {
-                project.paths.build_command = "./install.sh -cn"
+                noOptimizations = "-n"
             }
         }
     }
@@ -29,7 +30,7 @@ def runCompileCommand(platform, project, jobName, boolean sameOrg=false)
                 ${getRocBLAS}
                 ${auxiliary.exitIfNotSuccess()}
                 ${centos}
-                ${sles} ${project.paths.build_command} ${hipClang} ${debug}
+                ${sles} ${project.paths.build_command} ${hipClang} ${debug} ${noOptimizations}
                 ${auxiliary.exitIfNotSuccess()}
                 """
     platform.runCommand(this, command)


### PR DESCRIPTION
Overriding the build command drops the static flag. Instead, just
append the noOptimizations flag.

It's not possible to build a dynamic version of rocSOLVER with a static
version of rocBLAS. The rocBLAS symbols are marked as hidden, and
cannot be used in rocsolver.so. Attempting to use them results in a
link failure like this:

    /usr/bin/ld: ../staging/example-c-basic: hidden symbol `rocblas_dtrsm' in /opt/rocm-3.7.0-6/rocblas/lib/librocblas.a(rocblas_trsm.cpp.o) is referenced by DSO
    /usr/bin/ld: final link failed: Bad value
    clang-11: error: linker command failed with exit code 1 (use -v to see invocation)