### PR TITLE
Enable checkin tests in debug mode on CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/CHANGELOG.md merge=union

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -39,14 +39,15 @@ def runCompileCommand(platform, project, jobName, boolean sameOrg=false)
 def runTestCommand (platform, project, gfilter)
 {
     String sudo = auxiliary.sudo(platform.jenkinsLabel)
+    String buildType = project.buildName.contains('Debug') ? 'debug' : 'release'
     def command = """#!/usr/bin/env bash
                 set -x
-                cd ${project.paths.project_build_prefix}/build/release/clients/staging
+                cd ${project.paths.project_build_prefix}/build/${buildType}/clients/staging
                 ${sudo} GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./rocsolver-test --gtest_output=xml --gtest_color=yes --gtest_filter=${gfilter}
                 """
 
     platform.runCommand(this, command)
-    junit "${project.paths.project_build_prefix}/build/release/clients/staging/*.xml"
+    junit "${project.paths.project_build_prefix}/build/${buildType}/clients/staging/*.xml"
 }
 
 def runPackageCommand(platform, project)

--- a/.jenkins/debug.groovy
+++ b/.jenkins/debug.groovy
@@ -32,6 +32,15 @@ def runCI =
         commonGroovy.runCompileCommand(platform, project, jobName)
     }
 
+    def testCommand =
+    {
+        platform, project->
+
+        // Skip the SVD tests as they're too slow in debug mode
+        def gfilter = '*checkin_lapack*-*SVD*'
+        commonGroovy.runTestCommand(platform, project, gfilter)
+    }
+
     def packageCommand =
     {
         platform, project->
@@ -39,7 +48,7 @@ def runCI =
         commonGroovy.runPackageCommand(platform, project)
     }
 
-    buildProject(prj, formatCheck, nodes.dockerArray, compileCommand, null, packageCommand)
+    buildProject(prj, formatCheck, nodes.dockerArray, compileCommand, testCommand, packageCommand)
 
 }
 

--- a/.jenkins/debug.groovy
+++ b/.jenkins/debug.groovy
@@ -36,8 +36,7 @@ def runCI =
     {
         platform, project->
 
-        // Skip the SVD tests as they're too slow in debug mode
-        def gfilter = '*checkin_lapack*-*SVD*'
+        def gfilter = '*checkin_lapack*'
         commonGroovy.runTestCommand(platform, project, gfilter)
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 ### Removed
 
 ### Fixed
-- Fixed default launch bounds causing run-time failures in Debug mode
+- Fixed runtime errors in debug mode caused by incorrect kernel launch bounds
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](https://rocsolver.readthedocs.io/en/latest/).
 
+## [(Unreleased) rocSOLVER for ROCm 4.1.0]
+### Added
+
+### Optimizations
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+
+
 ## [(Unreleased) rocSOLVER 3.11.0 for ROCm 4.0.0]
 ### Added
 - Eigensolver routines for symmetric/hermitian matrices:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 ### Removed
 
 ### Fixed
+- Fixed default launch bounds causing run-time failures in Debug mode
 
 
 

--- a/rocsolver/library/src/CMakeLists.txt
+++ b/rocsolver/library/src/CMakeLists.txt
@@ -143,6 +143,9 @@ add_library( roc::rocsolver ALIAS rocsolver )
 target_link_libraries( rocsolver PRIVATE hip::device --rtlib=compiler-rt --unwindlib=libgcc )
 set_target_properties( rocsolver PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED ON )
 
+# In ROCm 4.0 and earlier, the default maximum threads per block is 256
+target_compile_options( rocsolver PRIVATE --gpu-max-threads-per-block=1024 )
+
 if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
   # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
   # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"


### PR DESCRIPTION
This change adds a new CI job that runs the checkin tests in Debug
mode.

On my local machine, running all checkin tests in debug mode takes
37 minutes, but 35 of those minutes are spent on the SVD tests. I've
excluded them from this new CI job (for now) to keep the job fast.