### PR TITLE
Fix uninitialized values in getrf/getf2 nvpt and larft

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,11 @@ endif( )
 set( ARMOR_LEVEL "${DEFAULT_ARMOR_LEVEL}" CACHE STRING "Enables increasingly expensive runtime correctness checks" )
 include( armor-config )
 
+# set the optimization level for debug mode
+if( CMAKE_BUILD_TYPE STREQUAL "Debug" )
+  add_compile_options( -O0 )
+endif( )
+
 # BUILD_SHARED_LIBS is a cmake built-in; we make it an explicit option such that it shows in cmake-gui
 option( BUILD_SHARED_LIBS "Build rocSOLVER as a shared library" ON )
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_larft.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_larft.hpp
@@ -113,9 +113,9 @@ void rocsolver_larft_getMemorySize(const rocblas_int n, const rocblas_int k,
                                    size_t *size_workArr) {
   // if quick return, no workspace is needed
   if (n == 0 || batch_count == 0) {
-    size_scalars = 0;
-    size_work = 0;
-    size_workArr = 0;
+    *size_scalars = 0;
+    *size_work = 0;
+    *size_workArr = 0;
     return;
   }
 

--- a/rocsolver/library/src/lapack/roclapack_getf2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getf2.cpp
@@ -17,7 +17,8 @@ rocblas_status rocsolver_getf2_impl(rocblas_handle handle, const rocblas_int m,
   // logging is missing ???
 
   // argument checking
-  rocblas_status st = rocsolver_getf2_getrf_argCheck(m, n, lda, A, ipiv, info);
+  rocblas_status st =
+      rocsolver_getf2_getrf_argCheck(m, n, lda, A, ipiv, info, pivot);
   if (st != rocblas_status_continue)
     return st;
 
@@ -110,14 +111,14 @@ rocblas_status rocsolver_zgetf2(rocblas_handle handle, const rocblas_int m,
 rocblas_status rocsolver_sgetf2_npvt(rocblas_handle handle, const rocblas_int m,
                                      const rocblas_int n, float *A,
                                      const rocblas_int lda, rocblas_int *info) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getf2_impl<float>(handle, m, n, A, lda, ipiv, info, 0);
 }
 
 rocblas_status rocsolver_dgetf2_npvt(rocblas_handle handle, const rocblas_int m,
                                      const rocblas_int n, double *A,
                                      const rocblas_int lda, rocblas_int *info) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getf2_impl<double>(handle, m, n, A, lda, ipiv, info, 0);
 }
 
@@ -125,7 +126,7 @@ rocblas_status rocsolver_cgetf2_npvt(rocblas_handle handle, const rocblas_int m,
                                      const rocblas_int n,
                                      rocblas_float_complex *A,
                                      const rocblas_int lda, rocblas_int *info) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getf2_impl<rocblas_float_complex>(handle, m, n, A, lda, ipiv,
                                                      info, 0);
 }
@@ -134,7 +135,7 @@ rocblas_status rocsolver_zgetf2_npvt(rocblas_handle handle, const rocblas_int m,
                                      const rocblas_int n,
                                      rocblas_double_complex *A,
                                      const rocblas_int lda, rocblas_int *info) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getf2_impl<rocblas_double_complex>(handle, m, n, A, lda,
                                                       ipiv, info, 0);
 }

--- a/rocsolver/library/src/lapack/roclapack_getf2.hpp
+++ b/rocsolver/library/src/lapack/roclapack_getf2.hpp
@@ -743,9 +743,11 @@ void rocsolver_getf2_getMemorySize(const rocblas_int m, const rocblas_int n,
 }
 
 template <typename T>
-rocblas_status rocsolver_getf2_getrf_argCheck(
-    const rocblas_int m, const rocblas_int n, const rocblas_int lda, T A,
-    rocblas_int *ipiv, rocblas_int *info, const rocblas_int batch_count = 1) {
+rocblas_status
+rocsolver_getf2_getrf_argCheck(const rocblas_int m, const rocblas_int n,
+                               const rocblas_int lda, T A, rocblas_int *ipiv,
+                               rocblas_int *info, const rocblas_int pivot,
+                               const rocblas_int batch_count = 1) {
   // order is important for unit tests:
 
   // 1. invalid/non-supported values
@@ -756,7 +758,7 @@ rocblas_status rocsolver_getf2_getrf_argCheck(
     return rocblas_status_invalid_size;
 
   // 3. invalid pointers
-  if ((m * n && !A) || (m * n && !ipiv) || (batch_count && !info))
+  if ((m * n && !A) || (m * n && pivot && !ipiv) || (batch_count && !info))
     return rocblas_status_invalid_pointer;
 
   return rocblas_status_continue;

--- a/rocsolver/library/src/lapack/roclapack_getf2.hpp
+++ b/rocsolver/library/src/lapack/roclapack_getf2.hpp
@@ -35,6 +35,8 @@ __global__ void __launch_bounds__(GETF2_MAX_THDS)
                         const rocblas_int shiftP, const rocblas_stride strideP,
                         rocblas_int *infoA, const rocblas_int batch_count,
                         const int pivot) {
+  using S = decltype(std::real(T{}));
+
   const int myrow = hipThreadIdx_x;
   const int id = hipBlockIdx_x;
 
@@ -99,8 +101,8 @@ __global__ void __launch_bounds__(GETF2_MAX_THDS)
     }
 
     // check singularity and scale value for current column
-    if (pivot_value != T(0.0))
-      pivot_value = 1.0 / pivot_value;
+    if (pivot_value != T(0))
+      pivot_value = S(1) / pivot_value;
     else if (myinfo == 0)
       myinfo = k + 1;
 
@@ -156,6 +158,8 @@ __global__ void __launch_bounds__(GETF2_MAX_THDS)
                             rocblas_int *ipivA, const rocblas_int shiftP,
                             const rocblas_stride strideP, rocblas_int *infoA,
                             const rocblas_int batch_count, const int pivot) {
+  using S = decltype(std::real(T{}));
+
   const int myrow = hipThreadIdx_x;
   const int id = hipBlockIdx_x;
 
@@ -222,8 +226,8 @@ __global__ void __launch_bounds__(GETF2_MAX_THDS)
     }
 
     // check singularity and scale value for current column
-    if (pivot_value != T(0.0))
-      pivot_value = 1.0 / pivot_value;
+    if (pivot_value != T(0))
+      pivot_value = S(1) / pivot_value;
     else if (myinfo == 0)
       myinfo = k + 1;
 
@@ -345,6 +349,8 @@ __global__ void __launch_bounds__(GETF2_MAX_THDS)
                         rocblas_int *ipivA, const rocblas_int shiftP,
                         const rocblas_stride strideP, rocblas_int *infoA,
                         const rocblas_int batch_count, const int pivot) {
+  using S = decltype(std::real(T{}));
+
   int myrow = hipThreadIdx_x;
   const int ty = hipThreadIdx_y;
   const int id = hipBlockIdx_x * hipBlockDim_y + ty;
@@ -400,8 +406,8 @@ __global__ void __launch_bounds__(GETF2_MAX_THDS)
     }
 
     // check singularity and scale value for current column
-    if (pivot_value != T(0.0))
-      pivot_value = 1.0 / pivot_value;
+    if (pivot_value != T(0))
+      pivot_value = S(1) / pivot_value;
     else if (myinfo == 0)
       myinfo = k + 1;
 
@@ -680,6 +686,8 @@ __global__ void getf2_check_singularity(
     rocblas_int *ipivA, const rocblas_int shiftP, const rocblas_stride strideP,
     const rocblas_int j, const rocblas_int lda, T *pivot_val,
     rocblas_int *pivot_idx, rocblas_int *info, const int pivot) {
+  using S = decltype(std::real(T{}));
+
   const int id = hipBlockIdx_x;
   rocblas_int idx;
 
@@ -694,11 +702,11 @@ __global__ void getf2_check_singularity(
     idx = j * lda + j;
 
   if (A[idx] == 0) {
-    pivot_val[id] = 1.0;
+    pivot_val[id] = 1;
     if (info[id] == 0)
       info[id] = j + 1; // use Fortran 1-based indexing
   } else
-    pivot_val[id] = 1.0 / A[idx];
+    pivot_val[id] = S(1) / A[idx];
 }
 
 template <bool ISBATCHED, typename T, typename S>

--- a/rocsolver/library/src/lapack/roclapack_getf2.hpp
+++ b/rocsolver/library/src/lapack/roclapack_getf2.hpp
@@ -35,8 +35,8 @@ __global__ void __launch_bounds__(GETF2_MAX_THDS)
                         const rocblas_int shiftP, const rocblas_stride strideP,
                         rocblas_int *infoA, const rocblas_int batch_count,
                         const int pivot) {
-  int myrow = hipThreadIdx_x;
-  int id = hipBlockIdx_x;
+  const int myrow = hipThreadIdx_x;
+  const int id = hipBlockIdx_x;
 
   // batch instance
   T *A = load_ptr_batch<T>(AA, id, shiftA, strideA);
@@ -156,8 +156,8 @@ __global__ void __launch_bounds__(GETF2_MAX_THDS)
                             rocblas_int *ipivA, const rocblas_int shiftP,
                             const rocblas_stride strideP, rocblas_int *infoA,
                             const rocblas_int batch_count, const int pivot) {
-  int myrow = hipThreadIdx_x;
-  int id = hipBlockIdx_x;
+  const int myrow = hipThreadIdx_x;
+  const int id = hipBlockIdx_x;
 
   // batch instance
   T *A = load_ptr_batch<T>(AA, id, shiftA, strideA);
@@ -345,9 +345,9 @@ __global__ void __launch_bounds__(GETF2_MAX_THDS)
                         rocblas_int *ipivA, const rocblas_int shiftP,
                         const rocblas_stride strideP, rocblas_int *infoA,
                         const rocblas_int batch_count, const int pivot) {
-  int ty = hipThreadIdx_y;
   int myrow = hipThreadIdx_x;
-  int id = hipBlockIdx_x * hipBlockDim_y + ty;
+  const int ty = hipThreadIdx_y;
+  const int id = hipBlockIdx_x * hipBlockDim_y + ty;
 
   if (id >= batch_count)
     return;
@@ -680,7 +680,7 @@ __global__ void getf2_check_singularity(
     rocblas_int *ipivA, const rocblas_int shiftP, const rocblas_stride strideP,
     const rocblas_int j, const rocblas_int lda, T *pivot_val,
     rocblas_int *pivot_idx, rocblas_int *info, const int pivot) {
-  int id = hipBlockIdx_x;
+  const int id = hipBlockIdx_x;
   rocblas_int idx;
 
   T *A = load_ptr_batch<T>(AA, id, shiftA, strideA);

--- a/rocsolver/library/src/lapack/roclapack_getf2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getf2_batched.cpp
@@ -17,8 +17,8 @@ rocblas_status rocsolver_getf2_batched_impl(
   // logging is missing ???
 
   // argument checking
-  rocblas_status st =
-      rocsolver_getf2_getrf_argCheck(m, n, lda, A, ipiv, info, batch_count);
+  rocblas_status st = rocsolver_getf2_getrf_argCheck(m, n, lda, A, ipiv, info,
+                                                     pivot, batch_count);
   if (st != rocblas_status_continue)
     return st;
 
@@ -121,7 +121,7 @@ rocsolver_sgetf2_npvt_batched(rocblas_handle handle, const rocblas_int m,
                               const rocblas_int n, float *const A[],
                               const rocblas_int lda, rocblas_int *info,
                               const rocblas_int batch_count) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getf2_batched_impl<float>(handle, m, n, A, lda, ipiv, 0,
                                              info, batch_count, 0);
 }
@@ -131,7 +131,7 @@ rocsolver_dgetf2_npvt_batched(rocblas_handle handle, const rocblas_int m,
                               const rocblas_int n, double *const A[],
                               const rocblas_int lda, rocblas_int *info,
                               const rocblas_int batch_count) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getf2_batched_impl<double>(handle, m, n, A, lda, ipiv, 0,
                                               info, batch_count, 0);
 }
@@ -140,7 +140,7 @@ rocblas_status rocsolver_cgetf2_npvt_batched(
     rocblas_handle handle, const rocblas_int m, const rocblas_int n,
     rocblas_float_complex *const A[], const rocblas_int lda, rocblas_int *info,
     const rocblas_int batch_count) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getf2_batched_impl<rocblas_float_complex>(
       handle, m, n, A, lda, ipiv, 0, info, batch_count, 0);
 }
@@ -149,7 +149,7 @@ rocblas_status rocsolver_zgetf2_npvt_batched(
     rocblas_handle handle, const rocblas_int m, const rocblas_int n,
     rocblas_double_complex *const A[], const rocblas_int lda, rocblas_int *info,
     const rocblas_int batch_count) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getf2_batched_impl<rocblas_double_complex>(
       handle, m, n, A, lda, ipiv, 0, info, batch_count, 0);
 }

--- a/rocsolver/library/src/lapack/roclapack_getf2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getf2_strided_batched.cpp
@@ -18,8 +18,8 @@ rocblas_status rocsolver_getf2_strided_batched_impl(
   // logging is missing ???
 
   // argument checking
-  rocblas_status st =
-      rocsolver_getf2_getrf_argCheck(m, n, lda, A, ipiv, info, batch_count);
+  rocblas_status st = rocsolver_getf2_getrf_argCheck(m, n, lda, A, ipiv, info,
+                                                     pivot, batch_count);
   if (st != rocblas_status_continue)
     return st;
 
@@ -116,7 +116,7 @@ rocblas_status rocsolver_sgetf2_npvt_strided_batched(
     rocblas_handle handle, const rocblas_int m, const rocblas_int n, float *A,
     const rocblas_int lda, const rocblas_stride strideA, rocblas_int *info,
     const rocblas_int batch_count) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getf2_strided_batched_impl<float>(
       handle, m, n, A, lda, strideA, ipiv, 0, info, batch_count, 0);
 }
@@ -125,7 +125,7 @@ rocblas_status rocsolver_dgetf2_npvt_strided_batched(
     rocblas_handle handle, const rocblas_int m, const rocblas_int n, double *A,
     const rocblas_int lda, const rocblas_stride strideA, rocblas_int *info,
     const rocblas_int batch_count) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getf2_strided_batched_impl<double>(
       handle, m, n, A, lda, strideA, ipiv, 0, info, batch_count, 0);
 }
@@ -135,7 +135,7 @@ rocblas_status rocsolver_cgetf2_npvt_strided_batched(
     rocblas_float_complex *A, const rocblas_int lda,
     const rocblas_stride strideA, rocblas_int *info,
     const rocblas_int batch_count) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getf2_strided_batched_impl<rocblas_float_complex>(
       handle, m, n, A, lda, strideA, ipiv, 0, info, batch_count, 0);
 }
@@ -145,7 +145,7 @@ rocblas_status rocsolver_zgetf2_npvt_strided_batched(
     rocblas_double_complex *A, const rocblas_int lda,
     const rocblas_stride strideA, rocblas_int *info,
     const rocblas_int batch_count) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getf2_strided_batched_impl<rocblas_double_complex>(
       handle, m, n, A, lda, strideA, ipiv, 0, info, batch_count, 0);
 }

--- a/rocsolver/library/src/lapack/roclapack_getrf.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getrf.cpp
@@ -17,7 +17,8 @@ rocblas_status rocsolver_getrf_impl(rocblas_handle handle, const rocblas_int m,
   // logging is missing ???
 
   // argument checking
-  rocblas_status st = rocsolver_getf2_getrf_argCheck(m, n, lda, A, ipiv, info);
+  rocblas_status st =
+      rocsolver_getf2_getrf_argCheck(m, n, lda, A, ipiv, info, pivot);
   if (st != rocblas_status_continue)
     return st;
 
@@ -123,14 +124,14 @@ rocblas_status rocsolver_zgetrf(rocblas_handle handle, const rocblas_int m,
 rocblas_status rocsolver_sgetrf_npvt(rocblas_handle handle, const rocblas_int m,
                                      const rocblas_int n, float *A,
                                      const rocblas_int lda, rocblas_int *info) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getrf_impl<float>(handle, m, n, A, lda, ipiv, info, 0);
 }
 
 rocblas_status rocsolver_dgetrf_npvt(rocblas_handle handle, const rocblas_int m,
                                      const rocblas_int n, double *A,
                                      const rocblas_int lda, rocblas_int *info) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getrf_impl<double>(handle, m, n, A, lda, ipiv, info, 0);
 }
 
@@ -138,7 +139,7 @@ rocblas_status rocsolver_cgetrf_npvt(rocblas_handle handle, const rocblas_int m,
                                      const rocblas_int n,
                                      rocblas_float_complex *A,
                                      const rocblas_int lda, rocblas_int *info) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getrf_impl<rocblas_float_complex>(handle, m, n, A, lda, ipiv,
                                                      info, 0);
 }
@@ -147,7 +148,7 @@ rocblas_status rocsolver_zgetrf_npvt(rocblas_handle handle, const rocblas_int m,
                                      const rocblas_int n,
                                      rocblas_double_complex *A,
                                      const rocblas_int lda, rocblas_int *info) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getrf_impl<rocblas_double_complex>(handle, m, n, A, lda,
                                                       ipiv, info, 0);
 }

--- a/rocsolver/library/src/lapack/roclapack_getrf_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getrf_batched.cpp
@@ -17,8 +17,8 @@ rocblas_status rocsolver_getrf_batched_impl(
   // logging is missing ???
 
   // argument checking
-  rocblas_status st =
-      rocsolver_getf2_getrf_argCheck(m, n, lda, A, ipiv, info, batch_count);
+  rocblas_status st = rocsolver_getf2_getrf_argCheck(m, n, lda, A, ipiv, info,
+                                                     pivot, batch_count);
   if (st != rocblas_status_continue)
     return st;
 
@@ -134,7 +134,7 @@ rocsolver_sgetrf_npvt_batched(rocblas_handle handle, const rocblas_int m,
                               const rocblas_int n, float *const A[],
                               const rocblas_int lda, rocblas_int *info,
                               const rocblas_int batch_count) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getrf_batched_impl<float>(handle, m, n, A, lda, ipiv, 0,
                                              info, batch_count, 0);
 }
@@ -144,7 +144,7 @@ rocsolver_dgetrf_npvt_batched(rocblas_handle handle, const rocblas_int m,
                               const rocblas_int n, double *const A[],
                               const rocblas_int lda, rocblas_int *info,
                               const rocblas_int batch_count) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getrf_batched_impl<double>(handle, m, n, A, lda, ipiv, 0,
                                               info, batch_count, 0);
 }
@@ -153,7 +153,7 @@ rocblas_status rocsolver_cgetrf_npvt_batched(
     rocblas_handle handle, const rocblas_int m, const rocblas_int n,
     rocblas_float_complex *const A[], const rocblas_int lda, rocblas_int *info,
     const rocblas_int batch_count) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getrf_batched_impl<rocblas_float_complex>(
       handle, m, n, A, lda, ipiv, 0, info, batch_count, 0);
 }
@@ -162,7 +162,7 @@ rocblas_status rocsolver_zgetrf_npvt_batched(
     rocblas_handle handle, const rocblas_int m, const rocblas_int n,
     rocblas_double_complex *const A[], const rocblas_int lda, rocblas_int *info,
     const rocblas_int batch_count) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getrf_batched_impl<rocblas_double_complex>(
       handle, m, n, A, lda, ipiv, 0, info, batch_count, 0);
 }

--- a/rocsolver/library/src/lapack/roclapack_getrf_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getrf_strided_batched.cpp
@@ -18,8 +18,8 @@ rocblas_status rocsolver_getrf_strided_batched_impl(
   // logging is missing ???
 
   // argument checking
-  rocblas_status st =
-      rocsolver_getf2_getrf_argCheck(m, n, lda, A, ipiv, info, batch_count);
+  rocblas_status st = rocsolver_getf2_getrf_argCheck(m, n, lda, A, ipiv, info,
+                                                     pivot, batch_count);
   if (st != rocblas_status_continue)
     return st;
 
@@ -129,7 +129,7 @@ rocblas_status rocsolver_sgetrf_npvt_strided_batched(
     rocblas_handle handle, const rocblas_int m, const rocblas_int n, float *A,
     const rocblas_int lda, const rocblas_stride strideA, rocblas_int *info,
     const rocblas_int batch_count) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getrf_strided_batched_impl<float>(
       handle, m, n, A, lda, strideA, ipiv, 0, info, batch_count, 0);
 }
@@ -138,7 +138,7 @@ rocblas_status rocsolver_dgetrf_npvt_strided_batched(
     rocblas_handle handle, const rocblas_int m, const rocblas_int n, double *A,
     const rocblas_int lda, const rocblas_stride strideA, rocblas_int *info,
     const rocblas_int batch_count) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getrf_strided_batched_impl<double>(
       handle, m, n, A, lda, strideA, ipiv, 0, info, batch_count, 0);
 }
@@ -148,7 +148,7 @@ rocblas_status rocsolver_cgetrf_npvt_strided_batched(
     rocblas_float_complex *A, const rocblas_int lda,
     const rocblas_stride strideA, rocblas_int *info,
     const rocblas_int batch_count) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getrf_strided_batched_impl<rocblas_float_complex>(
       handle, m, n, A, lda, strideA, ipiv, 0, info, batch_count, 0);
 }
@@ -158,7 +158,7 @@ rocblas_status rocsolver_zgetrf_npvt_strided_batched(
     rocblas_double_complex *A, const rocblas_int lda,
     const rocblas_stride strideA, rocblas_int *info,
     const rocblas_int batch_count) {
-  rocblas_int *ipiv;
+  rocblas_int *ipiv = nullptr;
   return rocsolver_getrf_strided_batched_impl<rocblas_double_complex>(
       handle, m, n, A, lda, strideA, ipiv, 0, info, batch_count, 0);
 }


### PR DESCRIPTION
This fixes some uses of uninitialized variables in certain cases in the non-pivoting getrf/getf2 functions, and in the larft quick return cases. There's also a couple minor tweaks that I made as was reading through the code.

If you disable optimizations, then rocsolver-test should now pass when running in debug mode. At least, for the checkin tests. Unfortunately, those take 37 minutes on my machine when we have no optimizations enabled. Given that the debug mode can identify problems not seen in other builds, perhaps we should be running the debug mode checkin tests in the CI with a frequency similar to that of the release mode extended tests?