### PR TITLE
fix bug in getf2 get mem size

### DIFF
--- a/rocsolver/library/src/lapack/roclapack_getf2.hpp
+++ b/rocsolver/library/src/lapack/roclapack_getf2.hpp
@@ -660,6 +660,7 @@ void rocsolver_getf2_getMemorySize(const rocblas_int m,
         *size_work = 0;
         *size_pivotval = 0;
         *size_pivotidx = 0;
+        return;
     }
 
 #ifdef OPTIMAL
@@ -673,6 +674,7 @@ void rocsolver_getf2_getMemorySize(const rocblas_int m,
             *size_work = 0;
             *size_pivotval = 0;
             *size_pivotidx = 0;
+            return;
         }
     }
 #endif


### PR DESCRIPTION
(This bug could be related with problems we are observing in NAVI21 with hipBLAS)