### PR TITLE
Set xnack and sram-ecc as needed per architecture

### DIFF
--- a/rocsolver/library/src/CMakeLists.txt
+++ b/rocsolver/library/src/CMakeLists.txt
@@ -122,8 +122,9 @@ if(CMAKE_CXX_COMPILER MATCHES ".*/hipcc$")
   # explicit xnack compilation flags
   target_compile_options( rocsolver PRIVATE
     -mno-xnack
-    -Xarch_gfx906 -mno-sram-ecc
-    -Xarch_gfx908 -msram-ecc
+    "SHELL:-Xarch_gfx900 -mno-sram-ecc"
+    "SHELL:-Xarch_gfx906 -mno-sram-ecc"
+    "SHELL:-Xarch_gfx908 -msram-ecc"
   )
 endif()
 

--- a/rocsolver/library/src/CMakeLists.txt
+++ b/rocsolver/library/src/CMakeLists.txt
@@ -120,7 +120,7 @@ endif()
 
 # explicit xnack compilation flags
 if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
-  set( gfx906_options "-Xarch_gfx906 -mno-sram-ecc" )
+  set( gfx906_options "-Xarch_gfx906 -msram-ecc" )
   set( gfx908_options "-Xarch_gfx908 -msram-ecc" )
   if( CMAKE_VERSION VERSION_LESS 3.12 )
     set_target_properties( rocsolver PROPERTIES

--- a/rocsolver/library/src/CMakeLists.txt
+++ b/rocsolver/library/src/CMakeLists.txt
@@ -118,6 +118,15 @@ else()
   target_link_libraries( rocsolver PRIVATE hip::device hcc::hccshared )
 endif()
 
+if(CMAKE_CXX_COMPILER MATCHES ".*/hipcc$")
+  # explicit xnack compilation flags
+  target_compile_options( rocsolver PRIVATE
+    -mno-xnack
+    -Xarch_gfx906 -mno-sram-ecc
+    -Xarch_gfx908 -msram-ecc
+  )
+endif()
+
 set_target_properties( rocsolver PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED ON )
 
 if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )

--- a/rocsolver/library/src/CMakeLists.txt
+++ b/rocsolver/library/src/CMakeLists.txt
@@ -118,25 +118,23 @@ else()
   target_link_libraries( rocsolver PRIVATE hip::device hcc::hccshared )
 endif()
 
-if(CMAKE_CXX_COMPILER MATCHES ".*/hipcc$")
-  # explicit xnack compilation flags
-  set( gfx900_options "-Xarch_gfx900 -mno-sram-ecc" )
+# explicit xnack compilation flags
+if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
   set( gfx906_options "-Xarch_gfx906 -mno-sram-ecc" )
   set( gfx908_options "-Xarch_gfx908 -msram-ecc" )
-  if(CMAKE_VERSION VERSION_LESS 3.12)
+  if( CMAKE_VERSION VERSION_LESS 3.12 )
     set_target_properties( rocsolver PROPERTIES
       COMPILE_FLAGS
-        "-mno-xnack ${gfx900_options} ${gfx906_options} ${gfx908_options}"
+        "-mno-xnack ${gfx906_options} ${gfx908_options}"
     )
-  else ()
+  else( )
     target_compile_options( rocsolver PRIVATE
       -mno-xnack
-      "SHELL:${gfx900_options}"
       "SHELL:${gfx906_options}"
       "SHELL:${gfx908_options}"
     )
-  endif()
-endif()
+  endif( )
+endif( )
 
 set_target_properties( rocsolver PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED ON )
 

--- a/rocsolver/library/src/CMakeLists.txt
+++ b/rocsolver/library/src/CMakeLists.txt
@@ -120,12 +120,22 @@ endif()
 
 if(CMAKE_CXX_COMPILER MATCHES ".*/hipcc$")
   # explicit xnack compilation flags
-  target_compile_options( rocsolver PRIVATE
-    -mno-xnack
-    "SHELL:-Xarch_gfx900 -mno-sram-ecc"
-    "SHELL:-Xarch_gfx906 -mno-sram-ecc"
-    "SHELL:-Xarch_gfx908 -msram-ecc"
-  )
+  set( gfx900_options "-Xarch_gfx900 -mno-sram-ecc" )
+  set( gfx906_options "-Xarch_gfx906 -mno-sram-ecc" )
+  set( gfx908_options "-Xarch_gfx908 -msram-ecc" )
+  if(CMAKE_VERSION VERSION_LESS 3.12)
+    set_target_properties( rocsolver PROPERTIES
+      COMPILE_FLAGS
+        "-mno-xnack ${gfx900_options} ${gfx906_options} ${gfx908_options}"
+    )
+  else ()
+    target_compile_options( rocsolver PRIVATE
+      -mno-xnack
+      "SHELL:${gfx900_options}"
+      "SHELL:${gfx906_options}"
+      "SHELL:${gfx908_options}"
+    )
+  endif()
 endif()
 
 set_target_properties( rocsolver PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED ON )

--- a/rocsolver/library/src/CMakeLists.txt
+++ b/rocsolver/library/src/CMakeLists.txt
@@ -118,18 +118,19 @@ else()
   target_link_libraries( rocsolver PRIVATE hip::device hcc::hccshared )
 endif()
 
-# explicit xnack compilation flags
+# explicit xnack and sram-ecc compilation flags
 if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
+  target_compile_options( rocsolver PRIVATE -mno-xnack )
+
+  # architecture-specific flags
   set( gfx906_options "-Xarch_gfx906 -msram-ecc" )
   set( gfx908_options "-Xarch_gfx908 -msram-ecc" )
   if( CMAKE_VERSION VERSION_LESS 3.12 )
     set_target_properties( rocsolver PROPERTIES
-      COMPILE_FLAGS
-        "-mno-xnack ${gfx906_options} ${gfx908_options}"
+      COMPILE_FLAGS "${gfx906_options} ${gfx908_options}"
     )
   else( )
     target_compile_options( rocsolver PRIVATE
-      -mno-xnack
       "SHELL:${gfx906_options}"
       "SHELL:${gfx908_options}"
     )


### PR DESCRIPTION
I don't understand the full reasoning behind these, but this matched
what rocBLAS will set.

edit: I figured out how to include the gfx900 flag, assuming we want that.