### PR TITLE
Configure gtest to pretty-print rocblas_status

### DIFF
--- a/rocsolver/clients/include/rocsolver_test.hpp
+++ b/rocsolver/clients/include/rocsolver_test.hpp
@@ -65,4 +65,11 @@ inline T sconj(T scalar)
     return std::conj(scalar);
 }
 
+// gtest printers
+
+inline std::ostream& operator<<(std::ostream& os, rocblas_status x)
+{
+    return os << rocblas_status_to_string(x);
+}
+
 #endif


### PR DESCRIPTION
This is a pretty small change, but I figured you might want to discuss it separately from gels.

Before:
```
[ RUN      ] checkin_lapack/GELS.__float/0
/src/rocSOLVER-gels/rocsolver/clients/gtest/../include/testing_gels.hpp:56: Failure
Expected equality of these values:
  rocsolver_gels(STRIDED, handle, trans, m, n, 0, dA, lda, stA, (U) nullptr, ldc, stC, info, bc)
    Which is: 5
  rocblas_status_success
[  FAILED  ] checkin_lapack/GELS.__float/0, where GetParam() = ({ 0, 1, 1 }, { 0, 0 }) (196 ms)
```
After:
```
[ RUN      ] checkin_lapack/GELS.__float/0
/src/rocSOLVER-gels/rocsolver/clients/gtest/../include/testing_gels.hpp:56: Failure
Expected equality of these values:
  rocsolver_gels(STRIDED, handle, trans, m, n, 0, dA, lda, stA, (U) nullptr, ldc, stC, info, bc)
    Which is: rocblas_status_invalid_pointer
  rocblas_status_success
[  FAILED  ] checkin_lapack/GELS.__float/0, where GetParam() = ({ 0, 1, 1 }, { 0, 0 }) (196 ms)
```