### PR TITLE
Updates to debian package name

### DIFF
--- a/docs/source/userguide_install.rst
+++ b/docs/source/userguide_install.rst
@@ -284,7 +284,7 @@ This is equivalent to ``./install.sh -p``.
     CXX=/opt/rocm/bin/hcc cmake -DCMAKE_INSTALL_PREFIX=rocsolver-install -DCPACK_SET_DESTDIR=OFF -DCPACK_PACKAGING_INSTALL_PREFIX=/package/install/path ../..
     make install
     make package
-    sudo dpkg -i rocsolver-*.deb
+    sudo dpkg -i rocsolver[-\_]*.deb
 
 On an Ubuntu system, for example, this would be equivalent to ``./install.sh -i --install_dir /package/install/path``.
 

--- a/install.sh
+++ b/install.sh
@@ -541,7 +541,7 @@ if [[ "${build_package}" == true ]]; then
   if [[ "${install_package}" == true ]]; then
     case "${ID}" in
       ubuntu)
-        elevate_if_not_root dpkg -i rocsolver-*.deb
+        elevate_if_not_root dpkg -i rocsolver[-\_]*.deb
         ;;
       centos|rhel)
         elevate_if_not_root yum -y localinstall rocsolver-*.rpm


### PR DESCRIPTION
- According to debian standards, package name and package
  version should be seperated by '_'.