### PR TITLE
Add debug asserts to client containers

### DIFF
--- a/rocblascommon/clients/include/device_batch_vector.hpp
+++ b/rocblascommon/clients/include/device_batch_vector.hpp
@@ -207,9 +207,14 @@ public:
         //
         for(rocblas_int batch_index = 0; batch_index < this->m_batch_count; ++batch_index)
         {
-            if(hipSuccess
-               != (hip_err = hipMemcpy((*this)[batch_index], that[batch_index],
-                                       sizeof(T) * this->nmemb(), hipMemcpyHostToDevice)))
+            T* dst = (*this)[batch_index];
+            const T* src = that[batch_index];
+            const size_t bytes = sizeof(T) * this->nmemb();
+            assert(dst || bytes == 0);
+            assert(src || bytes == 0);
+            assert(this->nmemb() == that.nmemb());
+            hip_err = hipMemcpy(dst, src, bytes, hipMemcpyHostToDevice);
+            if(hipSuccess != hip_err)
             {
                 return hip_err;
             }

--- a/rocblascommon/clients/include/device_batch_vector.hpp
+++ b/rocblascommon/clients/include/device_batch_vector.hpp
@@ -154,7 +154,7 @@ public:
     //!
     T* operator[](rocblas_int batch_index)
     {
-        assert(this->m_data || batch_index == 0);
+        assert(this->m_data);
         assert(batch_index < this->m_batch_count);
         return this->m_data[batch_index];
     }
@@ -166,7 +166,7 @@ public:
     //!
     const T* operator[](rocblas_int batch_index) const
     {
-        assert(this->m_data || batch_index == 0);
+        assert(this->m_data);
         assert(batch_index < this->m_batch_count);
         return this->m_data[batch_index];
     }

--- a/rocblascommon/clients/include/device_batch_vector.hpp
+++ b/rocblascommon/clients/include/device_batch_vector.hpp
@@ -3,6 +3,8 @@
 //
 #pragma once
 
+#include <assert.h>
+
 #include "d_vector.hpp"
 
 //
@@ -152,6 +154,7 @@ public:
     //!
     T* operator[](rocblas_int batch_index)
     {
+        assert(this->m_data || batch_index == 0);
         return this->m_data[batch_index];
     }
 
@@ -162,6 +165,7 @@ public:
     //!
     const T* operator[](rocblas_int batch_index) const
     {
+        assert(this->m_data || batch_index == 0);
         return this->m_data[batch_index];
     }
 

--- a/rocblascommon/clients/include/device_batch_vector.hpp
+++ b/rocblascommon/clients/include/device_batch_vector.hpp
@@ -155,6 +155,7 @@ public:
     T* operator[](rocblas_int batch_index)
     {
         assert(this->m_data || batch_index == 0);
+        assert(batch_index < this->m_batch_count);
         return this->m_data[batch_index];
     }
 
@@ -166,6 +167,7 @@ public:
     const T* operator[](rocblas_int batch_index) const
     {
         assert(this->m_data || batch_index == 0);
+        assert(batch_index < this->m_batch_count);
         return this->m_data[batch_index];
     }
 

--- a/rocblascommon/clients/include/device_batch_vector.hpp
+++ b/rocblascommon/clients/include/device_batch_vector.hpp
@@ -155,6 +155,7 @@ public:
     T* operator[](rocblas_int batch_index)
     {
         assert(this->m_data);
+        assert(batch_index >= 0);
         assert(batch_index < this->m_batch_count);
         return this->m_data[batch_index];
     }
@@ -167,6 +168,7 @@ public:
     const T* operator[](rocblas_int batch_index) const
     {
         assert(this->m_data);
+        assert(batch_index >= 0);
         assert(batch_index < this->m_batch_count);
         return this->m_data[batch_index];
     }

--- a/rocblascommon/clients/include/device_strided_batch_vector.hpp
+++ b/rocblascommon/clients/include/device_strided_batch_vector.hpp
@@ -159,6 +159,7 @@ public:
             ? batch_index * this->m_stride
             : (batch_index + 1 - this->m_batch_count) * this->m_stride;
         assert(this->m_data || offset == 0);
+        assert(offset >= 0);
         assert(offset < this->nmemb());
         return this->m_data + offset;
     }
@@ -174,6 +175,7 @@ public:
             ? batch_index * this->m_stride
             : (batch_index + 1 - this->m_batch_count) * this->m_stride;
         assert(this->m_data || offset == 0);
+        assert(offset >= 0);
         assert(offset < this->nmemb());
         return this->m_data + offset;
     }

--- a/rocblascommon/clients/include/device_strided_batch_vector.hpp
+++ b/rocblascommon/clients/include/device_strided_batch_vector.hpp
@@ -159,6 +159,7 @@ public:
             ? batch_index * this->m_stride
             : (batch_index + 1 - this->m_batch_count) * this->m_stride;
         assert(this->m_data || offset == 0);
+        assert(offset < this->nmemb());
         return this->m_data + offset;
     }
 
@@ -173,6 +174,7 @@ public:
             ? batch_index * this->m_stride
             : (batch_index + 1 - this->m_batch_count) * this->m_stride;
         assert(this->m_data || offset == 0);
+        assert(offset < this->nmemb());
         return this->m_data + offset;
     }
 

--- a/rocblascommon/clients/include/device_strided_batch_vector.hpp
+++ b/rocblascommon/clients/include/device_strided_batch_vector.hpp
@@ -243,6 +243,7 @@ private:
         case storage::block: return size_t(std::abs(stride)) * batch_count;
         case storage::interleave: return size_t(n) * std::abs(inc);
         }
+        assert(false);
         return 0;
     }
 };

--- a/rocblascommon/clients/include/device_strided_batch_vector.hpp
+++ b/rocblascommon/clients/include/device_strided_batch_vector.hpp
@@ -209,7 +209,13 @@ public:
     //!
     hipError_t transfer_from(const host_strided_batch_vector<T>& that)
     {
-        return hipMemcpy(this->data(), that.data(), sizeof(T) * this->nmemb(), hipMemcpyHostToDevice);
+        T* dst = this->data();
+        const T* src = that.data();
+        const size_t bytes = sizeof(T) * this->nmemb();
+        assert(dst || bytes == 0);
+        assert(src || bytes == 0);
+        assert(this->nmemb() == that.nmemb());
+        return hipMemcpy(dst, src, bytes, hipMemcpyHostToDevice);
     }
 
     //!

--- a/rocblascommon/clients/include/device_strided_batch_vector.hpp
+++ b/rocblascommon/clients/include/device_strided_batch_vector.hpp
@@ -3,6 +3,8 @@
 //
 #pragma once
 
+#include <assert.h>
+
 //
 // Local declaration of the host strided batch vector.
 //
@@ -153,9 +155,11 @@ public:
     //!
     T* operator[](rocblas_int batch_index)
     {
-        return (this->m_stride >= 0)
-            ? this->m_data + batch_index * this->m_stride
-            : this->m_data + (batch_index + 1 - this->m_batch_count) * this->m_stride;
+        auto offset = (this->m_stride >= 0)
+            ? batch_index * this->m_stride
+            : (batch_index + 1 - this->m_batch_count) * this->m_stride;
+        assert(this->m_data || offset == 0);
+        return this->m_data + offset;
     }
 
     //!
@@ -165,9 +169,11 @@ public:
     //!
     const T* operator[](rocblas_int batch_index) const
     {
-        return (this->m_stride >= 0)
-            ? this->m_data + batch_index * this->m_stride
-            : this->m_data + (batch_index + 1 - this->m_batch_count) * this->m_stride;
+        auto offset = (this->m_stride >= 0)
+            ? batch_index * this->m_stride
+            : (batch_index + 1 - this->m_batch_count) * this->m_stride;
+        assert(this->m_data || offset == 0);
+        return this->m_data + offset;
     }
 
     //!

--- a/rocblascommon/clients/include/device_vector.hpp
+++ b/rocblascommon/clients/include/device_vector.hpp
@@ -148,8 +148,13 @@ public:
     //!
     hipError_t transfer_from(const host_vector<T>& that)
     {
-        return hipMemcpy(this->m_data, (const T*)that, this->nmemb() * sizeof(T),
-                         hipMemcpyHostToDevice);
+        T* dst = this->m_data;
+        const T* src = that.data();
+        const size_t bytes = this->nmemb() * sizeof(T);
+        assert(dst || bytes == 0);
+        assert(src || bytes == 0);
+        assert(this->nmemb() == that.nmemb());
+        return hipMemcpy(dst, src, bytes, hipMemcpyHostToDevice);
     }
 
     hipError_t memcheck() const

--- a/rocblascommon/clients/include/host_batch_vector.hpp
+++ b/rocblascommon/clients/include/host_batch_vector.hpp
@@ -121,6 +121,7 @@ public:
     T* operator[](rocblas_int batch_index)
     {
         assert(this->m_data);
+        assert(batch_index >= 0);
         assert(batch_index < this->m_batch_count);
         return this->m_data[batch_index];
     }
@@ -133,6 +134,7 @@ public:
     const T* operator[](rocblas_int batch_index) const
     {
         assert(this->m_data);
+        assert(batch_index >= 0);
         assert(batch_index < this->m_batch_count);
         return this->m_data[batch_index];
     }

--- a/rocblascommon/clients/include/host_batch_vector.hpp
+++ b/rocblascommon/clients/include/host_batch_vector.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "rocblas_init.hpp"
+#include <assert.h>
 #include <string.h>
 
 //
@@ -111,6 +112,7 @@ public:
     //!
     T* operator[](rocblas_int batch_index)
     {
+        assert(this->m_data || batch_index == 0);
         return this->m_data[batch_index];
     }
 
@@ -121,6 +123,7 @@ public:
     //!
     const T* operator[](rocblas_int batch_index) const
     {
+        assert(this->m_data || batch_index == 0);
         return this->m_data[batch_index];
     }
 

--- a/rocblascommon/clients/include/host_batch_vector.hpp
+++ b/rocblascommon/clients/include/host_batch_vector.hpp
@@ -120,7 +120,7 @@ public:
     //!
     T* operator[](rocblas_int batch_index)
     {
-        assert(this->m_data || batch_index == 0);
+        assert(this->m_data);
         assert(batch_index < this->m_batch_count);
         return this->m_data[batch_index];
     }
@@ -132,7 +132,7 @@ public:
     //!
     const T* operator[](rocblas_int batch_index) const
     {
-        assert(this->m_data || batch_index == 0);
+        assert(this->m_data);
         assert(batch_index < this->m_batch_count);
         return this->m_data[batch_index];
     }

--- a/rocblascommon/clients/include/host_batch_vector.hpp
+++ b/rocblascommon/clients/include/host_batch_vector.hpp
@@ -121,6 +121,7 @@ public:
     T* operator[](rocblas_int batch_index)
     {
         assert(this->m_data || batch_index == 0);
+        assert(batch_index < this->m_batch_count);
         return this->m_data[batch_index];
     }
 
@@ -132,6 +133,7 @@ public:
     const T* operator[](rocblas_int batch_index) const
     {
         assert(this->m_data || batch_index == 0);
+        assert(batch_index < this->m_batch_count);
         return this->m_data[batch_index];
     }
 

--- a/rocblascommon/clients/include/host_pinned_vector.hpp
+++ b/rocblascommon/clients/include/host_pinned_vector.hpp
@@ -50,8 +50,13 @@ struct host_pinned_vector : std::vector<T, pinned_memory_allocator<T>>
     //!
     hipError_t transfer_from(const device_vector<T>& that)
     {
-        return hipMemcpy(this->data(), (const T*)that, sizeof(T) * this->size(),
-                         hipMemcpyDeviceToHost);
+        T* dst = this->data();
+        const T* src = that.data();
+        const size_t bytes = sizeof(T) * this->size();
+        assert(dst || bytes == 0);
+        assert(src || bytes == 0);
+        assert(this->size() == that.size());
+        return hipMemcpy(dst, src, bytes, hipMemcpyDeviceToHost);
     }
 
     //!

--- a/rocblascommon/clients/include/host_strided_batch_vector.hpp
+++ b/rocblascommon/clients/include/host_strided_batch_vector.hpp
@@ -169,6 +169,7 @@ public:
             ? this->m_stride * batch_index
             : (batch_index + 1 - this->m_batch_count) * this->m_stride;
         assert(this->m_data || offset == 0);
+        assert(offset >= 0);
         assert(offset < this->m_nmemb);
         return this->m_data + offset;
     }
@@ -184,6 +185,7 @@ public:
             ? this->m_stride * batch_index
             : (batch_index + 1 - this->m_batch_count) * this->m_stride;
         assert(this->m_data || offset == 0);
+        assert(offset >= 0);
         assert(offset < this->m_nmemb);
         return this->m_data + offset;
     }

--- a/rocblascommon/clients/include/host_strided_batch_vector.hpp
+++ b/rocblascommon/clients/include/host_strided_batch_vector.hpp
@@ -151,6 +151,14 @@ public:
     }
 
     //!
+    //! @brief The number of members in each vector.
+    //!
+    size_t nmemb() const
+    {
+        return this->m_nmemb;
+    }
+
+    //!
     //! @brief Returns pointer.
     //! @param batch_index The batch index.
     //! @return A mutable pointer to the batch_index'th vector.
@@ -214,6 +222,9 @@ public:
         if(that.n() == this->m_n && that.inc() == this->m_inc && that.stride() == this->m_stride
            && that.batch_count() == this->m_batch_count)
         {
+            assert(this->data());
+            assert(that.data());
+            assert(this->m_nmemb == that.nmemb());
             memcpy(this->data(), that.data(), sizeof(T) * this->m_nmemb);
             return true;
         }
@@ -231,7 +242,13 @@ public:
     template <size_t PAD, typename U>
     hipError_t transfer_from(const device_strided_batch_vector<T, PAD, U>& that)
     {
-        return hipMemcpy(this->m_data, that.data(), sizeof(T) * this->m_nmemb, hipMemcpyDeviceToHost);
+        T* dst = this->m_data;
+        const T* src = that.data();
+        const size_t bytes = sizeof(T) * this->m_nmemb;
+        assert(dst || bytes == 0);
+        assert(src || bytes == 0);
+        assert(this->m_nmemb == that.nmemb());
+        return hipMemcpy(dst, src, bytes, hipMemcpyDeviceToHost);
     }
 
     //!

--- a/rocblascommon/clients/include/host_strided_batch_vector.hpp
+++ b/rocblascommon/clients/include/host_strided_batch_vector.hpp
@@ -3,6 +3,8 @@
 //
 #pragma once
 
+#include <assert.h>
+
 //
 // Local declaration of the device strided batch vector.
 //
@@ -155,9 +157,11 @@ public:
     //!
     T* operator[](rocblas_int batch_index)
     {
-        return (this->m_stride >= 0)
-            ? this->m_data + this->m_stride * batch_index
-            : this->m_data + (batch_index + 1 - this->m_batch_count) * this->m_stride;
+        auto offset = (this->m_stride >= 0)
+            ? this->m_stride * batch_index
+            : (batch_index + 1 - this->m_batch_count) * this->m_stride;
+        assert(this->m_data || offset == 0);
+        return this->m_data + offset;
     }
 
     //!
@@ -167,9 +171,11 @@ public:
     //!
     const T* operator[](rocblas_int batch_index) const
     {
-        return (this->m_stride >= 0)
-            ? this->m_data + this->m_stride * batch_index
-            : this->m_data + (batch_index + 1 - this->m_batch_count) * this->m_stride;
+        auto offset = (this->m_stride >= 0)
+            ? this->m_stride * batch_index
+            : (batch_index + 1 - this->m_batch_count) * this->m_stride;
+        assert(this->m_data || offset == 0);
+        return this->m_data + offset;
     }
 
     //!

--- a/rocblascommon/clients/include/host_strided_batch_vector.hpp
+++ b/rocblascommon/clients/include/host_strided_batch_vector.hpp
@@ -169,6 +169,7 @@ public:
             ? this->m_stride * batch_index
             : (batch_index + 1 - this->m_batch_count) * this->m_stride;
         assert(this->m_data || offset == 0);
+        assert(offset < this->m_nmemb);
         return this->m_data + offset;
     }
 
@@ -183,6 +184,7 @@ public:
             ? this->m_stride * batch_index
             : (batch_index + 1 - this->m_batch_count) * this->m_stride;
         assert(this->m_data || offset == 0);
+        assert(offset < this->m_nmemb);
         return this->m_data + offset;
     }
 

--- a/rocblascommon/clients/include/host_strided_batch_vector.hpp
+++ b/rocblascommon/clients/include/host_strided_batch_vector.hpp
@@ -263,6 +263,7 @@ private:
         case storage::block: return size_t(std::abs(stride)) * batch_count;
         case storage::interleave: return size_t(n) * std::abs(inc);
         }
+        assert(false);
         return 0;
     }
 };

--- a/rocblascommon/clients/include/host_vector.hpp
+++ b/rocblascommon/clients/include/host_vector.hpp
@@ -62,7 +62,13 @@ struct host_vector : std::vector<T>
     //!
     hipError_t transfer_from(const device_vector<T>& that)
     {
-        return hipMemcpy(*this, that, sizeof(T) * this->size(), hipMemcpyDeviceToHost);
+        T* dst = this->data();
+        const T* src = that.data();
+        const size_t bytes = sizeof(T) * this->size();
+        assert(dst || bytes == 0);
+        assert(src || bytes == 0);
+        assert(this->size() == that.size());
+        return hipMemcpy(dst, src, bytes, hipMemcpyDeviceToHost);
     }
 
     //!


### PR DESCRIPTION
I've added some debug assertions to the client containers. The focus here was on changing as little as possible about how these functions work, so the checks are rather limited. (e.g. In the batched cases, they ensure that you're not exceeding the batch count, but they can't tell if you access one of the matrices in the batch with an out-of-bounds index.)

I had entirely reworked the client containers to be able to check more, but let's just start with this. It's a much smaller change than that was going to be, and I think it will be easier to upstream into rocBLAS.