### PR TITLE
Skip pointer arg check if in query mode

### DIFF
--- a/rocsolver/library/src/auxiliary/rocauxiliary_bdsqr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_bdsqr.cpp
@@ -28,7 +28,7 @@ rocblas_status rocsolver_bdsqr_impl(rocblas_handle handle,
 
     // argument checking
     rocblas_status st
-        = rocsolver_bdsqr_argCheck(uplo, n, nv, nu, nc, ldv, ldu, ldc, D, E, V, U, C, info);
+        = rocsolver_bdsqr_argCheck(handle, uplo, n, nv, nu, nc, ldv, ldu, ldc, D, E, V, U, C, info);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_bdsqr.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_bdsqr.hpp
@@ -481,7 +481,8 @@ void rocsolver_bdsqr_getMemorySize(const rocblas_int n,
 }
 
 template <typename S, typename W>
-rocblas_status rocsolver_bdsqr_argCheck(const rocblas_fill uplo,
+rocblas_status rocsolver_bdsqr_argCheck(rocblas_handle handle,
+                                        const rocblas_fill uplo,
                                         const rocblas_int n,
                                         const rocblas_int nv,
                                         const rocblas_int nu,
@@ -508,6 +509,10 @@ rocblas_status rocsolver_bdsqr_argCheck(const rocblas_fill uplo,
         return rocblas_status_invalid_size;
     if((nv > 0 && ldv < n) || (nc > 0 && ldc < n))
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((n && !D) || (n > 1 && !E) || (n * nv && !V) || (n * nu && !U) || (n * nc && !C) || !info)

--- a/rocsolver/library/src/auxiliary/rocauxiliary_labrd.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_labrd.cpp
@@ -26,7 +26,8 @@ rocblas_status rocsolver_labrd_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_labrd_argCheck(m, n, k, lda, ldx, ldy, A, D, E, tauq, taup, X, Y);
+    rocblas_status st
+        = rocsolver_labrd_argCheck(handle, m, n, k, lda, ldx, ldy, A, D, E, tauq, taup, X, Y);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_labrd.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_labrd.hpp
@@ -53,7 +53,8 @@ void rocsolver_labrd_getMemorySize(const rocblas_int m,
 }
 
 template <typename S, typename T, typename U>
-rocblas_status rocsolver_labrd_argCheck(const rocblas_int m,
+rocblas_status rocsolver_labrd_argCheck(rocblas_handle handle,
+                                        const rocblas_int m,
                                         const rocblas_int n,
                                         const rocblas_int nb,
                                         const rocblas_int lda,
@@ -76,6 +77,10 @@ rocblas_status rocsolver_labrd_argCheck(const rocblas_int m,
     // 2. invalid size
     if(m < 0 || n < 0 || nb < 0 || nb > min(m, n) || lda < m || ldx < m || ldy < n || batch_count < 0)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((m * n && !A) || (nb && !D) || (nb && !E) || (nb && !tauq) || (nb && !taup) || (m * nb && !X)

--- a/rocsolver/library/src/auxiliary/rocauxiliary_lacgv.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_lacgv.cpp
@@ -14,7 +14,7 @@ rocblas_status
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_lacgv_argCheck(n, incx, x);
+    rocblas_status st = rocsolver_lacgv_argCheck(handle, n, incx, x);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_lacgv.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_lacgv.hpp
@@ -44,7 +44,8 @@ __global__ void conj_in_place(const rocblas_int m,
 }
 
 template <typename T>
-rocblas_status rocsolver_lacgv_argCheck(const rocblas_int n, const rocblas_int incx, T x)
+rocblas_status
+    rocsolver_lacgv_argCheck(rocblas_handle handle, const rocblas_int n, const rocblas_int incx, T x)
 {
     // order is important for unit tests:
 
@@ -54,6 +55,10 @@ rocblas_status rocsolver_lacgv_argCheck(const rocblas_int n, const rocblas_int i
     // 2. invalid size
     if(n < 0 || !incx)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if(n && !x)

--- a/rocsolver/library/src/auxiliary/rocauxiliary_larf.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_larf.cpp
@@ -21,7 +21,7 @@ rocblas_status rocsolver_larf_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_larf_argCheck(side, m, n, lda, incx, x, A, alpha);
+    rocblas_status st = rocsolver_larf_argCheck(handle, side, m, n, lda, incx, x, A, alpha);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_larf.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_larf.hpp
@@ -51,7 +51,8 @@ void rocsolver_larf_getMemorySize(const rocblas_side side,
 }
 
 template <typename T, typename U>
-rocblas_status rocsolver_larf_argCheck(const rocblas_side side,
+rocblas_status rocsolver_larf_argCheck(rocblas_handle handle,
+                                       const rocblas_side side,
                                        const rocblas_int m,
                                        const rocblas_int n,
                                        const rocblas_int lda,
@@ -70,6 +71,10 @@ rocblas_status rocsolver_larf_argCheck(const rocblas_side side,
     // 2. invalid size
     if(n < 0 || m < 0 || lda < m || !incx)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((m * n && !A) || (left && m && (!alpha || !x)) || (!left && n && (!alpha || !x)))

--- a/rocsolver/library/src/auxiliary/rocauxiliary_larfb.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_larfb.cpp
@@ -26,8 +26,8 @@ rocblas_status rocsolver_larfb_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st
-        = rocsolver_larfb_argCheck(side, trans, direct, storev, m, n, k, ldv, ldf, lda, V, A, F);
+    rocblas_status st = rocsolver_larfb_argCheck(handle, side, trans, direct, storev, m, n, k, ldv,
+                                                 ldf, lda, V, A, F);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_larfb.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_larfb.hpp
@@ -103,7 +103,8 @@ void rocsolver_larfb_getMemorySize(const rocblas_side side,
 }
 
 template <typename T, typename U>
-rocblas_status rocsolver_larfb_argCheck(const rocblas_side side,
+rocblas_status rocsolver_larfb_argCheck(rocblas_handle handle,
+                                        const rocblas_side side,
                                         const rocblas_operation trans,
                                         const rocblas_direct direct,
                                         const rocblas_storev storev,
@@ -139,6 +140,10 @@ rocblas_status rocsolver_larfb_argCheck(const rocblas_side side,
         return rocblas_status_invalid_size;
     if((!row && left && ldv < m) || (!row && !left && ldv < n))
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((left && m && !V) || (!left && n && !V) || (m * n && !A) || !F)

--- a/rocsolver/library/src/auxiliary/rocauxiliary_larfg.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_larfg.cpp
@@ -18,7 +18,7 @@ rocblas_status rocsolver_larfg_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_larfg_argCheck(n, incx, alpha, x, tau);
+    rocblas_status st = rocsolver_larfg_argCheck(handle, n, incx, alpha, x, tau);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_larfg.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_larfg.hpp
@@ -118,8 +118,12 @@ void rocsolver_larfg_getMemorySize(const rocblas_int n,
 }
 
 template <typename T, typename U>
-rocblas_status
-    rocsolver_larfg_argCheck(const rocblas_int n, const rocblas_int incx, T alpha, T x, U tau)
+rocblas_status rocsolver_larfg_argCheck(rocblas_handle handle,
+                                        const rocblas_int n,
+                                        const rocblas_int incx,
+                                        T alpha,
+                                        T x,
+                                        U tau)
 {
     // order is important for unit tests:
 
@@ -129,6 +133,10 @@ rocblas_status
     // 2. invalid size
     if(n < 0 || incx < 1)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((n > 1 && !x) || (n && !alpha) || (n && !tau))

--- a/rocsolver/library/src/auxiliary/rocauxiliary_larft.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_larft.cpp
@@ -22,7 +22,7 @@ rocblas_status rocsolver_larft_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_larft_argCheck(direct, storev, n, k, ldv, ldf, V, tau, F);
+    rocblas_status st = rocsolver_larft_argCheck(handle, direct, storev, n, k, ldv, ldf, V, tau, F);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_larft.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_larft.hpp
@@ -168,7 +168,8 @@ void rocsolver_larft_getMemorySize(const rocblas_int n,
 }
 
 template <typename T, typename U>
-rocblas_status rocsolver_larft_argCheck(const rocblas_direct direct,
+rocblas_status rocsolver_larft_argCheck(rocblas_handle handle,
+                                        const rocblas_direct direct,
                                         const rocblas_storev storev,
                                         const rocblas_int n,
                                         const rocblas_int k,
@@ -192,6 +193,10 @@ rocblas_status rocsolver_larft_argCheck(const rocblas_direct direct,
         return rocblas_status_invalid_size;
     if((row && ldv < k) || (!row && ldv < n))
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((n && !V) || !tau || !F)

--- a/rocsolver/library/src/auxiliary/rocauxiliary_laswp.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_laswp.cpp
@@ -20,7 +20,7 @@ rocblas_status rocsolver_laswp_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_laswp_argCheck(n, lda, k1, k2, incx, A, ipiv);
+    rocblas_status st = rocsolver_laswp_argCheck(handle, n, lda, k1, k2, incx, A, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_laswp.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_laswp.hpp
@@ -42,7 +42,8 @@ __global__ void laswp_kernel(const rocblas_int n,
 }
 
 template <typename T>
-rocblas_status rocsolver_laswp_argCheck(const rocblas_int n,
+rocblas_status rocsolver_laswp_argCheck(rocblas_handle handle,
+                                        const rocblas_int n,
                                         const rocblas_int lda,
                                         const rocblas_int k1,
                                         const rocblas_int k2,
@@ -58,6 +59,10 @@ rocblas_status rocsolver_laswp_argCheck(const rocblas_int n,
     // 2. invalid size
     if(n < 0 || lda < 1 || !incx || k1 < 1 || k2 < 1 || k2 < k1)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((n && !A) || !ipiv)

--- a/rocsolver/library/src/auxiliary/rocauxiliary_latrd.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_latrd.cpp
@@ -22,7 +22,7 @@ rocblas_status rocsolver_latrd_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_latrd_argCheck(uplo, n, k, lda, ldw, A, E, tau, W);
+    rocblas_status st = rocsolver_latrd_argCheck(handle, uplo, n, k, lda, ldw, A, E, tau, W);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_latrd.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_latrd.hpp
@@ -49,7 +49,8 @@ void rocsolver_latrd_getMemorySize(const rocblas_int n,
 }
 
 template <typename S, typename T, typename U>
-rocblas_status rocsolver_latrd_argCheck(const rocblas_fill uplo,
+rocblas_status rocsolver_latrd_argCheck(rocblas_handle handle,
+                                        const rocblas_fill uplo,
                                         const rocblas_int n,
                                         const rocblas_int k,
                                         const rocblas_int lda,
@@ -69,6 +70,10 @@ rocblas_status rocsolver_latrd_argCheck(const rocblas_fill uplo,
     // 2. invalid size
     if(n < 0 || k < 0 || k > n || lda < n || ldw < n || batch_count < 0)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((n && !A) || (n && !E) || (n && !tau) || (n * k && !W))

--- a/rocsolver/library/src/auxiliary/rocauxiliary_org2l_ung2l.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_org2l_ung2l.cpp
@@ -19,7 +19,7 @@ rocblas_status rocsolver_org2l_ung2l_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_org2l_orgql_argCheck(m, n, k, lda, A, ipiv);
+    rocblas_status st = rocsolver_org2l_orgql_argCheck(handle, m, n, k, lda, A, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_org2l_ung2l.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_org2l_ung2l.hpp
@@ -67,7 +67,8 @@ void rocsolver_org2l_ung2l_getMemorySize(const rocblas_int m,
 }
 
 template <typename T, typename U>
-rocblas_status rocsolver_org2l_orgql_argCheck(const rocblas_int m,
+rocblas_status rocsolver_org2l_orgql_argCheck(rocblas_handle handle,
+                                              const rocblas_int m,
                                               const rocblas_int n,
                                               const rocblas_int k,
                                               const rocblas_int lda,
@@ -82,6 +83,10 @@ rocblas_status rocsolver_org2l_orgql_argCheck(const rocblas_int m,
     // 2. invalid size
     if(m < 0 || n < 0 || m < n || k < 0 || k > n || lda < m)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((k && !ipiv) || (m * n && !A))

--- a/rocsolver/library/src/auxiliary/rocauxiliary_org2r_ung2r.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_org2r_ung2r.cpp
@@ -19,7 +19,7 @@ rocblas_status rocsolver_org2r_ung2r_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_org2r_orgqr_argCheck(m, n, k, lda, A, ipiv);
+    rocblas_status st = rocsolver_org2r_orgqr_argCheck(handle, m, n, k, lda, A, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_org2r_ung2r.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_org2r_ung2r.hpp
@@ -68,7 +68,8 @@ void rocsolver_org2r_ung2r_getMemorySize(const rocblas_int m,
 }
 
 template <typename T, typename U>
-rocblas_status rocsolver_org2r_orgqr_argCheck(const rocblas_int m,
+rocblas_status rocsolver_org2r_orgqr_argCheck(rocblas_handle handle,
+                                              const rocblas_int m,
                                               const rocblas_int n,
                                               const rocblas_int k,
                                               const rocblas_int lda,
@@ -83,6 +84,10 @@ rocblas_status rocsolver_org2r_orgqr_argCheck(const rocblas_int m,
     // 2. invalid size
     if(m < 0 || n < 0 || n > m || k < 0 || k > n || lda < m)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((k && !ipiv) || (m * n && !A))

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgbr_ungbr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgbr_ungbr.cpp
@@ -20,7 +20,7 @@ rocblas_status rocsolver_orgbr_ungbr_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_orgbr_argCheck(storev, m, n, k, lda, A, ipiv);
+    rocblas_status st = rocsolver_orgbr_argCheck(handle, storev, m, n, k, lda, A, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgbr_ungbr.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgbr_ungbr.hpp
@@ -80,7 +80,8 @@ void rocsolver_orgbr_ungbr_getMemorySize(const rocblas_storev storev,
 }
 
 template <typename T, typename U>
-rocblas_status rocsolver_orgbr_argCheck(const rocblas_storev storev,
+rocblas_status rocsolver_orgbr_argCheck(rocblas_handle handle,
+                                        const rocblas_storev storev,
                                         const rocblas_int m,
                                         const rocblas_int n,
                                         const rocblas_int k,
@@ -102,6 +103,10 @@ rocblas_status rocsolver_orgbr_argCheck(const rocblas_storev storev,
         return rocblas_status_invalid_size;
     if(row && (m > n || m < min(n, k)))
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((m * n && !A) || (row && min(n, k) > 0 && !ipiv) || (!row && min(m, k) > 0 && !ipiv))

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgl2_ungl2.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgl2_ungl2.cpp
@@ -19,7 +19,7 @@ rocblas_status rocsolver_orgl2_ungl2_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_orgl2_orglq_argCheck(m, n, k, lda, A, ipiv);
+    rocblas_status st = rocsolver_orgl2_orglq_argCheck(handle, m, n, k, lda, A, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgl2_ungl2.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgl2_ungl2.hpp
@@ -69,7 +69,8 @@ void rocsolver_orgl2_ungl2_getMemorySize(const rocblas_int m,
 }
 
 template <typename T, typename U>
-rocblas_status rocsolver_orgl2_orglq_argCheck(const rocblas_int m,
+rocblas_status rocsolver_orgl2_orglq_argCheck(rocblas_handle handle,
+                                              const rocblas_int m,
                                               const rocblas_int n,
                                               const rocblas_int k,
                                               const rocblas_int lda,
@@ -84,6 +85,10 @@ rocblas_status rocsolver_orgl2_orglq_argCheck(const rocblas_int m,
     // 2. invalid size
     if(m < 0 || n < 0 || n < m || k < 0 || k > m || lda < m)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((k && !ipiv) || (m * n && !A))

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orglq_unglq.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orglq_unglq.cpp
@@ -19,7 +19,7 @@ rocblas_status rocsolver_orglq_unglq_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_orgl2_orglq_argCheck(m, n, k, lda, A, ipiv);
+    rocblas_status st = rocsolver_orgl2_orglq_argCheck(handle, m, n, k, lda, A, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgql_ungql.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgql_ungql.cpp
@@ -19,7 +19,7 @@ rocblas_status rocsolver_orgql_ungql_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_org2l_orgql_argCheck(m, n, k, lda, A, ipiv);
+    rocblas_status st = rocsolver_org2l_orgql_argCheck(handle, m, n, k, lda, A, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgqr_ungqr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgqr_ungqr.cpp
@@ -19,7 +19,7 @@ rocblas_status rocsolver_orgqr_ungqr_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_org2r_orgqr_argCheck(m, n, k, lda, A, ipiv);
+    rocblas_status st = rocsolver_org2r_orgqr_argCheck(handle, m, n, k, lda, A, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgtr_ungtr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgtr_ungtr.cpp
@@ -18,7 +18,7 @@ rocblas_status rocsolver_orgtr_ungtr_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_orgtr_argCheck(uplo, n, lda, A, ipiv);
+    rocblas_status st = rocsolver_orgtr_argCheck(handle, uplo, n, lda, A, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgtr_ungtr.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgtr_ungtr.hpp
@@ -57,7 +57,8 @@ void rocsolver_orgtr_ungtr_getMemorySize(const rocblas_fill uplo,
 }
 
 template <typename T, typename U>
-rocblas_status rocsolver_orgtr_argCheck(const rocblas_fill uplo,
+rocblas_status rocsolver_orgtr_argCheck(rocblas_handle handle,
+                                        const rocblas_fill uplo,
                                         const rocblas_int n,
                                         const rocblas_int lda,
                                         T A,
@@ -72,6 +73,10 @@ rocblas_status rocsolver_orgtr_argCheck(const rocblas_fill uplo,
     // 2. invalid size
     if(n < 0 || lda < n)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((n && !A) || (n && !ipiv))

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orm2l_unm2l.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orm2l_unm2l.cpp
@@ -23,8 +23,8 @@ rocblas_status rocsolver_orm2l_unm2l_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st
-        = rocsolver_orm2l_ormql_argCheck<COMPLEX>(side, trans, m, n, k, lda, ldc, A, C, ipiv);
+    rocblas_status st = rocsolver_orm2l_ormql_argCheck<COMPLEX>(handle, side, trans, m, n, k, lda,
+                                                                ldc, A, C, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orm2l_unm2l.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orm2l_unm2l.hpp
@@ -45,7 +45,8 @@ void rocsolver_orm2l_unm2l_getMemorySize(const rocblas_side side,
 }
 
 template <bool COMPLEX, typename T, typename U>
-rocblas_status rocsolver_orm2l_ormql_argCheck(const rocblas_side side,
+rocblas_status rocsolver_orm2l_ormql_argCheck(rocblas_handle handle,
+                                              const rocblas_side side,
                                               const rocblas_operation trans,
                                               const rocblas_int m,
                                               const rocblas_int n,
@@ -76,6 +77,10 @@ rocblas_status rocsolver_orm2l_ormql_argCheck(const rocblas_side side,
         return rocblas_status_invalid_size;
     if(!left && (lda < n || k > n))
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((m * n && !C) || (k && !ipiv) || (left && m * k && !A) || (!left && n * k && !A))

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orm2r_unm2r.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orm2r_unm2r.cpp
@@ -23,8 +23,8 @@ rocblas_status rocsolver_orm2r_unm2r_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st
-        = rocsolver_orm2r_ormqr_argCheck<COMPLEX>(side, trans, m, n, k, lda, ldc, A, C, ipiv);
+    rocblas_status st = rocsolver_orm2r_ormqr_argCheck<COMPLEX>(handle, side, trans, m, n, k, lda,
+                                                                ldc, A, C, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orm2r_unm2r.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orm2r_unm2r.hpp
@@ -45,7 +45,8 @@ void rocsolver_orm2r_unm2r_getMemorySize(const rocblas_side side,
 }
 
 template <bool COMPLEX, typename T, typename U>
-rocblas_status rocsolver_orm2r_ormqr_argCheck(const rocblas_side side,
+rocblas_status rocsolver_orm2r_ormqr_argCheck(rocblas_handle handle,
+                                              const rocblas_side side,
                                               const rocblas_operation trans,
                                               const rocblas_int m,
                                               const rocblas_int n,
@@ -76,6 +77,10 @@ rocblas_status rocsolver_orm2r_ormqr_argCheck(const rocblas_side side,
         return rocblas_status_invalid_size;
     if(!left && (k > n || lda < n))
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((m * n && !C) || (k && !ipiv) || (left && m * k && !A) || (!left && n * k && !A))

--- a/rocsolver/library/src/auxiliary/rocauxiliary_ormbr_unmbr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_ormbr_unmbr.cpp
@@ -24,8 +24,8 @@ rocblas_status rocsolver_ormbr_unmbr_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st
-        = rocsolver_ormbr_argCheck<COMPLEX>(storev, side, trans, m, n, k, lda, ldc, A, C, ipiv);
+    rocblas_status st = rocsolver_ormbr_argCheck<COMPLEX>(handle, storev, side, trans, m, n, k, lda,
+                                                          ldc, A, C, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_ormbr_unmbr.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_ormbr_unmbr.hpp
@@ -54,7 +54,8 @@ void rocsolver_ormbr_unmbr_getMemorySize(const rocblas_storev storev,
 }
 
 template <bool COMPLEX, typename T, typename U>
-rocblas_status rocsolver_ormbr_argCheck(const rocblas_storev storev,
+rocblas_status rocsolver_ormbr_argCheck(rocblas_handle handle,
+                                        const rocblas_storev storev,
                                         const rocblas_side side,
                                         const rocblas_operation trans,
                                         const rocblas_int m,
@@ -90,6 +91,10 @@ rocblas_status rocsolver_ormbr_argCheck(const rocblas_storev storev,
         return rocblas_status_invalid_size;
     if(row && lda < min(nq, k))
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((min(nq, k) > 0 && !A) || (min(nq, k) > 0 && !ipiv) || (m * n && !C))

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orml2_unml2.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orml2_unml2.cpp
@@ -23,8 +23,8 @@ rocblas_status rocsolver_orml2_unml2_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st
-        = rocsolver_orml2_ormlq_argCheck<COMPLEX>(side, trans, m, n, k, lda, ldc, A, C, ipiv);
+    rocblas_status st = rocsolver_orml2_ormlq_argCheck<COMPLEX>(handle, side, trans, m, n, k, lda,
+                                                                ldc, A, C, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orml2_unml2.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orml2_unml2.hpp
@@ -45,7 +45,8 @@ void rocsolver_orml2_unml2_getMemorySize(const rocblas_side side,
 }
 
 template <bool COMPLEX, typename T, typename U>
-rocblas_status rocsolver_orml2_ormlq_argCheck(const rocblas_side side,
+rocblas_status rocsolver_orml2_ormlq_argCheck(rocblas_handle handle,
+                                              const rocblas_side side,
                                               const rocblas_operation trans,
                                               const rocblas_int m,
                                               const rocblas_int n,
@@ -76,6 +77,10 @@ rocblas_status rocsolver_orml2_ormlq_argCheck(const rocblas_side side,
         return rocblas_status_invalid_size;
     if(!left && k > n)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((m * n && !C) || (k && !ipiv) || (left && m * k && !A) || (!left && n * k && !A))

--- a/rocsolver/library/src/auxiliary/rocauxiliary_ormlq_unmlq.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_ormlq_unmlq.cpp
@@ -23,8 +23,8 @@ rocblas_status rocsolver_ormlq_unmlq_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st
-        = rocsolver_orml2_ormlq_argCheck<COMPLEX>(side, trans, m, n, k, lda, ldc, A, C, ipiv);
+    rocblas_status st = rocsolver_orml2_ormlq_argCheck<COMPLEX>(handle, side, trans, m, n, k, lda,
+                                                                ldc, A, C, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_ormql_unmql.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_ormql_unmql.cpp
@@ -23,8 +23,8 @@ rocblas_status rocsolver_ormql_unmql_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st
-        = rocsolver_orm2l_ormql_argCheck<COMPLEX>(side, trans, m, n, k, lda, ldc, A, C, ipiv);
+    rocblas_status st = rocsolver_orm2l_ormql_argCheck<COMPLEX>(handle, side, trans, m, n, k, lda,
+                                                                ldc, A, C, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_ormqr_unmqr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_ormqr_unmqr.cpp
@@ -23,8 +23,8 @@ rocblas_status rocsolver_ormqr_unmqr_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st
-        = rocsolver_orm2r_ormqr_argCheck<COMPLEX>(side, trans, m, n, k, lda, ldc, A, C, ipiv);
+    rocblas_status st = rocsolver_orm2r_ormqr_argCheck<COMPLEX>(handle, side, trans, m, n, k, lda,
+                                                                ldc, A, C, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_ormtr_unmtr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_ormtr_unmtr.cpp
@@ -24,7 +24,7 @@ rocblas_status rocsolver_ormtr_unmtr_impl(rocblas_handle handle,
 
     // argument checking
     rocblas_status st
-        = rocsolver_ormtr_argCheck<COMPLEX>(side, uplo, trans, m, n, lda, ldc, A, C, ipiv);
+        = rocsolver_ormtr_argCheck<COMPLEX>(handle, side, uplo, trans, m, n, lda, ldc, A, C, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_ormtr_unmtr.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_ormtr_unmtr.hpp
@@ -53,7 +53,8 @@ void rocsolver_ormtr_unmtr_getMemorySize(const rocblas_side side,
 }
 
 template <bool COMPLEX, typename T, typename U>
-rocblas_status rocsolver_ormtr_argCheck(const rocblas_side side,
+rocblas_status rocsolver_ormtr_argCheck(rocblas_handle handle,
+                                        const rocblas_side side,
                                         const rocblas_fill uplo,
                                         const rocblas_operation trans,
                                         const rocblas_int m,
@@ -83,6 +84,10 @@ rocblas_status rocsolver_ormtr_argCheck(const rocblas_side side,
     rocblas_int nq = left ? m : n;
     if(m < 0 || n < 0 || ldc < m || lda < nq)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((nq > 0 && !A) || (nq > 0 && !ipiv) || (m * n && !C))

--- a/rocsolver/library/src/auxiliary/rocauxiliary_steqr.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_steqr.cpp
@@ -20,7 +20,7 @@ rocblas_status rocsolver_steqr_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_steqr_argCheck(compc, n, D, E, C, ldc, info);
+    rocblas_status st = rocsolver_steqr_argCheck(handle, compc, n, D, E, C, ldc, info);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_steqr.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_steqr.hpp
@@ -312,7 +312,8 @@ void rocsolver_steqr_getMemorySize(const rocblas_evect compc,
 }
 
 template <typename S, typename T>
-rocblas_status rocsolver_steqr_argCheck(const rocblas_evect compc,
+rocblas_status rocsolver_steqr_argCheck(rocblas_handle handle,
+                                        const rocblas_evect compc,
                                         const rocblas_int n,
                                         S D,
                                         S E,
@@ -332,6 +333,10 @@ rocblas_status rocsolver_steqr_argCheck(const rocblas_evect compc,
         return rocblas_status_invalid_size;
     if(compc != rocblas_evect_none && ldc < n)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((n && !D) || (n && !E) || (compc != rocblas_evect_none && n && !C) || !info)

--- a/rocsolver/library/src/auxiliary/rocauxiliary_sterf.cpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_sterf.cpp
@@ -14,7 +14,7 @@ rocblas_status
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_sterf_argCheck(n, D, E, info);
+    rocblas_status st = rocsolver_sterf_argCheck(handle, n, D, E, info);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/auxiliary/rocauxiliary_sterf.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_sterf.hpp
@@ -276,7 +276,8 @@ void rocsolver_sterf_getMemorySize(const rocblas_int n,
 }
 
 template <typename T>
-rocblas_status rocsolver_sterf_argCheck(const rocblas_int n, T D, T E, rocblas_int* info)
+rocblas_status
+    rocsolver_sterf_argCheck(rocblas_handle handle, const rocblas_int n, T D, T E, rocblas_int* info)
 {
     // order is important for unit tests:
 
@@ -285,6 +286,10 @@ rocblas_status rocsolver_sterf_argCheck(const rocblas_int n, T D, T E, rocblas_i
     // 2. invalid size
     if(n < 0)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((n && !D) || (n && !E) || !info)

--- a/rocsolver/library/src/lapack/roclapack_gebd2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gebd2.cpp
@@ -21,7 +21,7 @@ rocblas_status rocsolver_gebd2_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_gebd2_gebrd_argCheck(m, n, lda, A, D, E, tauq, taup);
+    rocblas_status st = rocsolver_gebd2_gebrd_argCheck(handle, m, n, lda, A, D, E, tauq, taup);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_gebd2.hpp
+++ b/rocsolver/library/src/lapack/roclapack_gebd2.hpp
@@ -45,7 +45,8 @@ void rocsolver_gebd2_getMemorySize(const rocblas_int m,
 }
 
 template <typename S, typename T, typename U>
-rocblas_status rocsolver_gebd2_gebrd_argCheck(const rocblas_int m,
+rocblas_status rocsolver_gebd2_gebrd_argCheck(rocblas_handle handle,
+                                              const rocblas_int m,
                                               const rocblas_int n,
                                               const rocblas_int lda,
                                               T A,
@@ -63,6 +64,10 @@ rocblas_status rocsolver_gebd2_gebrd_argCheck(const rocblas_int m,
     // 2. invalid size
     if(m < 0 || n < 0 || lda < m || batch_count < 0)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((m * n && !A) || (m * n && !D) || (m * n && !E) || (m * n && !tauq) || (m * n && !taup))

--- a/rocsolver/library/src/lapack/roclapack_gebd2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gebd2_batched.cpp
@@ -26,7 +26,8 @@ rocblas_status rocsolver_gebd2_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_gebd2_gebrd_argCheck(m, n, lda, A, D, E, tauq, taup, batch_count);
+    rocblas_status st
+        = rocsolver_gebd2_gebrd_argCheck(handle, m, n, lda, A, D, E, tauq, taup, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_gebd2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gebd2_strided_batched.cpp
@@ -27,7 +27,8 @@ rocblas_status rocsolver_gebd2_strided_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_gebd2_gebrd_argCheck(m, n, lda, A, D, E, tauq, taup, batch_count);
+    rocblas_status st
+        = rocsolver_gebd2_gebrd_argCheck(handle, m, n, lda, A, D, E, tauq, taup, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_gebrd.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gebrd.cpp
@@ -21,7 +21,7 @@ rocblas_status rocsolver_gebrd_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_gebd2_gebrd_argCheck(m, n, lda, A, D, E, tauq, taup);
+    rocblas_status st = rocsolver_gebd2_gebrd_argCheck(handle, m, n, lda, A, D, E, tauq, taup);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_gebrd_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gebrd_batched.cpp
@@ -26,7 +26,8 @@ rocblas_status rocsolver_gebrd_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_gebd2_gebrd_argCheck(m, n, lda, A, D, E, tauq, taup, batch_count);
+    rocblas_status st
+        = rocsolver_gebd2_gebrd_argCheck(handle, m, n, lda, A, D, E, tauq, taup, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_gebrd_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gebrd_strided_batched.cpp
@@ -27,7 +27,8 @@ rocblas_status rocsolver_gebrd_strided_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_gebd2_gebrd_argCheck(m, n, lda, A, D, E, tauq, taup, batch_count);
+    rocblas_status st
+        = rocsolver_gebd2_gebrd_argCheck(handle, m, n, lda, A, D, E, tauq, taup, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_gelq2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelq2.cpp
@@ -18,7 +18,7 @@ rocblas_status rocsolver_gelq2_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_gelq2_gelqf_argCheck(m, n, lda, A, ipiv);
+    rocblas_status st = rocsolver_gelq2_gelqf_argCheck(handle, m, n, lda, A, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_gelq2.hpp
+++ b/rocsolver/library/src/lapack/roclapack_gelq2.hpp
@@ -49,7 +49,8 @@ void rocsolver_gelq2_getMemorySize(const rocblas_int m,
 }
 
 template <typename T, typename U>
-rocblas_status rocsolver_gelq2_gelqf_argCheck(const rocblas_int m,
+rocblas_status rocsolver_gelq2_gelqf_argCheck(rocblas_handle handle,
+                                              const rocblas_int m,
                                               const rocblas_int n,
                                               const rocblas_int lda,
                                               T A,
@@ -64,6 +65,10 @@ rocblas_status rocsolver_gelq2_gelqf_argCheck(const rocblas_int m,
     // 2. invalid size
     if(m < 0 || n < 0 || lda < m || batch_count < 0)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((m * n && !A) || (m * n && !ipiv))

--- a/rocsolver/library/src/lapack/roclapack_gelq2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelq2_batched.cpp
@@ -20,7 +20,7 @@ rocblas_status rocsolver_gelq2_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_gelq2_gelqf_argCheck(m, n, lda, A, ipiv, batch_count);
+    rocblas_status st = rocsolver_gelq2_gelqf_argCheck(handle, m, n, lda, A, ipiv, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_gelq2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelq2_strided_batched.cpp
@@ -21,7 +21,7 @@ rocblas_status rocsolver_gelq2_strided_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_gelq2_gelqf_argCheck(m, n, lda, A, ipiv, batch_count);
+    rocblas_status st = rocsolver_gelq2_gelqf_argCheck(handle, m, n, lda, A, ipiv, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_gelqf.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelqf.cpp
@@ -18,7 +18,7 @@ rocblas_status rocsolver_gelqf_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_gelq2_gelqf_argCheck(m, n, lda, A, ipiv);
+    rocblas_status st = rocsolver_gelq2_gelqf_argCheck(handle, m, n, lda, A, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_gelqf_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelqf_batched.cpp
@@ -20,7 +20,7 @@ rocblas_status rocsolver_gelqf_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_gelq2_gelqf_argCheck(m, n, lda, A, ipiv, batch_count);
+    rocblas_status st = rocsolver_gelq2_gelqf_argCheck(handle, m, n, lda, A, ipiv, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_gelqf_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gelqf_strided_batched.cpp
@@ -21,7 +21,7 @@ rocblas_status rocsolver_gelqf_strided_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_gelq2_gelqf_argCheck(m, n, lda, A, ipiv, batch_count);
+    rocblas_status st = rocsolver_gelq2_gelqf_argCheck(handle, m, n, lda, A, ipiv, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_gels.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gels.cpp
@@ -22,7 +22,7 @@ rocblas_status rocsolver_gels_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_gels_argCheck(trans, m, n, nrhs, A, lda, B, ldb, info);
+    rocblas_status st = rocsolver_gels_argCheck(handle, trans, m, n, nrhs, A, lda, B, ldb, info);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_gels.hpp
+++ b/rocsolver/library/src/lapack/roclapack_gels.hpp
@@ -66,7 +66,8 @@ void rocsolver_gels_getMemorySize(const rocblas_int m,
 }
 
 template <typename T>
-rocblas_status rocsolver_gels_argCheck(rocblas_operation trans,
+rocblas_status rocsolver_gels_argCheck(rocblas_handle handle,
+                                       rocblas_operation trans,
                                        const rocblas_int m,
                                        const rocblas_int n,
                                        const rocblas_int nrhs,
@@ -89,6 +90,10 @@ rocblas_status rocsolver_gels_argCheck(rocblas_operation trans,
     // 3. invalid size
     if(m < 0 || n < 0 || nrhs < 0 || lda < m || ldb < m || ldb < n || batch_count < 0)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 4. invalid pointers
     if((m * n && !A) || ((m * nrhs || n * nrhs) && !B) || (batch_count && !info))

--- a/rocsolver/library/src/lapack/roclapack_gels_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gels_batched.cpp
@@ -23,7 +23,8 @@ rocblas_status rocsolver_gels_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_gels_argCheck(trans, m, n, nrhs, A, lda, B, ldb, info, batch_count);
+    rocblas_status st
+        = rocsolver_gels_argCheck(handle, trans, m, n, nrhs, A, lda, B, ldb, info, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_gels_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gels_strided_batched.cpp
@@ -25,7 +25,8 @@ rocblas_status rocsolver_gels_strided_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_gels_argCheck(trans, m, n, nrhs, A, lda, B, ldb, info, batch_count);
+    rocblas_status st
+        = rocsolver_gels_argCheck(handle, trans, m, n, nrhs, A, lda, B, ldb, info, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_geql2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geql2.cpp
@@ -18,7 +18,7 @@ rocblas_status rocsolver_geql2_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_geql2_geqlf_argCheck(m, n, lda, A, ipiv);
+    rocblas_status st = rocsolver_geql2_geqlf_argCheck(handle, m, n, lda, A, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_geql2.hpp
+++ b/rocsolver/library/src/lapack/roclapack_geql2.hpp
@@ -49,7 +49,8 @@ void rocsolver_geql2_getMemorySize(const rocblas_int m,
 }
 
 template <typename T, typename U>
-rocblas_status rocsolver_geql2_geqlf_argCheck(const rocblas_int m,
+rocblas_status rocsolver_geql2_geqlf_argCheck(rocblas_handle handle,
+                                              const rocblas_int m,
                                               const rocblas_int n,
                                               const rocblas_int lda,
                                               T A,
@@ -64,6 +65,10 @@ rocblas_status rocsolver_geql2_geqlf_argCheck(const rocblas_int m,
     // 2. invalid size
     if(m < 0 || n < 0 || lda < m || batch_count < 0)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((m * n && !A) || (m * n && !ipiv))

--- a/rocsolver/library/src/lapack/roclapack_geql2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geql2_batched.cpp
@@ -20,7 +20,7 @@ rocblas_status rocsolver_geql2_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_geql2_geqlf_argCheck(m, n, lda, A, ipiv, batch_count);
+    rocblas_status st = rocsolver_geql2_geqlf_argCheck(handle, m, n, lda, A, ipiv, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_geql2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geql2_strided_batched.cpp
@@ -21,7 +21,7 @@ rocblas_status rocsolver_geql2_strided_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_geql2_geqlf_argCheck(m, n, lda, A, ipiv, batch_count);
+    rocblas_status st = rocsolver_geql2_geqlf_argCheck(handle, m, n, lda, A, ipiv, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_geqlf.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqlf.cpp
@@ -18,7 +18,7 @@ rocblas_status rocsolver_geqlf_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_geql2_geqlf_argCheck(m, n, lda, A, ipiv);
+    rocblas_status st = rocsolver_geql2_geqlf_argCheck(handle, m, n, lda, A, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_geqlf_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqlf_batched.cpp
@@ -20,7 +20,7 @@ rocblas_status rocsolver_geqlf_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_geql2_geqlf_argCheck(m, n, lda, A, ipiv, batch_count);
+    rocblas_status st = rocsolver_geql2_geqlf_argCheck(handle, m, n, lda, A, ipiv, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_geqlf_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqlf_strided_batched.cpp
@@ -21,7 +21,7 @@ rocblas_status rocsolver_geqlf_strided_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_geql2_geqlf_argCheck(m, n, lda, A, ipiv, batch_count);
+    rocblas_status st = rocsolver_geql2_geqlf_argCheck(handle, m, n, lda, A, ipiv, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_geqr2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqr2.cpp
@@ -18,7 +18,7 @@ rocblas_status rocsolver_geqr2_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_geqr2_geqrf_argCheck(m, n, lda, A, ipiv);
+    rocblas_status st = rocsolver_geqr2_geqrf_argCheck(handle, m, n, lda, A, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_geqr2.hpp
+++ b/rocsolver/library/src/lapack/roclapack_geqr2.hpp
@@ -49,7 +49,8 @@ void rocsolver_geqr2_getMemorySize(const rocblas_int m,
 }
 
 template <typename T, typename U>
-rocblas_status rocsolver_geqr2_geqrf_argCheck(const rocblas_int m,
+rocblas_status rocsolver_geqr2_geqrf_argCheck(rocblas_handle handle,
+                                              const rocblas_int m,
                                               const rocblas_int n,
                                               const rocblas_int lda,
                                               T A,
@@ -64,6 +65,10 @@ rocblas_status rocsolver_geqr2_geqrf_argCheck(const rocblas_int m,
     // 2. invalid size
     if(m < 0 || n < 0 || lda < m || batch_count < 0)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((m * n && !A) || (m * n && !ipiv))

--- a/rocsolver/library/src/lapack/roclapack_geqr2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqr2_batched.cpp
@@ -20,7 +20,7 @@ rocblas_status rocsolver_geqr2_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_geqr2_geqrf_argCheck(m, n, lda, A, ipiv, batch_count);
+    rocblas_status st = rocsolver_geqr2_geqrf_argCheck(handle, m, n, lda, A, ipiv, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_geqr2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqr2_strided_batched.cpp
@@ -21,7 +21,7 @@ rocblas_status rocsolver_geqr2_strided_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_geqr2_geqrf_argCheck(m, n, lda, A, ipiv, batch_count);
+    rocblas_status st = rocsolver_geqr2_geqrf_argCheck(handle, m, n, lda, A, ipiv, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_geqrf.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqrf.cpp
@@ -18,7 +18,7 @@ rocblas_status rocsolver_geqrf_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_geqr2_geqrf_argCheck(m, n, lda, A, ipiv);
+    rocblas_status st = rocsolver_geqr2_geqrf_argCheck(handle, m, n, lda, A, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_geqrf_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqrf_batched.cpp
@@ -20,7 +20,7 @@ rocblas_status rocsolver_geqrf_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_geqr2_geqrf_argCheck(m, n, lda, A, ipiv, batch_count);
+    rocblas_status st = rocsolver_geqr2_geqrf_argCheck(handle, m, n, lda, A, ipiv, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_geqrf_ptr_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqrf_ptr_batched.cpp
@@ -37,7 +37,7 @@ rocblas_status rocsolver_geqrf_ptr_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_geqr2_geqrf_argCheck(m, n, lda, A, tau, batch_count);
+    rocblas_status st = rocsolver_geqr2_geqrf_argCheck(handle, m, n, lda, A, tau, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_geqrf_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_geqrf_strided_batched.cpp
@@ -21,7 +21,7 @@ rocblas_status rocsolver_geqrf_strided_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_geqr2_geqrf_argCheck(m, n, lda, A, ipiv, batch_count);
+    rocblas_status st = rocsolver_geqr2_geqrf_argCheck(handle, m, n, lda, A, ipiv, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_gesvd.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gesvd.cpp
@@ -27,8 +27,8 @@ rocblas_status rocsolver_gesvd_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_gesvd_argCheck(left_svect, right_svect, m, n, A, lda, S, U, ldu,
-                                                 V, ldv, E, info);
+    rocblas_status st = rocsolver_gesvd_argCheck(handle, left_svect, right_svect, m, n, A, lda, S,
+                                                 U, ldu, V, ldv, E, info);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_gesvd.hpp
+++ b/rocsolver/library/src/lapack/roclapack_gesvd.hpp
@@ -154,7 +154,8 @@ void local_bdsqr_template(rocblas_handle handle,
 
 /** Argument checking **/
 template <typename T, typename TT, typename W>
-rocblas_status rocsolver_gesvd_argCheck(const rocblas_svect left_svect,
+rocblas_status rocsolver_gesvd_argCheck(rocblas_handle handle,
+                                        const rocblas_svect left_svect,
                                         const rocblas_svect right_svect,
                                         const rocblas_int m,
                                         const rocblas_int n,
@@ -187,6 +188,10 @@ rocblas_status rocsolver_gesvd_argCheck(const rocblas_svect left_svect,
     if((right_svect == rocblas_svect_all && ldv < n)
        || (right_svect == rocblas_svect_singular && ldv < min(m, n)))
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((n * m && !A) || (min(m, n) > 1 && !E) || (min(m, n) && !S) || (batch_count && !info))

--- a/rocsolver/library/src/lapack/roclapack_gesvd_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gesvd_batched.cpp
@@ -32,8 +32,8 @@ rocblas_status rocsolver_gesvd_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_gesvd_argCheck(left_svect, right_svect, m, n, A, lda, S, U, ldu,
-                                                 V, ldv, E, info, batch_count);
+    rocblas_status st = rocsolver_gesvd_argCheck(handle, left_svect, right_svect, m, n, A, lda, S,
+                                                 U, ldu, V, ldv, E, info, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_gesvd_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_gesvd_strided_batched.cpp
@@ -33,8 +33,8 @@ rocblas_status rocsolver_gesvd_strided_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_gesvd_argCheck(left_svect, right_svect, m, n, A, lda, S, U, ldu,
-                                                 V, ldv, E, info, batch_count);
+    rocblas_status st = rocsolver_gesvd_argCheck(handle, left_svect, right_svect, m, n, A, lda, S,
+                                                 U, ldu, V, ldv, E, info, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_getf2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getf2.cpp
@@ -22,7 +22,7 @@ rocblas_status rocsolver_getf2_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_getf2_getrf_argCheck(m, n, lda, A, ipiv, info, pivot);
+    rocblas_status st = rocsolver_getf2_getrf_argCheck(handle, m, n, lda, A, ipiv, info, pivot);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_getf2.hpp
+++ b/rocsolver/library/src/lapack/roclapack_getf2.hpp
@@ -692,7 +692,8 @@ void rocsolver_getf2_getMemorySize(const rocblas_int m,
 }
 
 template <typename T>
-rocblas_status rocsolver_getf2_getrf_argCheck(const rocblas_int m,
+rocblas_status rocsolver_getf2_getrf_argCheck(rocblas_handle handle,
+                                              const rocblas_int m,
                                               const rocblas_int n,
                                               const rocblas_int lda,
                                               T A,
@@ -709,6 +710,10 @@ rocblas_status rocsolver_getf2_getrf_argCheck(const rocblas_int m,
     // 2. invalid size
     if(m < 0 || n < 0 || lda < m || batch_count < 0)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((m * n && !A) || (m * n && pivot && !ipiv) || (batch_count && !info))

--- a/rocsolver/library/src/lapack/roclapack_getf2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getf2_batched.cpp
@@ -24,7 +24,8 @@ rocblas_status rocsolver_getf2_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_getf2_getrf_argCheck(m, n, lda, A, ipiv, info, pivot, batch_count);
+    rocblas_status st
+        = rocsolver_getf2_getrf_argCheck(handle, m, n, lda, A, ipiv, info, pivot, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_getf2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getf2_strided_batched.cpp
@@ -25,7 +25,8 @@ rocblas_status rocsolver_getf2_strided_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_getf2_getrf_argCheck(m, n, lda, A, ipiv, info, pivot, batch_count);
+    rocblas_status st
+        = rocsolver_getf2_getrf_argCheck(handle, m, n, lda, A, ipiv, info, pivot, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_getrf.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getrf.cpp
@@ -22,7 +22,7 @@ rocblas_status rocsolver_getrf_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_getf2_getrf_argCheck(m, n, lda, A, ipiv, info, pivot);
+    rocblas_status st = rocsolver_getf2_getrf_argCheck(handle, m, n, lda, A, ipiv, info, pivot);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_getrf_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getrf_batched.cpp
@@ -24,7 +24,8 @@ rocblas_status rocsolver_getrf_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_getf2_getrf_argCheck(m, n, lda, A, ipiv, info, pivot, batch_count);
+    rocblas_status st
+        = rocsolver_getf2_getrf_argCheck(handle, m, n, lda, A, ipiv, info, pivot, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_getrf_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getrf_strided_batched.cpp
@@ -25,7 +25,8 @@ rocblas_status rocsolver_getrf_strided_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_getf2_getrf_argCheck(m, n, lda, A, ipiv, info, pivot, batch_count);
+    rocblas_status st
+        = rocsolver_getf2_getrf_argCheck(handle, m, n, lda, A, ipiv, info, pivot, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_getri.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getri.cpp
@@ -18,7 +18,7 @@ rocblas_status rocsolver_getri_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_getri_argCheck(n, lda, A, ipiv, info);
+    rocblas_status st = rocsolver_getri_argCheck(handle, n, lda, A, ipiv, info);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_getri.hpp
+++ b/rocsolver/library/src/lapack/roclapack_getri.hpp
@@ -504,7 +504,8 @@ void rocsolver_getri_getMemorySize(const rocblas_int n,
 }
 
 template <typename T>
-rocblas_status rocsolver_getri_argCheck(const rocblas_int n,
+rocblas_status rocsolver_getri_argCheck(rocblas_handle handle,
+                                        const rocblas_int n,
                                         const rocblas_int lda,
                                         T A,
                                         rocblas_int* ipiv,
@@ -520,6 +521,10 @@ rocblas_status rocsolver_getri_argCheck(const rocblas_int n,
     if(n < 0 || lda < n || batch_count < 0)
         return rocblas_status_invalid_size;
 
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
+
     // 3. invalid pointers
     if((n && !A) || (n && !ipiv) || (batch_count && !info))
         return rocblas_status_invalid_pointer;
@@ -528,7 +533,8 @@ rocblas_status rocsolver_getri_argCheck(const rocblas_int n,
 }
 
 template <typename T>
-rocblas_status rocsolver_getri_argCheck(const rocblas_int n,
+rocblas_status rocsolver_getri_argCheck(rocblas_handle handle,
+                                        const rocblas_int n,
                                         const rocblas_int lda,
                                         const rocblas_int ldc,
                                         T A,
@@ -545,6 +551,10 @@ rocblas_status rocsolver_getri_argCheck(const rocblas_int n,
     // 2. invalid size
     if(n < 0 || lda < n || ldc < n || batch_count < 0)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((n && !A) || (n && !C) || (n && !ipiv) || (batch_count && !info))

--- a/rocsolver/library/src/lapack/roclapack_getri_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getri_batched.cpp
@@ -20,7 +20,7 @@ rocblas_status rocsolver_getri_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_getri_argCheck(n, lda, A, ipiv, info, batch_count);
+    rocblas_status st = rocsolver_getri_argCheck(handle, n, lda, A, ipiv, info, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_getri_outofplace_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getri_outofplace_batched.cpp
@@ -30,7 +30,7 @@ rocblas_status rocsolver_getri_outofplace_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_getri_argCheck(n, lda, ldc, A, C, ipiv, info, batch_count);
+    rocblas_status st = rocsolver_getri_argCheck(handle, n, lda, ldc, A, C, ipiv, info, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_getri_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getri_strided_batched.cpp
@@ -21,7 +21,7 @@ rocblas_status rocsolver_getri_strided_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_getri_argCheck(n, lda, A, ipiv, info, batch_count);
+    rocblas_status st = rocsolver_getri_argCheck(handle, n, lda, A, ipiv, info, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_getrs.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getrs.cpp
@@ -21,7 +21,7 @@ rocblas_status rocsolver_getrs_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_getrs_argCheck(trans, n, nrhs, lda, ldb, A, B, ipiv);
+    rocblas_status st = rocsolver_getrs_argCheck(handle, trans, n, nrhs, lda, ldb, A, B, ipiv);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_getrs.hpp
+++ b/rocsolver/library/src/lapack/roclapack_getrs.hpp
@@ -15,7 +15,8 @@
 #include "rocsolver.h"
 
 template <typename T>
-rocblas_status rocsolver_getrs_argCheck(const rocblas_operation trans,
+rocblas_status rocsolver_getrs_argCheck(rocblas_handle handle,
+                                        const rocblas_operation trans,
                                         const rocblas_int n,
                                         const rocblas_int nrhs,
                                         const rocblas_int lda,
@@ -35,6 +36,10 @@ rocblas_status rocsolver_getrs_argCheck(const rocblas_operation trans,
     // 2. invalid size
     if(n < 0 || nrhs < 0 || lda < n || ldb < n || batch_count < 0)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((n && !A) || (n && !ipiv) || (nrhs * n && !B))

--- a/rocsolver/library/src/lapack/roclapack_getrs_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getrs_batched.cpp
@@ -23,7 +23,8 @@ rocblas_status rocsolver_getrs_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_getrs_argCheck(trans, n, nrhs, lda, ldb, A, B, ipiv, batch_count);
+    rocblas_status st
+        = rocsolver_getrs_argCheck(handle, trans, n, nrhs, lda, ldb, A, B, ipiv, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_getrs_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_getrs_strided_batched.cpp
@@ -25,7 +25,8 @@ rocblas_status rocsolver_getrs_strided_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_getrs_argCheck(trans, n, nrhs, lda, ldb, A, B, ipiv, batch_count);
+    rocblas_status st
+        = rocsolver_getrs_argCheck(handle, trans, n, nrhs, lda, ldb, A, B, ipiv, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_potf2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potf2.cpp
@@ -18,7 +18,7 @@ rocblas_status rocsolver_potf2_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_potf2_potrf_argCheck(uplo, n, lda, A, info);
+    rocblas_status st = rocsolver_potf2_potrf_argCheck(handle, uplo, n, lda, A, info);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_potf2.hpp
+++ b/rocsolver/library/src/lapack/roclapack_potf2.hpp
@@ -103,7 +103,8 @@ void rocsolver_potf2_getMemorySize(const rocblas_int n,
 }
 
 template <typename T>
-rocblas_status rocsolver_potf2_potrf_argCheck(const rocblas_fill uplo,
+rocblas_status rocsolver_potf2_potrf_argCheck(rocblas_handle handle,
+                                              const rocblas_fill uplo,
                                               const rocblas_int n,
                                               const rocblas_int lda,
                                               T A,
@@ -119,6 +120,10 @@ rocblas_status rocsolver_potf2_potrf_argCheck(const rocblas_fill uplo,
     // 2. invalid size
     if(n < 0 || lda < n || batch_count < 0)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((n && !A) || (batch_count && !info))

--- a/rocsolver/library/src/lapack/roclapack_potf2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potf2_batched.cpp
@@ -19,7 +19,7 @@ rocblas_status rocsolver_potf2_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_potf2_potrf_argCheck(uplo, n, lda, A, info, batch_count);
+    rocblas_status st = rocsolver_potf2_potrf_argCheck(handle, uplo, n, lda, A, info, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_potf2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potf2_strided_batched.cpp
@@ -20,7 +20,7 @@ rocblas_status rocsolver_potf2_strided_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_potf2_potrf_argCheck(uplo, n, lda, A, info, batch_count);
+    rocblas_status st = rocsolver_potf2_potrf_argCheck(handle, uplo, n, lda, A, info, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_potrf.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potrf.cpp
@@ -18,7 +18,7 @@ rocblas_status rocsolver_potrf_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_potf2_potrf_argCheck(uplo, n, lda, A, info);
+    rocblas_status st = rocsolver_potf2_potrf_argCheck(handle, uplo, n, lda, A, info);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_potrf_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potrf_batched.cpp
@@ -19,7 +19,7 @@ rocblas_status rocsolver_potrf_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_potf2_potrf_argCheck(uplo, n, lda, A, info, batch_count);
+    rocblas_status st = rocsolver_potf2_potrf_argCheck(handle, uplo, n, lda, A, info, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_potrf_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_potrf_strided_batched.cpp
@@ -20,7 +20,7 @@ rocblas_status rocsolver_potrf_strided_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_potf2_potrf_argCheck(uplo, n, lda, A, info, batch_count);
+    rocblas_status st = rocsolver_potf2_potrf_argCheck(handle, uplo, n, lda, A, info, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_sytd2_hetd2.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytd2_hetd2.cpp
@@ -20,7 +20,7 @@ rocblas_status rocsolver_sytd2_hetd2_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_sytd2_hetd2_argCheck(uplo, n, lda, A, D, E, tau);
+    rocblas_status st = rocsolver_sytd2_hetd2_argCheck(handle, uplo, n, lda, A, D, E, tau);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_sytd2_hetd2.hpp
+++ b/rocsolver/library/src/lapack/roclapack_sytd2_hetd2.hpp
@@ -140,7 +140,8 @@ void rocsolver_sytd2_hetd2_getMemorySize(const rocblas_int n,
 }
 
 template <typename S, typename T, typename U>
-rocblas_status rocsolver_sytd2_hetd2_argCheck(const rocblas_fill uplo,
+rocblas_status rocsolver_sytd2_hetd2_argCheck(rocblas_handle handle,
+                                              const rocblas_fill uplo,
                                               const rocblas_int n,
                                               const rocblas_int lda,
                                               T A,
@@ -158,6 +159,10 @@ rocblas_status rocsolver_sytd2_hetd2_argCheck(const rocblas_fill uplo,
     // 2. invalid size
     if(n < 0 || lda < n || batch_count < 0)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((n && !A) || (n && !D) || (n && !E) || (n && !tau))

--- a/rocsolver/library/src/lapack/roclapack_sytd2_hetd2_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytd2_hetd2_batched.cpp
@@ -24,7 +24,8 @@ rocblas_status rocsolver_sytd2_hetd2_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_sytd2_hetd2_argCheck(uplo, n, lda, A, D, E, tau, batch_count);
+    rocblas_status st
+        = rocsolver_sytd2_hetd2_argCheck(handle, uplo, n, lda, A, D, E, tau, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_sytd2_hetd2_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytd2_hetd2_strided_batched.cpp
@@ -25,7 +25,8 @@ rocblas_status rocsolver_sytd2_hetd2_strided_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_sytd2_hetd2_argCheck(uplo, n, lda, A, D, E, tau, batch_count);
+    rocblas_status st
+        = rocsolver_sytd2_hetd2_argCheck(handle, uplo, n, lda, A, D, E, tau, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_sytrd_hetrd.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytrd_hetrd.cpp
@@ -20,7 +20,7 @@ rocblas_status rocsolver_sytrd_hetrd_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_sytrd_hetrd_argCheck(uplo, n, lda, A, D, E, tau);
+    rocblas_status st = rocsolver_sytrd_hetrd_argCheck(handle, uplo, n, lda, A, D, E, tau);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_sytrd_hetrd.hpp
+++ b/rocsolver/library/src/lapack/roclapack_sytrd_hetrd.hpp
@@ -53,7 +53,8 @@ void rocsolver_sytrd_hetrd_getMemorySize(const rocblas_int n,
 }
 
 template <typename S, typename T, typename U>
-rocblas_status rocsolver_sytrd_hetrd_argCheck(const rocblas_fill uplo,
+rocblas_status rocsolver_sytrd_hetrd_argCheck(rocblas_handle handle,
+                                              const rocblas_fill uplo,
                                               const rocblas_int n,
                                               const rocblas_int lda,
                                               T A,
@@ -71,6 +72,10 @@ rocblas_status rocsolver_sytrd_hetrd_argCheck(const rocblas_fill uplo,
     // 2. invalid size
     if(n < 0 || lda < n || batch_count < 0)
         return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
 
     // 3. invalid pointers
     if((n && !A) || (n && !D) || (n && !E) || (n && !tau))

--- a/rocsolver/library/src/lapack/roclapack_sytrd_hetrd_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytrd_hetrd_batched.cpp
@@ -24,7 +24,8 @@ rocblas_status rocsolver_sytrd_hetrd_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_sytrd_hetrd_argCheck(uplo, n, lda, A, D, E, tau, batch_count);
+    rocblas_status st
+        = rocsolver_sytrd_hetrd_argCheck(handle, uplo, n, lda, A, D, E, tau, batch_count);
     if(st != rocblas_status_continue)
         return st;
 

--- a/rocsolver/library/src/lapack/roclapack_sytrd_hetrd_strided_batched.cpp
+++ b/rocsolver/library/src/lapack/roclapack_sytrd_hetrd_strided_batched.cpp
@@ -25,7 +25,8 @@ rocblas_status rocsolver_sytrd_hetrd_strided_batched_impl(rocblas_handle handle,
     // logging is missing ???
 
     // argument checking
-    rocblas_status st = rocsolver_sytrd_hetrd_argCheck(uplo, n, lda, A, D, E, tau, batch_count);
+    rocblas_status st
+        = rocsolver_sytrd_hetrd_argCheck(handle, uplo, n, lda, A, D, E, tau, batch_count);
     if(st != rocblas_status_continue)
         return st;
 


### PR DESCRIPTION
In order to calculate appropriate memory sizes for hipSOLVER bufferSize functions, we need to be able to call rocSOLVER in query mode with some null or invalid pointers. This PR accommodates that by skipping the invalid pointer checks in argCheck functions when we are in query mode.