### PR TITLE
File reorganization

### DIFF
--- a/rocsolver/library/src/auxiliary/rocauxiliary_bdsqr.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_bdsqr.hpp
@@ -10,9 +10,8 @@
 #ifndef ROCLAPACK_BDSQR_H
 #define ROCLAPACK_BDSQR_H
 
-#include "common_device.hpp"
+#include "lapack_device_functions.hpp"
 #include "rocblas.hpp"
-#include "rocblas_device_functions.hpp"
 #include "rocsolver.h"
 
 /****************************************************************************

--- a/rocsolver/library/src/auxiliary/rocauxiliary_labrd.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_labrd.hpp
@@ -12,7 +12,6 @@
 
 #include "../auxiliary/rocauxiliary_lacgv.hpp"
 #include "../auxiliary/rocauxiliary_larfg.hpp"
-#include "common_device.hpp"
 #include "rocblas.hpp"
 #include "rocsolver.h"
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_lacgv.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_lacgv.hpp
@@ -10,7 +10,6 @@
 #ifndef ROCLAPACK_LACGV_HPP
 #define ROCLAPACK_LACGV_HPP
 
-#include "common_device.hpp"
 #include "rocblas.hpp"
 #include "rocsolver.h"
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_latrd.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_latrd.hpp
@@ -12,7 +12,6 @@
 
 #include "../auxiliary/rocauxiliary_lacgv.hpp"
 #include "../auxiliary/rocauxiliary_larfg.hpp"
-#include "common_device.hpp"
 #include "rocblas.hpp"
 #include "rocsolver.h"
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_steqr.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_steqr.hpp
@@ -10,9 +10,9 @@
 #ifndef ROCLAPACK_STEQR_HPP
 #define ROCLAPACK_STEQR_HPP
 
+#include "lapack_device_functions.hpp"
 #include "rocauxiliary_sterf.hpp"
 #include "rocblas.hpp"
-#include "rocblas_device_functions.hpp"
 #include "rocsolver.h"
 
 /****************************************************************************

--- a/rocsolver/library/src/auxiliary/rocauxiliary_sterf.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_sterf.hpp
@@ -10,8 +10,8 @@
 #ifndef ROCLAPACK_STERF_HPP
 #define ROCLAPACK_STERF_HPP
 
+#include "lapack_device_functions.hpp"
 #include "rocblas.hpp"
-#include "rocblas_device_functions.hpp"
 #include "rocsolver.h"
 
 /****************************************************************************

--- a/rocsolver/library/src/include/common_device_helpers.hpp
+++ b/rocsolver/library/src/include/common_device_helpers.hpp
@@ -13,7 +13,7 @@
  * ===========================================================================
  *    common location for device functions and kernels that are used across
  *    several rocSOLVER routines, excepting those device functions and kernels
- *    that reproduce LAPACK functionality (see lapack_device_functions).
+ *    that reproduce LAPACK functionality (see lapack_device_functions.hpp).
  * ===========================================================================
  */
 

--- a/rocsolver/library/src/include/common_device_helpers.hpp
+++ b/rocsolver/library/src/include/common_device_helpers.hpp
@@ -2,12 +2,20 @@
  * Copyright (c) 2019-2020 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
-#ifndef COMMON_DEVICE_H
-#define COMMON_DEVICE_H
+#ifndef COMMON_DEVICE_HELPERS_H
+#define COMMON_DEVICE_HELPERS_H
 
 #include "ideal_sizes.hpp"
 #include "libcommon.hpp"
 #include <hip/hip_runtime.h>
+
+/*
+ * ===========================================================================
+ *    common location for device functions and kernels that are used across
+ *    several rocSOLVER routines, excepting those device functions and kernels
+ *    that reproduce LAPACK functionality (see lapack_device_functions).
+ * ===========================================================================
+ */
 
 // **********************************************************
 // device functions that are used by many kernels

--- a/rocsolver/library/src/include/common_host_helpers.hpp
+++ b/rocsolver/library/src/include/common_host_helpers.hpp
@@ -2,8 +2,8 @@
  * Copyright (c) 2019-2020 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
-#ifndef HELPERS_H
-#define HELPERS_H
+#ifndef COMMON_HOST_HELPERS_H
+#define COMMON_HOST_HELPERS_H
 
 #include <cassert>
 #include <cstdlib>

--- a/rocsolver/library/src/include/common_host_helpers.hpp
+++ b/rocsolver/library/src/include/common_host_helpers.hpp
@@ -12,6 +12,14 @@
 #include <iostream>
 #include <limits>
 
+/*
+ * ===========================================================================
+ *    common location for functions that are used across several rocSOLVER
+ *    routines, excepting device functions and kernels (see
+ *    common_device_helpers.hpp and lapack_device_functions.hpp).
+ * ===========================================================================
+ */
+
 template <typename T, std::enable_if_t<!is_complex<T>, int> = 0>
 constexpr double get_epsilon()
 {

--- a/rocsolver/library/src/include/lapack_device_functions.hpp
+++ b/rocsolver/library/src/include/lapack_device_functions.hpp
@@ -1,12 +1,21 @@
 /* ************************************************************************
  * Copyright (c) 2019-2020 Advanced Micro Devices, Inc.
  * ************************************************************************ */
-#pragma once
-#ifndef _ROCBLAS_DEVICE_FUNCTIONS_HPP_
-#define _ROCBLAS_DEVICE_FUNCTIONS_HPP_
 
-#include "common_device.hpp"
+#pragma once
+#ifndef _LAPACK_DEVICE_FUNCTIONS_HPP_
+#define _LAPACK_DEVICE_FUNCTIONS_HPP_
+
+#include "common_device_helpers.hpp"
 #include "rocsolver.h"
+
+/*
+ * ===========================================================================
+ *    common location for device functions and kernels that reproduce LAPACK
+ *    and BLAS functionality. Includes some reproduction of rocBLAS
+ *    functionality since rocBLAS cannot be called from within a kernel.
+ * ===========================================================================
+ */
 
 template <typename T>
 __device__ void trtri_kernel_upper(const rocblas_diagonal diag,
@@ -643,4 +652,4 @@ __device__ void lasrt_increasing(const rocblas_int n, T* D, rocblas_int* stack)
     }
 }
 
-#endif // _ROCBLAS_DEVICE_FUNCTIONS_HPP_
+#endif // _LAPACK_DEVICE_FUNCTIONS_HPP_

--- a/rocsolver/library/src/include/lapack_device_functions.hpp
+++ b/rocsolver/library/src/include/lapack_device_functions.hpp
@@ -3,8 +3,8 @@
  * ************************************************************************ */
 
 #pragma once
-#ifndef _LAPACK_DEVICE_FUNCTIONS_HPP_
-#define _LAPACK_DEVICE_FUNCTIONS_HPP_
+#ifndef LAPACK_DEVICE_FUNCTIONS_HPP
+#define LAPACK_DEVICE_FUNCTIONS_HPP
 
 #include "common_device_helpers.hpp"
 #include "rocsolver.h"
@@ -652,4 +652,4 @@ __device__ void lasrt_increasing(const rocblas_int n, T* D, rocblas_int* stack)
     }
 }
 
-#endif // _LAPACK_DEVICE_FUNCTIONS_HPP_
+#endif // LAPACK_DEVICE_FUNCTIONS_HPP

--- a/rocsolver/library/src/include/rocblas.hpp
+++ b/rocsolver/library/src/include/rocblas.hpp
@@ -8,8 +8,8 @@
 template <typename T>
 struct rocblas_index_value_t;
 
-#include "common_device.hpp"
-#include "helpers.hpp"
+#include "common_device_helpers.hpp"
+#include "common_host_helpers.hpp"
 #include "internal/rocblas-exported-proto.hpp"
 #include "internal/rocblas_device_malloc.hpp"
 #include <rocblas.h>

--- a/rocsolver/library/src/lapack/roclapack_gebd2.hpp
+++ b/rocsolver/library/src/lapack/roclapack_gebd2.hpp
@@ -13,7 +13,6 @@
 #include "../auxiliary/rocauxiliary_lacgv.hpp"
 #include "../auxiliary/rocauxiliary_larf.hpp"
 #include "../auxiliary/rocauxiliary_larfg.hpp"
-#include "common_device.hpp"
 #include "rocblas.hpp"
 #include "rocsolver.h"
 

--- a/rocsolver/library/src/lapack/roclapack_gebrd.hpp
+++ b/rocsolver/library/src/lapack/roclapack_gebrd.hpp
@@ -11,7 +11,6 @@
 #define ROCLAPACK_GEBRD_H
 
 #include "../auxiliary/rocauxiliary_labrd.hpp"
-#include "common_device.hpp"
 #include "rocblas.hpp"
 #include "roclapack_gebd2.hpp"
 #include "rocsolver.h"

--- a/rocsolver/library/src/lapack/roclapack_gesvd.hpp
+++ b/rocsolver/library/src/lapack/roclapack_gesvd.hpp
@@ -12,7 +12,6 @@
 
 #include "../auxiliary/rocauxiliary_bdsqr.hpp"
 #include "../auxiliary/rocauxiliary_orgbr_ungbr.hpp"
-#include "common_device.hpp"
 #include "rocblas.hpp"
 #include "roclapack_gebrd.hpp"
 #include "rocsolver.h"

--- a/rocsolver/library/src/lapack/roclapack_getf2.hpp
+++ b/rocsolver/library/src/lapack/roclapack_getf2.hpp
@@ -15,7 +15,6 @@
 #define ROCLAPACK_GETF2_H
 
 #include "../auxiliary/rocauxiliary_laswp.hpp"
-#include "common_device.hpp"
 #include "rocblas.hpp"
 #include "rocsolver.h"
 

--- a/rocsolver/library/src/lapack/roclapack_getri.hpp
+++ b/rocsolver/library/src/lapack/roclapack_getri.hpp
@@ -10,8 +10,8 @@
 #ifndef ROCLAPACK_GETRI_H
 #define ROCLAPACK_GETRI_H
 
+#include "lapack_device_functions.hpp"
 #include "rocblas.hpp"
-#include "rocblas_device_functions.hpp"
 #include "rocsolver.h"
 
 #ifdef OPTIMAL

--- a/rocsolver/library/src/lapack/roclapack_sytd2_hetd2.hpp
+++ b/rocsolver/library/src/lapack/roclapack_sytd2_hetd2.hpp
@@ -11,7 +11,6 @@
 #define ROCLAPACK_TD2_H
 
 #include "../auxiliary/rocauxiliary_larfg.hpp"
-#include "common_device.hpp"
 #include "rocblas.hpp"
 #include "rocsolver.h"
 

--- a/rocsolver/library/src/lapack/roclapack_sytrd_hetrd.hpp
+++ b/rocsolver/library/src/lapack/roclapack_sytrd_hetrd.hpp
@@ -11,7 +11,6 @@
 #define ROCLAPACK_TRD_H
 
 #include "../auxiliary/rocauxiliary_latrd.hpp"
-#include "common_device.hpp"
 #include "rocblas.hpp"
 #include "roclapack_sytd2_hetd2.hpp"
 #include "rocsolver.h"


### PR DESCRIPTION
Reorganizing files as per https://github.com/ROCmSoftwarePlatform/rocSOLVER/pull/178#discussion_r520259462

Summary of changes:
- Renamed common_device.hpp to common_device_helpers.hpp
- Renamed helpers.hpp to common_host_helpers.hpp
- Renamed rocblas_device_helpers.hpp to lapack_device_helpers.hpp
- Removed include for common_device_helpers.hpp from all files except rocblas.hpp in light of the fact that it is used everywhere but only included by some function headers, and to reflect the include pattern of common_host_helpers.hpp