### PR TITLE
Tridiagonalization of symmetric/hermitian matrices - 3/3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ __anchor__CB
 __anchor__JZ
 - Extended test coverage for functions returning info
 - Changelog file
+- Tridiagonalization routines for symmetric and hermitian matrices:
+    - LATRD
+    - SYTD2, SYTRD (with batched and strided\_batched versions)
+    - HETD2, HETRD (with batched and strided\_batched versions)
 
 ### Optimizations
 __anchor__TA

--- a/docs/source/userguide_api.rst
+++ b/docs/source/userguide_api.rst
@@ -767,6 +767,42 @@ rocsolver_<type>hetd2_strided_batched()
    :outline:
 .. doxygenfunction:: rocsolver_chetd2_strided_batched
 
+rocsolver_<type>sytrd()
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygenfunction:: rocsolver_dsytrd
+   :outline:
+.. doxygenfunction:: rocsolver_ssytrd
+
+rocsolver_<type>sytrd_batched()
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygenfunction:: rocsolver_dsytrd_batched
+   :outline:
+.. doxygenfunction:: rocsolver_ssytrd_batched
+
+rocsolver_<type>sytrd_strided_batched()
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygenfunction:: rocsolver_dsytrd_strided_batched
+   :outline:
+.. doxygenfunction:: rocsolver_ssytrd_strided_batched
+
+rocsolver_<type>hetrd()
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygenfunction:: rocsolver_zhetrd
+   :outline:
+.. doxygenfunction:: rocsolver_chetrd
+
+rocsolver_<type>hetrd_batched()
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygenfunction:: rocsolver_zhetrd_batched
+   :outline:
+.. doxygenfunction:: rocsolver_chetrd_batched
+
+rocsolver_<type>hetrd_strided_batched()
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. doxygenfunction:: rocsolver_zhetrd_strided_batched
+   :outline:
+.. doxygenfunction:: rocsolver_chetrd_strided_batched
+
 
 General Matrix Inversion
 --------------------------

--- a/docs/source/userguide_intro.rst
+++ b/docs/source/userguide_intro.rst
@@ -120,7 +120,13 @@ rocsolver_gesvd_strided_batched x      x          x             x
 **rocsolver_sytd2**             x      x
 rocsolver_sytd2_batched         x      x
 rocsolver_sytd2_strided_batched x      x
+**rocsolver_sytrd**             x      x
+rocsolver_sytd2_batched         x      x
+rocsolver_sytd2_strided_batched x      x
 **rocsolver_hetd2**                               x             x
+rocsolver_hetd2_batched                           x             x
+rocsolver_hetd2_strided_batched                   x             x
+**rocsolver_hetrd**                               x             x
 rocsolver_hetd2_batched                           x             x
 rocsolver_hetd2_strided_batched                   x             x
 =============================== ====== ====== ============== ==============

--- a/docs/source/userguide_intro.rst
+++ b/docs/source/userguide_intro.rst
@@ -121,14 +121,14 @@ rocsolver_gesvd_strided_batched x      x          x             x
 rocsolver_sytd2_batched         x      x
 rocsolver_sytd2_strided_batched x      x
 **rocsolver_sytrd**             x      x
-rocsolver_sytd2_batched         x      x
-rocsolver_sytd2_strided_batched x      x
+rocsolver_sytrd_batched         x      x
+rocsolver_sytrd_strided_batched x      x
 **rocsolver_hetd2**                               x             x
 rocsolver_hetd2_batched                           x             x
 rocsolver_hetd2_strided_batched                   x             x
 **rocsolver_hetrd**                               x             x
-rocsolver_hetd2_batched                           x             x
-rocsolver_hetd2_strided_batched                   x             x
+rocsolver_hetrd_batched                           x             x
+rocsolver_hetrd_strided_batched                   x             x
 =============================== ====== ====== ============== ==============
 
 ==================================== ====== ====== ============== ==============

--- a/rocsolver/clients/gtest/sytxx_hetxx_gtest.cpp
+++ b/rocsolver/clients/gtest/sytxx_hetxx_gtest.cpp
@@ -379,7 +379,7 @@ INSTANTIATE_TEST_SUITE_P(daily_lapack,
 INSTANTIATE_TEST_SUITE_P(checkin_lapack,
                          HETD2,
                          Combine(ValuesIn(matrix_size_range), ValuesIn(uplo_range)));
-/*
+
 INSTANTIATE_TEST_SUITE_P(daily_lapack,
                          SYTRD,
                          Combine(ValuesIn(large_matrix_size_range), ValuesIn(uplo_range)));
@@ -395,4 +395,4 @@ INSTANTIATE_TEST_SUITE_P(daily_lapack,
 INSTANTIATE_TEST_SUITE_P(checkin_lapack,
                          HETRD,
                          Combine(ValuesIn(matrix_size_range), ValuesIn(uplo_range)));
-*/
+

--- a/rocsolver/clients/gtest/sytxx_hetxx_gtest.cpp
+++ b/rocsolver/clients/gtest/sytxx_hetxx_gtest.cpp
@@ -395,4 +395,3 @@ INSTANTIATE_TEST_SUITE_P(daily_lapack,
 INSTANTIATE_TEST_SUITE_P(checkin_lapack,
                          HETRD,
                          Combine(ValuesIn(matrix_size_range), ValuesIn(uplo_range)));
-

--- a/rocsolver/library/src/include/ideal_sizes.hpp
+++ b/rocsolver/library/src/include/ideal_sizes.hpp
@@ -51,6 +51,10 @@
 // gebd2/gebrd
 #define GEBRD_GEBD2_SWITCHSIZE 32
 
+// xxtd2/xxtrd
+#define xxTRD_xxTD2_BLOCKSIZE 32
+#define xxTRD_xxTD2_SWITCHSIZE 64
+
 // gesvd
 // This value should be ~1.6 (to be tuned).
 // For now, it is set to a very high value until the thin-SVD algorithm is

--- a/rocsolver/library/src/include/rocblas.hpp
+++ b/rocsolver/library/src/include/rocblas.hpp
@@ -714,7 +714,6 @@ rocblas_status rocblasCall_trmm(rocblas_handle handle,
     return status;
 }
 
-
 // syr2
 template <typename T, typename U, typename V, std::enable_if_t<!is_complex<T>, int> = 0>
 rocblas_status rocblasCall_syr2_her2(rocblas_handle handle,
@@ -879,59 +878,59 @@ rocblas_status rocblasCall_syrk_herk(rocblas_handle handle,
                                  cast2constType<S>(beta), C, offsetC, ldc, strideC, batch_count);
 }
 
-
 // syr2k
 template <typename T, typename Ua, typename Ub, typename V, std::enable_if_t<!is_complex<T>, int> = 0>
 rocblas_status rocblasCall_syr2k_her2k(rocblas_handle handle,
-                                     rocblas_fill uplo,
-                                     rocblas_operation trans,
-                                     rocblas_int n,
-                                     rocblas_int k,
-                                     Ua alpha,
-                                     V A,
-                                     rocblas_int offsetA,
-                                     rocblas_int lda,
-                                     rocblas_stride strideA,
-                                     V B,
-                                     rocblas_int offsetB,
-                                     rocblas_int ldb,
-                                     rocblas_stride strideB,
-                                     Ub beta,
-                                     V C,
-                                     rocblas_int offsetC,
-                                     rocblas_int ldc,
-                                     rocblas_stride strideC,
-                                     rocblas_int batch_count,
-                                     T** work = nullptr)
+                                       rocblas_fill uplo,
+                                       rocblas_operation trans,
+                                       rocblas_int n,
+                                       rocblas_int k,
+                                       Ua alpha,
+                                       V A,
+                                       rocblas_int offsetA,
+                                       rocblas_int lda,
+                                       rocblas_stride strideA,
+                                       V B,
+                                       rocblas_int offsetB,
+                                       rocblas_int ldb,
+                                       rocblas_stride strideB,
+                                       Ub beta,
+                                       V C,
+                                       rocblas_int offsetC,
+                                       rocblas_int ldc,
+                                       rocblas_stride strideC,
+                                       rocblas_int batch_count,
+                                       T** work = nullptr)
 {
-    return rocblas_syr2k_template<true>(handle, uplo, trans, n, k, cast2constType<T>(alpha), cast2constType<T>(A),
-                                 offsetA, lda, strideA, cast2constType<T>(B), offsetB, ldb,
-                                 strideB, cast2constType<T>(beta), C, offsetC, ldc, strideC, batch_count);
+    return rocblas_syr2k_template<true>(
+        handle, uplo, trans, n, k, cast2constType<T>(alpha), cast2constType<T>(A), offsetA, lda,
+        strideA, cast2constType<T>(B), offsetB, ldb, strideB, cast2constType<T>(beta), C, offsetC,
+        ldc, strideC, batch_count);
 }
 
 // syr2k overload
 template <typename T, typename Ua, typename Ub, std::enable_if_t<!is_complex<T>, int> = 0>
 rocblas_status rocblasCall_syr2k_her2k(rocblas_handle handle,
-                                     rocblas_fill uplo,
-                                     rocblas_operation trans,
-                                     rocblas_int n,
-                                     rocblas_int k,
-                                     Ua alpha,
-                                     T *const A[],
-                                     rocblas_int offsetA,
-                                     rocblas_int lda,
-                                     rocblas_stride strideA,
-                                     T* B,
-                                     rocblas_int offsetB,
-                                     rocblas_int ldb,
-                                     rocblas_stride strideB,
-                                     Ub beta,
-                                     T *const C[],
-                                     rocblas_int offsetC,
-                                     rocblas_int ldc,
-                                     rocblas_stride strideC,
-                                     rocblas_int batch_count,
-                                     T** work = nullptr)
+                                       rocblas_fill uplo,
+                                       rocblas_operation trans,
+                                       rocblas_int n,
+                                       rocblas_int k,
+                                       Ua alpha,
+                                       T* const A[],
+                                       rocblas_int offsetA,
+                                       rocblas_int lda,
+                                       rocblas_stride strideA,
+                                       T* B,
+                                       rocblas_int offsetB,
+                                       rocblas_int ldb,
+                                       rocblas_stride strideB,
+                                       Ub beta,
+                                       T* const C[],
+                                       rocblas_int offsetC,
+                                       rocblas_int ldc,
+                                       rocblas_stride strideC,
+                                       rocblas_int batch_count,
+                                       T** work = nullptr)
 {
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
@@ -939,65 +938,66 @@ rocblas_status rocblasCall_syr2k_her2k(rocblas_handle handle,
     rocblas_int blocks = (batch_count - 1) / 256 + 1;
     hipLaunchKernelGGL(get_array, dim3(blocks), dim3(256), 0, stream, work, B, strideB, batch_count);
 
-    return rocblas_syr2k_template<true>(handle, uplo, trans, n, k, cast2constType<T>(alpha), cast2constType<T>(A),
-                                 offsetA, lda, strideA, cast2constType<T>(work), offsetB, ldb,
-                                 strideB, cast2constType<T>(beta), C, offsetC, ldc, strideC, batch_count);
+    return rocblas_syr2k_template<true>(
+        handle, uplo, trans, n, k, cast2constType<T>(alpha), cast2constType<T>(A), offsetA, lda,
+        strideA, cast2constType<T>(work), offsetB, ldb, strideB, cast2constType<T>(beta), C,
+        offsetC, ldc, strideC, batch_count);
 }
-
 
 // her2k
 template <typename T, typename Ua, typename Ub, typename V, std::enable_if_t<is_complex<T>, int> = 0>
 rocblas_status rocblasCall_syr2k_her2k(rocblas_handle handle,
-                                     rocblas_fill uplo,
-                                     rocblas_operation trans,
-                                     rocblas_int n,
-                                     rocblas_int k,
-                                     Ua alpha,
-                                     V A,
-                                     rocblas_int offsetA,
-                                     rocblas_int lda,
-                                     rocblas_stride strideA,
-                                     V B,
-                                     rocblas_int offsetB,
-                                     rocblas_int ldb,
-                                     rocblas_stride strideB,
-                                     Ub beta,
-                                     V C,
-                                     rocblas_int offsetC,
-                                     rocblas_int ldc,
-                                     rocblas_stride strideC,
-                                     rocblas_int batch_count,
-                                     T** work = nullptr)
+                                       rocblas_fill uplo,
+                                       rocblas_operation trans,
+                                       rocblas_int n,
+                                       rocblas_int k,
+                                       Ua alpha,
+                                       V A,
+                                       rocblas_int offsetA,
+                                       rocblas_int lda,
+                                       rocblas_stride strideA,
+                                       V B,
+                                       rocblas_int offsetB,
+                                       rocblas_int ldb,
+                                       rocblas_stride strideB,
+                                       Ub beta,
+                                       V C,
+                                       rocblas_int offsetC,
+                                       rocblas_int ldc,
+                                       rocblas_stride strideC,
+                                       rocblas_int batch_count,
+                                       T** work = nullptr)
 {
     using S = decltype(std::real(T{}));
-    return rocblas_her2k_template<true>(handle, uplo, trans, n, k, cast2constType<T>(alpha), cast2constType<T>(A),
-                                 offsetA, lda, strideA, cast2constType<T>(B), offsetB, ldb,
-                                 strideB, cast2constType<S>(beta), C, offsetC, ldc, strideC, batch_count);
+    return rocblas_her2k_template<true>(
+        handle, uplo, trans, n, k, cast2constType<T>(alpha), cast2constType<T>(A), offsetA, lda,
+        strideA, cast2constType<T>(B), offsetB, ldb, strideB, cast2constType<S>(beta), C, offsetC,
+        ldc, strideC, batch_count);
 }
 
 // her2k overload
 template <typename T, typename Ua, typename Ub, std::enable_if_t<is_complex<T>, int> = 0>
 rocblas_status rocblasCall_syr2k_her2k(rocblas_handle handle,
-                                     rocblas_fill uplo,
-                                     rocblas_operation trans,
-                                     rocblas_int n,
-                                     rocblas_int k,
-                                     Ua alpha,
-                                     T *const A[],
-                                     rocblas_int offsetA,
-                                     rocblas_int lda,
-                                     rocblas_stride strideA,
-                                     T* B,
-                                     rocblas_int offsetB,
-                                     rocblas_int ldb,
-                                     rocblas_stride strideB,
-                                     Ub beta,
-                                     T *const C[],
-                                     rocblas_int offsetC,
-                                     rocblas_int ldc,
-                                     rocblas_stride strideC,
-                                     rocblas_int batch_count,
-                                     T** work = nullptr)
+                                       rocblas_fill uplo,
+                                       rocblas_operation trans,
+                                       rocblas_int n,
+                                       rocblas_int k,
+                                       Ua alpha,
+                                       T* const A[],
+                                       rocblas_int offsetA,
+                                       rocblas_int lda,
+                                       rocblas_stride strideA,
+                                       T* B,
+                                       rocblas_int offsetB,
+                                       rocblas_int ldb,
+                                       rocblas_stride strideB,
+                                       Ub beta,
+                                       T* const C[],
+                                       rocblas_int offsetC,
+                                       rocblas_int ldc,
+                                       rocblas_stride strideC,
+                                       rocblas_int batch_count,
+                                       T** work = nullptr)
 {
     using S = decltype(std::real(T{}));
 
@@ -1007,11 +1007,11 @@ rocblas_status rocblasCall_syr2k_her2k(rocblas_handle handle,
     rocblas_int blocks = (batch_count - 1) / 256 + 1;
     hipLaunchKernelGGL(get_array, dim3(blocks), dim3(256), 0, stream, work, B, strideB, batch_count);
 
-    return rocblas_her2k_template<true>(handle, uplo, trans, n, k, cast2constType<T>(alpha), cast2constType<T>(A),
-                                 offsetA, lda, strideA, cast2constType<T>(work), offsetB, ldb,
-                                 strideB, cast2constType<S>(beta), C, offsetC, ldc, strideC, batch_count);
+    return rocblas_her2k_template<true>(
+        handle, uplo, trans, n, k, cast2constType<T>(alpha), cast2constType<T>(A), offsetA, lda,
+        strideA, cast2constType<T>(work), offsetB, ldb, strideB, cast2constType<S>(beta), C,
+        offsetC, ldc, strideC, batch_count);
 }
-
 
 // symv
 template <typename T, typename U, typename V, std::enable_if_t<!is_complex<T>, int> = 0>

--- a/rocsolver/library/src/lapack/roclapack_sytrd_hetrd.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytrd_hetrd.cpp
@@ -50,7 +50,8 @@ rocblas_status rocsolver_sytrd_hetrd_impl(rocblas_handle handle,
 
     // memory workspace allocation
     void *scalars, *work, *norms, *tmptau_W, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work, size_norms, size_tmptau_W, size_workArr);
+    rocblas_device_malloc mem(handle, size_scalars, size_work, size_norms, size_tmptau_W,
+                              size_workArr);
 
     if(!mem)
         return rocblas_status_memory_error;

--- a/rocsolver/library/src/lapack/roclapack_sytrd_hetrd.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytrd_hetrd.cpp
@@ -38,18 +38,19 @@ rocblas_status rocsolver_sytrd_hetrd_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // extra requirements for calling SYTD2/HETD2
-    size_t size_norms, size_work, size_tmptau;
+    size_t size_norms, size_work, size_tmptau_W;
     // size of array of pointers to workspace (batched case)
     size_t size_workArr;
     rocsolver_sytrd_hetrd_getMemorySize<T, false>(n, batch_count, &size_scalars, &size_work,
-                                                  &size_norms, &size_tmptau, &size_workArr);
+                                                  &size_norms, &size_tmptau_W, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work, size_norms);
+        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work, size_norms,
+                                                      size_tmptau_W, size_workArr);
 
     // memory workspace allocation
-    void *scalars, *work, *norms, *tmptau, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work, size_norms, size_tmptau, size_workArr);
+    void *scalars, *work, *norms, *tmptau_W, *workArr;
+    rocblas_device_malloc mem(handle, size_scalars, size_work, size_norms, size_tmptau_W, size_workArr);
 
     if(!mem)
         return rocblas_status_memory_error;
@@ -57,7 +58,7 @@ rocblas_status rocsolver_sytrd_hetrd_impl(rocblas_handle handle,
     scalars = mem[0];
     work = mem[1];
     norms = mem[2];
-    tmptau = mem[3];
+    tmptau_W = mem[3];
     workArr = mem[4];
     T sca[] = {-1, 0, 1};
     RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
@@ -65,7 +66,7 @@ rocblas_status rocsolver_sytrd_hetrd_impl(rocblas_handle handle,
     // execution
     return rocsolver_sytrd_hetrd_template(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,
                                           strideE, tau, strideP, batch_count, (T*)scalars, (T*)work,
-                                          (T*)norms, (T*)tmptau, (T**)workArr);
+                                          (T*)norms, (T*)tmptau_W, (T**)workArr);
 }
 
 /*

--- a/rocsolver/library/src/lapack/roclapack_sytrd_hetrd.hpp
+++ b/rocsolver/library/src/lapack/roclapack_sytrd_hetrd.hpp
@@ -10,8 +10,10 @@
 #ifndef ROCLAPACK_TRD_H
 #define ROCLAPACK_TRD_H
 
-#include "rocblas.hpp"
 #include "roclapack_sytd2_hetd2.hpp"
+#include "../auxiliary/rocauxiliary_latrd.hpp"
+#include "common_device.hpp"
+#include "rocblas.hpp"
 #include "rocsolver.h"
 
 template <typename T, bool BATCHED>
@@ -20,7 +22,7 @@ void rocsolver_sytrd_hetrd_getMemorySize(const rocblas_int n,
                                          size_t* size_scalars,
                                          size_t* size_work,
                                          size_t* size_norms,
-                                         size_t* size_tmptau,
+                                         size_t* size_tmptau_W,
                                          size_t* size_workArr)
 {
     // if quick return no workspace needed
@@ -29,14 +31,25 @@ void rocsolver_sytrd_hetrd_getMemorySize(const rocblas_int n,
         *size_scalars = 0;
         *size_work = 0;
         *size_norms = 0;
-        *size_tmptau = 0;
+        *size_tmptau_W = 0;
         *size_workArr = 0;
         return;
     }
 
+    size_t s1 = 0, s2;
+
+    // size required to store temporary matrix W
+    if(n > xxTRD_xxTD2_SWITCHSIZE)
+    {
+        s1 = n * xxTRD_xxTD2_BLOCKSIZE;   
+        s1 *= sizeof(T) * batch_count;
+    } 
+
     // extra requirements to call SYTD2/HETD2
     rocsolver_sytd2_hetd2_getMemorySize<T, BATCHED>(n, batch_count, size_scalars, size_work,
-                                                    size_norms, size_tmptau, size_workArr);
+                                                    size_norms, &s2, size_workArr);
+
+    *size_tmptau_W = max(s1, s2);
 }
 
 template <typename S, typename T, typename U>
@@ -84,14 +97,105 @@ rocblas_status rocsolver_sytrd_hetrd_template(rocblas_handle handle,
                                               T* scalars,
                                               T* work,
                                               T* norms,
-                                              T* tmptau,
+                                              T* tmptau_W,
                                               T** workArr)
 {
     // quick return
     if(n == 0 || batch_count == 0)
         return rocblas_status_success;
 
-    return rocblas_status_not_implemented;
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    rocblas_int k = xxTRD_xxTD2_BLOCKSIZE;
+    rocblas_int kk = xxTRD_xxTD2_SWITCHSIZE;
+
+    // if the matrix is too small, use the unblocked variant of the algorithm
+    if(n <= kk)
+        return rocsolver_sytd2_hetd2_template(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, 
+                                            E, strideE, tau, strideP, batch_count, scalars, work,
+                                            norms, tmptau_W, workArr);
+
+    // everything must be executed with scalars on the host
+    rocblas_pointer_mode old_mode;
+    rocblas_get_pointer_mode(handle, &old_mode);
+    rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
+
+    // scalars for rocblas calls
+    T minonej = -1; //complex -1
+    S one = 1;      //real 1
+
+    rocblas_int ldw = n;
+    rocblas_stride strideW = n*k;
+    rocblas_int j;
+
+    if(uplo == rocblas_fill_lower)
+    {
+        // reduce the lower part of A
+        // main loop running forwards (for each block of columns)
+        // when the unreduced part is not large enough, switch to unblocked algorithm
+        j = 0;
+        while(j < n - kk)
+        {
+            // reduce columns j:j+k-1
+            rocsolver_latrd_template(handle, uplo, n-j, k, A, shiftA + idx2D(j, j, lda), lda, 
+                                    strideA, (E + j), strideE, (tau + j), strideP, tmptau_W, 0, 
+                                    ldw, strideW, batch_count, scalars, work, norms, workArr); 
+
+            // update unreduced block as a rank-2k update
+            // A = A - V*W' - W*V'
+            rocblasCall_syr2k_her2k<T>(handle, uplo, rocblas_operation_none, n-j-k, k, &minonej,
+                                        A, shiftA + idx2D(j+k,j,lda), lda, strideA, tmptau_W,
+                                        idx2D(k,0,ldw), ldw, strideW, &one, A, 
+                                        shiftA + idx2D(j+k,j+k,lda), lda, strideA, 
+                                        batch_count, workArr);
+
+            j += k;
+        }
+
+        // reduce last columns of A
+        rocsolver_sytd2_hetd2_template(handle, uplo, n-j, A, shiftA + idx2D(j, j, lda), lda, strideA, 
+                                        (D + j), strideD, (E + j), strideE, (tau + j), strideP, 
+                                        batch_count, scalars, work, norms, tmptau_W, workArr);        
+    }
+
+    else
+    {
+        // reduce the upper part of A
+        // main loop running backwards (for each block of columns)
+        // when the unreduced part is not large enough, switch to unblocked algorithm
+        j = n - k;
+        rocblas_int upkk = n - ((n - kk + k - 1) / k) * k;
+        while(j >= upkk)
+        {
+            // reduce columns j:j+k-1
+            rocsolver_latrd_template(handle, uplo, j+k, k, A, shiftA, lda,
+                                    strideA, E, strideE, tau, strideP, tmptau_W, 0,
+                                    ldw, strideW, batch_count, scalars, work, norms, workArr);
+
+            // update unreduced block as a rank-2k update
+            // A = A - V*W' - W*V'
+            rocblasCall_syr2k_her2k<T>(handle, uplo, rocblas_operation_none, j, k, &minonej,
+                                        A, shiftA + idx2D(0,j,lda), lda, strideA, tmptau_W,
+                                        0, ldw, strideW, &one, A, shiftA, lda, strideA, 
+                                        batch_count, workArr);
+            j -= k;
+        }
+
+        // reduce first columns of A
+        rocsolver_sytd2_hetd2_template(handle, uplo, upkk, A, shiftA, lda, strideA,
+                                        D, strideD, E, strideE, tau, strideP,
+                                        batch_count, scalars, work, norms, tmptau_W, workArr);
+    }
+
+    // Copy results (set tridiagonal form in A)
+    rocblas_int blocks = (n - 1) / BLOCKSIZE + 1;
+    hipLaunchKernelGGL((set_tridiag<S, T>), dim3(blocks,batch_count), dim3(BLOCKSIZE), 0, stream, 
+                        uplo, n, A, shiftA, lda, strideA, D, strideD, E, strideE);
+
+
+    rocblas_set_pointer_mode(handle, old_mode);
+    return rocblas_status_success;
 }
 
 #endif

--- a/rocsolver/library/src/lapack/roclapack_sytrd_hetrd_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytrd_hetrd_batched.cpp
@@ -38,19 +38,19 @@ rocblas_status rocsolver_sytrd_hetrd_batched_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // extra requirements for calling SYTD2/HETD2
-    size_t size_norms, size_work, size_tmptau;
+    size_t size_norms, size_work, size_tmptau_W;
     // size of array of pointers to workspace (batched case)
     size_t size_workArr;
     rocsolver_sytrd_hetrd_getMemorySize<T, true>(n, batch_count, &size_scalars, &size_work,
-                                                 &size_norms, &size_tmptau, &size_workArr);
+                                                 &size_norms, &size_tmptau_W, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work, size_norms,
-                                                      size_tmptau, size_workArr);
+                                                      size_tmptau_W, size_workArr);
 
     // memory workspace allocation
-    void *scalars, *work, *norms, *tmptau, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work, size_norms, size_tmptau, size_workArr);
+    void *scalars, *work, *norms, *tmptau_W, *workArr;
+    rocblas_device_malloc mem(handle, size_scalars, size_work, size_norms, size_tmptau_W, size_workArr);
 
     if(!mem)
         return rocblas_status_memory_error;
@@ -58,7 +58,7 @@ rocblas_status rocsolver_sytrd_hetrd_batched_impl(rocblas_handle handle,
     scalars = mem[0];
     work = mem[1];
     norms = mem[2];
-    tmptau = mem[3];
+    tmptau_W = mem[3];
     workArr = mem[4];
     T sca[] = {-1, 0, 1};
     RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
@@ -66,7 +66,7 @@ rocblas_status rocsolver_sytrd_hetrd_batched_impl(rocblas_handle handle,
     // execution
     return rocsolver_sytrd_hetrd_template(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,
                                           strideE, tau, strideP, batch_count, (T*)scalars, (T*)work,
-                                          (T*)norms, (T*)tmptau, (T**)workArr);
+                                          (T*)norms, (T*)tmptau_W, (T**)workArr);
 }
 
 /*

--- a/rocsolver/library/src/lapack/roclapack_sytrd_hetrd_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytrd_hetrd_batched.cpp
@@ -50,7 +50,8 @@ rocblas_status rocsolver_sytrd_hetrd_batched_impl(rocblas_handle handle,
 
     // memory workspace allocation
     void *scalars, *work, *norms, *tmptau_W, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work, size_norms, size_tmptau_W, size_workArr);
+    rocblas_device_malloc mem(handle, size_scalars, size_work, size_norms, size_tmptau_W,
+                              size_workArr);
 
     if(!mem)
         return rocblas_status_memory_error;

--- a/rocsolver/library/src/lapack/roclapack_sytrd_hetrd_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytrd_hetrd_strided_batched.cpp
@@ -48,7 +48,8 @@ rocblas_status rocsolver_sytrd_hetrd_strided_batched_impl(rocblas_handle handle,
 
     // memory workspace allocation
     void *scalars, *work, *norms, *tmptau_W, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work, size_norms, size_tmptau_W, size_workArr);
+    rocblas_device_malloc mem(handle, size_scalars, size_work, size_norms, size_tmptau_W,
+                              size_workArr);
 
     if(!mem)
         return rocblas_status_memory_error;

--- a/rocsolver/library/src/lapack/roclapack_sytrd_hetrd_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytrd_hetrd_strided_batched.cpp
@@ -36,19 +36,19 @@ rocblas_status rocsolver_sytrd_hetrd_strided_batched_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // extra requirements for calling SYTD2/HETD2
-    size_t size_norms, size_work, size_tmptau;
+    size_t size_norms, size_work, size_tmptau_W;
     // size of array of pointers to workspace (batched case)
     size_t size_workArr;
     rocsolver_sytrd_hetrd_getMemorySize<T, false>(n, batch_count, &size_scalars, &size_work,
-                                                  &size_norms, &size_tmptau, &size_workArr);
+                                                  &size_norms, &size_tmptau_W, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work, size_norms,
-                                                      size_tmptau, size_workArr);
+                                                      size_tmptau_W, size_workArr);
 
     // memory workspace allocation
-    void *scalars, *work, *norms, *tmptau, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work, size_norms, size_tmptau, size_workArr);
+    void *scalars, *work, *norms, *tmptau_W, *workArr;
+    rocblas_device_malloc mem(handle, size_scalars, size_work, size_norms, size_tmptau_W, size_workArr);
 
     if(!mem)
         return rocblas_status_memory_error;
@@ -56,7 +56,7 @@ rocblas_status rocsolver_sytrd_hetrd_strided_batched_impl(rocblas_handle handle,
     scalars = mem[0];
     work = mem[1];
     norms = mem[2];
-    tmptau = mem[3];
+    tmptau_W = mem[3];
     workArr = mem[4];
     T sca[] = {-1, 0, 1};
     RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
@@ -64,7 +64,7 @@ rocblas_status rocsolver_sytrd_hetrd_strided_batched_impl(rocblas_handle handle,
     // execution
     return rocsolver_sytrd_hetrd_template(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,
                                           strideE, tau, strideP, batch_count, (T*)scalars, (T*)work,
-                                          (T*)norms, (T*)tmptau, (T**)workArr);
+                                          (T*)norms, (T*)tmptau_W, (T**)workArr);
 }
 
 /*


### PR DESCRIPTION
Dividing the Tridiagonalization functionality in 3 parts to facilitate reviewing process:
1/3: Unblocked algorithm (SYTD2/HETD2),
2/3: Block auxiliary (LATRD), and
3/3: Blocked algorithm (SYTRD/HETRD)