### PR TITLE
Disable git hook auto-install

### DIFF
--- a/.githooks/install
+++ b/.githooks/install
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-cd $(git rev-parse --git-dir)
-cd hooks
-
-echo "Installing hooks..."
-ln -s ../../.githooks/pre-commit pre-commit
-echo "Done!"

--- a/.githooks/install
+++ b/.githooks/install
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+cd $(git rev-parse --git-dir)
+cd hooks
+
+echo "Installing hooks..."
+ln -s ../../.githooks/pre-commit pre-commit
+echo "Done!"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ and rocSOLVER shared libraries will become link-time and run-time dependencies
 for the user application.
 
 If you are a developer contributing to rocSOLVER, you may wish to run
-`./install.sh --hooks` to install the git hooks for autoformatting.
+`.githooks/install` to install the git hooks for autoformatting.
 
 ## Using rocSOLVER
 

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 rocSOLVER is a work-in-progress implementation of a subset of [LAPACK][1]
 functionality on the [ROCm platform][2].
 
-# Documentation
+## Documentation
 
 For a detailed description of the rocSOLVER library, its implemented routines,
 the installation process and user guide, see the [rocSOLVER documentation][3].
 
-# Quick start
+## Building rocSOLVER
 
-To download rocSOLVER source code, clone this repository with the command:
+To download the rocSOLVER source code, clone this repository with the command:
 
     git clone https://github.com/ROCmSoftwarePlatform/rocSOLVER.git
 
@@ -21,7 +21,7 @@ more information about rocBLAS and how to install it, see the
 After a standard installation of rocBLAS, the following commands will build
 rocSOLVER and install to `/opt/rocm/rocsolver`:
 
-    cd rocsolver
+    cd rocSOLVER
     ./install.sh -i
 
 Once installed, rocSOLVER can be used just like any other library with a C API.
@@ -29,11 +29,16 @@ The header file will need to be included in the user code, and both the rocBLAS
 and rocSOLVER shared libraries will become link-time and run-time dependencies
 for the user application.
 
-# Using rocSOLVER example
+If you are a developer contributing to rocSOLVER, you may wish to run
+`./install.sh --hooks` to install the git hooks for autoformatting.
 
-The following code snippet uses rocSOLVER to compute the QR factorization of a
-general m-by-n real matrix in double precision. For a description of the
-function `rocsolver_dgeqrf`, see the [API documentation][5].
+## Using rocSOLVER
+
+The following code snippet shows how to compute the QR factorization of a
+general m-by-n real matrix in double precision using rocSOLVER. A longer
+version of this example is provided in the [rocSOLVER samples][5].
+For a description of the function `rocsolver_dgeqrf`, see the
+[API documentation][6].
 
 ```cpp
 /////////////////////////////
@@ -97,4 +102,5 @@ system environment, but here is a typical example:
 [2]: https://rocm.github.io
 [3]: https://rocsolver.readthedocs.io/en/latest
 [4]: https://rocblas.readthedocs.io/en/latest
-[5]: https://rocsolver.readthedocs.io/en/latest/userguide_api.html#rocsolver-type-geqrf
+[5]: rocsolver/clients/samples/example_basic.cpp
+[6]: https://rocsolver.readthedocs.io/en/latest/userguide_api.html#rocsolver-type-geqrf

--- a/install.sh
+++ b/install.sh
@@ -59,6 +59,8 @@ Options:
 
   -n | --no-optimizations     Pass this flag to disable optimizations for small sizes.
 
+  --hooks                     Pass this flag to link the git hooks used for development into .git/hooks.
+
   --docs                      (experimental) Pass this flag to build the documentation from source.
                               Official documentation is available online at https://rocsolver.readthedocs.io/
                               Building locally with this flag will require docker on your machine. If you are
@@ -69,9 +71,6 @@ EOF
 
 # Find project root directory
 main=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-
-# Adding pre-commit hook
-/bin/ln -fs ../../.githooks/pre-commit "$main/.git/hooks/"
 
 # This function is helpful for dockerfiles that do not have sudo installed, but the default user is root
 # true is a system command that completes successfully, function returns success
@@ -308,6 +307,7 @@ supported_distro
 install_package=false
 build_package=false
 install_dependencies=false
+install_hooks=false
 static_lib=false
 build_clients=false
 build_hcc=false
@@ -332,7 +332,7 @@ fi
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,package,clients,dependencies,debug,hip-clang,hcc,build_dir:,rocblas_dir:,lib_dir:,install_dir:,static,relocatable,no-optimizations,docs --options hipcdgsrn -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,package,clients,dependencies,debug,hip-clang,hcc,build_dir:,rocblas_dir:,lib_dir:,install_dir:,static,relocatable,no-optimizations,docs,hooks --options hipcdgsrn -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -394,6 +394,9 @@ while true; do
     --docs)
         build_docs=true
         shift ;;
+    --hooks)
+        install_hooks=true
+        shift ;;
     -r|--relocatable)
         build_relocatable=true
         shift ;;
@@ -404,6 +407,12 @@ while true; do
         ;;
   esac
 done
+
+# Add pre-commit hook
+if [[ "${install_hooks}" == true ]]; then
+  ln -s ../../.githooks/pre-commit "$main/.git/hooks/"
+  exit
+fi
 
 set -x
 printf "\033[32mCreating project build directory in: \033[33m${build_dir}\033[0m\n"

--- a/install.sh
+++ b/install.sh
@@ -70,9 +70,6 @@ EOF
 # Find project root directory
 main=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
-# Adding pre-commit hook
-/bin/ln -fs ../../.githooks/pre-commit "$main/.git/hooks/"
-
 # This function is helpful for dockerfiles that do not have sudo installed, but the default user is root
 # true is a system command that completes successfully, function returns success
 # prereq: ${ID} must be defined before calling

--- a/install.sh
+++ b/install.sh
@@ -59,8 +59,6 @@ Options:
 
   -n | --no-optimizations     Pass this flag to disable optimizations for small sizes.
 
-  --hooks                     Pass this flag to link the git hooks used for development into .git/hooks.
-
   --docs                      (experimental) Pass this flag to build the documentation from source.
                               Official documentation is available online at https://rocsolver.readthedocs.io/
                               Building locally with this flag will require docker on your machine. If you are
@@ -71,6 +69,9 @@ EOF
 
 # Find project root directory
 main=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# Adding pre-commit hook
+/bin/ln -fs ../../.githooks/pre-commit "$main/.git/hooks/"
 
 # This function is helpful for dockerfiles that do not have sudo installed, but the default user is root
 # true is a system command that completes successfully, function returns success
@@ -307,7 +308,6 @@ supported_distro
 install_package=false
 build_package=false
 install_dependencies=false
-install_hooks=false
 static_lib=false
 build_clients=false
 build_hcc=false
@@ -332,7 +332,7 @@ fi
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,package,clients,dependencies,debug,hip-clang,hcc,build_dir:,rocblas_dir:,lib_dir:,install_dir:,static,relocatable,no-optimizations,docs,hooks --options hipcdgsrn -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,package,clients,dependencies,debug,hip-clang,hcc,build_dir:,rocblas_dir:,lib_dir:,install_dir:,static,relocatable,no-optimizations,docs --options hipcdgsrn -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -394,9 +394,6 @@ while true; do
     --docs)
         build_docs=true
         shift ;;
-    --hooks)
-        install_hooks=true
-        shift ;;
     -r|--relocatable)
         build_relocatable=true
         shift ;;
@@ -407,12 +404,6 @@ while true; do
         ;;
   esac
 done
-
-# Add pre-commit hook
-if [[ "${install_hooks}" == true ]]; then
-  ln -s ../../.githooks/pre-commit "$main/.git/hooks/"
-  exit
-fi
 
 set -x
 printf "\033[32mCreating project build directory in: \033[33m${build_dir}\033[0m\n"


### PR DESCRIPTION
Install hooks with `./install.sh --hooks`.

Making this process explicit may prevent surprises and frustration.