### PR TITLE
Added sterf and steqr

### DIFF
--- a/.jenkins/staticanalysis.groovy
+++ b/.jenkins/staticanalysis.groovy
@@ -17,7 +17,6 @@ def runCompileCommand(platform, project, jobName, boolean debug=false)
             set -x
             ${project.paths.project_build_prefix}/docs/run_doc.sh
             """
-    command = """ """
 
     try
     {
@@ -28,14 +27,13 @@ def runCompileCommand(platform, project, jobName, boolean debug=false)
         throw e
     }
 
-    /* publishHTML([allowMissing: false,
+    publishHTML([allowMissing: false,
                 alwaysLinkToLastBuild: false,
                 keepAll: false,
-                reportDir: "${project.paths.project_build_prefix}/docs/docBin/html",
+                reportDir: "${project.paths.project_build_prefix}/docs/build/html",
                 reportFiles: "index.html",
                 reportName: "Documentation",
                 reportTitles: "Documentation"])
-    */
 }
 
 def runCI =

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 ### Added
 __anchor__TA
 - Eigensolver routines for symmetric/hermitian matrices:
-    - STERF
+    - STERF, STEQR
 
 __anchor__CB
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 ## [(Unreleased) rocSOLVER for ROCm 4.0.0]
 ### Added
 __anchor__TA
+- Eigensolver routines for symmetric/hermitian matrices:
+    - STERF
 
 __anchor__CB
 

--- a/docs/source/userguide_api.rst
+++ b/docs/source/userguide_api.rst
@@ -329,6 +329,15 @@ rocsolver_<type>unmtr()
    :outline:
 .. doxygenfunction:: rocsolver_cunmtr
 
+Eigensolvers
+--------------------------
+
+rocsolver_<type>sterf()
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygenfunction:: rocsolver_dsterf
+   :outline:
+.. doxygenfunction:: rocsolver_ssterf
+
 
 
 LAPACK Functions

--- a/docs/source/userguide_api.rst
+++ b/docs/source/userguide_api.rst
@@ -32,6 +32,10 @@ rocblas_svect
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. doxygenenum:: rocblas_svect
 
+rocblas_evect
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygenenum:: rocblas_evect
+
 rocblas_workmode
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. doxygenenum:: rocblas_workmode

--- a/docs/source/userguide_api.rst
+++ b/docs/source/userguide_api.rst
@@ -338,6 +338,16 @@ rocsolver_<type>sterf()
    :outline:
 .. doxygenfunction:: rocsolver_ssterf
 
+rocsolver_<type>steqr()
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygenfunction:: rocsolver_zsteqr
+   :outline:
+.. doxygenfunction:: rocsolver_csteqr
+   :outline:
+.. doxygenfunction:: rocsolver_dsteqr
+   :outline:
+.. doxygenfunction:: rocsolver_ssteqr
+
 
 
 LAPACK Functions

--- a/docs/source/userguide_api.rst
+++ b/docs/source/userguide_api.rst
@@ -7,74 +7,18 @@ rocSOLVER API
    :maxdepth: 4
    :caption: Contents:
 
-This section provides details of the rocSOLVER library API as in last ROCm release.
+This section provides details of the rocSOLVER library API.
 
 Types
 =====
 
-rocSOLVER Types
------------------
-
-Most rocSOLVER types are aliases of rocBLAS types.
-See the `rocBLAS types <https://rocblas.readthedocs.io/en/latest/api.html#types>`_.
-
-rocsolver_int
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. doxygentypedef:: rocsolver_int
-.. deprecated:: 3.5
-   Use :c:type:`rocblas_int`.
-
-rocsolver_handle
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. doxygentypedef:: rocsolver_handle
-.. deprecated:: 3.5
-   Use :c:type:`rocblas_handle`.
-
-rocsolver_direction
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. doxygentypedef:: rocsolver_direction
-.. deprecated:: 3.5
-   Use :c:enum:`rocblas_direct`.
-
-rocsolver_storev
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. doxygentypedef:: rocsolver_storev
-.. deprecated:: 3.5
-   Use :c:enum:`rocblas_storev`.
-
-rocsolver_operation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. doxygentypedef:: rocsolver_operation
-.. deprecated:: 3.5
-   Use :c:enum:`rocblas_operation`.
-
-rocsolver_fill
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. doxygentypedef:: rocsolver_fill
-.. deprecated:: 3.5
-   Use :c:enum:`rocblas_fill`.
-
-rocsolver_diagonal
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. doxygentypedef:: rocsolver_diagonal
-.. deprecated:: 3.5
-   Use :c:enum:`rocblas_diagonal`.
-
-rocsolver_side
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. doxygentypedef:: rocsolver_side
-.. deprecated:: 3.5
-   Use :c:enum:`rocblas_side`.
-
-rocsolver_status
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. doxygentypedef:: rocsolver_status
-.. deprecated:: 3.5
-   Use :c:enum:`rocblas_status`.
-
+rocSOLVER uses types and enumerations defined by the rocBLAS API. For more information, see the
+`rocBLAS types <https://rocblas.readthedocs.io/en/latest/functions.html#rocblas-types>`_.
 
 Additional Types
 -------------------
+
+These are types that extend the rocBLAS API.
 
 rocblas_direct
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -981,14 +925,75 @@ rocsolver_<type>getrf_npvt_strided_batched()
 
 
 
-Auxiliaries
-=========================
+Deprecated
+==========
+
+Types
+-----------------
+
+See the `rocBLAS types <https://rocblas.readthedocs.io/en/latest/functions.html#rocblas-types>`_
+documentation for information on the suggested replacements.
+
+rocsolver_int
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygentypedef:: rocsolver_int
+.. deprecated:: 3.5
+   Use :c:type:`rocblas_int`.
+
+rocsolver_handle
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygentypedef:: rocsolver_handle
+.. deprecated:: 3.5
+   Use :c:type:`rocblas_handle`.
+
+rocsolver_direction
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygentypedef:: rocsolver_direction
+.. deprecated:: 3.5
+   Use :c:enum:`rocblas_direct`.
+
+rocsolver_storev
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygentypedef:: rocsolver_storev
+.. deprecated:: 3.5
+   Use :c:enum:`rocblas_storev`.
+
+rocsolver_operation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygentypedef:: rocsolver_operation
+.. deprecated:: 3.5
+   Use :c:enum:`rocblas_operation`.
+
+rocsolver_fill
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygentypedef:: rocsolver_fill
+.. deprecated:: 3.5
+   Use :c:enum:`rocblas_fill`.
+
+rocsolver_diagonal
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygentypedef:: rocsolver_diagonal
+.. deprecated:: 3.5
+   Use :c:enum:`rocblas_diagonal`.
+
+rocsolver_side
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygentypedef:: rocsolver_side
+.. deprecated:: 3.5
+   Use :c:enum:`rocblas_side`.
+
+rocsolver_status
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygentypedef:: rocsolver_status
+.. deprecated:: 3.5
+   Use :c:enum:`rocblas_status`.
+
 
 Auxiliary Functions
 ---------------------
 
-rocSOLVER auxiliary functions are aliases of rocBLAS auxiliary functions.
-See the `rocBLAS auxiliary functions <https://rocblas.readthedocs.io/en/latest/api.html#auxiliary>`_.
+See the `rocBLAS auxiliary functions <https://rocblas.readthedocs.io/en/latest/functions.html#auxiliary>`_
+documentation for information on the suggested replacements.
 
 rocsolver_create_handle()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/userguide_intro.rst
+++ b/docs/source/userguide_intro.rst
@@ -67,6 +67,7 @@ LAPACK Auxiliary Function       single double single complex double complex
 **rocsolver_unmbr**                              x              x
 **rocsolver_unmtr**                              x              x
 **rocsolver_sterf**             x      x
+**rocsolver_steqr**             x      x         x              x
 =============================== ====== ====== ============== ==============
 
 =============================== ====== ====== ============== ==============

--- a/docs/source/userguide_intro.rst
+++ b/docs/source/userguide_intro.rst
@@ -66,6 +66,7 @@ LAPACK Auxiliary Function       single double single complex double complex
 **rocsolver_unmql**                              x              x
 **rocsolver_unmbr**                              x              x
 **rocsolver_unmtr**                              x              x
+**rocsolver_sterf**             x      x
 =============================== ====== ====== ============== ==============
 
 =============================== ====== ====== ============== ==============

--- a/rocblascommon/clients/include/utility.hpp
+++ b/rocblascommon/clients/include/utility.hpp
@@ -148,7 +148,7 @@ inline void rocblas_print_matrix(T* CPU_result, T* GPU_result, size_t m, size_t 
         {
             rocblas_cout << "matrix  col " << i << ", row " << j
                          << ", CPU result=" << CPU_result[j + i * lda]
-                         << ", GPU result=" << GPU_result[j + i * lda] << "\n";
+                         << ", GPU result=" << GPU_result[j + i * lda] << std::endl;
         }
 }
 

--- a/rocsolver/clients/benchmarks/client.cpp
+++ b/rocsolver/clients/benchmarks/client.cpp
@@ -214,6 +214,10 @@ try
 
         ("rightsv",
          po::value<char>(&argus.right_svect)->default_value('N'),
+         "Only applicable to certain routines")
+
+        ("evect",
+         po::value<char>(&argus.evect)->default_value('N'),
          "Only applicable to certain routines");
     // clang-format on
 
@@ -281,7 +285,11 @@ try
        && argus.right_svect != 'N')
         throw std::invalid_argument("Invalid value for --rightsv");
 
-    // rightsv
+    // evect
+    if(argus.evect != 'V' && argus.evect != 'I' && argus.evect != 'N')
+        throw std::invalid_argument("Invalid value for --evect");
+
+    // workmode
     if(argus.workmode != 'O' && argus.workmode != 'I')
         throw std::invalid_argument("Invalid value for --workmode");
 

--- a/rocsolver/clients/benchmarks/client.cpp
+++ b/rocsolver/clients/benchmarks/client.cpp
@@ -30,6 +30,7 @@
 #include "testing_ormxl_unmxl.hpp"
 #include "testing_ormxr_unmxr.hpp"
 #include "testing_potf2_potrf.hpp"
+#include "testing_sterf.hpp"
 #include "testing_sytxx_hetxx.hpp"
 #include <boost/program_options.hpp>
 
@@ -1330,6 +1331,15 @@ try
             testing_sytxx_hetxx<false, true, 1, rocblas_float_complex>(argus);
         else if(precision == 'z')
             testing_sytxx_hetxx<false, true, 1, rocblas_double_complex>(argus);
+        else
+            throw std::invalid_argument("This function does not support the given --precision");
+    }
+    else if(function == "sterf")
+    {
+        if(precision == 's')
+            testing_sterf<float>(argus);
+        else if(precision == 'd')
+            testing_sterf<double>(argus);
         else
             throw std::invalid_argument("This function does not support the given --precision");
     }

--- a/rocsolver/clients/benchmarks/client.cpp
+++ b/rocsolver/clients/benchmarks/client.cpp
@@ -30,6 +30,7 @@
 #include "testing_ormxl_unmxl.hpp"
 #include "testing_ormxr_unmxr.hpp"
 #include "testing_potf2_potrf.hpp"
+#include "testing_steqr.hpp"
 #include "testing_sterf.hpp"
 #include "testing_sytxx_hetxx.hpp"
 #include <boost/program_options.hpp>
@@ -1348,6 +1349,19 @@ try
             testing_sterf<float>(argus);
         else if(precision == 'd')
             testing_sterf<double>(argus);
+        else
+            throw std::invalid_argument("This function does not support the given --precision");
+    }
+    else if(function == "steqr")
+    {
+        if(precision == 's')
+            testing_steqr<float, float>(argus);
+        else if(precision == 'd')
+            testing_steqr<double, double>(argus);
+        else if(precision == 'c')
+            testing_steqr<float, rocblas_float_complex>(argus);
+        else if(precision == 'z')
+            testing_steqr<double, rocblas_double_complex>(argus);
         else
             throw std::invalid_argument("This function does not support the given --precision");
     }

--- a/rocsolver/clients/benchmarks/client.cpp
+++ b/rocsolver/clients/benchmarks/client.cpp
@@ -1362,8 +1362,6 @@ try
             testing_steqr<float, rocblas_float_complex>(argus);
         else if(precision == 'z')
             testing_steqr<double, rocblas_double_complex>(argus);
-        else
-            throw std::invalid_argument("This function does not support the given --precision");
     }
     else
         throw std::invalid_argument("Invalid value for --function");

--- a/rocsolver/clients/common/cblas_interface.cpp
+++ b/rocsolver/clients/common/cblas_interface.cpp
@@ -1274,6 +1274,25 @@ void zgesvd_(char* jobu,
 void ssterf_(int* n, float* D, float* E, int* info);
 void dsterf_(int* n, double* D, double* E, int* info);
 
+void ssteqr_(char* compc, int* n, float* D, float* E, float* C, int* ldc, float* work, int* info);
+void dsteqr_(char* compc, int* n, double* D, double* E, double* C, int* ldc, double* work, int* info);
+void csteqr_(char* compc,
+             int* n,
+             float* D,
+             float* E,
+             rocblas_float_complex* C,
+             int* ldc,
+             float* work,
+             int* info);
+void zsteqr_(char* compc,
+             int* n,
+             double* D,
+             double* E,
+             rocblas_double_complex* C,
+             int* ldc,
+             double* work,
+             int* info);
+
 #ifdef __cplusplus
 }
 #endif
@@ -4535,4 +4554,60 @@ void cblas_sterf<double>(rocblas_int n, double* D, double* E)
 {
     int info;
     dsterf_(&n, D, E, &info);
+}
+
+// steqr
+template <>
+void cblas_steqr<float, float>(rocblas_evect compc,
+                               rocblas_int n,
+                               float* D,
+                               float* E,
+                               float* C,
+                               rocblas_int ldc,
+                               float* work)
+{
+    rocblas_int info;
+    char compcC = rocblas2char_evect(compc);
+    ssteqr_(&compcC, &n, D, E, C, &ldc, work, &info);
+}
+
+template <>
+void cblas_steqr<double, double>(rocblas_evect compc,
+                                 rocblas_int n,
+                                 double* D,
+                                 double* E,
+                                 double* C,
+                                 rocblas_int ldc,
+                                 double* work)
+{
+    rocblas_int info;
+    char compcC = rocblas2char_evect(compc);
+    dsteqr_(&compcC, &n, D, E, C, &ldc, work, &info);
+}
+template <>
+void cblas_steqr<float, rocblas_float_complex>(rocblas_evect compc,
+                                               rocblas_int n,
+                                               float* D,
+                                               float* E,
+                                               rocblas_float_complex* C,
+                                               rocblas_int ldc,
+                                               float* work)
+{
+    rocblas_int info;
+    char compcC = rocblas2char_evect(compc);
+    csteqr_(&compcC, &n, D, E, C, &ldc, work, &info);
+}
+
+template <>
+void cblas_steqr<double, rocblas_double_complex>(rocblas_evect compc,
+                                                 rocblas_int n,
+                                                 double* D,
+                                                 double* E,
+                                                 rocblas_double_complex* C,
+                                                 rocblas_int ldc,
+                                                 double* work)
+{
+    rocblas_int info;
+    char compcC = rocblas2char_evect(compc);
+    zsteqr_(&compcC, &n, D, E, C, &ldc, work, &info);
 }

--- a/rocsolver/clients/common/cblas_interface.cpp
+++ b/rocsolver/clients/common/cblas_interface.cpp
@@ -1271,6 +1271,9 @@ void zgesvd_(char* jobu,
              double* E,
              int* info);
 
+void ssterf_(int* n, float* D, float* E, int* info);
+void dsterf_(int* n, double* D, double* E, int* info);
+
 #ifdef __cplusplus
 }
 #endif
@@ -4517,4 +4520,19 @@ void cblas_sytd2_hetd2<double, rocblas_double_complex>(rocblas_fill uplo,
     int info;
     char uploC = rocblas2char_fill(uplo);
     zhetd2_(&uploC, &n, A, &lda, D, E, tau, &info);
+}
+
+// sterf
+template <>
+void cblas_sterf<float>(rocblas_int n, float* D, float* E)
+{
+    int info;
+    ssterf_(&n, D, E, &info);
+}
+
+template <>
+void cblas_sterf<double>(rocblas_int n, double* D, double* E)
+{
+    int info;
+    dsterf_(&n, D, E, &info);
 }

--- a/rocsolver/clients/common/cblas_interface.cpp
+++ b/rocsolver/clients/common/cblas_interface.cpp
@@ -19,6 +19,47 @@
 extern "C" {
 #endif
 
+void ssymv_(char* uplo,
+            int* n,
+            float* alpha,
+            float* A,
+            int* lda,
+            float* x,
+            int* incx,
+            float* beta,
+            float* y,
+            int* incy);
+void dsymv_(char* uplo,
+            int* n,
+            double* alpha,
+            double* A,
+            int* lda,
+            double* x,
+            int* incx,
+            double* beta,
+            double* y,
+            int* incy);
+void chemv_(char* uplo,
+            int* n,
+            rocblas_float_complex* alpha,
+            rocblas_float_complex* A,
+            int* lda,
+            rocblas_float_complex* x,
+            int* incx,
+            rocblas_float_complex* beta,
+            rocblas_float_complex* y,
+            int* incy);
+void zhemv_(char* uplo,
+            int* n,
+            rocblas_double_complex* alpha,
+            rocblas_double_complex* A,
+            int* lda,
+            rocblas_double_complex* x,
+            int* incx,
+            rocblas_double_complex* beta,
+            rocblas_double_complex* y,
+            int* incy);
+
 void strtri_(char* uplo, char* diag, int* n, float* A, int* lda, int* info);
 void dtrtri_(char* uplo, char* diag, int* n, double* A, int* lda, int* info);
 void ctrtri_(char* uplo, char* diag, int* n, rocblas_float_complex* A, int* lda, int* info);
@@ -3307,43 +3348,71 @@ void cblas_gemv<rocblas_double_complex>(
   cblas_zgemv(CblasColMajor, (CBLAS_TRANSPOSE)transA, m, n, &alpha, A, lda, x,
               incx, &beta, y, incy);
 }
-
+*/
 template <>
-void cblas_symv<float>(rocblas_fill uplo, rocblas_int n, float alpha, float *A,
-                       rocblas_int lda, float *x, rocblas_int incx, float beta,
-                       float *y, rocblas_int incy) {
-  cblas_ssymv(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, A, lda, x, incx, beta,
-              y, incy);
+void cblas_symv_hemv<float>(rocblas_fill uplo,
+                            rocblas_int n,
+                            float alpha,
+                            float* A,
+                            rocblas_int lda,
+                            float* x,
+                            rocblas_int incx,
+                            float beta,
+                            float* y,
+                            rocblas_int incy)
+{
+    char uploC = rocblas2char_fill(uplo);
+    ssymv_(&uploC, &n, &alpha, A, &lda, x, &incx, &beta, y, &incy);
 }
 
 template <>
-void cblas_symv<double>(rocblas_fill uplo, rocblas_int n, double alpha,
-                        double *A, rocblas_int lda, double *x, rocblas_int incx,
-                        double beta, double *y, rocblas_int incy) {
-  cblas_dsymv(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, A, lda, x, incx, beta,
-              y, incy);
+void cblas_symv_hemv<double>(rocblas_fill uplo,
+                             rocblas_int n,
+                             double alpha,
+                             double* A,
+                             rocblas_int lda,
+                             double* x,
+                             rocblas_int incx,
+                             double beta,
+                             double* y,
+                             rocblas_int incy)
+{
+    char uploC = rocblas2char_fill(uplo);
+    dsymv_(&uploC, &n, &alpha, A, &lda, x, &incx, &beta, y, &incy);
 }
 
 template <>
-void cblas_hemv<rocblas_float_complex>(
-    rocblas_fill uplo, rocblas_int n, rocblas_float_complex alpha,
-    rocblas_float_complex *A, rocblas_int lda, rocblas_float_complex *x,
-    rocblas_int incx, rocblas_float_complex beta, rocblas_float_complex *y,
-    rocblas_int incy) {
-  cblas_chemv(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, A, lda, x, incx,
-              &beta, y, incy);
+void cblas_symv_hemv<rocblas_float_complex>(rocblas_fill uplo,
+                                            rocblas_int n,
+                                            rocblas_float_complex alpha,
+                                            rocblas_float_complex* A,
+                                            rocblas_int lda,
+                                            rocblas_float_complex* x,
+                                            rocblas_int incx,
+                                            rocblas_float_complex beta,
+                                            rocblas_float_complex* y,
+                                            rocblas_int incy)
+{
+    char uploC = rocblas2char_fill(uplo);
+    chemv_(&uploC, &n, &alpha, A, &lda, x, &incx, &beta, y, &incy);
 }
 
 template <>
-void cblas_hemv<rocblas_double_complex>(
-    rocblas_fill uplo, rocblas_int n, rocblas_double_complex alpha,
-    rocblas_double_complex *A, rocblas_int lda, rocblas_double_complex *x,
-    rocblas_int incx, rocblas_double_complex beta, rocblas_double_complex *y,
-    rocblas_int incy) {
-  cblas_zhemv(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, A, lda, x, incx,
-              &beta, y, incy);
+void cblas_symv_hemv<rocblas_double_complex>(rocblas_fill uplo,
+                                             rocblas_int n,
+                                             rocblas_double_complex alpha,
+                                             rocblas_double_complex* A,
+                                             rocblas_int lda,
+                                             rocblas_double_complex* x,
+                                             rocblas_int incx,
+                                             rocblas_double_complex beta,
+                                             rocblas_double_complex* y,
+                                             rocblas_int incy)
+{
+    char uploC = rocblas2char_fill(uplo);
+    zhemv_(&uploC, &n, &alpha, A, &lda, x, &incx, &beta, y, &incy);
 }
-
+/*
 template <>
 void cblas_ger<float>(rocblas_int m, rocblas_int n, float alpha, float *x,
                       rocblas_int incx, float *y, rocblas_int incy, float *A,

--- a/rocsolver/clients/gtest/CMakeLists.txt
+++ b/rocsolver/clients/gtest/CMakeLists.txt
@@ -59,6 +59,7 @@ set(roclapack_test_source
     # tridiagonal matrices and eigensolvers
     sytxx_hetxx_gtest.cpp
     sterf_gtest.cpp
+    steqr_gtest.cpp
     # orthogonal factorizations
     geqr2_geqrf_gtest.cpp
     geql2_geqlf_gtest.cpp

--- a/rocsolver/clients/gtest/CMakeLists.txt
+++ b/rocsolver/clients/gtest/CMakeLists.txt
@@ -58,6 +58,7 @@ set(roclapack_test_source
     bdsqr_gtest.cpp
     # tridiagonal matrices and eigensolvers
     sytxx_hetxx_gtest.cpp
+    sterf_gtest.cpp
     # orthogonal factorizations
     geqr2_geqrf_gtest.cpp
     geql2_geqlf_gtest.cpp

--- a/rocsolver/clients/gtest/steqr_gtest.cpp
+++ b/rocsolver/clients/gtest/steqr_gtest.cpp
@@ -39,7 +39,7 @@ const vector<vector<int>> matrix_size_range = {
     {35, 40}};
 
 // for daily_lapack tests
-const vector<vector<int>> large_matrix_size_range = {{192, 192}, {640, 640}, {1000, 1024}};
+const vector<vector<int>> large_matrix_size_range = {{192, 192}};
 
 Arguments steqr_setup_arguments(steqr_tuple tup)
 {

--- a/rocsolver/clients/gtest/steqr_gtest.cpp
+++ b/rocsolver/clients/gtest/steqr_gtest.cpp
@@ -1,0 +1,115 @@
+/* ************************************************************************
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include "testing_steqr.hpp"
+
+using ::testing::Combine;
+using ::testing::TestWithParam;
+using ::testing::Values;
+using ::testing::ValuesIn;
+using namespace std;
+
+typedef std::tuple<vector<int>, vector<int>> steqr_tuple;
+
+// each size_range vector is a {N, ldc}
+
+// each op_range vector is a {e}
+// if e = 0, then evect = 'N'
+// if e = 1, then evect = 'I'
+// if e = 2, then evect = 'V'
+
+// case when N == 0 and evect == N will also execute the bad arguments test
+// (null handle, null pointers and invalid values)
+
+const vector<vector<int>> op_range = {{0}, {1}, {2}};
+
+// for checkin_lapack tests
+const vector<vector<int>> matrix_size_range = {
+    // quick return
+    {0, 1},
+    // invalid
+    {-1, 1},
+    // invalid for case evect != N
+    {2, 1},
+    // normal (valid) samples
+    {12, 12},
+    {20, 30},
+    {35, 40}};
+
+// for daily_lapack tests
+const vector<vector<int>> large_matrix_size_range = {{192, 192}, {640, 640}, {1000, 1024}};
+
+Arguments steqr_setup_arguments(steqr_tuple tup)
+{
+    vector<int> size = std::get<0>(tup);
+    vector<int> op = std::get<1>(tup);
+
+    Arguments arg;
+
+    arg.N = size[0];
+    arg.ldc = size[1];
+
+    arg.evect = (op[0] == 0 ? 'N' : (op[0] == 1 ? 'I' : 'V'));
+
+    arg.timing = 0;
+
+    return arg;
+}
+
+class STEQR : public ::TestWithParam<steqr_tuple>
+{
+protected:
+    STEQR() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+};
+
+TEST_P(STEQR, __float)
+{
+    Arguments arg = steqr_setup_arguments(GetParam());
+
+    if(arg.N == 0 && arg.evect == 'N')
+        testing_steqr_bad_arg<float, float>();
+
+    testing_steqr<float, float>(arg);
+}
+
+TEST_P(STEQR, __double)
+{
+    Arguments arg = steqr_setup_arguments(GetParam());
+
+    if(arg.N == 0 && arg.evect == 'N')
+        testing_steqr_bad_arg<double, double>();
+
+    testing_steqr<double, double>(arg);
+}
+
+TEST_P(STEQR, __float_complex)
+{
+    Arguments arg = steqr_setup_arguments(GetParam());
+
+    if(arg.N == 0 && arg.evect == 'N')
+        testing_steqr_bad_arg<float, rocblas_float_complex>();
+
+    testing_steqr<float, rocblas_float_complex>(arg);
+}
+
+TEST_P(STEQR, __double_complex)
+{
+    Arguments arg = steqr_setup_arguments(GetParam());
+
+    if(arg.N == 0 && arg.evect == 'N')
+        testing_steqr_bad_arg<double, rocblas_double_complex>();
+
+    testing_steqr<double, rocblas_double_complex>(arg);
+}
+
+INSTANTIATE_TEST_SUITE_P(daily_lapack,
+                         STEQR,
+                         Combine(ValuesIn(large_matrix_size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+                         STEQR,
+                         Combine(ValuesIn(matrix_size_range), ValuesIn(op_range)));

--- a/rocsolver/clients/gtest/steqr_gtest.cpp
+++ b/rocsolver/clients/gtest/steqr_gtest.cpp
@@ -39,7 +39,7 @@ const vector<vector<int>> matrix_size_range = {
     {35, 40}};
 
 // for daily_lapack tests
-const vector<vector<int>> large_matrix_size_range = {{192, 192}};
+const vector<vector<int>> large_matrix_size_range = {{192, 192}, {256, 270}, {300, 300}};
 
 Arguments steqr_setup_arguments(steqr_tuple tup)
 {

--- a/rocsolver/clients/gtest/sterf_gtest.cpp
+++ b/rocsolver/clients/gtest/sterf_gtest.cpp
@@ -30,7 +30,7 @@ const vector<vector<int>> matrix_size_range = {
     {35}};
 
 // for daily_lapack tests
-const vector<vector<int>> large_matrix_size_range = {{192}, {640}, {1024}};
+const vector<vector<int>> large_matrix_size_range = {{192}, {256}, {300}};
 
 Arguments sterf_setup_arguments(sterf_tuple tup)
 {

--- a/rocsolver/clients/gtest/sterf_gtest.cpp
+++ b/rocsolver/clients/gtest/sterf_gtest.cpp
@@ -1,0 +1,76 @@
+/* ************************************************************************
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include "testing_sterf.hpp"
+
+using ::testing::Combine;
+using ::testing::TestWithParam;
+using ::testing::Values;
+using ::testing::ValuesIn;
+using namespace std;
+
+typedef vector<int> sterf_tuple;
+
+// each size_range vector is a {N}
+
+// case when N == 0 will also execute the bad arguments test
+// (null handle, null pointers and invalid values)
+
+// for checkin_lapack tests
+const vector<vector<int>> matrix_size_range = {
+    // quick return
+    {0},
+    // invalid
+    {-1},
+    // normal (valid) samples
+    {12},
+    {20},
+    {35}};
+
+// for daily_lapack tests
+const vector<vector<int>> large_matrix_size_range = {{192}, {640}, {1024}};
+
+Arguments sterf_setup_arguments(sterf_tuple tup)
+{
+    Arguments arg;
+
+    arg.N = tup[0];
+
+    arg.timing = 0;
+
+    return arg;
+}
+
+class STERF : public ::TestWithParam<sterf_tuple>
+{
+protected:
+    STERF() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+};
+
+TEST_P(STERF, __float)
+{
+    Arguments arg = sterf_setup_arguments(GetParam());
+
+    if(arg.N == 0)
+        testing_sterf_bad_arg<float>();
+
+    testing_sterf<float>(arg);
+}
+
+TEST_P(STERF, __double)
+{
+    Arguments arg = sterf_setup_arguments(GetParam());
+
+    if(arg.N == 0)
+        testing_sterf_bad_arg<double>();
+
+    testing_sterf<double>(arg);
+}
+
+INSTANTIATE_TEST_SUITE_P(daily_lapack, STERF, ValuesIn(large_matrix_size_range));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack, STERF, ValuesIn(matrix_size_range));

--- a/rocsolver/clients/include/cblas_interface.h
+++ b/rocsolver/clients/include/cblas_interface.h
@@ -481,4 +481,7 @@ void cblas_gesvd(rocblas_svect leftv,
 template <typename T>
 void cblas_sterf(rocblas_int n, T* D, T* E);
 
+template <typename S, typename T>
+void cblas_steqr(rocblas_evect compc, rocblas_int n, S* D, S* E, T* C, rocblas_int ldc, S* work);
+
 #endif /* _CBLAS_INTERFACE_ */

--- a/rocsolver/clients/include/cblas_interface.h
+++ b/rocsolver/clients/include/cblas_interface.h
@@ -478,4 +478,7 @@ void cblas_gesvd(rocblas_svect leftv,
                  W* E,
                  rocblas_int* info);
 
+template <typename T>
+void cblas_sterf(rocblas_int n, T* D, T* E);
+
 #endif /* _CBLAS_INTERFACE_ */

--- a/rocsolver/clients/include/cblas_interface.h
+++ b/rocsolver/clients/include/cblas_interface.h
@@ -52,23 +52,25 @@ void cblas_gemv(rocblas_operation transA, rocblas_int m, rocblas_int n, T alpha,
                 rocblas_int incy);
 
 template <typename T>
-void cblas_symv(rocblas_fill uplo, rocblas_int n, T alpha, T *A,
-                rocblas_int lda, T *x, rocblas_int incx, T beta, T *y,
-                rocblas_int incy);
-
-template <typename T>
 void cblas_ger(rocblas_int m, rocblas_int n, T alpha, T *x, rocblas_int incx,
                T *y, rocblas_int incy, T *A, rocblas_int lda);
 
 template <typename T>
 void cblas_syr(rocblas_fill uplo, rocblas_int n, T alpha, T *x,
                rocblas_int incx, T *A, rocblas_int lda);
-
-template <typename T>
-void cblas_hemv(rocblas_fill uplo, rocblas_int n, T alpha, T *A,
-                rocblas_int lda, T *x, rocblas_int incx, T beta, T *y,
-                rocblas_int incy);
 */
+template <typename T>
+void cblas_symv_hemv(rocblas_fill uplo,
+                     rocblas_int n,
+                     T alpha,
+                     T* A,
+                     rocblas_int lda,
+                     T* x,
+                     rocblas_int incx,
+                     T beta,
+                     T* y,
+                     rocblas_int incy);
+
 template <typename T>
 void cblas_gemm(rocblas_operation transA,
                 rocblas_operation transB,

--- a/rocsolver/clients/include/rocsolver.hpp
+++ b/rocsolver/clients/include/rocsolver.hpp
@@ -1155,7 +1155,7 @@ inline rocblas_status rocsolver_steqr(rocblas_handle handle,
                                       rocblas_int ldc,
                                       rocblas_int* info)
 {
-    return rocblas_status_not_implemented; // rocsolver_ssteqr(handle, compc, n, D, E, C, ldc, info);
+    return rocsolver_ssteqr(handle, compc, n, D, E, C, ldc, info);
 }
 
 inline rocblas_status rocsolver_steqr(rocblas_handle handle,
@@ -1167,7 +1167,7 @@ inline rocblas_status rocsolver_steqr(rocblas_handle handle,
                                       rocblas_int ldc,
                                       rocblas_int* info)
 {
-    return rocblas_status_not_implemented; // rocsolver_dsteqr(handle, compc, n, D, E, C, ldc, info);
+    return rocsolver_dsteqr(handle, compc, n, D, E, C, ldc, info);
 }
 
 inline rocblas_status rocsolver_steqr(rocblas_handle handle,
@@ -1179,7 +1179,7 @@ inline rocblas_status rocsolver_steqr(rocblas_handle handle,
                                       rocblas_int ldc,
                                       rocblas_int* info)
 {
-    return rocblas_status_not_implemented; // rocsolver_csteqr(handle, compc, n, D, E, C, ldc, info);
+    return rocsolver_csteqr(handle, compc, n, D, E, C, ldc, info);
 }
 
 inline rocblas_status rocsolver_steqr(rocblas_handle handle,
@@ -1191,7 +1191,7 @@ inline rocblas_status rocsolver_steqr(rocblas_handle handle,
                                       rocblas_int ldc,
                                       rocblas_int* info)
 {
-    return rocblas_status_not_implemented; // rocsolver_zsteqr(handle, compc, n, D, E, C, ldc, info);
+    return rocsolver_zsteqr(handle, compc, n, D, E, C, ldc, info);
 }
 /********************************************************/
 

--- a/rocsolver/clients/include/rocsolver.hpp
+++ b/rocsolver/clients/include/rocsolver.hpp
@@ -1131,6 +1131,20 @@ inline rocblas_status rocsolver_ormtr_unmtr(rocblas_handle handle,
 }
 /***************************************************************/
 
+/******************** STERF ********************/
+inline rocblas_status
+    rocsolver_sterf(rocblas_handle handle, rocblas_int n, float* D, float* E, rocblas_int* info)
+{
+    return rocblas_status_not_implemented; // rocsolver_ssterf(handle, n, D, E, info);
+}
+
+inline rocblas_status
+    rocsolver_sterf(rocblas_handle handle, rocblas_int n, double* D, double* E, rocblas_int* info)
+{
+    return rocblas_status_not_implemented; // rocsolver_dsterf(handle, n, D, E, info);
+}
+/********************************************************/
+
 /******************** POTF2_POTRF ********************/
 // normal and strided_batched
 inline rocblas_status rocsolver_potf2_potrf(bool STRIDED,

--- a/rocsolver/clients/include/rocsolver.hpp
+++ b/rocsolver/clients/include/rocsolver.hpp
@@ -1145,6 +1145,56 @@ inline rocblas_status
 }
 /********************************************************/
 
+/******************** STEQR ********************/
+inline rocblas_status rocsolver_steqr(rocblas_handle handle,
+                                      rocblas_evect compc,
+                                      rocblas_int n,
+                                      float* D,
+                                      float* E,
+                                      float* C,
+                                      rocblas_int ldc,
+                                      rocblas_int* info)
+{
+    return rocblas_status_not_implemented; // rocsolver_ssteqr(handle, compc, n, D, E, C, ldc, info);
+}
+
+inline rocblas_status rocsolver_steqr(rocblas_handle handle,
+                                      rocblas_evect compc,
+                                      rocblas_int n,
+                                      double* D,
+                                      double* E,
+                                      double* C,
+                                      rocblas_int ldc,
+                                      rocblas_int* info)
+{
+    return rocblas_status_not_implemented; // rocsolver_dsteqr(handle, compc, n, D, E, C, ldc, info);
+}
+
+inline rocblas_status rocsolver_steqr(rocblas_handle handle,
+                                      rocblas_evect compc,
+                                      rocblas_int n,
+                                      float* D,
+                                      float* E,
+                                      rocblas_float_complex* C,
+                                      rocblas_int ldc,
+                                      rocblas_int* info)
+{
+    return rocblas_status_not_implemented; // rocsolver_csteqr(handle, compc, n, D, E, C, ldc, info);
+}
+
+inline rocblas_status rocsolver_steqr(rocblas_handle handle,
+                                      rocblas_evect compc,
+                                      rocblas_int n,
+                                      double* D,
+                                      double* E,
+                                      rocblas_double_complex* C,
+                                      rocblas_int ldc,
+                                      rocblas_int* info)
+{
+    return rocblas_status_not_implemented; // rocsolver_zsteqr(handle, compc, n, D, E, C, ldc, info);
+}
+/********************************************************/
+
 /******************** POTF2_POTRF ********************/
 // normal and strided_batched
 inline rocblas_status rocsolver_potf2_potrf(bool STRIDED,

--- a/rocsolver/clients/include/rocsolver.hpp
+++ b/rocsolver/clients/include/rocsolver.hpp
@@ -1135,13 +1135,13 @@ inline rocblas_status rocsolver_ormtr_unmtr(rocblas_handle handle,
 inline rocblas_status
     rocsolver_sterf(rocblas_handle handle, rocblas_int n, float* D, float* E, rocblas_int* info)
 {
-    return rocblas_status_not_implemented; // rocsolver_ssterf(handle, n, D, E, info);
+    return rocsolver_ssterf(handle, n, D, E, info);
 }
 
 inline rocblas_status
     rocsolver_sterf(rocblas_handle handle, rocblas_int n, double* D, double* E, rocblas_int* info)
 {
-    return rocblas_status_not_implemented; // rocsolver_dsterf(handle, n, D, E, info);
+    return rocsolver_dsterf(handle, n, D, E, info);
 }
 /********************************************************/
 

--- a/rocsolver/clients/include/rocsolver_arguments.hpp
+++ b/rocsolver/clients/include/rocsolver_arguments.hpp
@@ -48,6 +48,7 @@ public:
     char storev = 'C';
     char left_svect = 'N';
     char right_svect = 'N';
+    char evect = 'N';
 
     rocblas_int apiCallCount = 1;
     rocblas_int batch_count = 5;

--- a/rocsolver/clients/include/rocsolver_datatype2string.hpp
+++ b/rocsolver/clients/include/rocsolver_datatype2string.hpp
@@ -53,6 +53,17 @@ constexpr auto rocblas2char_svect(rocblas_svect value)
     return '\0';
 }
 
+constexpr auto rocblas2char_evect(rocblas_evect value)
+{
+    switch(value)
+    {
+    case rocblas_evect_original: return 'V';
+    case rocblas_evect_tridiagonal: return 'I';
+    case rocblas_evect_none: return 'N';
+    }
+    return '\0';
+}
+
 /*  Convert lapack char constants to rocblas type. */
 
 constexpr rocblas_direct char2rocblas_direct(char value)
@@ -94,6 +105,17 @@ constexpr rocblas_svect char2rocblas_svect(char value)
     case 'O': return rocblas_svect_overwrite;
     case 'N': return rocblas_svect_none;
     default: return static_cast<rocblas_svect>(-1);
+    }
+}
+
+constexpr rocblas_evect char2rocblas_evect(char value)
+{
+    switch(value)
+    {
+    case 'V': return rocblas_evect_original;
+    case 'I': return rocblas_evect_tridiagonal;
+    case 'N': return rocblas_evect_none;
+    default: return static_cast<rocblas_evect>(-1);
     }
 }
 

--- a/rocsolver/clients/include/testing_steqr.hpp
+++ b/rocsolver/clients/include/testing_steqr.hpp
@@ -1,0 +1,356 @@
+/* ************************************************************************
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include "cblas_interface.h"
+#include "clientcommon.hpp"
+#include "norm.hpp"
+#include "rocsolver.hpp"
+#include "rocsolver_arguments.hpp"
+#include "rocsolver_test.hpp"
+
+template <typename S, typename T, typename U>
+void steqr_checkBadArgs(const rocblas_handle handle,
+                        const rocblas_evect compc,
+                        const rocblas_int n,
+                        S dD,
+                        S dE,
+                        T dC,
+                        const rocblas_int ldc,
+                        U dInfo)
+{
+    // handle
+    EXPECT_ROCBLAS_STATUS(rocsolver_steqr(nullptr, compc, n, dD, dE, dC, ldc, dInfo),
+                          rocblas_status_invalid_handle);
+
+    // values
+    EXPECT_ROCBLAS_STATUS(rocsolver_steqr(handle, rocblas_evect(-1), n, dD, dE, dC, ldc, dInfo),
+                          rocblas_status_invalid_value);
+
+    // pointers
+    EXPECT_ROCBLAS_STATUS(rocsolver_steqr(handle, compc, n, (S) nullptr, dE, dC, ldc, dInfo),
+                          rocblas_status_invalid_pointer);
+    EXPECT_ROCBLAS_STATUS(rocsolver_steqr(handle, compc, n, dD, (S) nullptr, dC, ldc, dInfo),
+                          rocblas_status_invalid_pointer);
+    EXPECT_ROCBLAS_STATUS(rocsolver_steqr(handle, compc, n, dD, dE, (T) nullptr, ldc, dInfo),
+                          rocblas_status_invalid_pointer);
+    EXPECT_ROCBLAS_STATUS(rocsolver_steqr(handle, compc, n, dD, dE, dC, ldc, (U) nullptr),
+                          rocblas_status_invalid_pointer);
+
+    // quick return with invalid pointers
+    EXPECT_ROCBLAS_STATUS(
+        rocsolver_steqr(handle, compc, 0, (S) nullptr, (S) nullptr, (T) nullptr, ldc, dInfo),
+        rocblas_status_success);
+}
+
+template <typename S, typename T>
+void testing_steqr_bad_arg()
+{
+    // safe arguments
+    rocblas_local_handle handle;
+    rocblas_evect compc = rocblas_evect_original;
+    rocblas_int n = 1;
+    rocblas_int ldc = 1;
+
+    // memory allocations
+    device_strided_batch_vector<S> dD(1, 1, 1, 1);
+    device_strided_batch_vector<S> dE(1, 1, 1, 1);
+    device_strided_batch_vector<T> dC(1, 1, 1, 1);
+    device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, 1);
+    CHECK_HIP_ERROR(dD.memcheck());
+    CHECK_HIP_ERROR(dE.memcheck());
+    CHECK_HIP_ERROR(dC.memcheck());
+    CHECK_HIP_ERROR(dInfo.memcheck());
+
+    // check bad arguments
+    steqr_checkBadArgs(handle, compc, n, dD.data(), dE.data(), dC.data(), ldc, dInfo.data());
+}
+
+template <bool CPU, bool GPU, typename S, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+void steqr_initData(const rocblas_handle handle,
+                    const rocblas_evect compc,
+                    const rocblas_int n,
+                    Sd& dD,
+                    Sd& dE,
+                    Td& dC,
+                    const rocblas_int ldc,
+                    Ud& dInfo,
+                    Sh& hD,
+                    Sh& hE,
+                    Th& hC,
+                    Uh& hInfo,
+                    std::vector<T>& hW,
+                    size_t size_W)
+{
+    if(CPU)
+    {
+        std::vector<T> ipiv(n - 1);
+        int ldc_valid = max(n, ldc);
+
+        rocblas_init<T>(hC, true);
+
+        // scale C to avoid singularities
+        for(rocblas_int i = 0; i < n; i++)
+        {
+            for(rocblas_int j = 0; j < n; j++)
+            {
+                if(i == j)
+                    hC[0][i + j * ldc_valid] += 400;
+                else
+                    hC[0][i + j * ldc_valid] -= 4;
+            }
+        }
+
+        // compute sytrd/hetrd
+        cblas_sytrd_hetrd<S, T>(rocblas_fill_upper, n, hC[0], ldc_valid, hD[0], hE[0], ipiv.data(),
+                                hW.data(), size_W);
+
+        if(compc == rocblas_evect_original)
+            cblas_orgtr_ungtr<T>(rocblas_fill_upper, n, hC[0], ldc_valid, ipiv.data(), hW.data(),
+                                 size_W);
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dD.transfer_from(hD));
+        CHECK_HIP_ERROR(dE.transfer_from(hE));
+
+        if(compc == rocblas_evect_original)
+            CHECK_HIP_ERROR(dC.transfer_from(hC));
+    }
+}
+
+template <typename S, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+void steqr_getError(const rocblas_handle handle,
+                    const rocblas_evect compc,
+                    const rocblas_int n,
+                    Sd& dD,
+                    Sd& dE,
+                    Td& dC,
+                    const rocblas_int ldc,
+                    Ud& dInfo,
+                    Sh& hD,
+                    Sh& hDRes,
+                    Sh& hE,
+                    Sh& hERes,
+                    Th& hC,
+                    Th& hCRes,
+                    Uh& hInfo,
+                    double* max_err)
+{
+    size_t size_W = n * 32;
+    size_t size_W2 = (compc == rocblas_evect_none ? 0 : 2 * n - 2);
+    std::vector<T> hW(size_W);
+    std::vector<S> hW2(size_W2);
+    int ldc_valid = max(n, ldc);
+
+    // input data initialization
+    steqr_initData<true, true, S, T>(handle, compc, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo,
+                                     hW, size_W);
+
+    // execute computations
+    // GPU lapack
+    CHECK_ROCBLAS_ERROR(
+        rocsolver_steqr(handle, compc, n, dD.data(), dE.data(), dC.data(), ldc, dInfo.data()));
+    CHECK_HIP_ERROR(hDRes.transfer_from(dD));
+    CHECK_HIP_ERROR(hERes.transfer_from(dE));
+    if(compc != rocblas_evect_none)
+        CHECK_HIP_ERROR(hCRes.transfer_from(dC));
+
+    // CPU lapack
+    cblas_steqr<S, T>(compc, n, hD[0], hE[0], hC[0], ldc_valid, hW2.data());
+
+    // error is ||hD - hDRes|| / ||hD||
+    // using frobenius norm
+    double err;
+    *max_err = norm_error('F', 1, n, 1, hD[0], hDRes[0]);
+    if(compc != rocblas_evect_none)
+    {
+        err = norm_error('F', n, n, ldc, hC[0], hCRes[0]);
+        *max_err = err > *max_err ? err : *max_err;
+    }
+}
+
+template <typename S, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+void steqr_getPerfData(const rocblas_handle handle,
+                       const rocblas_evect compc,
+                       const rocblas_int n,
+                       Sd& dD,
+                       Sd& dE,
+                       Td& dC,
+                       const rocblas_int ldc,
+                       Ud& dInfo,
+                       Sh& hD,
+                       Sh& hE,
+                       Th& hC,
+                       Uh& hInfo,
+                       double* gpu_time_used,
+                       double* cpu_time_used,
+                       const rocblas_int hot_calls,
+                       const bool perf)
+{
+    size_t size_W = n * 32;
+    size_t size_W2 = (compc == rocblas_evect_none ? 0 : 2 * n - 2);
+    std::vector<T> hW(size_W);
+    std::vector<S> hW2(size_W2);
+    int ldc_valid = max(n, ldc);
+
+    if(!perf)
+    {
+        steqr_initData<true, false, S, T>(handle, compc, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
+                                          hInfo, hW, size_W);
+
+        // cpu-lapack performance (only if not in perf mode)
+        *cpu_time_used = get_time_us();
+        cblas_steqr<S, T>(compc, n, hD[0], hE[0], hC[0], ldc_valid, hW2.data());
+        *cpu_time_used = get_time_us() - *cpu_time_used;
+    }
+
+    steqr_initData<true, false, S, T>(handle, compc, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo,
+                                      hW, size_W);
+
+    // cold calls
+    for(int iter = 0; iter < 2; iter++)
+    {
+        steqr_initData<false, true, S, T>(handle, compc, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
+                                          hInfo, hW, size_W);
+
+        CHECK_ROCBLAS_ERROR(
+            rocsolver_steqr(handle, compc, n, dD.data(), dE.data(), dC.data(), ldc, dInfo.data()));
+    }
+
+    // gpu-lapack performance
+    double start;
+    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    {
+        steqr_initData<false, true, S, T>(handle, compc, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
+                                          hInfo, hW, size_W);
+
+        start = get_time_us();
+        rocsolver_steqr(handle, compc, n, dD.data(), dE.data(), dC.data(), ldc, dInfo.data());
+        *gpu_time_used += get_time_us() - start;
+    }
+    *gpu_time_used /= hot_calls;
+}
+
+template <typename S, typename T>
+void testing_steqr(Arguments argus)
+{
+    // get arguments
+    rocblas_local_handle handle;
+    rocblas_int n = argus.N;
+    rocblas_int ldc = argus.ldc;
+    rocblas_int hot_calls = argus.iters;
+    char compcC = argus.evect;
+    rocblas_evect compc = char2rocblas_evect(compcC);
+
+    // check non-supported values
+    // N/A
+
+    // determine sizes
+    size_t size_D = n;
+    size_t size_E = n;
+    size_t size_C = max(n, ldc) * n;
+    double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
+
+    size_t size_DRes = (argus.unit_check || argus.norm_check) ? size_D : 0;
+    size_t size_ERes = (argus.unit_check || argus.norm_check) ? size_E : 0;
+    size_t size_CRes = (argus.unit_check || argus.norm_check) ? size_C : 0;
+
+    // check invalid sizes
+    bool invalid_size = (n < 0 || (compc != rocblas_evect_none && ldc < n));
+    if(invalid_size)
+    {
+        EXPECT_ROCBLAS_STATUS(rocsolver_steqr(handle, compc, n, (S*)nullptr, (S*)nullptr,
+                                              (T*)nullptr, ldc, (rocblas_int*)nullptr),
+                              rocblas_status_invalid_size);
+
+        if(argus.timing)
+            ROCSOLVER_BENCH_INFORM(1);
+
+        return;
+    }
+
+    // memory allocations
+    host_strided_batch_vector<S> hD(size_D, 1, size_D, 1);
+    host_strided_batch_vector<S> hDRes(size_DRes, 1, size_DRes, 1);
+    host_strided_batch_vector<S> hE(size_E, 1, size_E, 1);
+    host_strided_batch_vector<S> hERes(size_ERes, 1, size_ERes, 1);
+    host_strided_batch_vector<T> hC(size_C, 1, size_C, 1);
+    host_strided_batch_vector<T> hCRes(size_CRes, 1, size_CRes, 1);
+    host_strided_batch_vector<rocblas_int> hInfo(1, 1, 1, 1);
+    device_strided_batch_vector<S> dD(size_D, 1, size_D, 1);
+    device_strided_batch_vector<S> dE(size_E, 1, size_E, 1);
+    device_strided_batch_vector<T> dC(size_C, 1, size_C, 1);
+    device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, 1);
+    if(size_D)
+        CHECK_HIP_ERROR(dD.memcheck());
+    if(size_E)
+        CHECK_HIP_ERROR(dE.memcheck());
+    if(size_C)
+        CHECK_HIP_ERROR(dC.memcheck());
+    CHECK_HIP_ERROR(dInfo.memcheck());
+
+    // check quick return
+    if(n == 0)
+    {
+        EXPECT_ROCBLAS_STATUS(
+            rocsolver_steqr(handle, compc, n, dD.data(), dE.data(), dC.data(), ldc, dInfo.data()),
+            rocblas_status_success);
+        if(argus.timing)
+            ROCSOLVER_BENCH_INFORM(0);
+
+        return;
+    }
+
+    // check computations
+    if(argus.unit_check || argus.norm_check)
+        steqr_getError<S, T>(handle, compc, n, dD, dE, dC, ldc, dInfo, hD, hDRes, hE, hERes, hC,
+                             hCRes, hInfo, &max_error);
+
+    // collect performance data
+    if(argus.timing)
+        steqr_getPerfData<S, T>(handle, compc, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo,
+                                &gpu_time_used, &cpu_time_used, hot_calls, argus.perf);
+
+    // validate results for rocsolver-test
+    // using n * machine_precision as tolerance
+    if(argus.unit_check)
+        rocsolver_test_check<T>(max_error, n);
+
+    // output results for rocsolver-bench
+    if(argus.timing)
+    {
+        if(!argus.perf)
+        {
+            rocblas_cout << "\n============================================\n";
+            rocblas_cout << "Arguments:\n";
+            rocblas_cout << "============================================\n";
+            rocsolver_bench_output("compc", "n", "ldc");
+            rocsolver_bench_output(compcC, n, ldc);
+
+            rocblas_cout << "\n============================================\n";
+            rocblas_cout << "Results:\n";
+            rocblas_cout << "============================================\n";
+            if(argus.norm_check)
+            {
+                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
+            }
+            else
+            {
+                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output(cpu_time_used, gpu_time_used);
+            }
+            rocblas_cout << std::endl;
+        }
+        else
+        {
+            if(argus.norm_check)
+                rocsolver_bench_output(gpu_time_used, max_error);
+            else
+                rocsolver_bench_output(gpu_time_used);
+        }
+    }
+}

--- a/rocsolver/clients/include/testing_steqr.hpp
+++ b/rocsolver/clients/include/testing_steqr.hpp
@@ -108,6 +108,11 @@ void steqr_initData(const rocblas_handle handle,
         if(compc == rocblas_evect_original)
             cblas_orgtr_ungtr<T>(rocblas_fill_upper, n, hC[0], ldc_valid, ipiv.data(), hW.data(),
                                  size_W);
+
+        // add a split in the matrix to test split handling
+        rocblas_int k = n / 2;
+        hE[0][k] = 0;
+        hE[0][k - 1] = 0;
     }
 
     if(GPU)

--- a/rocsolver/clients/include/testing_steqr.hpp
+++ b/rocsolver/clients/include/testing_steqr.hpp
@@ -75,77 +75,39 @@ void steqr_initData(const rocblas_handle handle,
                     Td& dC,
                     const rocblas_int ldc,
                     Ud& dInfo,
-                    Th& hA,
                     Sh& hD,
                     Sh& hE,
                     Th& hC,
-                    Uh& hInfo,
-                    std::vector<T>& hW,
-                    size_t size_W)
+                    Uh& hInfo)
 {
     if(CPU)
     {
-        rocblas_int lda = n;
-        std::vector<T> ipiv(n - 1);
+        rocblas_init<S>(hD, true);
+        rocblas_init<S>(hE, true);
 
-        rocblas_init<T>(hA, true);
-
-        if(compc == rocblas_evect_none)
+        // scale matrix and add random splits
+        for(rocblas_int i = 0; i < n; i++)
         {
-            // scale A to avoid singularities
-            for(rocblas_int i = 0; i < n; i++)
-            {
-                for(rocblas_int j = 0; j < n; j++)
-                {
-                    if(i == j)
-                        hA[0][i + j * lda] += 400;
-                    else
-                        hA[0][i + j * lda] -= 4;
-                }
-            }
-
-            // compute sytrd/hetrd on A
-            cblas_sytrd_hetrd<S, T>(rocblas_fill_upper, n, hA[0], lda, hD[0], hE[0], ipiv.data(),
-                                    hW.data(), size_W);
-
-            // C is ignored
+            hD[0][i] += 400;
+            hE[0][i] -= 5;
         }
-        else
+
+        // add fixed splits in the matrix to test split handling
+        rocblas_int k = n / 2;
+        hE[0][k] = 0;
+        hE[0][k - 1] = 0;
+
+        // initialize C to the identity matrix
+        if(compc == rocblas_evect_original)
         {
-            // scale A to avoid singularities
             for(rocblas_int i = 0; i < n; i++)
             {
                 for(rocblas_int j = 0; j < n; j++)
                 {
                     if(i == j)
-                        hC[0][i + j * ldc] = hA[0][i + j * lda] += 400;
+                        hC[0][i + j * ldc] = 1;
                     else
-                        hC[0][i + j * ldc] = hA[0][i + j * lda] -= 4;
-                }
-            }
-
-            // compute sytrd/hetrd on C
-            cblas_sytrd_hetrd<S, T>(rocblas_fill_upper, n, hC[0], ldc, hD[0], hE[0], ipiv.data(),
-                                    hW.data(), size_W);
-
-            if(compc == rocblas_evect_original)
-            {
-                // A is the original matrix
-                cblas_orgtr_ungtr<T>(rocblas_fill_upper, n, hC[0], ldc, ipiv.data(), hW.data(),
-                                     size_W);
-            }
-            else
-            {
-                // A is the tridiagonal matrix
-                for(rocblas_int i = 0; i < n; i++)
-                {
-                    for(rocblas_int j = 0; j < n; j++)
-                    {
-                        if(i + 1 >= j)
-                            hA[0][i + j * lda] = hC[0][i + j * ldc];
-                        else
-                            hA[0][i + j * lda] = 0;
-                    }
+                        hC[0][i + j * ldc] = 0;
                 }
             }
         }
@@ -171,7 +133,6 @@ void steqr_getError(const rocblas_handle handle,
                     Td& dC,
                     const rocblas_int ldc,
                     Ud& dInfo,
-                    Th& hA,
                     Sh& hD,
                     Sh& hDRes,
                     Sh& hE,
@@ -181,12 +142,8 @@ void steqr_getError(const rocblas_handle handle,
                     Uh& hInfo,
                     double* max_err)
 {
-    size_t size_W = n * 32;
-    std::vector<T> hW(size_W);
-
     // input data initialization
-    steqr_initData<true, true, S, T>(handle, compc, n, dD, dE, dC, ldc, dInfo, hA, hD, hE, hC,
-                                     hInfo, hW, size_W);
+    steqr_initData<true, true, S, T>(handle, compc, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo);
 
     // execute computations
     // GPU lapack
@@ -197,32 +154,53 @@ void steqr_getError(const rocblas_handle handle,
     if(compc != rocblas_evect_none)
         CHECK_HIP_ERROR(hCRes.transfer_from(dC));
 
-    // CPU lapack
-    cblas_sterf<S>(n, hD[0], hE[0]);
-
-    // error is ||hD - hDRes|| / ||hD||
-    // using frobenius norm
-    double err;
-    *max_err = norm_error('F', 1, n, 1, hD[0], hDRes[0]);
-    if(compc != rocblas_evect_none)
+    if(compc == rocblas_evect_none)
     {
-        // need to implicitly test eigenvectors due to non-uniqueness of eigenvectors
-        // under scaling
+        // only eigenvalues needed; can compare with LAPACK
+
+        // CPU lapack
+        cblas_sterf<S>(n, hD[0], hE[0]);
+
+        // error is ||hD - hDRes|| / ||hD||
+        // using frobenius norm
+        *max_err = norm_error('F', 1, n, 1, hD[0], hDRes[0]);
+    }
+    else
+    {
+        // both eigenvalues and eigenvectors needed; need to implicitly test
+        // eigenvectors due to non-uniqueness of eigenvectors under scaling
+
+        // prepare matrix A (upper triangular)
         rocblas_int lda = n;
-        T alpha;
-        T beta = 0;
+        size_t size_A = lda * n;
+        host_strided_batch_vector<T> hA(size_A, 1, size_A, 1);
+        for(rocblas_int i = 0; i < n; i++)
+        {
+            for(rocblas_int j = i; j < n; j++)
+            {
+                if(i == j)
+                    hA[0][i + j * lda] = hD[0][i];
+                else if(i + 1 == j)
+                    hA[0][i + j * lda] = hE[0][i];
+                else
+                    hA[0][i + j * lda] = 0;
+            }
+        }
 
         // multiply A with each of the n eigenvectors and divide by corresponding
         // eigenvalues
+        T alpha;
+        T beta = 0;
         for(int j = 0; j < n; j++)
         {
-            alpha = T(1) / hD[0][j];
+            alpha = T(1) / hDRes[0][j];
             cblas_symv_hemv(rocblas_fill_upper, n, alpha, hA[0], lda, hCRes[0] + j * ldc, 1, beta,
                             hC[0] + j * ldc, 1);
         }
 
-        err = norm_error('F', n, n, ldc, hC[0], hCRes[0]);
-        *max_err = err > *max_err ? err : *max_err;
+        // error is ||hC - hCRes|| / ||hC||
+        // using frobenius norm
+        *max_err = norm_error('F', n, n, ldc, hC[0], hCRes[0]);
     }
 }
 
@@ -235,7 +213,6 @@ void steqr_getPerfData(const rocblas_handle handle,
                        Td& dC,
                        const rocblas_int ldc,
                        Ud& dInfo,
-                       Th& hA,
                        Sh& hD,
                        Sh& hE,
                        Th& hC,
@@ -245,30 +222,27 @@ void steqr_getPerfData(const rocblas_handle handle,
                        const rocblas_int hot_calls,
                        const bool perf)
 {
-    size_t size_W = n * 32;
-    size_t size_W2 = (compc == rocblas_evect_none ? 0 : 2 * n - 2);
-    std::vector<T> hW(size_W);
-    std::vector<S> hW2(size_W2);
+    size_t size_W = (compc == rocblas_evect_none ? 0 : 2 * n - 2);
+    std::vector<S> hW(size_W);
 
     if(!perf)
     {
-        steqr_initData<true, false, S, T>(handle, compc, n, dD, dE, dC, ldc, dInfo, hA, hD, hE, hC,
-                                          hInfo, hW, size_W);
+        steqr_initData<true, false, S, T>(handle, compc, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
+                                          hInfo);
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us();
-        cblas_steqr<S, T>(compc, n, hD[0], hE[0], hC[0], ldc, hW2.data());
+        cblas_steqr<S, T>(compc, n, hD[0], hE[0], hC[0], ldc, hW.data());
         *cpu_time_used = get_time_us() - *cpu_time_used;
     }
 
-    steqr_initData<true, false, S, T>(handle, compc, n, dD, dE, dC, ldc, dInfo, hA, hD, hE, hC,
-                                      hInfo, hW, size_W);
+    steqr_initData<true, false, S, T>(handle, compc, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo);
 
     // cold calls
     for(int iter = 0; iter < 2; iter++)
     {
-        steqr_initData<false, true, S, T>(handle, compc, n, dD, dE, dC, ldc, dInfo, hA, hD, hE, hC,
-                                          hInfo, hW, size_W);
+        steqr_initData<false, true, S, T>(handle, compc, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
+                                          hInfo);
 
         CHECK_ROCBLAS_ERROR(
             rocsolver_steqr(handle, compc, n, dD.data(), dE.data(), dC.data(), ldc, dInfo.data()));
@@ -278,8 +252,8 @@ void steqr_getPerfData(const rocblas_handle handle,
     double start;
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
-        steqr_initData<false, true, S, T>(handle, compc, n, dD, dE, dC, ldc, dInfo, hA, hD, hE, hC,
-                                          hInfo, hW, size_W);
+        steqr_initData<false, true, S, T>(handle, compc, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
+                                          hInfo);
 
         start = get_time_us();
         rocsolver_steqr(handle, compc, n, dD.data(), dE.data(), dC.data(), ldc, dInfo.data());
@@ -294,7 +268,6 @@ void testing_steqr(Arguments argus)
     // get arguments
     rocblas_local_handle handle;
     rocblas_int n = argus.N;
-    rocblas_int lda = argus.N;
     rocblas_int ldc = argus.ldc;
     rocblas_int hot_calls = argus.iters;
     char compcC = argus.evect;
@@ -304,7 +277,6 @@ void testing_steqr(Arguments argus)
     // N/A
 
     // determine sizes
-    size_t size_A = lda * n;
     size_t size_D = n;
     size_t size_E = n;
     size_t size_C = ldc * n;
@@ -329,7 +301,6 @@ void testing_steqr(Arguments argus)
     }
 
     // memory allocations
-    host_strided_batch_vector<T> hA(size_A, 1, size_A, 1);
     host_strided_batch_vector<S> hD(size_D, 1, size_D, 1);
     host_strided_batch_vector<S> hDRes(size_DRes, 1, size_DRes, 1);
     host_strided_batch_vector<S> hE(size_E, 1, size_E, 1);
@@ -363,12 +334,12 @@ void testing_steqr(Arguments argus)
 
     // check computations
     if(argus.unit_check || argus.norm_check)
-        steqr_getError<S, T>(handle, compc, n, dD, dE, dC, ldc, dInfo, hA, hD, hDRes, hE, hERes, hC,
+        steqr_getError<S, T>(handle, compc, n, dD, dE, dC, ldc, dInfo, hD, hDRes, hE, hERes, hC,
                              hCRes, hInfo, &max_error);
 
     // collect performance data
     if(argus.timing)
-        steqr_getPerfData<S, T>(handle, compc, n, dD, dE, dC, ldc, dInfo, hA, hD, hE, hC, hInfo,
+        steqr_getPerfData<S, T>(handle, compc, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo,
                                 &gpu_time_used, &cpu_time_used, hot_calls, argus.perf);
 
     // validate results for rocsolver-test

--- a/rocsolver/clients/include/testing_steqr.hpp
+++ b/rocsolver/clients/include/testing_steqr.hpp
@@ -206,15 +206,21 @@ void steqr_getError(const rocblas_handle handle,
     *max_err = norm_error('F', 1, n, 1, hD[0], hDRes[0]);
     if(compc != rocblas_evect_none)
     {
+        // need to implicitly test eigenvectors due to non-uniqueness of eigenvectors
+        // under scaling
         rocblas_int lda = n;
         T alpha;
         T beta = 0;
+
+        // multiply A with each of the n eigenvectors and divide by corresponding
+        // eigenvalues
         for(int j = 0; j < n; j++)
         {
             alpha = T(1) / hD[0][j];
             cblas_symv_hemv(rocblas_fill_upper, n, alpha, hA[0], lda, hCRes[0] + j * ldc, 1, beta,
                             hC[0] + j * ldc, 1);
         }
+
         err = norm_error('F', n, n, ldc, hC[0], hCRes[0]);
         *max_err = err > *max_err ? err : *max_err;
     }

--- a/rocsolver/clients/include/testing_sterf.hpp
+++ b/rocsolver/clients/include/testing_sterf.hpp
@@ -85,6 +85,11 @@ void sterf_initData(const rocblas_handle handle,
         // compute sytrd/hetrd
         cblas_sytrd_hetrd<T, T>(rocblas_fill_upper, n, hA[0], lda, hD[0], hE[0], ipiv.data(),
                                 hW.data(), size_W);
+
+        // add a split in the matrix to test split handling
+        rocblas_int k = n / 2;
+        hE[0][k] = 0;
+        hE[0][k - 1] = 0;
     }
 
     if(GPU)

--- a/rocsolver/clients/include/testing_sterf.hpp
+++ b/rocsolver/clients/include/testing_sterf.hpp
@@ -1,0 +1,293 @@
+/* ************************************************************************
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include "cblas_interface.h"
+#include "clientcommon.hpp"
+#include "norm.hpp"
+#include "rocsolver.hpp"
+#include "rocsolver_arguments.hpp"
+#include "rocsolver_test.hpp"
+
+template <typename T, typename U>
+void sterf_checkBadArgs(const rocblas_handle handle, const rocblas_int n, T dD, T dE, U dInfo)
+{
+    // handle
+    EXPECT_ROCBLAS_STATUS(rocsolver_sterf(nullptr, n, dD, dE, dInfo), rocblas_status_invalid_handle);
+
+    // values
+    // N/A
+
+    // pointers
+    EXPECT_ROCBLAS_STATUS(rocsolver_sterf(handle, n, (T) nullptr, dE, dInfo),
+                          rocblas_status_invalid_pointer);
+    EXPECT_ROCBLAS_STATUS(rocsolver_sterf(handle, n, dD, (T) nullptr, dInfo),
+                          rocblas_status_invalid_pointer);
+    EXPECT_ROCBLAS_STATUS(rocsolver_sterf(handle, n, dD, dE, (U) nullptr),
+                          rocblas_status_invalid_pointer);
+
+    // quick return with invalid pointers
+    EXPECT_ROCBLAS_STATUS(rocsolver_sterf(handle, 0, (T) nullptr, (T) nullptr, dInfo),
+                          rocblas_status_success);
+}
+
+template <typename T>
+void testing_sterf_bad_arg()
+{
+    // safe arguments
+    rocblas_local_handle handle;
+    rocblas_int n = 1;
+
+    // memory allocations
+    device_strided_batch_vector<T> dD(1, 1, 1, 1);
+    device_strided_batch_vector<T> dE(1, 1, 1, 1);
+    device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, 1);
+    CHECK_HIP_ERROR(dD.memcheck());
+    CHECK_HIP_ERROR(dE.memcheck());
+    CHECK_HIP_ERROR(dInfo.memcheck());
+
+    // check bad arguments
+    sterf_checkBadArgs(handle, n, dD.data(), dE.data(), dInfo.data());
+}
+
+template <bool CPU, bool GPU, typename T, typename Td, typename Ud, typename Th, typename Uh, typename Vh>
+void sterf_initData(const rocblas_handle handle,
+                    const rocblas_int n,
+                    Td& dD,
+                    Td& dE,
+                    Ud& dInfo,
+                    Vh& hA,
+                    Th& hD,
+                    Th& hE,
+                    Uh& hInfo,
+                    std::vector<T>& hW,
+                    size_t size_W)
+{
+    if(CPU)
+    {
+        rocblas_int lda = n;
+        std::vector<T> ipiv(n - 1);
+
+        rocblas_init<T>(hA, true);
+
+        // scale A to avoid singularities
+        for(rocblas_int i = 0; i < n; i++)
+        {
+            for(rocblas_int j = 0; j < n; j++)
+            {
+                if(i == j)
+                    hA[0][i + j * lda] += 400;
+                else
+                    hA[0][i + j * lda] -= 4;
+            }
+        }
+
+        // compute sytrd/hetrd
+        cblas_sytrd_hetrd<T, T>(rocblas_fill_upper, n, hA[0], lda, hD[0], hE[0], ipiv.data(),
+                                hW.data(), size_W);
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dD.transfer_from(hD));
+        CHECK_HIP_ERROR(dE.transfer_from(hE));
+    }
+}
+
+template <typename T, typename Td, typename Ud, typename Th, typename Uh, typename Vh>
+void sterf_getError(const rocblas_handle handle,
+                    const rocblas_int n,
+                    Td& dD,
+                    Td& dE,
+                    Ud& dInfo,
+                    Vh& hA,
+                    Th& hD,
+                    Th& hDRes,
+                    Th& hE,
+                    Th& hERes,
+                    Uh& hInfo,
+                    double* max_err)
+{
+    size_t size_W = n * 32;
+    std::vector<T> hW(size_W);
+
+    // input data initialization
+    sterf_initData<true, true, T>(handle, n, dD, dE, dInfo, hA, hD, hE, hInfo, hW, size_W);
+
+    // execute computations
+    // GPU lapack
+    CHECK_ROCBLAS_ERROR(rocsolver_sterf(handle, n, dD.data(), dE.data(), dInfo.data()));
+    CHECK_HIP_ERROR(hDRes.transfer_from(dD));
+    CHECK_HIP_ERROR(hERes.transfer_from(dE));
+
+    // CPU lapack
+    cblas_sterf<T>(n, hD[0], hE[0]);
+
+    // error is ||hD - hDRes|| / ||hD||
+    // using frobenius norm
+    *max_err = norm_error('F', 1, n, 1, hD[0], hDRes[0]);
+}
+
+template <typename T, typename Td, typename Ud, typename Th, typename Uh, typename Vh>
+void sterf_getPerfData(const rocblas_handle handle,
+                       const rocblas_int n,
+                       Td& dD,
+                       Td& dE,
+                       Ud& dInfo,
+                       Vh& hA,
+                       Th& hD,
+                       Th& hE,
+                       Uh& hInfo,
+                       double* gpu_time_used,
+                       double* cpu_time_used,
+                       const rocblas_int hot_calls,
+                       const bool perf)
+{
+    size_t size_W = n * 32;
+    std::vector<T> hW(size_W);
+
+    if(!perf)
+    {
+        sterf_initData<true, false, T>(handle, n, dD, dE, dInfo, hA, hD, hE, hInfo, hW, size_W);
+
+        // cpu-lapack performance (only if not in perf mode)
+        *cpu_time_used = get_time_us();
+        cblas_sterf<T>(n, hD[0], hE[0]);
+        *cpu_time_used = get_time_us() - *cpu_time_used;
+    }
+
+    sterf_initData<true, false, T>(handle, n, dD, dE, dInfo, hA, hD, hE, hInfo, hW, size_W);
+
+    // cold calls
+    for(int iter = 0; iter < 2; iter++)
+    {
+        sterf_initData<false, true, T>(handle, n, dD, dE, dInfo, hA, hD, hE, hInfo, hW, size_W);
+
+        CHECK_ROCBLAS_ERROR(rocsolver_sterf(handle, n, dD.data(), dE.data(), dInfo.data()));
+    }
+
+    // gpu-lapack performance
+    double start;
+    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    {
+        sterf_initData<false, true, T>(handle, n, dD, dE, dInfo, hA, hD, hE, hInfo, hW, size_W);
+
+        start = get_time_us();
+        rocsolver_sterf(handle, n, dD.data(), dE.data(), dInfo.data());
+        *gpu_time_used += get_time_us() - start;
+    }
+    *gpu_time_used /= hot_calls;
+}
+
+template <typename T>
+void testing_sterf(Arguments argus)
+{
+    // get arguments
+    rocblas_local_handle handle;
+    rocblas_int n = argus.N;
+    rocblas_int lda = argus.N;
+    rocblas_int hot_calls = argus.iters;
+
+    // check non-supported values
+    // N/A
+
+    // determine sizes
+    size_t size_A = lda * n;
+    size_t size_D = n;
+    size_t size_E = n;
+    double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
+
+    size_t size_DRes = (argus.unit_check || argus.norm_check) ? size_D : 0;
+    size_t size_ERes = (argus.unit_check || argus.norm_check) ? size_E : 0;
+
+    // check invalid sizes
+    bool invalid_size = (n < 0);
+    if(invalid_size)
+    {
+        EXPECT_ROCBLAS_STATUS(
+            rocsolver_sterf(handle, n, (T*)nullptr, (T*)nullptr, (rocblas_int*)nullptr),
+            rocblas_status_invalid_size);
+
+        if(argus.timing)
+            ROCSOLVER_BENCH_INFORM(1);
+
+        return;
+    }
+
+    // memory allocations
+    host_strided_batch_vector<T> hA(size_A, 1, size_A, 1);
+    host_strided_batch_vector<T> hD(size_D, 1, size_D, 1);
+    host_strided_batch_vector<T> hDRes(size_DRes, 1, size_DRes, 1);
+    host_strided_batch_vector<T> hE(size_E, 1, size_E, 1);
+    host_strided_batch_vector<T> hERes(size_ERes, 1, size_ERes, 1);
+    host_strided_batch_vector<rocblas_int> hInfo(1, 1, 1, 1);
+    device_strided_batch_vector<T> dD(size_D, 1, size_D, 1);
+    device_strided_batch_vector<T> dE(size_E, 1, size_E, 1);
+    device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, 1);
+    if(size_D)
+        CHECK_HIP_ERROR(dD.memcheck());
+    if(size_E)
+        CHECK_HIP_ERROR(dE.memcheck());
+    CHECK_HIP_ERROR(dInfo.memcheck());
+
+    // check quick return
+    if(n == 0)
+    {
+        EXPECT_ROCBLAS_STATUS(rocsolver_sterf(handle, n, dD.data(), dE.data(), dInfo.data()),
+                              rocblas_status_success);
+        if(argus.timing)
+            ROCSOLVER_BENCH_INFORM(0);
+
+        return;
+    }
+
+    // check computations
+    if(argus.unit_check || argus.norm_check)
+        sterf_getError<T>(handle, n, dD, dE, dInfo, hA, hD, hDRes, hE, hERes, hInfo, &max_error);
+
+    // collect performance data
+    if(argus.timing)
+        sterf_getPerfData<T>(handle, n, dD, dE, dInfo, hA, hD, hE, hInfo, &gpu_time_used,
+                             &cpu_time_used, hot_calls, argus.perf);
+
+    // validate results for rocsolver-test
+    // using n * machine_precision as tolerance
+    if(argus.unit_check)
+        rocsolver_test_check<T>(max_error, n);
+
+    // output results for rocsolver-bench
+    if(argus.timing)
+    {
+        if(!argus.perf)
+        {
+            rocblas_cout << "\n============================================\n";
+            rocblas_cout << "Arguments:\n";
+            rocblas_cout << "============================================\n";
+            rocsolver_bench_output("n");
+            rocsolver_bench_output(n);
+
+            rocblas_cout << "\n============================================\n";
+            rocblas_cout << "Results:\n";
+            rocblas_cout << "============================================\n";
+            if(argus.norm_check)
+            {
+                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
+            }
+            else
+            {
+                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output(cpu_time_used, gpu_time_used);
+            }
+            rocblas_cout << std::endl;
+        }
+        else
+        {
+            if(argus.norm_check)
+                rocsolver_bench_output(gpu_time_used, max_error);
+            else
+                rocsolver_bench_output(gpu_time_used);
+        }
+    }
+}

--- a/rocsolver/library/include/rocsolver-extra-types.h
+++ b/rocsolver/library/include/rocsolver-extra-types.h
@@ -36,25 +36,25 @@ typedef enum rocblas_svect_
     rocblas_svect_none = 194, /**< No singular vectors are computed. */
 } rocblas_svect;
 
-/*! \brief Used to specify how the eigenvectors are to be computed
- ********************************************************************************/
-typedef enum rocblas_evect_
-{
-    rocblas_evect_original = 201, /**< Compute eigenvectors for the original symmetric/Hermitian
-                                    matrix. */
-    rocblas_evect_tridiagonal = 202, /**< Compute eigenvectors for the symmetric tridiagonal
-                                    matrix. */
-    rocblas_evect_none = 203, /**< No eigenvectors are computed. */
-} rocblas_evect;
-
 /*! \brief Used to enable the use of fast algorithms (with out-of-place
  *computations) in some of the routines
  ********************************************************************************/
 typedef enum rocblas_workmode_
 {
-    rocblas_outofplace = 211, /**< Out-of-place computations are allowed; this
+    rocblas_outofplace = 201, /**< Out-of-place computations are allowed; this
                                requires enough free memory. */
-    rocblas_inplace = 212, /**< When not enough memory, this forces in-place computations  */
+    rocblas_inplace = 202, /**< When not enough memory, this forces in-place computations  */
 } rocblas_workmode;
+
+/*! \brief Used to specify how the eigenvectors are to be computed
+ ********************************************************************************/
+typedef enum rocblas_evect_
+{
+    rocblas_evect_original = 211, /**< Compute eigenvectors for the original symmetric/Hermitian
+                                    matrix. */
+    rocblas_evect_tridiagonal = 212, /**< Compute eigenvectors for the symmetric tridiagonal
+                                    matrix. */
+    rocblas_evect_none = 213, /**< No eigenvectors are computed. */
+} rocblas_evect;
 
 #endif

--- a/rocsolver/library/include/rocsolver-extra-types.h
+++ b/rocsolver/library/include/rocsolver-extra-types.h
@@ -36,14 +36,25 @@ typedef enum rocblas_svect_
     rocblas_svect_none = 194, /**< No singular vectors are computed. */
 } rocblas_svect;
 
+/*! \brief Used to specify how the eigenvectors are to be computed
+ ********************************************************************************/
+typedef enum rocblas_evect_
+{
+    rocblas_evect_original = 201, /**< Compute eigenvectors for the original symmetric/Hermitian
+                                    matrix. */
+    rocblas_evect_tridiagonal = 202, /**< Compute eigenvectors for the symmetric tridiagonal
+                                    matrix. */
+    rocblas_evect_none = 203, /**< No eigenvectors are computed. */
+} rocblas_evect;
+
 /*! \brief Used to enable the use of fast algorithms (with out-of-place
  *computations) in some of the routines
  ********************************************************************************/
 typedef enum rocblas_workmode_
 {
-    rocblas_outofplace = 201, /**< Out-of-place computations are allowed; this
+    rocblas_outofplace = 211, /**< Out-of-place computations are allowed; this
                                requires enough free memory. */
-    rocblas_inplace = 202, /**< When not enough memory, this forces in-place computations  */
+    rocblas_inplace = 212, /**< When not enough memory, this forces in-place computations  */
 } rocblas_workmode;
 
 #endif

--- a/rocsolver/library/include/rocsolver-functions.h
+++ b/rocsolver/library/include/rocsolver-functions.h
@@ -3226,6 +3226,95 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_dsterf(rocblas_handle handle,
                                                  rocblas_int* info);
 //! @}
 
+/*! @{
+    \brief STEQR computes the eigenvalues and (optionally) eigenvectors of
+    a symmetric tridiagonal matrix.
+
+    \details
+    The eigenvalues of the symmetric tridiagonal matrix are computed by the
+    implicit QL/QR algorithm, and returned in increasing order.
+
+    The matrix is not represented explicitly, but rather as the array of
+    diagonal elements D and the array of symmetric off-diagonal elements E
+    as returned by, e.g., SYTRD or HETRD. If the tridiagonal matrix is the
+    reduced form of a full symmetric/Hermitian matrix as returned by, e.g.,
+    SYTRD or HETRD, then the eigenvectors of the original matrix can also
+    be found.
+
+    @param[in]
+    handle    rocblas_handle.
+    @param[in]
+    compC     #rocblas_evect.\n
+              Specifies how the eigenvectors are computed.
+    @param[in]
+    n         rocblas_int. n >= 0.\n
+              The number of rows and columns of the tridiagonal matrix.
+    @param[inout]
+    D         pointer to real type. Array on the GPU of dimension n.\n
+              On entry, the diagonal elements of the matrix.
+              On exit, if info = 0, the eigenvalues in increasing order.
+    @param[inout]
+    E         pointer to real type. Array on the GPU of dimension n-1.\n
+              On entry, the off-diagonal elements of the matrix.
+              On exit, if info = 0, this matrix converges to zero.
+    @param[inout]
+    C         pointer to type. Array on the GPU of dimension ldc*n.\n
+              On entry, if compC is original, the orthogonal/unitary matrix
+              used for the reduction to tridiagonal form as returned by, e.g.,
+              ORGTR or UNGTR.
+              On exit, it is overwritten with the eigenvectors of the original
+              symmetric/Hermitian matrix (if compC is original), or the
+              eigenvectors of the tridiagonal matrix (if compC is tridiagonal).
+              (Not referenced if compC is none).
+    @param[in]
+    ldc       rocblas_int. ldc >= n if compc is original or tridiagonal.\n
+              Specifies the leading dimension of C.
+              (Not referenced if compC is none).
+    @param[out]
+    info      pointer to a rocblas_int on the GPU.\n
+              If info = 0, successful exit.
+              If info = i > 0, STEQR did not converge. i elements of E did not
+              converge to zero.
+
+    ********************************************************************/
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_ssteqr(rocblas_handle handle,
+                                                 const rocblas_evect compC,
+                                                 const rocblas_int n,
+                                                 float* D,
+                                                 float* E,
+                                                 float* C,
+                                                 const rocblas_int ldc,
+                                                 rocblas_int* info);
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_dsteqr(rocblas_handle handle,
+                                                 const rocblas_evect compC,
+                                                 const rocblas_int n,
+                                                 double* D,
+                                                 double* E,
+                                                 double* C,
+                                                 const rocblas_int ldc,
+                                                 rocblas_int* info);
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_csteqr(rocblas_handle handle,
+                                                 const rocblas_evect compC,
+                                                 const rocblas_int n,
+                                                 float* D,
+                                                 float* E,
+                                                 rocblas_float_complex* C,
+                                                 const rocblas_int ldc,
+                                                 rocblas_int* info);
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_zsteqr(rocblas_handle handle,
+                                                 const rocblas_evect compC,
+                                                 const rocblas_int n,
+                                                 double* D,
+                                                 double* E,
+                                                 rocblas_double_complex* C,
+                                                 const rocblas_int ldc,
+                                                 rocblas_int* info);
+//! @}
+
 /*
  * ===========================================================================
  *      LAPACK functions

--- a/rocsolver/library/include/rocsolver-functions.h
+++ b/rocsolver/library/include/rocsolver-functions.h
@@ -3178,13 +3178,59 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zbdsqr(rocblas_handle handle,
                                                  rocblas_double_complex* C,
                                                  const rocblas_int ldc,
                                                  rocblas_int* info);
+//! @}
+
+/*! @{
+    \brief STERF computes the eigenvalues of a symmetric tridiagonal matrix.
+
+    \details
+    The eigenvalues of the symmetric tridiagonal matrix are computed by the
+    Pal-Walker-Kahan variant of the QL/QR algorithm, and returned in
+    increasing order.
+
+    The matrix is not represented explicitly, but rather as the array of
+    diagonal elements D and the array of symmetric off-diagonal elements E
+    as returned by, e.g., SYTRD or HETRD.
+
+    @param[in]
+    handle    rocblas_handle.
+    @param[in]
+    n         rocblas_int. n >= 0.\n
+              The number of rows and columns of the tridiagonal matrix.
+    @param[inout]
+    D         pointer to real type. Array on the GPU of dimension n.\n
+              On entry, the diagonal elements of the matrix.
+              On exit, if info = 0, the eigenvalues in increasing order.
+    @param[inout]
+    E         pointer to real type. Array on the GPU of dimension n-1.\n
+              On entry, the off-diagonal elements of the matrix.
+              On exit, if info = 0, this matrix converges to zero.
+    @param[out]
+    info      pointer to a rocblas_int on the GPU.\n
+              If info = 0, successful exit.
+              If info = i > 0, STERF did not converge. i elements of E did not
+              converge to zero.
+
+    ********************************************************************/
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_ssterf(rocblas_handle handle,
+                                                 const rocblas_int n,
+                                                 float* D,
+                                                 float* E,
+                                                 rocblas_int* info);
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_dsterf(rocblas_handle handle,
+                                                 const rocblas_int n,
+                                                 double* D,
+                                                 double* E,
+                                                 rocblas_int* info);
+//! @}
 
 /*
  * ===========================================================================
  *      LAPACK functions
  * ===========================================================================
  */
-//! @}
 
 /*! @{
     \brief GETF2_NPVT computes the LU factorization of a general m-by-n matrix A

--- a/rocsolver/library/include/rocsolver-functions.h
+++ b/rocsolver/library/include/rocsolver-functions.h
@@ -3319,10 +3319,16 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zbdsqr(rocblas_handle handle,
     D         pointer to real type. Array on the GPU of dimension n.\n
               On entry, the diagonal elements of the matrix.
               On exit, if info = 0, the eigenvalues in increasing order.
+              If info > 0, the diagonal elements of a tridiagonal matrix
+              that is similar to the original matrix (i.e. has the same
+              eigenvalues).
     @param[inout]
     E         pointer to real type. Array on the GPU of dimension n-1.\n
               On entry, the off-diagonal elements of the matrix.
-              On exit, if info = 0, this matrix converges to zero.
+              On exit, if info = 0, this array converges to zero.
+              If info > 0, the off-diagonal elements of a tridiagonal matrix
+              that is similar to the original matrix (i.e. has the same
+              eigenvalues).
     @param[out]
     info      pointer to a rocblas_int on the GPU.\n
               If info = 0, successful exit.
@@ -3357,7 +3363,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_dsterf(rocblas_handle handle,
     as returned by, e.g., SYTRD or HETRD. If the tridiagonal matrix is the
     reduced form of a full symmetric/Hermitian matrix as returned by, e.g.,
     SYTRD or HETRD, then the eigenvectors of the original matrix can also
-    be found.
+    be computed, depending on the value of compC.
 
     @param[in]
     handle    rocblas_handle.
@@ -3371,10 +3377,16 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_dsterf(rocblas_handle handle,
     D         pointer to real type. Array on the GPU of dimension n.\n
               On entry, the diagonal elements of the matrix.
               On exit, if info = 0, the eigenvalues in increasing order.
+              If info > 0, the diagonal elements of a tridiagonal matrix
+              that is similar to the original matrix (i.e. has the same
+              eigenvalues).
     @param[inout]
     E         pointer to real type. Array on the GPU of dimension n-1.\n
               On entry, the off-diagonal elements of the matrix.
-              On exit, if info = 0, this matrix converges to zero.
+              On exit, if info = 0, this array converges to zero.
+              If info > 0, the off-diagonal elements of a tridiagonal matrix
+              that is similar to the original matrix (i.e. has the same
+              eigenvalues).
     @param[inout]
     C         pointer to type. Array on the GPU of dimension ldc*n.\n
               On entry, if compC is original, the orthogonal/unitary matrix

--- a/rocsolver/library/include/rocsolver-functions.h
+++ b/rocsolver/library/include/rocsolver-functions.h
@@ -249,7 +249,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zlarfg(rocblas_handle handle,
     n                   rocblas_int. n >= 0.\n
                         The order (size) of the block reflector.
     @param[in]
-    k                   rocsovler_int. k >= 1.\n
+    k                   rocblas_int. k >= 1.\n
                         The number of Householder matrices.
     @param[in]
     V                   pointer to type. Array on the GPU of size ldv*k if column-wise, or ldv*n if row-wise.\n
@@ -450,7 +450,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zlarf(rocblas_handle handle,
     n                   rocblas_int. n >= 0.\n
                         Number of columns of matrix A.
     @param[in]
-    k                   rocsovler_int. k >= 1.\n
+    k                   rocblas_int. k >= 1.\n
                         The number of Householder matrices.
     @param[in]
     V                   pointer to type. Array on the GPU of size ldv*k if column-wise, ldv*n if row-wise and applying from the right,
@@ -1621,7 +1621,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zungtr(rocblas_handle handle,
 
 /*! @{
     \brief ORM2R applies a matrix Q with orthonormal columns to a general m-by-n
-   matrix C.
+    matrix C.
 
     \details
     (This is the unblocked version of the algorithm).
@@ -2647,7 +2647,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zunmql(rocblas_handle handle,
 
 /*! @{
     \brief ORMBR applies a matrix Q with orthonormal rows or columns to a
-   general m-by-n matrix C.
+    general m-by-n matrix C.
 
     \details
     If storev is column-wise, then the matrix Q has orthonormal columns.
@@ -7625,7 +7625,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zpotrf_strided_batched(rocblas_handle 
 
     The computation of the singular vectors is optional and it is controlled by
     the function arguments left_svect and right_svect as described below. When
-    computed, this function returns the tranpose (or transpose conjugate) of the
+    computed, this function returns the transpose (or transpose conjugate) of the
     right singular vectors, i.e. the rows of V'.
 
     left_svect and right_svect are #rocblas_svect enums that can take the
@@ -7690,14 +7690,14 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zpotrf_strided_batched(rocblas_handle 
                 The leading dimension of U.
     @param[out]
     V           pointer to type. Array on the GPU of dimension ldv*n. \n
-                The matrix of right singular vectors stored as rows (transposed / conjugate-tranposed).
+                The matrix of right singular vectors stored as rows (transposed / conjugate-transposed).
                 Not referenced if right_svect is set to overwrite or none.
     @param[in]
     ldv         rocblas_int. ldv >= n if right_svect is all; ldv >= min(m,n) if right_svect is
                 set to singular; or ldv >= 1 otherwise.\n The leading dimension of V.
     @param[out]
     E           pointer to real type. Array on the GPU of dimension min(m,n)-1.\n
-                This array is used to work internaly with the bidiagonal matrix
+                This array is used to work internally with the bidiagonal matrix
                 B associated to A (using BDSQR). On exit, if info > 0, it contains the
                 unconverged off-diagonal elements of B (or properly speaking, a bidiagonal
                 matrix orthogonally equivalent to B). The diagonal elements of this matrix
@@ -7796,7 +7796,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgesvd(rocblas_handle handle,
 
     The computation of the singular vectors is optional and it is controlled by
     the function arguments left_svect and right_svect as described below. When
-    computed, this function returns the tranpose (or transpose conjugate) of the
+    computed, this function returns the transpose (or transpose conjugate) of the
     right singular vectors, i.e. the rows of V_j'.
 
     left_svect and right_svect are #rocblas_svect enums that can take the
@@ -7824,7 +7824,8 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgesvd(rocblas_handle handle,
     workspace. The parameter fast_alg controls whether the fast algorithm is
     executed or not. For more details see the sections
     "Tuning rocSOLVER performance" and "Memory model" on the User's guide.
-@param[in]
+
+    @param[in]
     handle      rocblas_handle.
     @param[in]
     left_svect  #rocblas_svect.\n
@@ -7871,7 +7872,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgesvd(rocblas_handle handle,
                 or strideU >= ldu*m when left_svect is equal to all.
     @param[out]
     V           pointer to type. Array on the GPU (the size depends on the value of strideV). \n
-                The matrices V_j of right singular vectors stored as rows (transposed / conjugate-tranposed).
+                The matrices V_j of right singular vectors stored as rows (transposed / conjugate-transposed).
                 Not referenced if right_svect is set to overwrite or none.
     @param[in]
     ldv         rocblas_int. ldv >= n if right_svect is all; ldv >= min(m,n) if
@@ -7884,7 +7885,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgesvd(rocblas_handle handle,
                 Normal use case is strideV >= ldv*n.
     @param[out]
     E           pointer to real type. Array on the GPU (the size depends on the value of strideE).\n
-                This array is used to work internaly with the bidiagonal matrix B_j associated to A_j (using BDSQR).
+                This array is used to work internally with the bidiagonal matrix B_j associated to A_j (using BDSQR).
                 On exit, if info > 0, it contains the unconverged off-diagonal elements of B_j (or properly speaking,
                 a bidiagonal matrix orthogonally equivalent to B_j). The diagonal elements of this matrix are in S_j;
                 those that converged correspond to a subset of the singular values of A_j (not necessarily ordered).
@@ -8008,7 +8009,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgesvd_batched(rocblas_handle handle,
 
     The computation of the singular vectors is optional and it is controlled by
     the function arguments left_svect and right_svect as described below. When
-    computed, this function returns the tranpose (or transpose conjugate) of the
+    computed, this function returns the transpose (or transpose conjugate) of the
     right singular vectors, i.e. the rows of V_j'.
 
     left_svect and right_svect are #rocblas_svect enums that can take the
@@ -8087,7 +8088,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgesvd_batched(rocblas_handle handle,
                 or strideU >= ldu*m when left_svect is equal to all.
     @param[out]
     V           pointer to type. Array on the GPU (the size depends on the value of strideV). \n
-                The matrices V_j of right singular vectors stored as rows (transposed / conjugate-tranposed).
+                The matrices V_j of right singular vectors stored as rows (transposed / conjugate-transposed).
                 Not referenced if right_svect is set to overwrite or none.
     @param[in]
     ldv         rocblas_int. ldv >= n if right_svect is all; ldv >= min(m,n) if right_svect is
@@ -8100,7 +8101,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgesvd_batched(rocblas_handle handle,
                 Normal use case is strideV >= ldv*n.
     @param[out]
     E           pointer to real type. Array on the GPU (the size depends on the value of strideE).\n
-                This array is used to work internaly with the bidiagonal matrix B_j associated to A_j (using BDSQR).
+                This array is used to work internally with the bidiagonal matrix B_j associated to A_j (using BDSQR).
                 On exit, if info > 0, it contains the unconverged off-diagonal elements of B_j (or properly speaking,
                 a bidiagonal matrix orthogonally equivalent to B_j). The diagonal elements of this matrix are in S_j;
                 those that converged correspond to a subset of the singular values of A_j (not necessarily ordered).
@@ -8211,7 +8212,6 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgesvd_strided_batched(rocblas_handle 
                                                                  rocblas_int* info,
                                                                  const rocblas_int batch_count);
 //! @}
-
 
 /*! @{
     \brief SYTD2 computes the tridiagonal form of a real symmetric matrix A.

--- a/rocsolver/library/src/CMakeLists.txt
+++ b/rocsolver/library/src/CMakeLists.txt
@@ -56,6 +56,8 @@ set( rocsolver_auxiliary_source
   # bidiagonal matrices and svd
   auxiliary/rocauxiliary_bdsqr.cpp
   auxiliary/rocauxiliary_labrd.cpp
+  # eigensolvers
+  auxiliary/rocauxiliary_sterf.cpp
 )
 
 set( rocsolver_lapack_source

--- a/rocsolver/library/src/CMakeLists.txt
+++ b/rocsolver/library/src/CMakeLists.txt
@@ -58,6 +58,7 @@ set( rocsolver_auxiliary_source
   auxiliary/rocauxiliary_labrd.cpp
   # eigensolvers
   auxiliary/rocauxiliary_sterf.cpp
+  auxiliary/rocauxiliary_steqr.cpp
 )
 
 set( rocsolver_lapack_source

--- a/rocsolver/library/src/auxiliary/rocauxiliary_bdsqr.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_bdsqr.hpp
@@ -146,11 +146,11 @@ __device__ void t2bQRstep(const rocblas_int n,
     if(nv)
         lasr(rocblas_side_left, rocblas_forward_direction, n, nv, rots, rots + n - 1, V, ldv);
     if(nu)
-        lasr(rocblas_side_right, rocblas_forward_direction, nu, n, rots + nr,
-                   rots + nr + n - 1, U, ldu);
+        lasr(rocblas_side_right, rocblas_forward_direction, nu, n, rots + nr, rots + nr + n - 1, U,
+             ldu);
     if(nc)
-        lasr(rocblas_side_left, rocblas_forward_direction, n, nc, rots + nr,
-                   rots + nr + n - 1, C, ldc);
+        lasr(rocblas_side_left, rocblas_forward_direction, n, nc, rots + nr, rots + nr + n - 1, C,
+             ldc);
 }
 
 /** B2TQRSTEP device function applies implicit QR interation to
@@ -195,8 +195,8 @@ __device__ void b2tQRstep(const rocblas_int n,
         // save rotations to update singular vectors
         if(nu || nc)
         {
-            rots[(k-1) + nr] = c;
-            rots[(k-1) + nr + n - 1] = s;
+            rots[(k - 1) + nr] = c;
+            rots[(k - 1) + nr + n - 1] = s;
         }
 
         // then apply rotation by columns
@@ -212,8 +212,8 @@ __device__ void b2tQRstep(const rocblas_int n,
         // save rotations to update singular vectors
         if(nv)
         {
-            rots[k-1] = c;
-            rots[(k-1) + n - 1] = s;
+            rots[k - 1] = c;
+            rots[(k - 1) + n - 1] = s;
         }
     }
     E[0] = f;
@@ -222,11 +222,11 @@ __device__ void b2tQRstep(const rocblas_int n,
     if(nv)
         lasr(rocblas_side_left, rocblas_backward_direction, n, nv, rots, rots + n - 1, V, ldv);
     if(nu)
-        lasr(rocblas_side_right, rocblas_backward_direction, nu, n, rots + nr,
-                   rots + nr + n - 1, U, ldu);
+        lasr(rocblas_side_right, rocblas_backward_direction, nu, n, rots + nr, rots + nr + n - 1, U,
+             ldu);
     if(nc)
-        lasr(rocblas_side_left, rocblas_backward_direction, n, nc, rots + nr,
-                   rots + nr + n - 1, C, ldc);
+        lasr(rocblas_side_left, rocblas_backward_direction, n, nc, rots + nr, rots + nr + n - 1, C,
+             ldc);
 }
 
 /** BDSQRKERNEL implements the main loop of the bdsqr algorithm

--- a/rocsolver/library/src/auxiliary/rocauxiliary_bdsqr.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_bdsqr.hpp
@@ -54,18 +54,6 @@ __device__ T estimate(const rocblas_int n, T* D, T* E, int t2b, T tol, int conve
     return smin;
 }
 
-/** MAXVAL device function extracts the maximum absolute value
-    element of all the n elements of vector V **/
-template <typename T>
-__device__ T maxval(const rocblas_int n, T* V)
-{
-    T maxv = std::abs(V[0]);
-    for(rocblas_int i = 1; i < n; ++i)
-        maxv = (std::abs(V[i]) > maxv) ? std::abs(V[i]) : maxv;
-
-    return maxv;
-}
-
 /** NEGVECT device function multiply a vector x of dimension n by -1**/
 template <typename T>
 __device__ void negvect(const rocblas_int n, T* x, const rocblas_int incx)
@@ -326,9 +314,7 @@ __global__ void bdsqrKernel(const rocblas_int n,
                 sh = std::abs(D[k]);
             }
             smin = estimate<S>(k - i + 1, D + i, E + i, t2b, tol, 1); // shift
-            smax = std::max(maxval<S>(k - i + 1, D + i),
-                            maxval<S>(k - i,
-                                      E + i)); // estimate of the largest singular value in the block
+            smax = find_max_tridiag(i, k, D, E); // estimate of the largest singular value in the block
 
             // check for gaps, if none then continue
             if(smin >= 0)

--- a/rocsolver/library/src/auxiliary/rocauxiliary_steqr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_steqr.cpp
@@ -1,0 +1,103 @@
+/* ************************************************************************
+ * Copyright (c) 2019-2020 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include "rocauxiliary_steqr.hpp"
+
+template <typename S, typename T>
+rocblas_status rocsolver_steqr_impl(rocblas_handle handle,
+                                    const rocblas_evect compc,
+                                    const rocblas_int n,
+                                    S* D,
+                                    S* E,
+                                    T* C,
+                                    const rocblas_int ldc,
+                                    rocblas_int* info)
+{
+    if(!handle)
+        return rocblas_status_invalid_handle;
+
+    // logging is missing ???
+
+    // argument checking
+    rocblas_status st = rocsolver_steqr_argCheck(compc, n, D, E, C, ldc, info);
+    if(st != rocblas_status_continue)
+        return st;
+
+    // working with unshifted arrays
+    rocblas_int shiftD = 0;
+    rocblas_int shiftE = 0;
+    rocblas_int shiftC = 0;
+
+    // normal (non-batched non-strided) execution
+    rocblas_stride strideD = 0;
+    rocblas_stride strideE = 0;
+    rocblas_stride strideC = 0;
+    rocblas_int batch_count = 1;
+
+    // this function does not require memory work space
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_size_unchanged;
+
+    // execution
+    return rocsolver_steqr_template<S, T>(handle, compc, n, D, shiftD, strideD, E, shiftE, strideE,
+                                          C, shiftC, ldc, strideC, info, batch_count);
+}
+
+/*
+ * ===========================================================================
+ *    C wrapper
+ * ===========================================================================
+ */
+
+extern "C" {
+
+rocblas_status rocsolver_ssteqr(rocblas_handle handle,
+                                const rocblas_evect compc,
+                                const rocblas_int n,
+                                float* D,
+                                float* E,
+                                float* C,
+                                const rocblas_int ldc,
+                                rocblas_int* info)
+{
+    return rocsolver_steqr_impl<float, float>(handle, compc, n, D, E, C, ldc, info);
+}
+
+rocblas_status rocsolver_dsteqr(rocblas_handle handle,
+                                const rocblas_evect compc,
+                                const rocblas_int n,
+                                double* D,
+                                double* E,
+                                double* C,
+                                const rocblas_int ldc,
+                                rocblas_int* info)
+{
+    return rocsolver_steqr_impl<double, double>(handle, compc, n, D, E, C, ldc, info);
+}
+
+rocblas_status rocsolver_csteqr(rocblas_handle handle,
+                                const rocblas_evect compc,
+                                const rocblas_int n,
+                                float* D,
+                                float* E,
+                                rocblas_float_complex* C,
+                                const rocblas_int ldc,
+                                rocblas_int* info)
+{
+    return rocsolver_steqr_impl<float, rocblas_float_complex>(handle, compc, n, D, E, C, ldc, info);
+}
+
+rocblas_status rocsolver_zsteqr(rocblas_handle handle,
+                                const rocblas_evect compc,
+                                const rocblas_int n,
+                                double* D,
+                                double* E,
+                                rocblas_double_complex* C,
+                                const rocblas_int ldc,
+                                rocblas_int* info)
+{
+    return rocsolver_steqr_impl<double, rocblas_double_complex>(handle, compc, n, D, E, C, ldc, info);
+}
+
+} // extern C

--- a/rocsolver/library/src/auxiliary/rocauxiliary_steqr.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_steqr.hpp
@@ -1,0 +1,65 @@
+/************************************************************************
+ * Derived from the BSD3-licensed
+ * LAPACK routine (version 3.7.0) --
+ *     Univ. of Tennessee, Univ. of California Berkeley,
+ *     Univ. of Colorado Denver and NAG Ltd..
+ *     December 2016
+ * Copyright (c) 2019-2020 Advanced Micro Devices, Inc.
+ * ***********************************************************************/
+
+#ifndef ROCLAPACK_STEQR_HPP
+#define ROCLAPACK_STEQR_HPP
+
+#include "rocblas.hpp"
+#include "rocsolver.h"
+
+template <typename S, typename T>
+rocblas_status rocsolver_steqr_argCheck(const rocblas_evect compc,
+                                        const rocblas_int n,
+                                        S D,
+                                        S E,
+                                        T C,
+                                        const rocblas_int ldc,
+                                        rocblas_int* info)
+{
+    // order is important for unit tests:
+
+    // 1. invalid/non-supported values
+    if(compc != rocblas_evect_none && compc != rocblas_evect_tridiagonal
+       && compc != rocblas_evect_original)
+        return rocblas_status_invalid_value;
+
+    // 2. invalid size
+    if(n < 0)
+        return rocblas_status_invalid_size;
+    if(compc != rocblas_evect_none && ldc < n)
+        return rocblas_status_invalid_size;
+
+    // 3. invalid pointers
+    if((n && !D) || (n && !E) || (compc != rocblas_evect_none && n && !C) || !info)
+        return rocblas_status_invalid_pointer;
+
+    return rocblas_status_continue;
+}
+
+template <typename S, typename T, typename U>
+rocblas_status rocsolver_steqr_template(rocblas_handle handle,
+                                        const rocblas_evect compc,
+                                        const rocblas_int n,
+                                        S* D,
+                                        const rocblas_int shiftD,
+                                        const rocblas_stride strideD,
+                                        S* E,
+                                        const rocblas_int shiftE,
+                                        const rocblas_stride strideE,
+                                        U C,
+                                        const rocblas_int shiftC,
+                                        const rocblas_int ldc,
+                                        const rocblas_stride strideC,
+                                        rocblas_int* info,
+                                        const rocblas_int batch_count)
+{
+    return rocblas_status_not_implemented;
+}
+
+#endif

--- a/rocsolver/library/src/auxiliary/rocauxiliary_steqr.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_steqr.hpp
@@ -10,8 +10,319 @@
 #ifndef ROCLAPACK_STEQR_HPP
 #define ROCLAPACK_STEQR_HPP
 
+#include "rocauxiliary_sterf.hpp"
 #include "rocblas.hpp"
+#include "rocblas_device_functions.hpp"
 #include "rocsolver.h"
+
+/****************************************************************************
+(TODO:THIS IS BASIC IMPLEMENTATION. THE ONLY PARALLELISM INTRODUCED HERE IS
+  FOR THE BATCHED VERSIONS (A DIFFERENT THREAD WORKS ON EACH INSTANCE OF THE
+  BATCH).
+***************************************************************************/
+
+/** STEQR_INF_NORM finds the infinity norm of the tridiagonal matrix **/
+template <typename T>
+__device__ void steqr_inf_norm(const rocblas_int start, const rocblas_int end, T* D, T* E, T& anorm)
+{
+    if(start == end)
+        anorm = abs(D[start]);
+    else
+    {
+        anorm = abs(D[start]) + abs(E[start]);
+        T sum = abs(E[end - 1]) + abs(D[end]);
+        if(anorm < sum)
+            anorm = sum;
+        for(int i = start + 1; i < end; i++)
+        {
+            sum = abs(D[i]) + abs(E[i]) + abs(E[i - 1]);
+            if(anorm < sum)
+                anorm = sum;
+        }
+    }
+}
+
+/** STERF_KERNEL implements the main loop of the sterf algorithm
+    to compute the eigenvalues of a symmetric tridiagonal matrix given by D
+    and E **/
+template <typename S, typename T, typename U>
+__global__ void steqr_kernel(const rocblas_int n,
+                             S* DD,
+                             const rocblas_stride strideD,
+                             S* EE,
+                             const rocblas_stride strideE,
+                             U CC,
+                             const rocblas_int shiftC,
+                             const rocblas_int ldc,
+                             const rocblas_stride strideC,
+                             rocblas_int* info,
+                             S* WW,
+                             const rocblas_int max_iters,
+                             const S eps,
+                             const S ssfmin,
+                             const S ssfmax)
+{
+    rocblas_int bid = hipBlockIdx_x;
+    rocblas_stride strideW = 2 * n - 2;
+
+    S* D = DD + (bid * strideD);
+    S* E = EE + (bid * strideE);
+    T* C = load_ptr_batch<T>(CC, bid, shiftC, strideC);
+    S* work = WW + (bid * strideW);
+
+    rocblas_int m, l, lsv, lend, lendsv;
+    rocblas_int l1 = 0;
+    rocblas_int iters = 0;
+    S b, f, g, anorm, p, r, c, s;
+
+    while(l1 < n && iters < max_iters)
+    {
+        // Determine submatrix indices
+        if(l1 > 0)
+            E[l1 - 1] = 0;
+        for(m = l1; m < n - 1; m++)
+        {
+            if(abs(E[m]) <= sqrt(abs(D[m])) * sqrt(abs(D[m + 1])) * eps)
+            {
+                E[m] = 0;
+                break;
+            }
+        }
+
+        lsv = l = l1;
+        lendsv = lend = m;
+        l1 = m + 1;
+        if(lend == l)
+            continue;
+
+        // Scale submatrix
+        steqr_inf_norm(l, lend, D, E, anorm);
+        if(anorm == 0)
+            continue;
+        else if(anorm > ssfmax)
+            sterf_scale(l, lend, D, E, anorm / ssfmax);
+        else if(anorm < ssfmin)
+            sterf_scale(l, lend, D, E, anorm / ssfmin);
+
+        // Choose iteration type (QL or QR)
+        if(abs(D[lend]) < abs(D[l]))
+        {
+            lend = lsv;
+            l = lendsv;
+        }
+
+        if(lend >= l)
+        {
+            // QL iteration
+            while(l <= lend && iters < max_iters)
+            {
+                // Find small subdiagonal element
+                for(m = l; m <= lend - 1; m++)
+                    if(abs(E[m] * E[m]) <= eps * eps * abs(D[m] * D[m + 1]))
+                        break;
+
+                if(m < lend)
+                    E[m] = 0;
+                p = D[l];
+                if(m == l)
+                {
+                    D[l] = p;
+                    l++;
+                }
+                else if(m == l + 1)
+                {
+                    // Use laev2 to compute 2x2 eigenvalues and eigenvectors
+                    laev2(D[l], E[l], D[l + 1], f, g, c, s);
+                    work[l] = c;
+                    work[n - 1 + l] = s;
+                    lasr(rocblas_side_right, rocblas_backward_direction, n, 2, work + l,
+                         work + n - 1 + l, C + 0 + l * ldc, ldc);
+
+                    D[l] = f;
+                    D[l + 1] = g;
+                    E[l] = 0;
+                    l = l + 2;
+                }
+                else
+                {
+                    if(iters == max_iters)
+                        break;
+                    iters++;
+
+                    // Form shift
+                    g = (D[l + 1] - p) / (2 * E[l]);
+                    if(g >= 0)
+                        r = abs(sqrt(1 + g * g));
+                    else
+                        r = -abs(sqrt(1 + g * g));
+                    g = D[m] - p + (E[l] / (g + r));
+
+                    c = 1;
+                    s = 1;
+                    p = 0;
+
+                    for(int i = m - 1; i >= l; i--)
+                    {
+                        f = s * E[i];
+                        b = c * E[i];
+                        lartg(g, f, c, s, r);
+                        if(i != m - 1)
+                            E[i + 1] = r;
+
+                        g = D[i + 1] - p;
+                        r = (D[i] - g) * s + 2 * c * b;
+                        p = s * r;
+                        D[i + 1] = g + p;
+                        g = c * r - b;
+
+                        // Save rotations
+                        work[i] = c;
+                        work[n - 1 + i] = -s;
+                    }
+
+                    // Apply saved rotations
+                    lasr(rocblas_side_right, rocblas_backward_direction, n, m - l + 1, work + l,
+                         work + n - 1 + l, C + 0 + l * ldc, ldc);
+
+                    D[l] -= p;
+                    E[l] = g;
+                }
+            }
+        }
+
+        else
+        {
+            // QR iteration
+            while(l >= lend && iters < max_iters)
+            {
+                // Find small subdiagonal element
+                for(m = l; m >= lend + 1; m--)
+                    if(abs(E[m - 1] * E[m - 1]) <= eps * eps * abs(D[m] * D[m - 1]))
+                        break;
+
+                if(m > lend)
+                    E[m - 1] = 0;
+                p = D[l];
+                if(m == l)
+                {
+                    D[l] = p;
+                    l--;
+                }
+                else if(m == l - 1)
+                {
+                    // Use laev2 to compute 2x2 eigenvalues and eigenvectors
+                    laev2(D[l - 1], E[l - 1], D[l], f, g, c, s);
+                    work[m] = c;
+                    work[n - 1 + m] = s;
+                    lasr(rocblas_side_right, rocblas_forward_direction, n, 2, work + m,
+                         work + n - 1 + m, C + 0 + (l - 1) * ldc, ldc);
+
+                    D[l - 1] = f;
+                    D[l] = g;
+                    E[l - 1] = 0;
+                    l = l - 2;
+                }
+                else
+                {
+                    if(iters == max_iters)
+                        break;
+                    iters++;
+
+                    // Form shift
+                    g = (D[l - 1] - p) / (2 * E[l - 1]);
+                    if(g >= 0)
+                        r = abs(sqrt(1 + g * g));
+                    else
+                        r = -abs(sqrt(1 + g * g));
+                    g = D[m] - p + (E[l - 1] / (g + r));
+
+                    c = 1;
+                    s = 1;
+                    p = 0;
+
+                    for(int i = m; i <= l - 1; i++)
+                    {
+                        f = s * E[i];
+                        b = c * E[i];
+                        lartg(g, f, c, s, r);
+                        if(i != m)
+                            E[i - 1] = r;
+
+                        g = D[i] - p;
+                        r = (D[i + 1] - g) * s + 2 * c * b;
+                        p = s * r;
+                        D[i] = g + p;
+                        g = c * r - b;
+
+                        // Save rotations
+                        work[i] = c;
+                        work[n - 1 + i] = s;
+                    }
+
+                    // Apply saved rotations
+                    lasr(rocblas_side_right, rocblas_forward_direction, n, l - m + 1, work + m,
+                         work + n - 1 + m, C + 0 + m * ldc, ldc);
+
+                    D[l] -= p;
+                    E[l - 1] = g;
+                }
+            }
+        }
+
+        // Undo scaling
+        if(anorm > ssfmax)
+            sterf_scale(lsv, lendsv, D, E, ssfmax / anorm);
+        if(anorm < ssfmin)
+            sterf_scale(lsv, lendsv, D, E, ssfmin / anorm);
+    }
+
+    // Check for convergence
+    for(int i = 0; i < n - 1; i++)
+        if(E[i] != 0)
+            info[bid]++;
+
+    // Sort eigenvalues and eigenvectors by selection sort
+    for(int ii = 1; ii < n; ii++)
+    {
+        l = ii - 1;
+        m = l;
+        p = D[l];
+        for(int j = ii; j < n; j++)
+        {
+            if(D[j] < p)
+            {
+                m = j;
+                p = D[j];
+            }
+        }
+        if(m != l)
+        {
+            D[m] = D[l];
+            D[l] = p;
+            swapvect(n, C + 0 + l * ldc, 1, C + 0 + m * ldc, 1);
+        }
+    }
+}
+
+template <typename S, typename T>
+void rocsolver_steqr_getMemorySize(const rocblas_evect compc,
+                                   const rocblas_int n,
+                                   const rocblas_int batch_count,
+                                   size_t* size_work_stack)
+{
+    // if quick return no workspace needed
+    if(n == 0 || !batch_count)
+    {
+        *size_work_stack = 0;
+        return;
+    }
+
+    // size of stack (for lasrt)
+    if(compc == rocblas_evect_none)
+        *size_work_stack = sizeof(rocblas_int) * (2 * 32) * batch_count;
+    else
+        *size_work_stack = sizeof(S) * (2 * n - 2) * batch_count;
+}
 
 template <typename S, typename T>
 rocblas_status rocsolver_steqr_argCheck(const rocblas_evect compc,
@@ -57,9 +368,53 @@ rocblas_status rocsolver_steqr_template(rocblas_handle handle,
                                         const rocblas_int ldc,
                                         const rocblas_stride strideC,
                                         rocblas_int* info,
-                                        const rocblas_int batch_count)
+                                        const rocblas_int batch_count,
+                                        void* work_stack)
 {
-    return rocblas_status_not_implemented;
+    // quick return
+    if(batch_count == 0)
+        return rocblas_status_success;
+
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    rocblas_int blocksReset = (batch_count - 1) / BLOCKSIZE + 1;
+    dim3 gridReset(blocksReset, 1, 1);
+    dim3 threads(BLOCKSIZE, 1, 1);
+
+    // info = 0
+    hipLaunchKernelGGL(reset_info, gridReset, threads, 0, stream, info, batch_count, 0);
+
+    // quick return
+    if(n == 1 && compc != rocblas_evect_none)
+        hipLaunchKernelGGL(reset_info, gridReset, threads, 0, stream, C, batch_count, 1);
+    if(n <= 1)
+        return rocblas_status_success;
+
+    // Initialize identity matrix
+    if(compc == rocblas_evect_tridiagonal)
+    {
+        rocblas_int blocks = (n - 1) / 32 + 1;
+        hipLaunchKernelGGL(init_ident<T>, dim3(blocks, blocks, batch_count), dim3(32, 32), 0,
+                           stream, n, n, C, shiftC, ldc, strideC);
+    }
+
+    S eps = get_epsilon<S>();
+    S ssfmin = get_safemin<S>();
+    S ssfmax = S(1.0) / ssfmin;
+    ssfmin = sqrt(ssfmin) / (eps * eps);
+    ssfmax = sqrt(ssfmax) / S(3.0);
+
+    if(compc == rocblas_evect_none)
+        hipLaunchKernelGGL(sterf_kernel<S>, dim3(batch_count), dim3(1), 0, stream, n, D + shiftD,
+                           strideD, E + shiftE, strideE, info, (rocblas_int*)work_stack, 30 * n,
+                           eps, ssfmin, ssfmax);
+    else
+        hipLaunchKernelGGL((steqr_kernel<S, T>), dim3(batch_count), dim3(1), 0, stream, n,
+                           D + shiftD, strideD, E + shiftE, strideE, C, shiftC, ldc, strideC, info,
+                           (S*)work_stack, 30 * n, eps, ssfmin, ssfmax);
+
+    return rocblas_status_success;
 }
 
 #endif

--- a/rocsolver/library/src/auxiliary/rocauxiliary_steqr.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_steqr.hpp
@@ -21,7 +21,7 @@
   BATCH).)
 ***************************************************************************/
 
-/** STERF_KERNEL implements the main loop of the sterf algorithm
+/** STEQR_KERNEL implements the main loop of the sterf algorithm
     to compute the eigenvalues of a symmetric tridiagonal matrix given by D
     and E **/
 template <typename S, typename T, typename U>

--- a/rocsolver/library/src/auxiliary/rocauxiliary_sterf.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_sterf.cpp
@@ -1,0 +1,62 @@
+/* ************************************************************************
+ * Copyright (c) 2019-2020 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include "rocauxiliary_sterf.hpp"
+
+template <typename T>
+rocblas_status
+    rocsolver_sterf_impl(rocblas_handle handle, const rocblas_int n, T* D, T* E, rocblas_int* info)
+{
+    if(!handle)
+        return rocblas_status_invalid_handle;
+
+    // logging is missing ???
+
+    // argument checking
+    rocblas_status st = rocsolver_sterf_argCheck(n, D, E, info);
+    if(st != rocblas_status_continue)
+        return st;
+
+    // working with unshifted arrays
+    rocblas_int shiftD = 0;
+    rocblas_int shiftE = 0;
+
+    // normal (non-batched non-strided) execution
+    rocblas_stride strideD = 0;
+    rocblas_stride strideE = 0;
+    rocblas_int batch_count = 1;
+
+    // this function does not require memory work space
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_size_unchanged;
+
+    // execution
+    return rocsolver_sterf_template<T>(handle, n, D, shiftD, strideD, E, shiftE, strideE, info,
+                                       batch_count);
+}
+
+/*
+ * ===========================================================================
+ *    C wrapper
+ * ===========================================================================
+ */
+
+extern "C" {
+
+rocblas_status
+    rocsolver_ssterf(rocblas_handle handle, const rocblas_int n, float* D, float* E, rocblas_int* info)
+{
+    return rocsolver_sterf_impl<float>(handle, n, D, E, info);
+}
+
+rocblas_status rocsolver_dsterf(rocblas_handle handle,
+                                const rocblas_int n,
+                                double* D,
+                                double* E,
+                                rocblas_int* info)
+{
+    return rocsolver_sterf_impl<double>(handle, n, D, E, info);
+}
+
+} // extern C

--- a/rocsolver/library/src/auxiliary/rocauxiliary_sterf.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_sterf.hpp
@@ -11,7 +11,292 @@
 #define ROCLAPACK_STERF_HPP
 
 #include "rocblas.hpp"
+#include "rocblas_device_functions.hpp"
 #include "rocsolver.h"
+
+/****************************************************************************
+(TODO:THIS IS BASIC IMPLEMENTATION. THE ONLY PARALLELISM INTRODUCED HERE IS
+  FOR THE BATCHED VERSIONS (A DIFFERENT THREAD WORKS ON EACH INSTANCE OF THE
+  BATCH).
+***************************************************************************/
+
+/** STERF_FIND_MAX finds the element with the largest magnitude in the
+    tridiagonal matrix **/
+template <typename T>
+__device__ void sterf_find_max(const rocblas_int start, const rocblas_int end, T* D, T* E, T& anorm)
+{
+    anorm = abs(D[end - 1]);
+    for(int i = start; i < end; i++)
+        anorm = max(anorm, max(abs(D[i - 1]), abs(E[i - 1])));
+}
+
+/** STERF_SCALE scales the elements of the tridiagonal matrix by a given
+    scale factor **/
+template <typename T>
+__device__ void sterf_scale(const rocblas_int start, const rocblas_int end, T* D, T* E, T scale)
+{
+    D[end - 1] *= scale;
+    for(int i = start; i < end; i++)
+    {
+        D[i - 1] *= scale;
+        E[i - 1] *= scale;
+    }
+}
+
+/** STERF_SQ_E squares the elements of E **/
+template <typename T>
+__device__ void sterf_sq_e(const rocblas_int start, const rocblas_int end, T* E)
+{
+    for(int i = start; i < end; i++)
+        E[i - 1] = E[i - 1] * E[i - 1];
+}
+
+/** STERF_KERNEL implements the main loop of the sterf algorithm
+    to compute the eigenvalues of a symmetric tridiagonal matrix given by D
+    and E **/
+template <typename T>
+__global__ void sterf_kernel(const rocblas_int n,
+                             T* DD,
+                             const rocblas_stride strideD,
+                             T* EE,
+                             const rocblas_stride strideE,
+                             rocblas_int* info,
+                             rocblas_int* stack,
+                             const rocblas_int max_iters,
+                             const T eps,
+                             const T ssfmin,
+                             const T ssfmax)
+{
+    rocblas_int bid = hipBlockIdx_x;
+
+    T* D = DD + (bid * strideD);
+    T* E = EE + (bid * strideE);
+
+    rocblas_int m, l, lsv, lend, lendsv;
+    rocblas_int l1 = 1;
+    rocblas_int iters = 0;
+    T sigma, gamma, anorm, bb, p, r_oldgam, rte_oldc, rt1_c, rt2_s;
+
+    while(l1 <= n && iters < max_iters)
+    {
+        // Determine submatrix indices
+        if(l1 > 1)
+            E[l1 - 1 - 1] = 0;
+        for(m = l1; m <= n - 1; m++)
+        {
+            if(abs(E[m - 1]) <= sqrt(abs(D[m - 1])) * sqrt(abs(D[m + 1 - 1])) * eps)
+            {
+                E[m - 1] = 0;
+                break;
+            }
+        }
+
+        lsv = l = l1;
+        lendsv = lend = m;
+        l1 = m + 1;
+        if(lend == l)
+            continue;
+
+        // Scale submatrix
+        sterf_find_max(l, lend, D, E, anorm);
+        if(anorm == 0)
+            continue;
+        else if(anorm > ssfmax)
+            sterf_scale(l, lend, D, E, anorm / ssfmax);
+        else if(anorm < ssfmin)
+            sterf_scale(l, lend, D, E, anorm / ssfmin);
+        sterf_sq_e(l, lend, E);
+
+        // Choose iteration type (QL or QR)
+        if(abs(D[lend - 1]) < abs(D[l - 1]))
+        {
+            lend = lsv;
+            l = lendsv;
+        }
+
+        if(lend >= l)
+        {
+            // QL iteration
+            while(l <= lend && iters < max_iters)
+            {
+                // Find small subdiagonal element
+                for(m = l; m <= lend - 1; m++)
+                    if(abs(E[m - 1]) <= eps * eps * abs(D[m - 1] * D[m + 1 - 1]))
+                        break;
+
+                if(m < lend)
+                    E[m - 1] = 0;
+                p = D[l - 1];
+                if(m == l)
+                {
+                    D[l - 1] = p;
+                    l++;
+                }
+                else if(m == l + 1)
+                {
+                    // Use lae2 to compute 2x2 eigenvalues. Using rte, rt1, rt2.
+                    rte_oldc = sqrt(E[l - 1]);
+                    lae2(D[l - 1], rte_oldc, D[l + 1 - 1], rt1_c, rt2_s);
+                    D[l - 1] = rt1_c;
+                    D[l + 1 - 1] = rt2_s;
+                    E[l - 1] = 0;
+                    l = l + 2;
+                }
+                else
+                {
+                    if(iters == max_iters)
+                        break;
+                    iters++;
+
+                    // Form shift. Using rte, r, c, s.
+                    rte_oldc = sqrt(E[l - 1]);
+                    sigma = (D[l + 1 - 1] - p) / (2 * rte_oldc);
+                    if(sigma >= 0)
+                        r_oldgam = abs(sqrt(1 + sigma * sigma));
+                    else
+                        r_oldgam = -abs(sqrt(1 + sigma * sigma));
+                    sigma = p - (rte_oldc / (sigma + r_oldgam));
+
+                    rt1_c = 1;
+                    rt2_s = 0;
+                    gamma = D[m - 1] - sigma;
+                    p = gamma * gamma;
+
+                    for(int i = m - 1; i >= l; i--)
+                    {
+                        bb = E[i - 1];
+                        r_oldgam = p + bb;
+                        if(i != m - 1)
+                            E[i + 1 - 1] = rt2_s * r_oldgam;
+
+                        // Using oldc, r, c, s.
+                        rte_oldc = rt1_c;
+                        rt1_c = p / r_oldgam;
+                        rt2_s = bb / r_oldgam;
+
+                        // Using oldc, oldgam, c, s.
+                        r_oldgam = gamma;
+                        gamma = rt1_c * (D[i - 1] - sigma) - rt2_s * r_oldgam;
+                        D[i + 1 - 1] = r_oldgam + (D[i - 1] - gamma);
+                        if(rt1_c != 0)
+                            p = (gamma * gamma) / rt1_c;
+                        else
+                            p = rte_oldc * bb;
+                    }
+
+                    E[l - 1] = rt2_s * p;
+                    D[l - 1] = sigma + gamma;
+                }
+            }
+        }
+
+        else
+        {
+            // QR iteration
+            while(l >= lend && iters < max_iters)
+            {
+                // Find small subdiagonal element
+                for(m = l; m >= lend + 1; m--)
+                    if(abs(E[m - 1 - 1]) <= eps * eps * abs(D[m - 1] * D[m - 1 - 1]))
+                        break;
+
+                if(m > lend)
+                    E[m - 1 - 1] = 0;
+                p = D[l - 1];
+                if(m == l)
+                {
+                    D[l - 1] = p;
+                    l--;
+                }
+                else if(m == l - 1)
+                {
+                    // Use lae2 to compute 2x2 eigenvalues. Using rte, rt1, rt2.
+                    rte_oldc = sqrt(E[l - 1 - 1]);
+                    lae2(D[l - 1], rte_oldc, D[l - 1 - 1], rt1_c, rt2_s);
+                    D[l - 1] = rt1_c;
+                    D[l - 1 - 1] = rt2_s;
+                    E[l - 1 - 1] = 0;
+                    l = l - 2;
+                }
+                else
+                {
+                    if(iters == max_iters)
+                        break;
+                    iters++;
+
+                    // Form shift. Using rte, r, c, s.
+                    rte_oldc = sqrt(E[l - 1 - 1]);
+                    sigma = (D[l - 1 - 1] - p) / (2 * rte_oldc);
+                    if(sigma >= 0)
+                        r_oldgam = abs(sqrt(1 + sigma * sigma));
+                    else
+                        r_oldgam = -abs(sqrt(1 + sigma * sigma));
+                    sigma = p - (rte_oldc / (sigma + r_oldgam));
+
+                    rt1_c = 1;
+                    rt2_s = 0;
+                    gamma = D[m - 1] - sigma;
+                    p = gamma * gamma;
+
+                    for(int i = m; i <= l - 1; i++)
+                    {
+                        bb = E[i - 1];
+                        r_oldgam = p + bb;
+                        if(i != m)
+                            E[i - 1 - 1] = rt2_s * r_oldgam;
+
+                        // Using oldc, r, c, s.
+                        rte_oldc = rt1_c;
+                        rt1_c = p / r_oldgam;
+                        rt2_s = bb / r_oldgam;
+
+                        // Using oldc, oldgam, c, s.
+                        r_oldgam = gamma;
+                        gamma = rt1_c * (D[i + 1 - 1] - sigma) - rt2_s * r_oldgam;
+                        D[i - 1] = r_oldgam + (D[i + 1 - 1] - gamma);
+                        if(rt1_c != 0)
+                            p = (gamma * gamma) / rt1_c;
+                        else
+                            p = rte_oldc * bb;
+                    }
+
+                    E[l - 1 - 1] = rt2_s * p;
+                    D[l - 1] = sigma + gamma;
+                }
+            }
+        }
+
+        // Undo scaling
+        if(anorm > ssfmax)
+            sterf_scale(lsv, lendsv, D, E, ssfmax / anorm);
+        if(anorm < ssfmin)
+            sterf_scale(lsv, lendsv, D, E, ssfmin / anorm);
+    }
+
+    // Check for convergence
+    for(int i = 1; i <= n - 1; i++)
+        if(E[i - 1] != 0)
+            info[bid]++;
+
+    // Sort eigenvalues
+    lasrt_increasing(n, D, stack + bid * (2 * 32));
+}
+
+template <typename T>
+void rocsolver_sterf_getMemorySize(const rocblas_int n,
+                                   const rocblas_int batch_count,
+                                   size_t* size_stack)
+{
+    // if quick return no workspace needed
+    if(n == 0 || !batch_count)
+    {
+        *size_stack = 0;
+        return;
+    }
+
+    // size of stack (for lasrt)
+    *size_stack = sizeof(rocblas_int) * (2 * 32) * batch_count;
+}
 
 template <typename T>
 rocblas_status rocsolver_sterf_argCheck(const rocblas_int n, T D, T E, rocblas_int* info)
@@ -41,9 +326,37 @@ rocblas_status rocsolver_sterf_template(rocblas_handle handle,
                                         const rocblas_int shiftE,
                                         const rocblas_stride strideE,
                                         rocblas_int* info,
-                                        const rocblas_int batch_count)
+                                        const rocblas_int batch_count,
+                                        rocblas_int* stack)
 {
-    return rocblas_status_not_implemented;
+    // quick return
+    if(batch_count == 0)
+        return rocblas_status_success;
+
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    rocblas_int blocksReset = (batch_count - 1) / BLOCKSIZE + 1;
+    dim3 gridReset(blocksReset, 1, 1);
+    dim3 threads(BLOCKSIZE, 1, 1);
+
+    // info = 0
+    hipLaunchKernelGGL(reset_info, gridReset, threads, 0, stream, info, batch_count, 0);
+
+    // quick return
+    if(n <= 1)
+        return rocblas_status_success;
+
+    T eps = get_epsilon<T>();
+    T ssfmin = get_safemin<T>();
+    T ssfmax = T(1.0) / ssfmin;
+    ssfmin = sqrt(ssfmin) / (eps * eps);
+    ssfmax = sqrt(ssfmax) / T(3.0);
+
+    hipLaunchKernelGGL(sterf_kernel<T>, dim3(batch_count), dim3(1), 0, stream, n, D + shiftD,
+                       strideD, E + shiftE, strideE, info, stack, 30 * n, eps, ssfmin, ssfmax);
+
+    return rocblas_status_success;
 }
 
 #endif

--- a/rocsolver/library/src/auxiliary/rocauxiliary_sterf.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_sterf.hpp
@@ -1,0 +1,49 @@
+/************************************************************************
+ * Derived from the BSD3-licensed
+ * LAPACK routine (version 3.7.0) --
+ *     Univ. of Tennessee, Univ. of California Berkeley,
+ *     Univ. of Colorado Denver and NAG Ltd..
+ *     December 2016
+ * Copyright (c) 2019-2020 Advanced Micro Devices, Inc.
+ * ***********************************************************************/
+
+#ifndef ROCLAPACK_STERF_HPP
+#define ROCLAPACK_STERF_HPP
+
+#include "rocblas.hpp"
+#include "rocsolver.h"
+
+template <typename T>
+rocblas_status rocsolver_sterf_argCheck(const rocblas_int n, T D, T E, rocblas_int* info)
+{
+    // order is important for unit tests:
+
+    // 1. invalid/non-supported values
+
+    // 2. invalid size
+    if(n < 0)
+        return rocblas_status_invalid_size;
+
+    // 3. invalid pointers
+    if((n && !D) || (n && !E) || !info)
+        return rocblas_status_invalid_pointer;
+
+    return rocblas_status_continue;
+}
+
+template <typename T, typename U>
+rocblas_status rocsolver_sterf_template(rocblas_handle handle,
+                                        const rocblas_int n,
+                                        U D,
+                                        const rocblas_int shiftD,
+                                        const rocblas_stride strideD,
+                                        U E,
+                                        const rocblas_int shiftE,
+                                        const rocblas_stride strideE,
+                                        rocblas_int* info,
+                                        const rocblas_int batch_count)
+{
+    return rocblas_status_not_implemented;
+}
+
+#endif

--- a/rocsolver/library/src/include/common_device.hpp
+++ b/rocsolver/library/src/include/common_device.hpp
@@ -51,6 +51,30 @@ __device__ void
     }
 }
 
+/** FIND_MAX_TRIDIAG finds the element with the largest magnitude in the
+    tridiagonal matrix **/
+template <typename T>
+__device__ T find_max_tridiag(const rocblas_int start, const rocblas_int end, T* D, T* E)
+{
+    T anorm = abs(D[end]);
+    for(int i = start; i < end; i++)
+        anorm = max(anorm, max(abs(D[i]), abs(E[i])));
+    return anorm;
+}
+
+/** SCALE_TRIDIAG scales the elements of the tridiagonal matrix by a given
+    scale factor **/
+template <typename T>
+__device__ void scale_tridiag(const rocblas_int start, const rocblas_int end, T* D, T* E, T scale)
+{
+    D[end] *= scale;
+    for(int i = start; i < end; i++)
+    {
+        D[i] *= scale;
+        E[i] *= scale;
+    }
+}
+
 // **********************************************************
 // GPU kernels that are used by many rocsolver functions
 // **********************************************************

--- a/rocsolver/library/src/include/common_device.hpp
+++ b/rocsolver/library/src/include/common_device.hpp
@@ -56,6 +56,29 @@ __device__ void
 // **********************************************************
 
 template <typename T, typename U>
+__global__ void init_ident(const rocblas_int m,
+                           const rocblas_int n,
+                           U A,
+                           const rocblas_int shiftA,
+                           const rocblas_int lda,
+                           const rocblas_stride strideA)
+{
+    const auto i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    const auto j = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    const auto b = hipBlockIdx_z;
+
+    if(i < m && j < n)
+    {
+        T* a = load_ptr_batch<T>(A, b, shiftA, strideA);
+
+        if(i == j)
+            a[i + j * lda] = 1.0;
+        else
+            a[i + j * lda] = 0.0;
+    }
+}
+
+template <typename T, typename U>
 __global__ void reset_info(T* info, const rocblas_int n, U val)
 {
     int idx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;

--- a/rocsolver/library/src/include/rocblas_device_functions.hpp
+++ b/rocsolver/library/src/include/rocblas_device_functions.hpp
@@ -6,6 +6,7 @@
 #define _ROCBLAS_DEVICE_FUNCTIONS_HPP_
 
 #include "common_device.hpp"
+#include "rocsolver.h"
 
 template <typename T>
 __device__ void trtri_kernel_upper(const rocblas_diagonal diag,
@@ -264,6 +265,377 @@ __device__ void gemm_kernel(const rocblas_int m,
             c[i + j * ldc] = *alpha * cij + *beta * c[i + j * ldc];
         }
         __syncthreads();
+    }
+}
+
+/** LARTG device function computes the sine (s) and cosine (c) values
+    to create a givens rotation such that:
+    [  c s ]' * [ f ] = [ r ]
+    [ -s c ]    [ g ]   [ 0 ] **/
+template <typename T, std::enable_if_t<!is_complex<T>, int> = 0>
+__device__ void lartg(T& f, T& g, T& c, T& s, T& r)
+{
+    if(g == 0)
+    {
+        c = 1;
+        s = 0;
+        r = f;
+    }
+    else if(f == 0)
+    {
+        c = 0;
+        s = 1;
+        r = g;
+    }
+    else
+    {
+        r = sqrt(f * f + g * g);
+        c = f / r;
+        s = g / r;
+
+        if(abs(f) > abs(g) && c < 0)
+        {
+            r = -r;
+            c = -c;
+            s = -s;
+        }
+    }
+}
+
+/** LASR device function applies a sequence of rotations P(i) i=1,2,...z
+    to a m-by-n matrix A from either the left (P*A with z=m) or the right (A*P'
+    with z=n). P = P(z-1)*...*P(1) if forward direction, P = P(1)*...*P(z-1) if
+    backward direction. **/
+template <typename T, typename W>
+__device__ void lasr(const rocblas_side side,
+                     const rocblas_direct direc,
+                     const rocblas_int m,
+                     const rocblas_int n,
+                     W* c,
+                     W* s,
+                     T* A,
+                     const rocblas_int lda)
+{
+    T temp;
+    W cs, sn;
+
+    if(side == rocblas_side_left)
+    {
+        if(direc == rocblas_forward_direction)
+        {
+            for(rocblas_int i = 0; i < m - 1; ++i)
+            {
+                for(rocblas_int j = 0; j < n; ++j)
+                {
+                    temp = A[i + j * lda];
+                    cs = c[i];
+                    sn = s[i];
+                    A[i + j * lda] = cs * temp + sn * A[i + 1 + j * lda];
+                    A[i + 1 + j * lda] = cs * A[i + 1 + j * lda] - sn * temp;
+                }
+            }
+        }
+        else
+        {
+            for(rocblas_int i = m - 1; i > 0; --i)
+            {
+                for(rocblas_int j = 0; j < n; ++j)
+                {
+                    temp = A[i + j * lda];
+                    cs = c[i - 1];
+                    sn = s[i - 1];
+                    A[i + j * lda] = cs * temp - sn * A[i - 1 + j * lda];
+                    A[i - 1 + j * lda] = cs * A[i - 1 + j * lda] + sn * temp;
+                }
+            }
+        }
+    }
+
+    else
+    {
+        if(direc == rocblas_forward_direction)
+        {
+            for(rocblas_int j = 0; j < n - 1; ++j)
+            {
+                for(rocblas_int i = 0; i < m; ++i)
+                {
+                    temp = A[i + j * lda];
+                    cs = c[j];
+                    sn = s[j];
+                    A[i + j * lda] = cs * temp + sn * A[i + (j + 1) * lda];
+                    A[i + (j + 1) * lda] = cs * A[i + (j + 1) * lda] - sn * temp;
+                }
+            }
+        }
+        else
+        {
+            for(rocblas_int j = n - 1; j > 0; --j)
+            {
+                for(rocblas_int i = 0; i < m; ++i)
+                {
+                    temp = A[i + j * lda];
+                    cs = c[j - 1];
+                    sn = s[j - 1];
+                    A[i + j * lda] = cs * temp - sn * A[i + (j - 1) * lda];
+                    A[i + (j - 1) * lda] = cs * A[i + (j - 1) * lda] + sn * temp;
+                }
+            }
+        }
+    }
+}
+
+/** LAE2 computes the eigenvalues of a 2x2 symmetric matrix
+    [ a b ]
+    [ b c ] **/
+template <typename T, std::enable_if_t<!is_complex<T>, int> = 0>
+__device__ void lae2(T& a, T& b, T& c, T& rt1, T& rt2)
+{
+    T sm = a + c;
+    T adf = abs(a - c);
+    T ab = abs(b + b);
+
+    T rt, acmx, acmn;
+    if(adf > ab)
+    {
+        rt = ab / adf;
+        rt = adf * sqrt(1 + rt * rt);
+    }
+    else if(adf < ab)
+    {
+        rt = adf / ab;
+        rt = ab * sqrt(1 + rt * rt);
+    }
+    else
+        rt = ab * sqrt(2);
+
+    // Compute the eigenvalues
+    if(abs(a) > abs(c))
+    {
+        acmx = a;
+        acmn = c;
+    }
+    else
+    {
+        acmx = c;
+        acmn = a;
+    }
+    if(sm < 0)
+    {
+        rt1 = T(0.5) * (sm - rt);
+        rt2 = T((acmx / (double)rt1) * acmn - (b / (double)rt1) * b);
+    }
+    else if(sm > 0)
+    {
+        rt1 = T(0.5) * (sm + rt);
+        rt2 = T((acmx / (double)rt1) * acmn - (b / (double)rt1) * b);
+    }
+    else
+    {
+        rt1 = T(0.5) * rt;
+        rt2 = T(-0.5) * rt;
+    }
+}
+
+/** LAEV2 computes the eigenvalues and eigenvectors of a 2x2 symmetric matrix
+    [ a b ]
+    [ b c ] **/
+template <typename T, std::enable_if_t<!is_complex<T>, int> = 0>
+__device__ void laev2(T& a, T& b, T& c, T& rt1, T& rt2, T& cs1, T& sn1)
+{
+    int sgn1, sgn2;
+
+    T sm = a + c;
+    T df = a - c;
+    T adf = abs(df);
+    T tb = b + b;
+    T ab = abs(tb);
+
+    T rt, temp1, temp2;
+    if(adf > ab)
+    {
+        rt = ab / adf;
+        rt = adf * sqrt(1 + rt * rt);
+    }
+    else if(adf < ab)
+    {
+        rt = adf / ab;
+        rt = ab * sqrt(1 + rt * rt);
+    }
+    else
+        rt = ab * sqrt(2);
+
+    // Compute the eigenvalues
+    if(abs(a) > abs(c))
+    {
+        temp1 = a;
+        temp2 = c;
+    }
+    else
+    {
+        temp1 = c;
+        temp2 = a;
+    }
+    if(sm < 0)
+    {
+        sgn1 = -1;
+        rt1 = T(0.5) * (sm - rt);
+        rt2 = T((temp1 / (double)rt1) * temp2 - (b / (double)rt1) * b);
+    }
+    else if(sm > 0)
+    {
+        sgn1 = 1;
+        rt1 = T(0.5) * (sm + rt);
+        rt2 = T((temp1 / (double)rt1) * temp2 - (b / (double)rt1) * b);
+    }
+    else
+    {
+        sgn1 = 1;
+        rt1 = T(0.5) * rt;
+        rt2 = T(-0.5) * rt;
+    }
+
+    // Compute the eigenvector
+    if(df >= 0)
+    {
+        temp1 = df + rt;
+        sgn2 = 1;
+    }
+    else
+    {
+        temp1 = df - rt;
+        sgn2 = -1;
+    }
+
+    if(abs(temp1) > ab)
+    {
+        // temp2 is cotan
+        temp2 = -tb / temp1;
+        sn1 = T(1) / sqrt(1 + temp2 * temp2);
+        cs1 = temp2 * sn1;
+    }
+    else
+    {
+        if(ab == 0)
+        {
+            cs1 = 1;
+            sn1 = 0;
+        }
+        else
+        {
+            // temp2 is tan
+            temp2 = -temp1 / tb;
+            cs1 = T(1) / sqrt(1 + temp2 * temp2);
+            sn1 = temp2 * cs1;
+        }
+    }
+
+    if(sgn1 == sgn2)
+    {
+        temp1 = cs1;
+        cs1 = -sn1;
+        sn1 = temp1;
+    }
+}
+
+/** LASRT_INCREASING sorts an array D in increasing order.
+    stack is a 32x2 array of integers on the device. **/
+template <typename T>
+__device__ void lasrt_increasing(const rocblas_int n, T* D, rocblas_int* stack)
+{
+    T d1, d2, d3, dmnmx, temp;
+    constexpr rocblas_int select = 20;
+    constexpr rocblas_int lds = 32;
+    rocblas_int i, j, start, endd;
+    rocblas_int stackptr = 0;
+
+    // Initialize stack[0, 0] and stack[1, 0]
+    stack[0 + 0 * lds] = 0;
+    stack[1 + 0 * lds] = n - 1;
+    while(stackptr >= 0)
+    {
+        start = stack[0 + stackptr * lds];
+        endd = stack[1 + stackptr * lds];
+        stackptr--;
+
+        if(endd - start <= select && endd - start > 0)
+        {
+            // Insertion sort
+            for(i = start + 1; i <= endd; i++)
+            {
+                for(j = i; j > start; j--)
+                {
+                    if(D[j] < D[j - 1])
+                    {
+                        dmnmx = D[j];
+                        D[j] = D[j - 1];
+                        D[j - 1] = dmnmx;
+                    }
+                    else
+                        break;
+                }
+            }
+        }
+        else if(endd - start > select)
+        {
+            // Partition and add to stack
+            d1 = D[start];
+            d2 = D[endd];
+            i = (start + endd) / 2;
+            d3 = D[i];
+
+            if(d1 < d2)
+            {
+                if(d3 < d1)
+                    dmnmx = d1;
+                else if(d3 < d2)
+                    dmnmx = d3;
+                else
+                    dmnmx = d2;
+            }
+            else
+            {
+                if(d3 < d2)
+                    dmnmx = d2;
+                else if(d3 < d1)
+                    dmnmx = d3;
+                else
+                    dmnmx = d1;
+            }
+
+            i = start;
+            j = endd;
+            while(i < j)
+            {
+                while(D[i] < dmnmx)
+                    i++;
+                while(D[j] > dmnmx)
+                    j--;
+                if(i < j)
+                {
+                    temp = D[i];
+                    D[i] = D[j];
+                    D[j] = temp;
+                }
+            }
+            if(j - start > endd - j - 1)
+            {
+                stackptr++;
+                stack[0 + stackptr * lds] = start;
+                stack[1 + stackptr * lds] = j;
+                stackptr++;
+                stack[0 + stackptr * lds] = j + 1;
+                stack[1 + stackptr * lds] = endd;
+            }
+            else
+            {
+                stackptr++;
+                stack[0 + stackptr * lds] = j + 1;
+                stack[1 + stackptr * lds] = endd;
+                stackptr++;
+                stack[0 + stackptr * lds] = start;
+                stack[1 + stackptr * lds] = j;
+            }
+        }
     }
 }
 

--- a/rocsolver/library/src/include/rocblas_device_functions.hpp
+++ b/rocsolver/library/src/include/rocblas_device_functions.hpp
@@ -293,13 +293,13 @@ __device__ void lartg(T& f, T& g, T& c, T& s, T& r)
         if(std::abs(g) > std::abs(f))
         {
             t = -f / g;
-            s = 1 / T(std::sqrt(1 + t * t));
+            s = 1 / std::sqrt(1 + t * t);
             c = s * t;
         }
         else
         {
             t = -g / f;
-            c = 1 / T(std::sqrt(1 + t * t));
+            c = 1 / std::sqrt(1 + t * t);
             s = c * t;
         }
         r = c * f - s * g;


### PR DESCRIPTION
Addresses SWDEV-247078.

Note that both sterf and steqr have been implemented without any parallelism (similar to bdsqr). steqr is quite slow at the moment. This can probably be addressed by adding some parallelism to lasr in the near future.