### PR TITLE
Add Changelog file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,176 @@
+# Change Log for rocSOLVER
+ 
+Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](https://rocsolver.readthedocs.io/en/latest/).
+ 
+## [(Unreleased) rocSOLVER x.y.z for ROCm 4.0.0]
+### Added
+__anchor__TA
+
+__anchor__CB
+
+__anchor__JZ
+- Extended test coverage for functions returning info 
+
+### Optimizations
+__anchor__TA
+
+__anchor__CB
+
+__anchor__JZ
+
+### Changed
+__anchor__TA
+
+__anchor__CB
+
+__anchor__JZ
+
+### Deprecated
+__anchor__TA
+
+__anchor__CB
+
+__anchor__JZ
+
+### Removed
+__anchor__TA
+
+__anchor__CB
+
+__anchor__JZ
+
+### Fixed
+__anchor__TA
+
+__anchor__CB
+
+__anchor__JZ
+
+### Known Issues
+__anchor__TA
+
+__anchor__CB
+
+__anchor__JZ
+
+### Security
+__anchor__TA
+
+__anchor__CB
+
+__anchor__JZ
+
+
+
+## [(Unreleased) rocSOLVER 3.10.0 for ROCm 3.10.0]
+### Added
+- Documentation improvements
+- Orthonormal/Unitary matrix generator routines (reverse order):
+    - ORG2L, UNG2L, ORGQL, UNGQL
+    - ORGTR, UNGTR
+- Orthonormal/Unitary matrix multiplications routines (reverse order):
+    - ORM2L, UNM2L, ORMQL, UNMQL
+    - ORMTR, UNMTR
+
+### Changed
+- Major library refactoring to adopt rocBLAS memory model
+
+### Fixed 
+- Different bugs in unit tests and clients
+- Return values in info parameter of functions dealing with singularities
+
+
+
+## [rocSOLVER 3.9.0 for ROCm 3.9.0]
+### Added
+- Option to build documentation from source
+- Improved debug build mode for developers
+- QL factorization routines:
+    - GEQL2, GEQLF (with batched and strided batched versions)
+- SVD of general matrices routines:
+    - GESVD (with batched and strided\_batched versions)
+
+### Optimizations
+- Mid-size matrix inversion (64 < n <= 2048)
+
+### Changed
+- Code is now clang-formated 
+
+
+
+## [rocSOLVER 3.8.0 for ROCm 3.8.0]
+### Added
+- Sample codes for C, C++ and FORTRAN
+- Documentation items and documentation improvements
+- LU factorization without pivoting routines:
+    - GETF2\_NPVT, GETRF\_NPVT (with batched and strided\_batched versions)
+
+### Optimizations
+- LU factorization of mid-size matrices (64 < n <= 2048)
+- Small-size matrix inversion (n <= 64)
+
+
+
+## [rocSOLVER 3.7.0 for ROCm 3.7.0]
+### Added
+- LU-factorization-based matrix inverse routines:
+    - GETRI (with batched and strided\_batched versions)
+- SVD of bidiagonal matrices routine:
+    - BDSQR
+- Documentation items and documentation improvements
+
+### Fixed
+- Ensure congruency on the input data when executing performance tests (benchmarks)
+
+
+
+## [rocSOLVER 3.6.0 for ROCm 3.6.0]
+### Added
+- Complex precision support for all existing rocSOLVER functions
+- Bidiagonalization routines:
+    - LABRD
+    - GEBD2, GEBRD (with batched and strided\_batched versions)
+- Integration of rocSOLVER to hipBLAS
+
+### Optimizations
+- LU factorization of tiny matrices (n <= 64)
+
+### Changed
+- Major clients refactoring to achieve better test coverage and bechmarking
+
+
+
+## [rocSOLVER 3.5.0 for ROCm 3.5.0]
+### Added
+- Installation script and new build procedure
+- Documentation and integration with ReadTheDocs
+- Orthonormal matrix multiplication routines:
+    - ORM2R, ORMQR
+    - ORML2, ORMLQ
+    - ORMBR
+
+### Changed
+- Switched to use all rocBLAS types and enumerations
+- Major library refactoring to achieve better integration and rocBLAS support
+- hip-clang is now default compiler
+
+### Deprecated
+- rocSOLVER types and enumerations
+- hcc compiler support
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ __anchor__CB
 
 __anchor__JZ
 - Extended test coverage for functions returning info 
+- Changelog file
 
 ### Optimizations
 __anchor__TA
@@ -24,6 +25,7 @@ __anchor__TA
 __anchor__CB
 
 __anchor__JZ
+- Switched to use semantic versioning for the library
 
 ### Deprecated
 __anchor__TA

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
  
 Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](https://rocsolver.readthedocs.io/en/latest/).
  
-## [(Unreleased) rocSOLVER x.y.z for ROCm 4.0.0]
+## [(Unreleased) rocSOLVER for ROCm 4.0.0]
 ### Added
 __anchor__TA
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,6 @@ __anchor__JZ
 
 ## [(Unreleased) rocSOLVER 3.10.0 for ROCm 3.10.0]
 ### Added
-- Documentation improvements
 - Orthonormal/Unitary matrix generator routines (reverse order):
     - ORG2L, UNG2L, ORGQL, UNGQL
     - ORGTR, UNGTR
@@ -78,38 +77,32 @@ __anchor__JZ
 - Major library refactoring to adopt rocBLAS memory model
 
 ### Fixed 
-- Different bugs in unit tests and clients
-- Return values in info parameter of functions dealing with singularities
+- Returned values in parameter info of functions dealing with singularities
 
 
 
 ## [rocSOLVER 3.9.0 for ROCm 3.9.0]
 ### Added
-- Option to build documentation from source
 - Improved debug build mode for developers
 - QL factorization routines:
-    - GEQL2, GEQLF (with batched and strided batched versions)
+    - GEQL2, GEQLF (with batched and strided\_batched versions)
 - SVD of general matrices routines:
     - GESVD (with batched and strided\_batched versions)
 
 ### Optimizations
-- Mid-size matrix inversion (64 < n <= 2048)
-
-### Changed
-- Code is now clang-formated 
+- Improved performance of mid-size matrix inversion (64 < n <= 2048)
 
 
 
 ## [rocSOLVER 3.8.0 for ROCm 3.8.0]
 ### Added
 - Sample codes for C, C++ and FORTRAN
-- Documentation items and documentation improvements
 - LU factorization without pivoting routines:
     - GETF2\_NPVT, GETRF\_NPVT (with batched and strided\_batched versions)
 
 ### Optimizations
-- LU factorization of mid-size matrices (64 < n <= 2048)
-- Small-size matrix inversion (n <= 64)
+- Improved performance of LU factorization of mid-size matrices (64 < n <= 2048)
+- Improved performance of small-size matrix inversion (n <= 64)
 
 
 
@@ -119,7 +112,6 @@ __anchor__JZ
     - GETRI (with batched and strided\_batched versions)
 - SVD of bidiagonal matrices routine:
     - BDSQR
-- Documentation items and documentation improvements
 
 ### Fixed
 - Ensure congruency on the input data when executing performance tests (benchmarks)
@@ -135,10 +127,10 @@ __anchor__JZ
 - Integration of rocSOLVER to hipBLAS
 
 ### Optimizations
-- LU factorization of tiny matrices (n <= 64)
+- Improved performance of LU factorization of tiny matrices (n <= 64)
 
 ### Changed
-- Major clients refactoring to achieve better test coverage and bechmarking
+- Major clients refactoring to achieve better test coverage and benchmarking
 
 
 
@@ -159,20 +151,4 @@ __anchor__JZ
 ### Deprecated
 - rocSOLVER types and enumerations
 - hcc compiler support
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,13 +97,15 @@ __anchor__JZ
 ## [rocSOLVER 3.8.0 for ROCm 3.8.0]
 ### Added
 - Sample codes for C, C++ and FORTRAN
-- LU factorization without pivoting routines:
+- LU factorization without pivoting routines: 
     - GETF2\_NPVT, GETRF\_NPVT (with batched and strided\_batched versions)
 
 ### Optimizations
 - Improved performance of LU factorization of mid-size matrices (64 < n <= 2048)
 - Improved performance of small-size matrix inversion (n <= 64)
 
+### Fixed
+- Ensure the public API is C compatible
 
 
 ## [rocSOLVER 3.7.0 for ROCm 3.7.0]


### PR DESCRIPTION
Following the same idea proposed by Andrew Chapman in rocBLAS to use __anchor__ to prevent too many merge conflicts during the development cycle.
TA: Troy, CB: Cory, JZ: Juan

(Component owner will remove the anchors and bump rocsolver version -following semantic versioning now-  before release)