### PR TITLE
Initialize scalars on user stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 ### Fixed
 - Fixed runtime errors in debug mode caused by incorrect kernel launch bounds
 - Fixed complex unit test bug caused by incorrect zaxpy function signature
+- Moved a small memory transfer from the default stream to the stream set in `rocblas_handle`
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 ### Fixed
 - Fixed runtime errors in debug mode caused by incorrect kernel launch bounds
 - Fixed complex unit test bug caused by incorrect zaxpy function signature
-- Moved a small memory transfer from the default stream to the stream set in `rocblas_handle`
+- Eliminated a small memory transfer that was being done on the default stream
 
 
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_labrd.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_labrd.cpp
@@ -69,7 +69,8 @@ rocblas_status rocsolver_labrd_impl(rocblas_handle handle,
     scalars = mem[0];
     work_workArr = mem[1];
     norms = mem[2];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_labrd_template<S, T>(handle, m, n, k, A, shiftA, lda, strideA, D, strideD, E,

--- a/rocsolver/library/src/auxiliary/rocauxiliary_labrd.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_labrd.cpp
@@ -69,8 +69,7 @@ rocblas_status rocsolver_labrd_impl(rocblas_handle handle,
     scalars = mem[0];
     work_workArr = mem[1];
     norms = mem[2];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_labrd_template<S, T>(handle, m, n, k, A, shiftA, lda, strideA, D, strideD, E,

--- a/rocsolver/library/src/auxiliary/rocauxiliary_larf.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_larf.cpp
@@ -57,8 +57,7 @@ rocblas_status rocsolver_larf_impl(rocblas_handle handle,
     scalars = mem[0];
     Abyx = mem[1];
     workArr = mem[2];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_larf_template<T>(handle, side, m, n, x, shiftx, incx, stridex, alpha, stridep,

--- a/rocsolver/library/src/auxiliary/rocauxiliary_larf.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_larf.cpp
@@ -57,7 +57,8 @@ rocblas_status rocsolver_larf_impl(rocblas_handle handle,
     scalars = mem[0];
     Abyx = mem[1];
     workArr = mem[2];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_larf_template<T>(handle, side, m, n, x, shiftx, incx, stridex, alpha, stridep,

--- a/rocsolver/library/src/auxiliary/rocauxiliary_larft.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_larft.cpp
@@ -57,7 +57,8 @@ rocblas_status rocsolver_larft_impl(rocblas_handle handle,
     scalars = mem[0];
     work = mem[1];
     workArr = mem[2];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_larft_template<T>(handle, direct, storev, n, k, V, shiftV, ldv, stridev, tau,

--- a/rocsolver/library/src/auxiliary/rocauxiliary_larft.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_larft.cpp
@@ -57,8 +57,7 @@ rocblas_status rocsolver_larft_impl(rocblas_handle handle,
     scalars = mem[0];
     work = mem[1];
     workArr = mem[2];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_larft_template<T>(handle, direct, storev, n, k, V, shiftV, ldv, stridev, tau,

--- a/rocsolver/library/src/auxiliary/rocauxiliary_latrd.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_latrd.cpp
@@ -62,7 +62,8 @@ rocblas_status rocsolver_latrd_impl(rocblas_handle handle,
     work = mem[1];
     norms = mem[2];
     workArr = mem[3];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_latrd_template(handle, uplo, n, k, A, shiftA, lda, strideA, E, strideE, tau,

--- a/rocsolver/library/src/auxiliary/rocauxiliary_latrd.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_latrd.cpp
@@ -62,8 +62,7 @@ rocblas_status rocsolver_latrd_impl(rocblas_handle handle,
     work = mem[1];
     norms = mem[2];
     workArr = mem[3];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_latrd_template(handle, uplo, n, k, A, shiftA, lda, strideA, E, strideE, tau,

--- a/rocsolver/library/src/auxiliary/rocauxiliary_org2l_ung2l.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_org2l_ung2l.cpp
@@ -53,7 +53,8 @@ rocblas_status rocsolver_org2l_ung2l_impl(rocblas_handle handle,
     scalars = mem[0];
     Abyx = mem[1];
     workArr = mem[2];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_org2l_ung2l_template<T>(handle, m, n, k, A, shiftA, lda, strideA, ipiv, strideP,

--- a/rocsolver/library/src/auxiliary/rocauxiliary_org2l_ung2l.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_org2l_ung2l.cpp
@@ -53,8 +53,7 @@ rocblas_status rocsolver_org2l_ung2l_impl(rocblas_handle handle,
     scalars = mem[0];
     Abyx = mem[1];
     workArr = mem[2];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_org2l_ung2l_template<T>(handle, m, n, k, A, shiftA, lda, strideA, ipiv, strideP,

--- a/rocsolver/library/src/auxiliary/rocauxiliary_org2r_ung2r.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_org2r_ung2r.cpp
@@ -53,7 +53,8 @@ rocblas_status rocsolver_org2r_ung2r_impl(rocblas_handle handle,
     scalars = mem[0];
     Abyx = mem[1];
     workArr = mem[2];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_org2r_ung2r_template<T>(handle, m, n, k, A, shiftA, lda, strideA, ipiv, strideP,

--- a/rocsolver/library/src/auxiliary/rocauxiliary_org2r_ung2r.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_org2r_ung2r.cpp
@@ -53,8 +53,7 @@ rocblas_status rocsolver_org2r_ung2r_impl(rocblas_handle handle,
     scalars = mem[0];
     Abyx = mem[1];
     workArr = mem[2];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_org2r_ung2r_template<T>(handle, m, n, k, A, shiftA, lda, strideA, ipiv, strideP,

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgbr_ungbr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgbr_ungbr.cpp
@@ -59,8 +59,7 @@ rocblas_status rocsolver_orgbr_ungbr_impl(rocblas_handle handle,
     Abyx_tmptr = mem[2];
     trfact = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_orgbr_ungbr_template<false, false, T>(

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgbr_ungbr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgbr_ungbr.cpp
@@ -59,7 +59,8 @@ rocblas_status rocsolver_orgbr_ungbr_impl(rocblas_handle handle,
     Abyx_tmptr = mem[2];
     trfact = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_orgbr_ungbr_template<false, false, T>(

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgl2_ungl2.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgl2_ungl2.cpp
@@ -53,7 +53,8 @@ rocblas_status rocsolver_orgl2_ungl2_impl(rocblas_handle handle,
     scalars = mem[0];
     Abyx = mem[1];
     workArr = mem[2];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_orgl2_ungl2_template<T>(handle, m, n, k, A, shiftA, lda, strideA, ipiv, strideP,

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgl2_ungl2.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgl2_ungl2.cpp
@@ -53,8 +53,7 @@ rocblas_status rocsolver_orgl2_ungl2_impl(rocblas_handle handle,
     scalars = mem[0];
     Abyx = mem[1];
     workArr = mem[2];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_orgl2_ungl2_template<T>(handle, m, n, k, A, shiftA, lda, strideA, ipiv, strideP,

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orglq_unglq.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orglq_unglq.cpp
@@ -61,7 +61,8 @@ rocblas_status rocsolver_orglq_unglq_impl(rocblas_handle handle,
     Abyx_tmptr = mem[2];
     trfact = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_orglq_unglq_template<false, false, T>(

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orglq_unglq.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orglq_unglq.cpp
@@ -61,8 +61,7 @@ rocblas_status rocsolver_orglq_unglq_impl(rocblas_handle handle,
     Abyx_tmptr = mem[2];
     trfact = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_orglq_unglq_template<false, false, T>(

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgql_ungql.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgql_ungql.cpp
@@ -61,7 +61,8 @@ rocblas_status rocsolver_orgql_ungql_impl(rocblas_handle handle,
     Abyx_tmptr = mem[2];
     trfact = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_orgql_ungql_template<false, false, T>(

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgql_ungql.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgql_ungql.cpp
@@ -61,8 +61,7 @@ rocblas_status rocsolver_orgql_ungql_impl(rocblas_handle handle,
     Abyx_tmptr = mem[2];
     trfact = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_orgql_ungql_template<false, false, T>(

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgqr_ungqr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgqr_ungqr.cpp
@@ -61,7 +61,8 @@ rocblas_status rocsolver_orgqr_ungqr_impl(rocblas_handle handle,
     Abyx_tmptr = mem[2];
     trfact = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_orgqr_ungqr_template<false, false, T>(

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgqr_ungqr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgqr_ungqr.cpp
@@ -61,8 +61,7 @@ rocblas_status rocsolver_orgqr_ungqr_impl(rocblas_handle handle,
     Abyx_tmptr = mem[2];
     trfact = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_orgqr_ungqr_template<false, false, T>(

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgtr_ungtr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgtr_ungtr.cpp
@@ -60,8 +60,7 @@ rocblas_status rocsolver_orgtr_ungtr_impl(rocblas_handle handle,
     Abyx_tmptr = mem[2];
     trfact = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_orgtr_ungtr_template<false, false, T>(

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgtr_ungtr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgtr_ungtr.cpp
@@ -60,7 +60,8 @@ rocblas_status rocsolver_orgtr_ungtr_impl(rocblas_handle handle,
     Abyx_tmptr = mem[2];
     trfact = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_orgtr_ungtr_template<false, false, T>(

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orm2l_unm2l.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orm2l_unm2l.cpp
@@ -64,7 +64,8 @@ rocblas_status rocsolver_orm2l_unm2l_impl(rocblas_handle handle,
     Abyx = mem[1];
     diag = mem[2];
     workArr = mem[3];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_orm2l_unm2l_template<T>(handle, side, trans, m, n, k, A, shiftA, lda, strideA,

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orm2l_unm2l.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orm2l_unm2l.cpp
@@ -64,8 +64,7 @@ rocblas_status rocsolver_orm2l_unm2l_impl(rocblas_handle handle,
     Abyx = mem[1];
     diag = mem[2];
     workArr = mem[3];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_orm2l_unm2l_template<T>(handle, side, trans, m, n, k, A, shiftA, lda, strideA,

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orm2r_unm2r.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orm2r_unm2r.cpp
@@ -64,8 +64,7 @@ rocblas_status rocsolver_orm2r_unm2r_impl(rocblas_handle handle,
     Abyx = mem[1];
     diag = mem[2];
     workArr = mem[3];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_orm2r_unm2r_template<T>(handle, side, trans, m, n, k, A, shiftA, lda, strideA,

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orm2r_unm2r.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orm2r_unm2r.cpp
@@ -64,7 +64,8 @@ rocblas_status rocsolver_orm2r_unm2r_impl(rocblas_handle handle,
     Abyx = mem[1];
     diag = mem[2];
     workArr = mem[3];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_orm2r_unm2r_template<T>(handle, side, trans, m, n, k, A, shiftA, lda, strideA,

--- a/rocsolver/library/src/auxiliary/rocauxiliary_ormbr_unmbr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_ormbr_unmbr.cpp
@@ -65,8 +65,7 @@ rocblas_status rocsolver_ormbr_unmbr_impl(rocblas_handle handle,
     diagORtmptr = mem[2];
     trfact = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_ormbr_unmbr_template<false, false, T>(

--- a/rocsolver/library/src/auxiliary/rocauxiliary_ormbr_unmbr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_ormbr_unmbr.cpp
@@ -65,7 +65,8 @@ rocblas_status rocsolver_ormbr_unmbr_impl(rocblas_handle handle,
     diagORtmptr = mem[2];
     trfact = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_ormbr_unmbr_template<false, false, T>(

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orml2_unml2.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orml2_unml2.cpp
@@ -64,8 +64,7 @@ rocblas_status rocsolver_orml2_unml2_impl(rocblas_handle handle,
     Abyx = mem[1];
     diag = mem[2];
     workArr = mem[3];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_orml2_unml2_template<T>(handle, side, trans, m, n, k, A, shiftA, lda, strideA,

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orml2_unml2.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orml2_unml2.cpp
@@ -64,7 +64,8 @@ rocblas_status rocsolver_orml2_unml2_impl(rocblas_handle handle,
     Abyx = mem[1];
     diag = mem[2];
     workArr = mem[3];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_orml2_unml2_template<T>(handle, side, trans, m, n, k, A, shiftA, lda, strideA,

--- a/rocsolver/library/src/auxiliary/rocauxiliary_ormlq_unmlq.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_ormlq_unmlq.cpp
@@ -67,8 +67,7 @@ rocblas_status rocsolver_ormlq_unmlq_impl(rocblas_handle handle,
     diagORtmptr = mem[2];
     trfact = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_ormlq_unmlq_template<false, false, T>(

--- a/rocsolver/library/src/auxiliary/rocauxiliary_ormlq_unmlq.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_ormlq_unmlq.cpp
@@ -67,7 +67,8 @@ rocblas_status rocsolver_ormlq_unmlq_impl(rocblas_handle handle,
     diagORtmptr = mem[2];
     trfact = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_ormlq_unmlq_template<false, false, T>(

--- a/rocsolver/library/src/auxiliary/rocauxiliary_ormql_unmql.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_ormql_unmql.cpp
@@ -67,8 +67,7 @@ rocblas_status rocsolver_ormql_unmql_impl(rocblas_handle handle,
     diagORtmptr = mem[2];
     trfact = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_ormql_unmql_template<false, false, T>(

--- a/rocsolver/library/src/auxiliary/rocauxiliary_ormql_unmql.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_ormql_unmql.cpp
@@ -67,7 +67,8 @@ rocblas_status rocsolver_ormql_unmql_impl(rocblas_handle handle,
     diagORtmptr = mem[2];
     trfact = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_ormql_unmql_template<false, false, T>(

--- a/rocsolver/library/src/auxiliary/rocauxiliary_ormqr_unmqr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_ormqr_unmqr.cpp
@@ -67,7 +67,8 @@ rocblas_status rocsolver_ormqr_unmqr_impl(rocblas_handle handle,
     diagORtmptr = mem[2];
     trfact = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_ormqr_unmqr_template<false, false, T>(

--- a/rocsolver/library/src/auxiliary/rocauxiliary_ormqr_unmqr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_ormqr_unmqr.cpp
@@ -67,8 +67,7 @@ rocblas_status rocsolver_ormqr_unmqr_impl(rocblas_handle handle,
     diagORtmptr = mem[2];
     trfact = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_ormqr_unmqr_template<false, false, T>(

--- a/rocsolver/library/src/auxiliary/rocauxiliary_ormtr_unmtr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_ormtr_unmtr.cpp
@@ -64,8 +64,7 @@ rocblas_status rocsolver_ormtr_unmtr_impl(rocblas_handle handle,
     diagORtmptr = mem[2];
     trfact = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_ormtr_unmtr_template<false, false, T>(

--- a/rocsolver/library/src/auxiliary/rocauxiliary_ormtr_unmtr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_ormtr_unmtr.cpp
@@ -64,7 +64,8 @@ rocblas_status rocsolver_ormtr_unmtr_impl(rocblas_handle handle,
     diagORtmptr = mem[2];
     trfact = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_ormtr_unmtr_template<false, false, T>(

--- a/rocsolver/library/src/include/common_host_helpers.hpp
+++ b/rocsolver/library/src/include/common_host_helpers.hpp
@@ -21,33 +21,23 @@
  * ===========================================================================
  */
 
-template <typename T, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T>
 constexpr double get_epsilon()
 {
-    return std::numeric_limits<T>::epsilon();
+    using S = decltype(std::real(T{}));
+    return std::numeric_limits<S>::epsilon();
 }
 
-template <typename T, std::enable_if_t<+is_complex<T>, int> = 0>
-constexpr auto get_epsilon()
-{
-    return get_epsilon<decltype(std::real(T{}))>();
-}
-
-template <typename T, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T>
 constexpr double get_safemin()
 {
-    auto eps = get_epsilon<T>();
-    auto s1 = std::numeric_limits<T>::min();
-    auto s2 = 1 / std::numeric_limits<T>::max();
+    using S = decltype(std::real(T{}));
+    auto eps = get_epsilon<S>();
+    auto s1 = std::numeric_limits<S>::min();
+    auto s2 = 1 / std::numeric_limits<S>::max();
     if(s2 > s1)
         return s2 * (1 + eps);
     return s1;
-}
-
-template <typename T, std::enable_if_t<+is_complex<T>, int> = 0>
-constexpr auto get_safemin()
-{
-    return get_safemin<decltype(std::real(T{}))>();
 }
 
 inline size_t idx2D(const size_t i, const size_t j, const size_t lda)
@@ -71,29 +61,25 @@ inline double machine_precision()
 template <typename T>
 T const* cast2constType(T* array)
 {
-    T const* R = array;
-    return R;
+    return array;
 }
 
 template <typename T>
 T const* const* cast2constType(T* const* array)
 {
-    T const* const* R = array;
-    return R;
+    return array;
 }
 
 template <typename T>
 T* cast2constPointer(T* array)
 {
-    T* R = array;
-    return R;
+    return array;
 }
 
 template <typename T>
 T* const* cast2constPointer(T** array)
 {
-    T* const* R = array;
-    return R;
+    return array;
 }
 
 template <typename T, typename U, std::enable_if_t<!is_complex<T>, int> = 0>
@@ -185,4 +171,4 @@ hipError_t init_scalars(rocblas_handle handle, T* scalars, size_t size_scalars)
 // which should explain why this invariant is believed to be guaranteed.
 #define ROCSOLVER_ASSUME_X(invariant, message) ROCSOLVER_ASSUME(invariant)
 
-#endif /* HELPERS_H */
+#endif /* COMMON_HOST_HELPERS_H */

--- a/rocsolver/library/src/include/common_host_helpers.hpp
+++ b/rocsolver/library/src/include/common_host_helpers.hpp
@@ -11,6 +11,7 @@
 #include <hip/hip_runtime.h>
 #include <iostream>
 #include <limits>
+#include <rocblas.h>
 
 /*
  * ===========================================================================
@@ -141,6 +142,18 @@ void print_device_matrix(const std::string name,
         }
         std::cerr << '\n';
     }
+}
+
+// Initializes scalars on the device.
+// size_scalars is expected to be 3*sizeof(T) or 0 (to skip initialization)
+template <typename T>
+hipError_t init_scalars(rocblas_handle handle, T* scalars, size_t size_scalars)
+{
+    const T s[] = {-1, 0, 1};
+
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+    return hipMemcpyAsync(scalars, s, size_scalars, hipMemcpyHostToDevice, stream);
 }
 
 // ROCSOLVER_UNREACHABLE is an alternative to __builtin_unreachable that verifies that the path is

--- a/rocsolver/library/src/include/common_host_helpers.hpp
+++ b/rocsolver/library/src/include/common_host_helpers.hpp
@@ -130,18 +130,6 @@ void print_device_matrix(const std::string name,
     }
 }
 
-// Initializes scalars on the device.
-// size_scalars is expected to be 3*sizeof(T) or 0 (to skip initialization)
-template <typename T>
-hipError_t init_scalars(rocblas_handle handle, T* scalars, size_t size_scalars)
-{
-    static const T s[] = {-1, 0, 1};
-
-    hipStream_t stream;
-    rocblas_get_stream(handle, &stream);
-    return hipMemcpyAsync(scalars, s, size_scalars, hipMemcpyHostToDevice, stream);
-}
-
 // ROCSOLVER_UNREACHABLE is an alternative to __builtin_unreachable that verifies that the path is
 // actually unreachable if ROCSOLVER_VERIFY_ASSUMPTIONS is defined.
 #ifdef ROCSOLVER_VERIFY_ASSUMPTIONS

--- a/rocsolver/library/src/include/common_host_helpers.hpp
+++ b/rocsolver/library/src/include/common_host_helpers.hpp
@@ -135,7 +135,7 @@ void print_device_matrix(const std::string name,
 template <typename T>
 hipError_t init_scalars(rocblas_handle handle, T* scalars, size_t size_scalars)
 {
-    const T s[] = {-1, 0, 1};
+    static const T s[] = {-1, 0, 1};
 
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);

--- a/rocsolver/library/src/include/init_scalars.hpp
+++ b/rocsolver/library/src/include/init_scalars.hpp
@@ -1,0 +1,28 @@
+/* ************************************************************************
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ * ************************************************************************/
+
+#define IOTA_MAX_THDS 32
+
+// Fills the given range with sequentially increasing values.
+// The name and interface is based on std::iota
+template <typename T>
+__global__ void __launch_bounds__(IOTA_MAX_THDS) iota_n(T* first, uint32_t count, T value)
+{
+    const auto idx = hipThreadIdx_x;
+    if(idx < count)
+    {
+        first[idx] = T(idx) + value;
+    }
+}
+
+// Initializes scalars on the device.
+template <typename T>
+void init_scalars(rocblas_handle handle, T* scalars)
+{
+    assert(scalars != nullptr);
+
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+    hipLaunchKernelGGL(iota_n<T>, dim3(1), dim3(IOTA_MAX_THDS), 0, stream, scalars, 3, -1);
+}

--- a/rocsolver/library/src/include/rocblas.hpp
+++ b/rocsolver/library/src/include/rocblas.hpp
@@ -10,6 +10,7 @@ struct rocblas_index_value_t;
 
 #include "common_device_helpers.hpp"
 #include "common_host_helpers.hpp"
+#include "init_scalars.hpp"
 #include "internal/rocblas-exported-proto.hpp"
 #include "internal/rocblas_device_malloc.hpp"
 #include <rocblas.h>

--- a/rocsolver/library/src/lapack/roclapack_gebd2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gebd2.cpp
@@ -60,8 +60,7 @@ rocblas_status rocsolver_gebd2_impl(rocblas_handle handle,
     scalars = mem[0];
     work_workArr = mem[1];
     Abyx_norms = mem[2];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_gebd2_template<S, T>(handle, m, n, A, shiftA, lda, strideA, D, strideD, E,

--- a/rocsolver/library/src/lapack/roclapack_gebd2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gebd2.cpp
@@ -60,7 +60,8 @@ rocblas_status rocsolver_gebd2_impl(rocblas_handle handle,
     scalars = mem[0];
     work_workArr = mem[1];
     Abyx_norms = mem[2];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_gebd2_template<S, T>(handle, m, n, A, shiftA, lda, strideA, D, strideD, E,

--- a/rocsolver/library/src/lapack/roclapack_gebd2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gebd2_batched.cpp
@@ -60,7 +60,8 @@ rocblas_status rocsolver_gebd2_batched_impl(rocblas_handle handle,
     scalars = mem[0];
     work_workArr = mem[1];
     Abyx_norms = mem[2];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_gebd2_template<S, T>(handle, m, n, A, shiftA, lda, strideA, D, strideD, E,

--- a/rocsolver/library/src/lapack/roclapack_gebd2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gebd2_batched.cpp
@@ -60,8 +60,7 @@ rocblas_status rocsolver_gebd2_batched_impl(rocblas_handle handle,
     scalars = mem[0];
     work_workArr = mem[1];
     Abyx_norms = mem[2];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_gebd2_template<S, T>(handle, m, n, A, shiftA, lda, strideA, D, strideD, E,

--- a/rocsolver/library/src/lapack/roclapack_gebd2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gebd2_strided_batched.cpp
@@ -58,7 +58,8 @@ rocblas_status rocsolver_gebd2_strided_batched_impl(rocblas_handle handle,
     scalars = mem[0];
     work_workArr = mem[1];
     Abyx_norms = mem[2];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_gebd2_template<S, T>(handle, m, n, A, shiftA, lda, strideA, D, strideD, E,

--- a/rocsolver/library/src/lapack/roclapack_gebd2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gebd2_strided_batched.cpp
@@ -58,8 +58,7 @@ rocblas_status rocsolver_gebd2_strided_batched_impl(rocblas_handle handle,
     scalars = mem[0];
     work_workArr = mem[1];
     Abyx_norms = mem[2];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_gebd2_template<S, T>(handle, m, n, A, shiftA, lda, strideA, D, strideD, E,

--- a/rocsolver/library/src/lapack/roclapack_gebrd.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gebrd.cpp
@@ -70,7 +70,8 @@ rocblas_status rocsolver_gebrd_impl(rocblas_handle handle,
     Abyx_norms = mem[2];
     X = mem[3];
     Y = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_gebrd_template<false, false, S, T>(

--- a/rocsolver/library/src/lapack/roclapack_gebrd.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gebrd.cpp
@@ -70,8 +70,7 @@ rocblas_status rocsolver_gebrd_impl(rocblas_handle handle,
     Abyx_norms = mem[2];
     X = mem[3];
     Y = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_gebrd_template<false, false, S, T>(

--- a/rocsolver/library/src/lapack/roclapack_gebrd_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gebrd_batched.cpp
@@ -70,7 +70,8 @@ rocblas_status rocsolver_gebrd_batched_impl(rocblas_handle handle,
     Abyx_norms = mem[2];
     X = mem[3];
     Y = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_gebrd_template<true, false, S, T>(

--- a/rocsolver/library/src/lapack/roclapack_gebrd_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gebrd_batched.cpp
@@ -70,8 +70,7 @@ rocblas_status rocsolver_gebrd_batched_impl(rocblas_handle handle,
     Abyx_norms = mem[2];
     X = mem[3];
     Y = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_gebrd_template<true, false, S, T>(

--- a/rocsolver/library/src/lapack/roclapack_gebrd_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gebrd_strided_batched.cpp
@@ -70,8 +70,7 @@ rocblas_status rocsolver_gebrd_strided_batched_impl(rocblas_handle handle,
     Abyx_norms = mem[2];
     X = mem[3];
     Y = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_gebrd_template<false, true, S, T>(

--- a/rocsolver/library/src/lapack/roclapack_gebrd_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gebrd_strided_batched.cpp
@@ -70,7 +70,8 @@ rocblas_status rocsolver_gebrd_strided_batched_impl(rocblas_handle handle,
     Abyx_norms = mem[2];
     X = mem[3];
     Y = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_gebrd_template<false, true, S, T>(

--- a/rocsolver/library/src/lapack/roclapack_gelq2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelq2.cpp
@@ -57,7 +57,8 @@ rocblas_status rocsolver_gelq2_impl(rocblas_handle handle,
     work_workArr = mem[1];
     Abyx_norms = mem[2];
     diag = mem[3];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_gelq2_template<T>(handle, m, n, A, shiftA, lda, strideA, ipiv, stridep,

--- a/rocsolver/library/src/lapack/roclapack_gelq2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelq2.cpp
@@ -57,8 +57,7 @@ rocblas_status rocsolver_gelq2_impl(rocblas_handle handle,
     work_workArr = mem[1];
     Abyx_norms = mem[2];
     diag = mem[3];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_gelq2_template<T>(handle, m, n, A, shiftA, lda, strideA, ipiv, stridep,

--- a/rocsolver/library/src/lapack/roclapack_gelq2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelq2_batched.cpp
@@ -57,8 +57,7 @@ rocblas_status rocsolver_gelq2_batched_impl(rocblas_handle handle,
     work_workArr = mem[1];
     Abyx_norms = mem[2];
     diag = mem[3];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_gelq2_template<T>(handle, m, n, A, shiftA, lda, strideA, ipiv, stridep,

--- a/rocsolver/library/src/lapack/roclapack_gelq2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelq2_batched.cpp
@@ -57,7 +57,8 @@ rocblas_status rocsolver_gelq2_batched_impl(rocblas_handle handle,
     work_workArr = mem[1];
     Abyx_norms = mem[2];
     diag = mem[3];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_gelq2_template<T>(handle, m, n, A, shiftA, lda, strideA, ipiv, stridep,

--- a/rocsolver/library/src/lapack/roclapack_gelq2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelq2_strided_batched.cpp
@@ -55,7 +55,8 @@ rocblas_status rocsolver_gelq2_strided_batched_impl(rocblas_handle handle,
     work_workArr = mem[1];
     Abyx_norms = mem[2];
     diag = mem[3];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_gelq2_template<T>(handle, m, n, A, shiftA, lda, strideA, ipiv, stridep,

--- a/rocsolver/library/src/lapack/roclapack_gelq2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelq2_strided_batched.cpp
@@ -55,8 +55,7 @@ rocblas_status rocsolver_gelq2_strided_batched_impl(rocblas_handle handle,
     work_workArr = mem[1];
     Abyx_norms = mem[2];
     diag = mem[3];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_gelq2_template<T>(handle, m, n, A, shiftA, lda, strideA, ipiv, stridep,

--- a/rocsolver/library/src/lapack/roclapack_gelqf.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelqf.cpp
@@ -60,7 +60,8 @@ rocblas_status rocsolver_gelqf_impl(rocblas_handle handle,
     Abyx_norms_trfact = mem[2];
     diag_tmptr = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_gelqf_template<false, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_gelqf.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelqf.cpp
@@ -60,8 +60,7 @@ rocblas_status rocsolver_gelqf_impl(rocblas_handle handle,
     Abyx_norms_trfact = mem[2];
     diag_tmptr = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_gelqf_template<false, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_gelqf_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelqf_batched.cpp
@@ -60,8 +60,7 @@ rocblas_status rocsolver_gelqf_batched_impl(rocblas_handle handle,
     Abyx_norms_trfact = mem[2];
     diag_tmptr = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_gelqf_template<true, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_gelqf_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelqf_batched.cpp
@@ -60,7 +60,8 @@ rocblas_status rocsolver_gelqf_batched_impl(rocblas_handle handle,
     Abyx_norms_trfact = mem[2];
     diag_tmptr = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_gelqf_template<true, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_gelqf_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelqf_strided_batched.cpp
@@ -58,7 +58,8 @@ rocblas_status rocsolver_gelqf_strided_batched_impl(rocblas_handle handle,
     Abyx_norms_trfact = mem[2];
     diag_tmptr = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_gelqf_template<false, true, T>(

--- a/rocsolver/library/src/lapack/roclapack_gelqf_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelqf_strided_batched.cpp
@@ -58,8 +58,7 @@ rocblas_status rocsolver_gelqf_strided_batched_impl(rocblas_handle handle,
     Abyx_norms_trfact = mem[2];
     diag_tmptr = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_gelqf_template<false, true, T>(

--- a/rocsolver/library/src/lapack/roclapack_gels.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gels.cpp
@@ -62,7 +62,8 @@ rocblas_status rocsolver_gels_impl(rocblas_handle handle,
     diag_trfac_invA = mem[3];
     trfact_workTrmm_invA = mem[4];
     ipiv = mem[5];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     return rocsolver_gels_template<false, false, T>(
         handle, trans, m, n, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, info,

--- a/rocsolver/library/src/lapack/roclapack_gels.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gels.cpp
@@ -62,8 +62,7 @@ rocblas_status rocsolver_gels_impl(rocblas_handle handle,
     diag_trfac_invA = mem[3];
     trfact_workTrmm_invA = mem[4];
     ipiv = mem[5];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     return rocsolver_gels_template<false, false, T>(
         handle, trans, m, n, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, info,

--- a/rocsolver/library/src/lapack/roclapack_gels_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gels_batched.cpp
@@ -62,8 +62,7 @@ rocblas_status rocsolver_gels_batched_impl(rocblas_handle handle,
     diag_trfac_invA = mem[3];
     trfact_workTrmm_invA = mem[4];
     ipiv = mem[5];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     return rocsolver_gels_template<true, false, T>(
         handle, trans, m, n, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, info,

--- a/rocsolver/library/src/lapack/roclapack_gels_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gels_batched.cpp
@@ -62,7 +62,8 @@ rocblas_status rocsolver_gels_batched_impl(rocblas_handle handle,
     diag_trfac_invA = mem[3];
     trfact_workTrmm_invA = mem[4];
     ipiv = mem[5];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     return rocsolver_gels_template<true, false, T>(
         handle, trans, m, n, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, info,

--- a/rocsolver/library/src/lapack/roclapack_gels_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gels_strided_batched.cpp
@@ -62,7 +62,8 @@ rocblas_status rocsolver_gels_strided_batched_impl(rocblas_handle handle,
     diag_trfac_invA = mem[3];
     trfact_workTrmm_invA_arr = mem[4];
     ipiv = mem[5];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     return rocsolver_gels_template<false, true, T>(
         handle, trans, m, n, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, info,

--- a/rocsolver/library/src/lapack/roclapack_gels_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gels_strided_batched.cpp
@@ -62,8 +62,7 @@ rocblas_status rocsolver_gels_strided_batched_impl(rocblas_handle handle,
     diag_trfac_invA = mem[3];
     trfact_workTrmm_invA_arr = mem[4];
     ipiv = mem[5];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy(scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     return rocsolver_gels_template<false, true, T>(
         handle, trans, m, n, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, info,

--- a/rocsolver/library/src/lapack/roclapack_geql2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geql2.cpp
@@ -57,8 +57,7 @@ rocblas_status rocsolver_geql2_impl(rocblas_handle handle,
     work_workArr = mem[1];
     Abyx_norms = mem[2];
     diag = mem[3];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_geql2_template<T>(handle, m, n, A, shiftA, lda, strideA, ipiv, stridep,

--- a/rocsolver/library/src/lapack/roclapack_geql2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geql2.cpp
@@ -57,7 +57,8 @@ rocblas_status rocsolver_geql2_impl(rocblas_handle handle,
     work_workArr = mem[1];
     Abyx_norms = mem[2];
     diag = mem[3];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_geql2_template<T>(handle, m, n, A, shiftA, lda, strideA, ipiv, stridep,

--- a/rocsolver/library/src/lapack/roclapack_geql2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geql2_batched.cpp
@@ -57,8 +57,7 @@ rocblas_status rocsolver_geql2_batched_impl(rocblas_handle handle,
     work_workArr = mem[1];
     Abyx_norms = mem[2];
     diag = mem[3];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_geql2_template<T>(handle, m, n, A, shiftA, lda, strideA, ipiv, stridep,

--- a/rocsolver/library/src/lapack/roclapack_geql2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geql2_batched.cpp
@@ -57,7 +57,8 @@ rocblas_status rocsolver_geql2_batched_impl(rocblas_handle handle,
     work_workArr = mem[1];
     Abyx_norms = mem[2];
     diag = mem[3];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_geql2_template<T>(handle, m, n, A, shiftA, lda, strideA, ipiv, stridep,

--- a/rocsolver/library/src/lapack/roclapack_geql2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geql2_strided_batched.cpp
@@ -55,7 +55,8 @@ rocblas_status rocsolver_geql2_strided_batched_impl(rocblas_handle handle,
     work_workArr = mem[1];
     Abyx_norms = mem[2];
     diag = mem[3];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_geql2_template<T>(handle, m, n, A, shiftA, lda, strideA, ipiv, stridep,

--- a/rocsolver/library/src/lapack/roclapack_geql2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geql2_strided_batched.cpp
@@ -55,8 +55,7 @@ rocblas_status rocsolver_geql2_strided_batched_impl(rocblas_handle handle,
     work_workArr = mem[1];
     Abyx_norms = mem[2];
     diag = mem[3];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_geql2_template<T>(handle, m, n, A, shiftA, lda, strideA, ipiv, stridep,

--- a/rocsolver/library/src/lapack/roclapack_geqlf.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqlf.cpp
@@ -60,8 +60,7 @@ rocblas_status rocsolver_geqlf_impl(rocblas_handle handle,
     Abyx_norms_trfact = mem[2];
     diag_tmptr = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_geqlf_template<false, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_geqlf.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqlf.cpp
@@ -60,7 +60,8 @@ rocblas_status rocsolver_geqlf_impl(rocblas_handle handle,
     Abyx_norms_trfact = mem[2];
     diag_tmptr = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_geqlf_template<false, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_geqlf_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqlf_batched.cpp
@@ -60,7 +60,8 @@ rocblas_status rocsolver_geqlf_batched_impl(rocblas_handle handle,
     Abyx_norms_trfact = mem[2];
     diag_tmptr = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_geqlf_template<true, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_geqlf_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqlf_batched.cpp
@@ -60,8 +60,7 @@ rocblas_status rocsolver_geqlf_batched_impl(rocblas_handle handle,
     Abyx_norms_trfact = mem[2];
     diag_tmptr = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_geqlf_template<true, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_geqlf_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqlf_strided_batched.cpp
@@ -58,7 +58,8 @@ rocblas_status rocsolver_geqlf_strided_batched_impl(rocblas_handle handle,
     Abyx_norms_trfact = mem[2];
     diag_tmptr = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_geqlf_template<false, true, T>(

--- a/rocsolver/library/src/lapack/roclapack_geqlf_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqlf_strided_batched.cpp
@@ -58,8 +58,7 @@ rocblas_status rocsolver_geqlf_strided_batched_impl(rocblas_handle handle,
     Abyx_norms_trfact = mem[2];
     diag_tmptr = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_geqlf_template<false, true, T>(

--- a/rocsolver/library/src/lapack/roclapack_geqr2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqr2.cpp
@@ -57,7 +57,8 @@ rocblas_status rocsolver_geqr2_impl(rocblas_handle handle,
     work_workArr = mem[1];
     Abyx_norms = mem[2];
     diag = mem[3];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_geqr2_template<T>(handle, m, n, A, shiftA, lda, strideA, ipiv, stridep,

--- a/rocsolver/library/src/lapack/roclapack_geqr2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqr2.cpp
@@ -57,8 +57,7 @@ rocblas_status rocsolver_geqr2_impl(rocblas_handle handle,
     work_workArr = mem[1];
     Abyx_norms = mem[2];
     diag = mem[3];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_geqr2_template<T>(handle, m, n, A, shiftA, lda, strideA, ipiv, stridep,

--- a/rocsolver/library/src/lapack/roclapack_geqr2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqr2_batched.cpp
@@ -57,8 +57,7 @@ rocblas_status rocsolver_geqr2_batched_impl(rocblas_handle handle,
     work_workArr = mem[1];
     Abyx_norms = mem[2];
     diag = mem[3];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_geqr2_template<T>(handle, m, n, A, shiftA, lda, strideA, ipiv, stridep,

--- a/rocsolver/library/src/lapack/roclapack_geqr2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqr2_batched.cpp
@@ -57,7 +57,8 @@ rocblas_status rocsolver_geqr2_batched_impl(rocblas_handle handle,
     work_workArr = mem[1];
     Abyx_norms = mem[2];
     diag = mem[3];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_geqr2_template<T>(handle, m, n, A, shiftA, lda, strideA, ipiv, stridep,

--- a/rocsolver/library/src/lapack/roclapack_geqr2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqr2_strided_batched.cpp
@@ -55,8 +55,7 @@ rocblas_status rocsolver_geqr2_strided_batched_impl(rocblas_handle handle,
     work_workArr = mem[1];
     Abyx_norms = mem[2];
     diag = mem[3];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_geqr2_template<T>(handle, m, n, A, shiftA, lda, strideA, ipiv, stridep,

--- a/rocsolver/library/src/lapack/roclapack_geqr2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqr2_strided_batched.cpp
@@ -55,7 +55,8 @@ rocblas_status rocsolver_geqr2_strided_batched_impl(rocblas_handle handle,
     work_workArr = mem[1];
     Abyx_norms = mem[2];
     diag = mem[3];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_geqr2_template<T>(handle, m, n, A, shiftA, lda, strideA, ipiv, stridep,

--- a/rocsolver/library/src/lapack/roclapack_geqrf.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqrf.cpp
@@ -60,7 +60,8 @@ rocblas_status rocsolver_geqrf_impl(rocblas_handle handle,
     Abyx_norms_trfact = mem[2];
     diag_tmptr = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_geqrf_template<false, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_geqrf.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqrf.cpp
@@ -60,8 +60,7 @@ rocblas_status rocsolver_geqrf_impl(rocblas_handle handle,
     Abyx_norms_trfact = mem[2];
     diag_tmptr = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_geqrf_template<false, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_geqrf_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqrf_batched.cpp
@@ -60,8 +60,7 @@ rocblas_status rocsolver_geqrf_batched_impl(rocblas_handle handle,
     Abyx_norms_trfact = mem[2];
     diag_tmptr = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_geqrf_template<true, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_geqrf_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqrf_batched.cpp
@@ -60,7 +60,8 @@ rocblas_status rocsolver_geqrf_batched_impl(rocblas_handle handle,
     Abyx_norms_trfact = mem[2];
     diag_tmptr = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_geqrf_template<true, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_geqrf_ptr_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqrf_ptr_batched.cpp
@@ -82,7 +82,8 @@ rocblas_status rocsolver_geqrf_ptr_batched_impl(rocblas_handle handle,
     diag_tmptr = mem[3];
     workArr = mem[4];
     ipiv = mem[5];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     rocblas_status status = rocsolver_geqrf_template<true, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_geqrf_ptr_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqrf_ptr_batched.cpp
@@ -82,8 +82,7 @@ rocblas_status rocsolver_geqrf_ptr_batched_impl(rocblas_handle handle,
     diag_tmptr = mem[3];
     workArr = mem[4];
     ipiv = mem[5];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     rocblas_status status = rocsolver_geqrf_template<true, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_geqrf_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqrf_strided_batched.cpp
@@ -58,7 +58,8 @@ rocblas_status rocsolver_geqrf_strided_batched_impl(rocblas_handle handle,
     Abyx_norms_trfact = mem[2];
     diag_tmptr = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_geqrf_template<false, true, T>(

--- a/rocsolver/library/src/lapack/roclapack_geqrf_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqrf_strided_batched.cpp
@@ -58,8 +58,7 @@ rocblas_status rocsolver_geqrf_strided_batched_impl(rocblas_handle handle,
     Abyx_norms_trfact = mem[2];
     diag_tmptr = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_geqrf_template<false, true, T>(

--- a/rocsolver/library/src/lapack/roclapack_gesvd.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gesvd.cpp
@@ -78,8 +78,7 @@ rocblas_status rocsolver_gesvd_impl(rocblas_handle handle,
     Y = mem[4];
     tau = mem[5];
     workArr = mem[6];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_gesvd_template<false, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_gesvd.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gesvd.cpp
@@ -78,7 +78,8 @@ rocblas_status rocsolver_gesvd_impl(rocblas_handle handle,
     Y = mem[4];
     tau = mem[5];
     workArr = mem[6];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_gesvd_template<false, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_gesvd_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gesvd_batched.cpp
@@ -78,7 +78,8 @@ rocblas_status rocsolver_gesvd_batched_impl(rocblas_handle handle,
     Y = mem[4];
     tau = mem[5];
     workArr = mem[6];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_gesvd_template<true, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_gesvd_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gesvd_batched.cpp
@@ -78,8 +78,7 @@ rocblas_status rocsolver_gesvd_batched_impl(rocblas_handle handle,
     Y = mem[4];
     tau = mem[5];
     workArr = mem[6];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_gesvd_template<true, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_gesvd_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gesvd_strided_batched.cpp
@@ -76,8 +76,7 @@ rocblas_status rocsolver_gesvd_strided_batched_impl(rocblas_handle handle,
     Y = mem[4];
     tau = mem[5];
     workArr = mem[6];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_gesvd_template<false, true, T>(

--- a/rocsolver/library/src/lapack/roclapack_gesvd_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gesvd_strided_batched.cpp
@@ -76,7 +76,8 @@ rocblas_status rocsolver_gesvd_strided_batched_impl(rocblas_handle handle,
     Y = mem[4];
     tau = mem[5];
     workArr = mem[6];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_gesvd_template<false, true, T>(

--- a/rocsolver/library/src/lapack/roclapack_getf2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getf2.cpp
@@ -61,8 +61,7 @@ rocblas_status rocsolver_getf2_impl(rocblas_handle handle,
     work = mem[1];
     pivotval = mem[2];
     pivotidx = mem[3];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_getf2_template<false, T, S>(

--- a/rocsolver/library/src/lapack/roclapack_getf2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getf2.cpp
@@ -61,7 +61,8 @@ rocblas_status rocsolver_getf2_impl(rocblas_handle handle,
     work = mem[1];
     pivotval = mem[2];
     pivotidx = mem[3];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_getf2_template<false, T, S>(

--- a/rocsolver/library/src/lapack/roclapack_getf2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getf2_batched.cpp
@@ -61,7 +61,8 @@ rocblas_status rocsolver_getf2_batched_impl(rocblas_handle handle,
     work = mem[1];
     pivotval = mem[2];
     pivotidx = mem[3];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_getf2_template<true, T, S>(

--- a/rocsolver/library/src/lapack/roclapack_getf2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getf2_batched.cpp
@@ -61,8 +61,7 @@ rocblas_status rocsolver_getf2_batched_impl(rocblas_handle handle,
     work = mem[1];
     pivotval = mem[2];
     pivotidx = mem[3];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_getf2_template<true, T, S>(

--- a/rocsolver/library/src/lapack/roclapack_getf2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getf2_strided_batched.cpp
@@ -59,7 +59,8 @@ rocblas_status rocsolver_getf2_strided_batched_impl(rocblas_handle handle,
     work = mem[1];
     pivotval = mem[2];
     pivotidx = mem[3];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_getf2_template<true, T, S>(

--- a/rocsolver/library/src/lapack/roclapack_getf2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getf2_strided_batched.cpp
@@ -59,8 +59,7 @@ rocblas_status rocsolver_getf2_strided_batched_impl(rocblas_handle handle,
     work = mem[1];
     pivotval = mem[2];
     pivotidx = mem[3];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_getf2_template<true, T, S>(

--- a/rocsolver/library/src/lapack/roclapack_getrf.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getrf.cpp
@@ -73,7 +73,8 @@ rocblas_status rocsolver_getrf_impl(rocblas_handle handle,
     pivotval = mem[6];
     pivotidx = mem[7];
     iinfo = mem[8];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_getrf_template<false, false, T, S>(

--- a/rocsolver/library/src/lapack/roclapack_getrf.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getrf.cpp
@@ -73,8 +73,7 @@ rocblas_status rocsolver_getrf_impl(rocblas_handle handle,
     pivotval = mem[6];
     pivotidx = mem[7];
     iinfo = mem[8];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_getrf_template<false, false, T, S>(

--- a/rocsolver/library/src/lapack/roclapack_getrf_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getrf_batched.cpp
@@ -73,8 +73,7 @@ rocblas_status rocsolver_getrf_batched_impl(rocblas_handle handle,
     pivotval = mem[6];
     pivotidx = mem[7];
     iinfo = mem[8];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_getrf_template<true, false, T, S>(

--- a/rocsolver/library/src/lapack/roclapack_getrf_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getrf_batched.cpp
@@ -73,7 +73,8 @@ rocblas_status rocsolver_getrf_batched_impl(rocblas_handle handle,
     pivotval = mem[6];
     pivotidx = mem[7];
     iinfo = mem[8];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_getrf_template<true, false, T, S>(

--- a/rocsolver/library/src/lapack/roclapack_getrf_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getrf_strided_batched.cpp
@@ -71,7 +71,8 @@ rocblas_status rocsolver_getrf_strided_batched_impl(rocblas_handle handle,
     pivotval = mem[6];
     pivotidx = mem[7];
     iinfo = mem[8];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_getrf_template<false, true, T, S>(

--- a/rocsolver/library/src/lapack/roclapack_getrf_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getrf_strided_batched.cpp
@@ -71,8 +71,7 @@ rocblas_status rocsolver_getrf_strided_batched_impl(rocblas_handle handle,
     pivotval = mem[6];
     pivotidx = mem[7];
     iinfo = mem[8];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_getrf_template<false, true, T, S>(

--- a/rocsolver/library/src/lapack/roclapack_getri.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getri.cpp
@@ -67,7 +67,8 @@ rocblas_status rocsolver_getri_impl(rocblas_handle handle,
     work4 = mem[4];
     tmpcopy = mem[5];
     workArr = mem[6];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // in-place execution
     return rocsolver_getri_template<false, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_getri.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getri.cpp
@@ -67,8 +67,7 @@ rocblas_status rocsolver_getri_impl(rocblas_handle handle,
     work4 = mem[4];
     tmpcopy = mem[5];
     workArr = mem[6];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // in-place execution
     return rocsolver_getri_template<false, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_getri_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getri_batched.cpp
@@ -67,7 +67,8 @@ rocblas_status rocsolver_getri_batched_impl(rocblas_handle handle,
     work4 = mem[4];
     tmpcopy = mem[5];
     workArr = mem[6];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // in-place execution
     return rocsolver_getri_template<true, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_getri_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getri_batched.cpp
@@ -67,8 +67,7 @@ rocblas_status rocsolver_getri_batched_impl(rocblas_handle handle,
     work4 = mem[4];
     tmpcopy = mem[5];
     workArr = mem[6];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // in-place execution
     return rocsolver_getri_template<true, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_getri_outofplace_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getri_outofplace_batched.cpp
@@ -79,7 +79,8 @@ rocblas_status rocsolver_getri_outofplace_batched_impl(rocblas_handle handle,
     work4 = mem[4];
     tmpcopy = mem[5];
     workArr = mem[6];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // out-of-place execution
     return rocsolver_getri_template<true, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_getri_outofplace_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getri_outofplace_batched.cpp
@@ -79,8 +79,7 @@ rocblas_status rocsolver_getri_outofplace_batched_impl(rocblas_handle handle,
     work4 = mem[4];
     tmpcopy = mem[5];
     workArr = mem[6];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // out-of-place execution
     return rocsolver_getri_template<true, false, T>(

--- a/rocsolver/library/src/lapack/roclapack_getri_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getri_strided_batched.cpp
@@ -65,7 +65,8 @@ rocblas_status rocsolver_getri_strided_batched_impl(rocblas_handle handle,
     work4 = mem[4];
     tmpcopy = mem[5];
     workArr = mem[6];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // in-place execution
     return rocsolver_getri_template<false, true, T>(

--- a/rocsolver/library/src/lapack/roclapack_getri_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getri_strided_batched.cpp
@@ -65,8 +65,7 @@ rocblas_status rocsolver_getri_strided_batched_impl(rocblas_handle handle,
     work4 = mem[4];
     tmpcopy = mem[5];
     workArr = mem[6];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // in-place execution
     return rocsolver_getri_template<false, true, T>(

--- a/rocsolver/library/src/lapack/roclapack_potf2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potf2.cpp
@@ -51,7 +51,8 @@ rocblas_status rocsolver_potf2_impl(rocblas_handle handle,
     scalars = mem[0];
     work = mem[1];
     pivots = mem[2];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_potf2_template<T>(handle, uplo, n, A, shiftA, lda, strideA, info, batch_count,

--- a/rocsolver/library/src/lapack/roclapack_potf2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potf2.cpp
@@ -51,8 +51,7 @@ rocblas_status rocsolver_potf2_impl(rocblas_handle handle,
     scalars = mem[0];
     work = mem[1];
     pivots = mem[2];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_potf2_template<T>(handle, uplo, n, A, shiftA, lda, strideA, info, batch_count,

--- a/rocsolver/library/src/lapack/roclapack_potf2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potf2_batched.cpp
@@ -51,8 +51,7 @@ rocblas_status rocsolver_potf2_batched_impl(rocblas_handle handle,
     scalars = mem[0];
     work = mem[1];
     pivots = mem[2];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_potf2_template<T>(handle, uplo, n, A, shiftA, lda, strideA, info, batch_count,

--- a/rocsolver/library/src/lapack/roclapack_potf2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potf2_batched.cpp
@@ -51,7 +51,8 @@ rocblas_status rocsolver_potf2_batched_impl(rocblas_handle handle,
     scalars = mem[0];
     work = mem[1];
     pivots = mem[2];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_potf2_template<T>(handle, uplo, n, A, shiftA, lda, strideA, info, batch_count,

--- a/rocsolver/library/src/lapack/roclapack_potf2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potf2_strided_batched.cpp
@@ -49,8 +49,7 @@ rocblas_status rocsolver_potf2_strided_batched_impl(rocblas_handle handle,
     scalars = mem[0];
     work = mem[1];
     pivots = mem[2];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_potf2_template<T>(handle, uplo, n, A, shiftA, lda, strideA, info, batch_count,

--- a/rocsolver/library/src/lapack/roclapack_potf2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potf2_strided_batched.cpp
@@ -49,7 +49,8 @@ rocblas_status rocsolver_potf2_strided_batched_impl(rocblas_handle handle,
     scalars = mem[0];
     work = mem[1];
     pivots = mem[2];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_potf2_template<T>(handle, uplo, n, A, shiftA, lda, strideA, info, batch_count,

--- a/rocsolver/library/src/lapack/roclapack_potrf.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potrf.cpp
@@ -65,8 +65,7 @@ rocblas_status rocsolver_potrf_impl(rocblas_handle handle,
     work4 = mem[4];
     pivots = mem[5];
     iinfo = mem[6];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_potrf_template<false, S, T>(handle, uplo, n, A, shiftA, lda, strideA, info,

--- a/rocsolver/library/src/lapack/roclapack_potrf.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potrf.cpp
@@ -65,7 +65,8 @@ rocblas_status rocsolver_potrf_impl(rocblas_handle handle,
     work4 = mem[4];
     pivots = mem[5];
     iinfo = mem[6];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_potrf_template<false, S, T>(handle, uplo, n, A, shiftA, lda, strideA, info,

--- a/rocsolver/library/src/lapack/roclapack_potrf_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potrf_batched.cpp
@@ -65,8 +65,7 @@ rocblas_status rocsolver_potrf_batched_impl(rocblas_handle handle,
     work4 = mem[4];
     pivots = mem[5];
     iinfo = mem[6];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_potrf_template<true, S, T>(handle, uplo, n, A, shiftA, lda, strideA, info,

--- a/rocsolver/library/src/lapack/roclapack_potrf_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potrf_batched.cpp
@@ -65,7 +65,8 @@ rocblas_status rocsolver_potrf_batched_impl(rocblas_handle handle,
     work4 = mem[4];
     pivots = mem[5];
     iinfo = mem[6];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_potrf_template<true, S, T>(handle, uplo, n, A, shiftA, lda, strideA, info,

--- a/rocsolver/library/src/lapack/roclapack_potrf_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potrf_strided_batched.cpp
@@ -63,8 +63,7 @@ rocblas_status rocsolver_potrf_strided_batched_impl(rocblas_handle handle,
     work4 = mem[4];
     pivots = mem[5];
     iinfo = mem[6];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_potrf_template<false, S, T>(handle, uplo, n, A, shiftA, lda, strideA, info,

--- a/rocsolver/library/src/lapack/roclapack_potrf_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potrf_strided_batched.cpp
@@ -63,7 +63,8 @@ rocblas_status rocsolver_potrf_strided_batched_impl(rocblas_handle handle,
     work4 = mem[4];
     pivots = mem[5];
     iinfo = mem[6];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_potrf_template<false, S, T>(handle, uplo, n, A, shiftA, lda, strideA, info,

--- a/rocsolver/library/src/lapack/roclapack_sytd2_hetd2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytd2_hetd2.cpp
@@ -62,8 +62,7 @@ rocblas_status rocsolver_sytd2_hetd2_impl(rocblas_handle handle,
     norms = mem[2];
     tmptau = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_sytd2_hetd2_template(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,

--- a/rocsolver/library/src/lapack/roclapack_sytd2_hetd2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytd2_hetd2.cpp
@@ -62,7 +62,8 @@ rocblas_status rocsolver_sytd2_hetd2_impl(rocblas_handle handle,
     norms = mem[2];
     tmptau = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_sytd2_hetd2_template(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,

--- a/rocsolver/library/src/lapack/roclapack_sytd2_hetd2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytd2_hetd2_batched.cpp
@@ -62,7 +62,8 @@ rocblas_status rocsolver_sytd2_hetd2_batched_impl(rocblas_handle handle,
     norms = mem[2];
     tmptau = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_sytd2_hetd2_template(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,

--- a/rocsolver/library/src/lapack/roclapack_sytd2_hetd2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytd2_hetd2_batched.cpp
@@ -62,8 +62,7 @@ rocblas_status rocsolver_sytd2_hetd2_batched_impl(rocblas_handle handle,
     norms = mem[2];
     tmptau = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_sytd2_hetd2_template(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,

--- a/rocsolver/library/src/lapack/roclapack_sytd2_hetd2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytd2_hetd2_strided_batched.cpp
@@ -60,7 +60,8 @@ rocblas_status rocsolver_sytd2_hetd2_strided_batched_impl(rocblas_handle handle,
     norms = mem[2];
     tmptau = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_sytd2_hetd2_template(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,

--- a/rocsolver/library/src/lapack/roclapack_sytd2_hetd2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytd2_hetd2_strided_batched.cpp
@@ -60,8 +60,7 @@ rocblas_status rocsolver_sytd2_hetd2_strided_batched_impl(rocblas_handle handle,
     norms = mem[2];
     tmptau = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_sytd2_hetd2_template(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,

--- a/rocsolver/library/src/lapack/roclapack_sytrd_hetrd.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytrd_hetrd.cpp
@@ -61,8 +61,7 @@ rocblas_status rocsolver_sytrd_hetrd_impl(rocblas_handle handle,
     norms = mem[2];
     tmptau_W = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_sytrd_hetrd_template(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,

--- a/rocsolver/library/src/lapack/roclapack_sytrd_hetrd.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytrd_hetrd.cpp
@@ -61,7 +61,8 @@ rocblas_status rocsolver_sytrd_hetrd_impl(rocblas_handle handle,
     norms = mem[2];
     tmptau_W = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_sytrd_hetrd_template(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,

--- a/rocsolver/library/src/lapack/roclapack_sytrd_hetrd_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytrd_hetrd_batched.cpp
@@ -61,8 +61,7 @@ rocblas_status rocsolver_sytrd_hetrd_batched_impl(rocblas_handle handle,
     norms = mem[2];
     tmptau_W = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_sytrd_hetrd_template(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,

--- a/rocsolver/library/src/lapack/roclapack_sytrd_hetrd_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytrd_hetrd_batched.cpp
@@ -61,7 +61,8 @@ rocblas_status rocsolver_sytrd_hetrd_batched_impl(rocblas_handle handle,
     norms = mem[2];
     tmptau_W = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_sytrd_hetrd_template(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,

--- a/rocsolver/library/src/lapack/roclapack_sytrd_hetrd_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytrd_hetrd_strided_batched.cpp
@@ -59,8 +59,7 @@ rocblas_status rocsolver_sytrd_hetrd_strided_batched_impl(rocblas_handle handle,
     norms = mem[2];
     tmptau_W = mem[3];
     workArr = mem[4];
-    T sca[] = {-1, 0, 1};
-    RETURN_IF_HIP_ERROR(hipMemcpy((T*)scalars, sca, size_scalars, hipMemcpyHostToDevice));
+    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
 
     // execution
     return rocsolver_sytrd_hetrd_template(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,

--- a/rocsolver/library/src/lapack/roclapack_sytrd_hetrd_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytrd_hetrd_strided_batched.cpp
@@ -59,7 +59,8 @@ rocblas_status rocsolver_sytrd_hetrd_strided_batched_impl(rocblas_handle handle,
     norms = mem[2];
     tmptau_W = mem[3];
     workArr = mem[4];
-    RETURN_IF_HIP_ERROR(init_scalars(handle, (T*)scalars, size_scalars));
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_sytrd_hetrd_template(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,


### PR DESCRIPTION
This change moves the copying of scalars from the default stream to the user-specified stream from the `rocblas_handle`. I'm still a little unclear with the semantics, but I think it will do a synchronous memcpy into a pinned memory, then enqueue a job to copy from pinned memory into device memory.

I also consolidated some code in helpers.hpp, since I was there anyway.