### PR TITLE
Add ./install.sh --docs to build documentation

### DIFF
--- a/docker/dockerfile-docs
+++ b/docker/dockerfile-docs
@@ -1,0 +1,5 @@
+FROM readthedocs/build:latest
+
+USER root:root
+RUN apt-get install -qq doxygen
+RUN pip3 install breathe sphinx sphinx_rtd_theme

--- a/install.sh
+++ b/install.sh
@@ -61,7 +61,7 @@ Options:
 
   --docs                      (experimental) Pass this flag to build the documentation from source.
                               Official documentation is available online at https://rocsolver.readthedocs.io/
-                              Building locally with flag will require docker on your machine. If you are
+                              Building locally with this flag will require docker on your machine. If you are
                               familiar with doxygen, sphinx and documentation tools, you can alternatively
                               use the scripts provided in rocsolver/docs.
 EOF

--- a/install.sh
+++ b/install.sh
@@ -59,7 +59,7 @@ Options:
 
   -n | --no-optimizations     Pass this flag to disable optimizations for small sizes.
 
-  --docs                      Pass this flag to build the documentation.
+  --docs                      Pass this flag to build the documentation. (experimental)
 EOF
 }
 
@@ -451,10 +451,10 @@ cmake_client_options=""
 # build documentation
 if [[ "${build_docs}" == true ]]; then
   mkdir -p "$build_dir"
-  container_name="build$(head -c 10 /dev/urandom | base32)"
+  container_name="build_$(head -c 10 /dev/urandom | base32)"
   docs_build_command='cp -r /mnt/rocsolver /home/docs/ && cd /home/docs/rocsolver/rocsolver/docs && ./run_doc.sh'
-  docker build -t rocsolver-docs:latest -f docker/dockerfile-docs .
-  docker run -v "$main:/mnt/rocsolver:ro" --name "$container_name" rocsolver-docs:latest /bin/bash -c "$docs_build_command"
+  docker build -t rocsolver:docs -f docker/dockerfile-docs .
+  docker run -v "$main:/mnt/rocsolver:ro" --name "$container_name" rocsolver:docs /bin/sh -c "$docs_build_command"
   docker cp "$container_name:/home/docs/rocsolver/rocsolver/docs/build" "$build_dir/docs"
   exit
 fi

--- a/install.sh
+++ b/install.sh
@@ -408,7 +408,7 @@ printf "\033[32mCreating project build directory in: \033[33m${build_dir}\033[0m
 # ensure a clean build environment
 if [[ "${build_docs}" == true ]]; then
   rm -rf -- "${build_dir}/docs"
-elif [[ "${build_release}" == true ]]; then
+elif [[ "${build_type}" == Release ]]; then
   rm -rf -- "${build_dir}/release"
 else
   rm -rf -- "${build_dir}/debug"
@@ -458,9 +458,10 @@ pushd .
 cmake_common_options=""
 cmake_client_options=""
 
+mkdir -p "$build_dir"
+
 # build documentation
 if [[ "${build_docs}" == true ]]; then
-  mkdir -p "$build_dir"
   container_name="build_$(head -c 10 /dev/urandom | base32)"
   docs_build_command='cp -r /mnt/rocsolver /home/docs/ && cd /home/docs/rocsolver/rocsolver/docs && ./run_doc.sh'
   docker build -t rocsolver:docs -f docker/dockerfile-docs .
@@ -469,7 +470,7 @@ if [[ "${build_docs}" == true ]]; then
   exit
 fi
 
-mkdir -p "${build_dir}" && cd "${build_dir}"
+cd "$build_dir"
 
 if [[ "${build_type}" == Debug ]]; then
   mkdir -p debug && cd debug

--- a/rocsolver/docs/source/conf.py
+++ b/rocsolver/docs/source/conf.py
@@ -34,8 +34,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'rocSOLVER'
-copyright = u'2020, Advanced Mirco Devices'
-author = u'Advanced Mirco Devices'
+copyright = u'2020, Advanced Micro Devices'
+author = u'Advanced Micro Devices'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -134,7 +134,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, 'rocSOLVER.tex', u'rocSOLVER Documentation',
-     u'Advanced Mirco Devices', 'manual'),
+     u'Advanced Micro Devices', 'manual'),
 ]
 
 

--- a/rocsolver/docs/source/userguide_api.rst
+++ b/rocsolver/docs/source/userguide_api.rst
@@ -30,14 +30,6 @@ rocsolver_handle
 .. deprecated:: 3.5
    Use :c:type:`rocblas_handle`.
 
-rocblas_direct
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. doxygenenum:: rocblas_direct
-
-rocblas_storev
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. doxygenenum:: rocblas_storev
-
 rocsolver_direction
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. doxygentypedef:: rocsolver_direction
@@ -81,6 +73,16 @@ rocsolver_status
    Use :c:enum:`rocblas_status`.
 
 
+Additional Types
+-------------------
+
+rocblas_direct
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygenenum:: rocblas_direct
+
+rocblas_storev
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygenenum:: rocblas_storev
 
 
 LAPACK Auxiliary Functions

--- a/rocsolver/docs/source/userguide_api.rst
+++ b/rocsolver/docs/source/userguide_api.rst
@@ -12,6 +12,9 @@ This section provides details of the rocSOLVER library API as in last ROCm relea
 Types
 =====
 
+rocSOLVER Types
+-----------------
+
 Most rocSOLVER types are aliases of rocBLAS types. 
 See the `rocBLAS types <https://rocblas.readthedocs.io/en/latest/api.html#types>`_.
 
@@ -594,6 +597,9 @@ rocsolver_<type>getrf_npvt_strided_batched()
 
 Auxiliaries
 =========================
+
+Auxiliary Functions
+---------------------
 
 rocSOLVER auxiliary functions are aliases of rocBLAS auxiliary functions.
 See the `rocBLAS auxiliary functions <https://rocblas.readthedocs.io/en/latest/api.html#auxiliary>`_.

--- a/rocsolver/docs/source/userguide_tuning.rst
+++ b/rocsolver/docs/source/userguide_tuning.rst
@@ -1,4 +1,4 @@
-.. _batch_label:
+.. _tuning_label:
 
 *******************************
 Tuning rocSOLVER Performance


### PR DESCRIPTION
It was kind of a pain to build the docs, so I will admit I did not actually compile them myself when I was reviewing PRs. Apparently we've introduced a few sphinx errors into our docs due to that.

You can build the docs with `./install.sh --docs`. It builds inside the `readthedocs:latest` docker container, then copies the results back out into `build/docs`. My hope is that this local build will closely match the results on the website.

I fixed up the sphinx errors and a handful of typos. This wraps up the work I started in #122.