### PR TITLE
Enable docs build on CI and minor fixes

### DIFF
--- a/.jenkins/staticanalysis.groovy
+++ b/.jenkins/staticanalysis.groovy
@@ -17,7 +17,6 @@ def runCompileCommand(platform, project, jobName, boolean debug=false)
             set -x
             ${project.paths.project_build_prefix}/docs/run_doc.sh
             """
-    command = """ """
 
     try
     {
@@ -28,14 +27,13 @@ def runCompileCommand(platform, project, jobName, boolean debug=false)
         throw e
     }
 
-    /* publishHTML([allowMissing: false,
+    publishHTML([allowMissing: false,
                 alwaysLinkToLastBuild: false,
                 keepAll: false,
                 reportDir: "${project.paths.project_build_prefix}/docs/docBin/html",
                 reportFiles: "index.html",
                 reportName: "Documentation",
                 reportTitles: "Documentation"])
-    */
 }
 
 def runCI =

--- a/.jenkins/staticanalysis.groovy
+++ b/.jenkins/staticanalysis.groovy
@@ -30,7 +30,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false)
     publishHTML([allowMissing: false,
                 alwaysLinkToLastBuild: false,
                 keepAll: false,
-                reportDir: "${project.paths.project_build_prefix}/docs/docBin/html",
+                reportDir: "${project.paths.project_build_prefix}/docs/build/html",
                 reportFiles: "index.html",
                 reportName: "Documentation",
                 reportTitles: "Documentation"])

--- a/docs/source/userguide_api.rst
+++ b/docs/source/userguide_api.rst
@@ -928,9 +928,8 @@ Deprecated
 Types
 -----------------
 
-See the documentation for the
-`rocBLAS types <https://rocblas.readthedocs.io/en/latest/functions.html#rocblas-types>`_.
-for information on the suggested replacements for these types.
+See the `rocBLAS types <https://rocblas.readthedocs.io/en/latest/functions.html#rocblas-types>`_
+documentation for information on the suggested replacements.
 
 rocsolver_int
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -990,9 +989,8 @@ rocsolver_status
 Auxiliary Functions
 ---------------------
 
-See the documentation for the
-`rocBLAS auxiliary functions <https://rocblas.readthedocs.io/en/latest/functions.html#auxiliary>`_
-for information on the suggested replacements for these functions.
+See the `rocBLAS auxiliary functions <https://rocblas.readthedocs.io/en/latest/functions.html#auxiliary>`_
+documentation for information on the suggested replacements.
 
 rocsolver_create_handle()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/userguide_api.rst
+++ b/docs/source/userguide_api.rst
@@ -16,7 +16,7 @@ rocSOLVER Types
 -----------------
 
 Most rocSOLVER types are aliases of rocBLAS types.
-See the `rocBLAS types <https://rocblas.readthedocs.io/en/latest/functions.html>`_.
+See the `rocBLAS types <https://rocblas.readthedocs.io/en/latest/functions.html#rocblas-types>`_.
 
 rocsolver_int
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -988,7 +988,7 @@ Auxiliary Functions
 ---------------------
 
 rocSOLVER auxiliary functions are aliases of rocBLAS auxiliary functions.
-See the `rocBLAS auxiliary functions <https://rocblas.readthedocs.io/en/latest/api.html#auxiliary>`_.
+See the `rocBLAS auxiliary functions <https://rocblas.readthedocs.io/en/latest/functions.html#auxiliary>`_.
 
 rocsolver_create_handle()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/userguide_api.rst
+++ b/docs/source/userguide_api.rst
@@ -12,6 +12,9 @@ This section provides details of the rocSOLVER library API.
 Types
 =====
 
+rocSOLVER uses types and enumerations defined by the rocBLAS API. For more information, see the
+`rocBLAS types <https://rocblas.readthedocs.io/en/latest/functions.html#rocblas-types>`_.
+
 Additional Types
 -------------------
 

--- a/docs/source/userguide_api.rst
+++ b/docs/source/userguide_api.rst
@@ -16,7 +16,7 @@ rocSOLVER Types
 -----------------
 
 Most rocSOLVER types are aliases of rocBLAS types.
-See the `rocBLAS types <https://rocblas.readthedocs.io/en/latest/api.html#types>`_.
+See the `rocBLAS types <https://rocblas.readthedocs.io/en/latest/functions.html>`_.
 
 rocsolver_int
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/userguide_api.rst
+++ b/docs/source/userguide_api.rst
@@ -7,74 +7,15 @@ rocSOLVER API
    :maxdepth: 4
    :caption: Contents:
 
-This section provides details of the rocSOLVER library API as in last ROCm release.
+This section provides details of the rocSOLVER library API.
 
 Types
 =====
 
-rocSOLVER Types
------------------
-
-Most rocSOLVER types are aliases of rocBLAS types.
-See the `rocBLAS types <https://rocblas.readthedocs.io/en/latest/functions.html#rocblas-types>`_.
-
-rocsolver_int
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. doxygentypedef:: rocsolver_int
-.. deprecated:: 3.5
-   Use :c:type:`rocblas_int`.
-
-rocsolver_handle
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. doxygentypedef:: rocsolver_handle
-.. deprecated:: 3.5
-   Use :c:type:`rocblas_handle`.
-
-rocsolver_direction
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. doxygentypedef:: rocsolver_direction
-.. deprecated:: 3.5
-   Use :c:enum:`rocblas_direct`.
-
-rocsolver_storev
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. doxygentypedef:: rocsolver_storev
-.. deprecated:: 3.5
-   Use :c:enum:`rocblas_storev`.
-
-rocsolver_operation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. doxygentypedef:: rocsolver_operation
-.. deprecated:: 3.5
-   Use :c:enum:`rocblas_operation`.
-
-rocsolver_fill
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. doxygentypedef:: rocsolver_fill
-.. deprecated:: 3.5
-   Use :c:enum:`rocblas_fill`.
-
-rocsolver_diagonal
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. doxygentypedef:: rocsolver_diagonal
-.. deprecated:: 3.5
-   Use :c:enum:`rocblas_diagonal`.
-
-rocsolver_side
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. doxygentypedef:: rocsolver_side
-.. deprecated:: 3.5
-   Use :c:enum:`rocblas_side`.
-
-rocsolver_status
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. doxygentypedef:: rocsolver_status
-.. deprecated:: 3.5
-   Use :c:enum:`rocblas_status`.
-
-
 Additional Types
 -------------------
+
+These are types that extend the rocBLAS API.
 
 rocblas_direct
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -981,14 +922,77 @@ rocsolver_<type>getrf_npvt_strided_batched()
 
 
 
-Auxiliaries
-=========================
+Deprecated
+==========
+
+Types
+-----------------
+
+See the documentation for the
+`rocBLAS types <https://rocblas.readthedocs.io/en/latest/functions.html#rocblas-types>`_.
+for information on the suggested replacements for these types.
+
+rocsolver_int
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygentypedef:: rocsolver_int
+.. deprecated:: 3.5
+   Use :c:type:`rocblas_int`.
+
+rocsolver_handle
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygentypedef:: rocsolver_handle
+.. deprecated:: 3.5
+   Use :c:type:`rocblas_handle`.
+
+rocsolver_direction
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygentypedef:: rocsolver_direction
+.. deprecated:: 3.5
+   Use :c:enum:`rocblas_direct`.
+
+rocsolver_storev
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygentypedef:: rocsolver_storev
+.. deprecated:: 3.5
+   Use :c:enum:`rocblas_storev`.
+
+rocsolver_operation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygentypedef:: rocsolver_operation
+.. deprecated:: 3.5
+   Use :c:enum:`rocblas_operation`.
+
+rocsolver_fill
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygentypedef:: rocsolver_fill
+.. deprecated:: 3.5
+   Use :c:enum:`rocblas_fill`.
+
+rocsolver_diagonal
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygentypedef:: rocsolver_diagonal
+.. deprecated:: 3.5
+   Use :c:enum:`rocblas_diagonal`.
+
+rocsolver_side
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygentypedef:: rocsolver_side
+.. deprecated:: 3.5
+   Use :c:enum:`rocblas_side`.
+
+rocsolver_status
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygentypedef:: rocsolver_status
+.. deprecated:: 3.5
+   Use :c:enum:`rocblas_status`.
+
 
 Auxiliary Functions
 ---------------------
 
-rocSOLVER auxiliary functions are aliases of rocBLAS auxiliary functions.
-See the `rocBLAS auxiliary functions <https://rocblas.readthedocs.io/en/latest/functions.html#auxiliary>`_.
+See the documentation for the
+`rocBLAS auxiliary functions <https://rocblas.readthedocs.io/en/latest/functions.html#auxiliary>`_
+for information on the suggested replacements for these functions.
 
 rocsolver_create_handle()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/install.sh
+++ b/install.sh
@@ -67,7 +67,7 @@ Options:
                               Official documentation is available online at https://rocsolver.readthedocs.io/
                               Building locally with this flag will require docker on your machine. If you are
                               familiar with doxygen, sphinx and documentation tools, you can alternatively
-                              use the scripts provided in rocsolver/docs.
+                              use the scripts provided in the docs directory.
 EOF
 }
 

--- a/install.sh
+++ b/install.sh
@@ -278,6 +278,11 @@ install_packages( )
   esac
 }
 
+# given a relative path, returns the absolute path
+make_absolute_path( ) {
+  (cd "$1" && pwd -P)
+}
+
 # #################################################
 # Pre-requisites check
 # #################################################
@@ -483,13 +488,18 @@ mkdir -p "$build_dir"
 if [[ "${build_docs}" == true ]]; then
   container_name="build_$(head -c 10 /dev/urandom | base32)"
   docs_build_command='cp -r /mnt/rocsolver /home/docs/ && /home/docs/rocsolver/docs/run_doc.sh'
-  docker build -t rocsolver:docs -f docker/dockerfile-docs .
+  docker build -t rocsolver:docs -f "$main/docker/dockerfile-docs" "$main/docker"
   docker run -v "$main:/mnt/rocsolver:ro" --name "$container_name" rocsolver:docs /bin/sh -c "$docs_build_command"
   docker cp "$container_name:/home/docs/rocsolver/docs/build" "$main/docs/"
   docker cp "$container_name:/home/docs/rocsolver/docs/docBin" "$main/docs/"
   mkdir -p "$build_dir/docs"
   ln -sr "$main/docs/docBin" "$build_dir/docs/doxygen"
   ln -sr "$main/docs/build" "$build_dir/docs/sphinx"
+  absolute_build_dir=$(make_absolute_path "$build_dir")
+  set +x
+  echo 'Documentation Built:'
+  echo "HTML: file://$absolute_build_dir/docs/sphinx/html/index.html"
+  echo "PDF:  file://$absolute_build_dir/docs/sphinx/latex/rocSOLVER.pdf"
   exit
 fi
 

--- a/rocsolver/library/include/rocsolver-functions.h
+++ b/rocsolver/library/include/rocsolver-functions.h
@@ -1621,7 +1621,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zungtr(rocblas_handle handle,
 
 /*! @{
     \brief ORM2R applies a matrix Q with orthonormal columns to a general m-by-n
-   matrix C.
+    matrix C.
 
     \details
     (This is the unblocked version of the algorithm).
@@ -2647,7 +2647,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zunmql(rocblas_handle handle,
 
 /*! @{
     \brief ORMBR applies a matrix Q with orthonormal rows or columns to a
-   general m-by-n matrix C.
+    general m-by-n matrix C.
 
     \details
     If storev is column-wise, then the matrix Q has orthonormal columns.
@@ -7625,7 +7625,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zpotrf_strided_batched(rocblas_handle 
 
     The computation of the singular vectors is optional and it is controlled by
     the function arguments left_svect and right_svect as described below. When
-    computed, this function returns the tranpose (or transpose conjugate) of the
+    computed, this function returns the transpose (or transpose conjugate) of the
     right singular vectors, i.e. the rows of V'.
 
     left_svect and right_svect are #rocblas_svect enums that can take the
@@ -7690,14 +7690,14 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zpotrf_strided_batched(rocblas_handle 
                 The leading dimension of U.
     @param[out]
     V           pointer to type. Array on the GPU of dimension ldv*n. \n
-                The matrix of right singular vectors stored as rows (transposed / conjugate-tranposed).
+                The matrix of right singular vectors stored as rows (transposed / conjugate-transposed).
                 Not referenced if right_svect is set to overwrite or none.
     @param[in]
     ldv         rocblas_int. ldv >= n if right_svect is all; ldv >= min(m,n) if right_svect is
                 set to singular; or ldv >= 1 otherwise.\n The leading dimension of V.
     @param[out]
     E           pointer to real type. Array on the GPU of dimension min(m,n)-1.\n
-                This array is used to work internaly with the bidiagonal matrix
+                This array is used to work internally with the bidiagonal matrix
                 B associated to A (using BDSQR). On exit, if info > 0, it contains the
                 unconverged off-diagonal elements of B (or properly speaking, a bidiagonal
                 matrix orthogonally equivalent to B). The diagonal elements of this matrix
@@ -7796,7 +7796,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgesvd(rocblas_handle handle,
 
     The computation of the singular vectors is optional and it is controlled by
     the function arguments left_svect and right_svect as described below. When
-    computed, this function returns the tranpose (or transpose conjugate) of the
+    computed, this function returns the transpose (or transpose conjugate) of the
     right singular vectors, i.e. the rows of V_j'.
 
     left_svect and right_svect are #rocblas_svect enums that can take the
@@ -7824,7 +7824,8 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgesvd(rocblas_handle handle,
     workspace. The parameter fast_alg controls whether the fast algorithm is
     executed or not. For more details see the sections
     "Tuning rocSOLVER performance" and "Memory model" on the User's guide.
-@param[in]
+
+    @param[in]
     handle      rocblas_handle.
     @param[in]
     left_svect  #rocblas_svect.\n
@@ -7871,7 +7872,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgesvd(rocblas_handle handle,
                 or strideU >= ldu*m when left_svect is equal to all.
     @param[out]
     V           pointer to type. Array on the GPU (the size depends on the value of strideV). \n
-                The matrices V_j of right singular vectors stored as rows (transposed / conjugate-tranposed).
+                The matrices V_j of right singular vectors stored as rows (transposed / conjugate-transposed).
                 Not referenced if right_svect is set to overwrite or none.
     @param[in]
     ldv         rocblas_int. ldv >= n if right_svect is all; ldv >= min(m,n) if
@@ -7884,7 +7885,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgesvd(rocblas_handle handle,
                 Normal use case is strideV >= ldv*n.
     @param[out]
     E           pointer to real type. Array on the GPU (the size depends on the value of strideE).\n
-                This array is used to work internaly with the bidiagonal matrix B_j associated to A_j (using BDSQR).
+                This array is used to work internally with the bidiagonal matrix B_j associated to A_j (using BDSQR).
                 On exit, if info > 0, it contains the unconverged off-diagonal elements of B_j (or properly speaking,
                 a bidiagonal matrix orthogonally equivalent to B_j). The diagonal elements of this matrix are in S_j;
                 those that converged correspond to a subset of the singular values of A_j (not necessarily ordered).
@@ -8008,7 +8009,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgesvd_batched(rocblas_handle handle,
 
     The computation of the singular vectors is optional and it is controlled by
     the function arguments left_svect and right_svect as described below. When
-    computed, this function returns the tranpose (or transpose conjugate) of the
+    computed, this function returns the transpose (or transpose conjugate) of the
     right singular vectors, i.e. the rows of V_j'.
 
     left_svect and right_svect are #rocblas_svect enums that can take the
@@ -8087,7 +8088,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgesvd_batched(rocblas_handle handle,
                 or strideU >= ldu*m when left_svect is equal to all.
     @param[out]
     V           pointer to type. Array on the GPU (the size depends on the value of strideV). \n
-                The matrices V_j of right singular vectors stored as rows (transposed / conjugate-tranposed).
+                The matrices V_j of right singular vectors stored as rows (transposed / conjugate-transposed).
                 Not referenced if right_svect is set to overwrite or none.
     @param[in]
     ldv         rocblas_int. ldv >= n if right_svect is all; ldv >= min(m,n) if right_svect is
@@ -8100,7 +8101,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgesvd_batched(rocblas_handle handle,
                 Normal use case is strideV >= ldv*n.
     @param[out]
     E           pointer to real type. Array on the GPU (the size depends on the value of strideE).\n
-                This array is used to work internaly with the bidiagonal matrix B_j associated to A_j (using BDSQR).
+                This array is used to work internally with the bidiagonal matrix B_j associated to A_j (using BDSQR).
                 On exit, if info > 0, it contains the unconverged off-diagonal elements of B_j (or properly speaking,
                 a bidiagonal matrix orthogonally equivalent to B_j). The diagonal elements of this matrix are in S_j;
                 those that converged correspond to a subset of the singular values of A_j (not necessarily ordered).

--- a/rocsolver/library/include/rocsolver-functions.h
+++ b/rocsolver/library/include/rocsolver-functions.h
@@ -249,7 +249,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zlarfg(rocblas_handle handle,
     n                   rocblas_int. n >= 0.\n
                         The order (size) of the block reflector.
     @param[in]
-    k                   rocsovler_int. k >= 1.\n
+    k                   rocblas_int. k >= 1.\n
                         The number of Householder matrices.
     @param[in]
     V                   pointer to type. Array on the GPU of size ldv*k if column-wise, or ldv*n if row-wise.\n
@@ -450,7 +450,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zlarf(rocblas_handle handle,
     n                   rocblas_int. n >= 0.\n
                         Number of columns of matrix A.
     @param[in]
-    k                   rocsovler_int. k >= 1.\n
+    k                   rocblas_int. k >= 1.\n
                         The number of Householder matrices.
     @param[in]
     V                   pointer to type. Array on the GPU of size ldv*k if column-wise, ldv*n if row-wise and applying from the right,

--- a/rocsolver/library/include/rocsolver-functions.h
+++ b/rocsolver/library/include/rocsolver-functions.h
@@ -8213,7 +8213,6 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgesvd_strided_batched(rocblas_handle 
                                                                  const rocblas_int batch_count);
 //! @}
 
-
 /*! @{
     \brief SYTD2 computes the tridiagonal form of a real symmetric matrix A.
 


### PR DESCRIPTION
This is a rollup of the various docs changes I've made over the past month or so.

Summary:
- Minor fixups of typos and broken links
- Moved deprecated items to their own section at the bottom of the page
- Enabled the docs build on the CI
- `./install.sh --docs` now prints clickable links to the built docs