### PR TITLE
Add -a|--architecture flag to install.sh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,9 @@ if( NOT ROCM_PATH )
   set( ROCM_PATH /opt/rocm )
 endif( )
 
+# CMake list of machine targets
+set( AMDGPU_TARGETS gfx803;gfx900;gfx906;gfx908 CACHE STRING "List of specific machine types for library to target" )
+
 find_package( ROCM CONFIG QUIET PATHS ${ROCM_PATH} )
 if( NOT ROCM_FOUND )
   set( rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download" )
@@ -197,9 +200,6 @@ endif( )
 find_package( rocblas REQUIRED CONFIG PATHS ${ROCM_PATH} )
 include_directories( ${rocblas_INCLUDE_DIR} )
 
-
-# CMake list of machine targets
-set( AMDGPU_TARGETS gfx803;gfx900;gfx906;gfx908 CACHE STRING "List of specific machine types for library to target" )
 
 add_subdirectory( rocsolver/library )
 

--- a/install.sh
+++ b/install.sh
@@ -59,6 +59,10 @@ Options:
 
   -n | --no-optimizations     Pass this flag to disable optimizations for small sizes.
 
+  -a | --architecture         Set GPU architecture target, e.g. "gfx803;gfx900;gfx906;gfx908".
+                              If you don't know the architecture of the GPU in your local machine, it can be
+                              queried by running "mygpu".
+
   --docs                      (experimental) Pass this flag to build the documentation from source.
                               Official documentation is available online at https://rocsolver.readthedocs.io/
                               Building locally with this flag will require docker on your machine. If you are
@@ -316,6 +320,7 @@ build_type=Release
 build_relocatable=false
 build_docs=false
 optimal=true
+architecture=all
 
 rocm_path=/opt/rocm
 if ! [ -z ${ROCM_PATH+x} ]; then
@@ -329,7 +334,7 @@ fi
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,package,clients,dependencies,debug,hip-clang,hcc,build_dir:,rocblas_dir:,lib_dir:,install_dir:,static,relocatable,no-optimizations,docs --options hipcdgsrn -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,package,clients,dependencies,debug,hip-clang,hcc,build_dir:,rocblas_dir:,lib_dir:,install_dir:,architecture:,static,relocatable,no-optimizations,docs --options hipcdgsrna: -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -387,6 +392,9 @@ while true; do
         shift 2 ;;
     --rocblas_dir)
         rocblas_dir=${2}
+        shift 2 ;;
+    -a|--architecture)
+        architecture=${2}
         shift 2 ;;
     --docs)
         build_docs=true
@@ -501,6 +509,10 @@ fi
 
 if [[ "${optimal}" == true ]]; then
   cmake_common_options="${cmake_common_options} -DOPTIMAL=ON"
+fi
+
+if [[ -n "${architecture}" ]]; then
+  cmake_common_options="${cmake_common_options} -DAMDGPU_TARGETS=${architecture}"
 fi
 
 if [[ "${build_clients}" == true ]]; then


### PR DESCRIPTION
`./install.sh -a "$(mygpu)"` is handy for development, as it reduces the
number of GPU kernels that must be compiled, and thus the overall
build times. This matches the rocBLAS flag.