### PR TITLE
Fixed erroneous zaxpy method signature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,10 +163,10 @@ endif( )
 set( ARMOR_LEVEL "${DEFAULT_ARMOR_LEVEL}" CACHE STRING "Enables increasingly expensive runtime correctness checks" )
 include( armor-config )
 
-# set the optimization level for debug mode
-if( CMAKE_BUILD_TYPE STREQUAL "Debug" )
-  add_compile_options( -O0 )
-endif( )
+# # set the optimization level for debug mode
+# if( CMAKE_BUILD_TYPE STREQUAL "Debug" )
+#   add_compile_options( -O0 )
+# endif( )
 
 # BUILD_SHARED_LIBS is a cmake built-in; we make it an explicit option such that it shows in cmake-gui
 option( BUILD_SHARED_LIBS "Build rocSOLVER as a shared library" ON )

--- a/rocsolver/clients/include/norm.hpp
+++ b/rocsolver/clients/include/norm.hpp
@@ -19,7 +19,7 @@ double zlange_(char* norm_type, int* m, int* n, rocblas_double_complex* A, int* 
 
 void daxpy_(int* n, double* alpha, double* x, int* incx, double* y, int* incy);
 void zaxpy_(int* n,
-            double* alpha,
+            rocblas_double_complex* alpha,
             rocblas_double_complex* x,
             int* incx,
             rocblas_double_complex* y,
@@ -52,7 +52,7 @@ inline void xaxpy(int* n, double* alpha, double* x, int* incx, double* y, int* i
 }
 
 inline void xaxpy(int* n,
-                  double* alpha,
+                  rocblas_double_complex* alpha,
                   rocblas_double_complex* x,
                   int* incx,
                   rocblas_double_complex* y,
@@ -111,7 +111,7 @@ double norm_error(char norm_type, rocblas_int M, rocblas_int N, rocblas_int lda,
 
     double work[M];
     rocblas_int incx = 1;
-    double alpha = -1.0;
+    rocblas_double_complex alpha = -1.0;
     rocblas_int size = lda * N;
 
     double gold_norm = xlange(&norm_type, &M, &N, gold_double.data(), &lda, work);


### PR DESCRIPTION
The method signature for zaxpy in norm.hpp had alpha as a double, whereas the LAPACK signature has alpha as a double complex. This is likely the cause of complex test failures when armor is enabled.