### PR TITLE
Cleanup CMake usage requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ __anchor__JZ
 __anchor__TA
 
 __anchor__CB
-- Bumped CMake minimum requirements for building rocSOLVER from source to CMake 3.8
+- Raised minimum requirement for building rocSOLVER from source to CMake 3.8
 
 __anchor__JZ
 - Switched to use semantic versioning for the library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ __anchor__JZ
 __anchor__TA
 
 __anchor__CB
+- Bumped CMake minimum requirements for building rocSOLVER from source to CMake 3.8
 
 __anchor__JZ
 - Switched to use semantic versioning for the library
@@ -42,6 +43,8 @@ __anchor__JZ
 __anchor__TA
 
 __anchor__CB
+- Removed `-DOPTIMAL` from the `roc::rocsolver` CMake usage requirements. This is an internal
+  rocSOLVER definition, and does not need to be defined by library users
 
 __anchor__JZ
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,7 @@
 # Copyright (c) 2019-2020 Advanced Micro Devices, Inc.
 # ########################################################################
 
-# The ROCm platform requires Ubuntu 16.04 or Fedora 24, which has cmake 3.5
-cmake_minimum_required( VERSION 3.5 )
+cmake_minimum_required( VERSION 3.8 )
 
 # We use C++14 features, this will add compile option: -std=c++14
 set( CMAKE_CXX_STANDARD 14 )
@@ -15,11 +14,6 @@ set( CMAKE_CXX_EXTENSIONS OFF )
 if( NOT DEFINED CMAKE_CONFIGURATION_TYPES AND NOT DEFINED CMAKE_BUILD_TYPE )
   set( CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." )
 endif()
-
-# Honor per-config flags in try_compile() source-file signature. cmake v3.7 and up
-if( POLICY CMP0066 )
-  cmake_policy( SET CMP0066 NEW )
-endif( )
 
 if ( NOT DEFINED CMAKE_Fortran_COMPILER AND NOT DEFINED ENV{FC} )
   set( CMAKE_Fortran_COMPILER  "gfortran" )

--- a/rocsolver/library/src/CMakeLists.txt
+++ b/rocsolver/library/src/CMakeLists.txt
@@ -170,7 +170,7 @@ if( NOT BUILD_SHARED_LIBS )
 endif( )
 
 if(OPTIMAL)
-  target_compile_definitions(rocsolver PUBLIC OPTIMAL)
+  target_compile_definitions(rocsolver PRIVATE OPTIMAL)
 endif( )
 
 add_armor_flags( rocsolver "${ARMOR_LEVEL}" )


### PR DESCRIPTION
This change updates rocSOLVER to match the rocBLAS CMake minimum
version requirements, and removes `-DOPTIMAL` from the CMake usage
requirements exported for rocSOLVER binary releases.

Ticket: SWDEV-260024