### PR TITLE
Clients updates (reallocation and stream)

### DIFF
--- a/rocblascommon/clients/include/rocblas_test.hpp
+++ b/rocblascommon/clients/include/rocblas_test.hpp
@@ -53,6 +53,14 @@
         }                                                                                  \
     } while(0)
 
+#define CHECK_ALLOC_QUERY(STATUS)                                  \
+    do                                                             \
+    {                                                              \
+        auto status__ = (STATUS);                                  \
+        ASSERT_TRUE(status__ == rocblas_status_size_increased      \
+                    || status__ == rocblas_status_size_unchanged); \
+    } while(0)
+
 #define EXPECT_ROCBLAS_STATUS ASSERT_EQ
 
 #else // GOOGLE_TEST
@@ -80,7 +88,21 @@ inline void rocblas_expect_status(rocblas_status status, rocblas_status expect)
         }                                                                          \
     } while(0)
 
-#define CHECK_DEVICE_ALLOCATION(ERROR)
+#define CHECK_ALLOC_QUERY(STATUS)                                                              \
+    do                                                                                         \
+    {                                                                                          \
+        auto status__ = (STATUS);                                                              \
+        if(!(status__ == rocblas_status_size_increased                                         \
+             || status__ == rocblas_status_size_unchanged))                                    \
+        {                                                                                      \
+            rocblas_cerr << "rocBLAS status error: Expected rocblas_status_size_unchanged or " \
+                            "rocblas_status_size_increase,\nreceived "                         \
+                         << rocblas_status_to_string(status__) << std::endl;                   \
+            rocblas_abort();                                                                   \
+        }                                                                                      \
+    } while(0)
+
+#define CHECK_DEVICE_ALLOCATION CHECK_HIP_ERROR
 
 #define EXPECT_ROCBLAS_STATUS rocblas_expect_status
 

--- a/rocblascommon/clients/include/rocblas_test.hpp
+++ b/rocblascommon/clients/include/rocblas_test.hpp
@@ -88,18 +88,17 @@ inline void rocblas_expect_status(rocblas_status status, rocblas_status expect)
         }                                                                          \
     } while(0)
 
-#define CHECK_ALLOC_QUERY(STATUS)                                                              \
-    do                                                                                         \
-    {                                                                                          \
-        auto status__ = (STATUS);                                                              \
-        if(!(status__ == rocblas_status_size_increased                                         \
-             || status__ == rocblas_status_size_unchanged))                                    \
-        {                                                                                      \
-            rocblas_cerr << "rocBLAS status error: Expected rocblas_status_size_unchanged or " \
-                            "rocblas_status_size_increase,\nreceived "                         \
-                         << rocblas_status_to_string(status__) << std::endl;                   \
-            rocblas_abort();                                                                   \
-        }                                                                                      \
+#define CHECK_ALLOC_QUERY(STATUS)                                                                     \
+    do                                                                                                \
+    {                                                                                                 \
+        auto status__ = (STATUS);                                                                     \
+        if(!(status__ == rocblas_status_size_increased || status__ == rocblas_status_size_unchanged)) \
+        {                                                                                             \
+            rocblas_cerr << "rocBLAS status error: Expected rocblas_status_size_unchanged or "        \
+                            "rocblas_status_size_increase,\nreceived "                                \
+                         << rocblas_status_to_string(status__) << std::endl;                          \
+            rocblas_abort();                                                                          \
+        }                                                                                             \
     } while(0)
 
 #define CHECK_DEVICE_ALLOCATION CHECK_HIP_ERROR

--- a/rocsolver/clients/include/rocsolver_test.hpp
+++ b/rocsolver/clients/include/rocsolver_test.hpp
@@ -11,7 +11,7 @@
 
 // If REALLOC is 0, automatic reallocation is disable and we will manually
 // reallocate workspace if the memory query resulted in more than DEFAULT_MEM
-#define REALLOC 1         
+#define REALLOC 1
 #define DEFAULT_MEM 33554432
 
 #define ROCSOLVER_BENCH_INFORM(case)                                       \

--- a/rocsolver/clients/include/rocsolver_test.hpp
+++ b/rocsolver/clients/include/rocsolver_test.hpp
@@ -10,7 +10,7 @@
 #include <limits>
 
 // If USE_ROCBLAS_REALLOC_ON_DEMAND is false, automatic reallocation is disable and we will manually
-// reallocate workspace 
+// reallocate workspace
 #define USE_ROCBLAS_REALLOC_ON_DEMAND true
 
 #define ROCSOLVER_BENCH_INFORM(case)                                       \

--- a/rocsolver/clients/include/rocsolver_test.hpp
+++ b/rocsolver/clients/include/rocsolver_test.hpp
@@ -10,9 +10,8 @@
 #include <limits>
 
 // If USE_ROCBLAS_REALLOC_ON_DEMAND is false, automatic reallocation is disable and we will manually
-// reallocate workspace if the memory query resulted in more than DEFAULT_MEM
+// reallocate workspace 
 #define USE_ROCBLAS_REALLOC_ON_DEMAND true
-#define DEFAULT_MEM 33554432
 
 #define ROCSOLVER_BENCH_INFORM(case)                                       \
     do                                                                     \

--- a/rocsolver/clients/include/rocsolver_test.hpp
+++ b/rocsolver/clients/include/rocsolver_test.hpp
@@ -9,9 +9,9 @@
 #include <cstdarg>
 #include <limits>
 
-// If REALLOC is 0, automatic reallocation is disable and we will manually
+// If USE_ROCBLAS_REALLOC_ON_DEMAND is false, automatic reallocation is disable and we will manually
 // reallocate workspace if the memory query resulted in more than DEFAULT_MEM
-#define REALLOC 1
+#define USE_ROCBLAS_REALLOC_ON_DEMAND true
 #define DEFAULT_MEM 33554432
 
 #define ROCSOLVER_BENCH_INFORM(case)                                       \

--- a/rocsolver/clients/include/rocsolver_test.hpp
+++ b/rocsolver/clients/include/rocsolver_test.hpp
@@ -9,6 +9,11 @@
 #include <cstdarg>
 #include <limits>
 
+// If REALLOC is 0, automatic reallocation is disable and we will manually
+// reallocate workspace if the memory query resulted in more than DEFAULT_MEM
+#define REALLOC 1         
+#define DEFAULT_MEM 33554432
+
 #define ROCSOLVER_BENCH_INFORM(case)                                       \
     do                                                                     \
     {                                                                      \

--- a/rocsolver/clients/include/testing_bdsqr.hpp
+++ b/rocsolver/clients/include/testing_bdsqr.hpp
@@ -383,7 +383,7 @@ void bdsqr_getPerfData(const rocblas_handle handle,
     hipStream_t stream;
     CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
-    
+
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
         bdsqr_initData<false, true, S, T>(handle, uplo, n, nv, nu, nc, dD, dE, dV, ldv, dU, ldu, dC,
@@ -489,8 +489,8 @@ void testing_bdsqr(Arguments argus)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_bdsqr(handle, uplo, n, nv, nu, nc, (S*)nullptr, (S*)nullptr,
-                                              (T*)nullptr, ldv, (T*)nullptr, ldu, (T*)nullptr, ldc,
-                                              (rocblas_int*)nullptr));
+                                          (T*)nullptr, ldv, (T*)nullptr, ldu, (T*)nullptr, ldc,
+                                          (rocblas_int*)nullptr));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_bdsqr.hpp
+++ b/rocsolver/clients/include/testing_bdsqr.hpp
@@ -485,7 +485,7 @@ void testing_bdsqr(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_bdsqr(handle, uplo, n, nv, nu, nc, (S*)nullptr, (S*)nullptr,

--- a/rocsolver/clients/include/testing_bdsqr.hpp
+++ b/rocsolver/clients/include/testing_bdsqr.hpp
@@ -494,9 +494,7 @@ void testing_bdsqr(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_gebd2_gebrd.hpp
+++ b/rocsolver/clients/include/testing_gebd2_gebrd.hpp
@@ -459,14 +459,13 @@ void testing_gebd2_gebrd(Arguments argus)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
-            CHECK_ALLOC_QUERY(rocsolver_gebd2_gebrd(STRIDED, GEBRD, handle, m, n,
-                                                        (T* const*)nullptr, lda, stA, (S*)nullptr,
-                                                        stD, (S*)nullptr, stE, (T*)nullptr, stQ,
-                                                        (T*)nullptr, stP, bc));
+            CHECK_ALLOC_QUERY(rocsolver_gebd2_gebrd(STRIDED, GEBRD, handle, m, n, (T* const*)nullptr,
+                                                    lda, stA, (S*)nullptr, stD, (S*)nullptr, stE,
+                                                    (T*)nullptr, stQ, (T*)nullptr, stP, bc));
         else
-            CHECK_ALLOC_QUERY(rocsolver_gebd2_gebrd(STRIDED, GEBRD, handle, m, n, (T*)nullptr,
-                                                        lda, stA, (S*)nullptr, stD, (S*)nullptr,
-                                                        stE, (T*)nullptr, stQ, (T*)nullptr, stP, bc));
+            CHECK_ALLOC_QUERY(rocsolver_gebd2_gebrd(STRIDED, GEBRD, handle, m, n, (T*)nullptr, lda,
+                                                    stA, (S*)nullptr, stD, (S*)nullptr, stE,
+                                                    (T*)nullptr, stQ, (T*)nullptr, stP, bc));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_gebd2_gebrd.hpp
+++ b/rocsolver/clients/include/testing_gebd2_gebrd.hpp
@@ -455,7 +455,7 @@ void testing_gebd2_gebrd(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)

--- a/rocsolver/clients/include/testing_gebd2_gebrd.hpp
+++ b/rocsolver/clients/include/testing_gebd2_gebrd.hpp
@@ -357,14 +357,14 @@ void gebd2_gebrd_getPerfData(const rocblas_handle handle,
                                                 stQ, dTaup, stP, bc, hA, hD, hE, hTauq, hTaup);
 
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         for(rocblas_int b = 0; b < bc; ++b)
         {
             GEBRD ? cblas_gebrd<S, T>(m, n, hA[b], lda, hD[b], hE[b], hTauq[b], hTaup[b], hW.data(),
                                       max(m, n))
                   : cblas_gebd2<S, T>(m, n, hA[b], lda, hD[b], hE[b], hTauq[b], hTaup[b], hW.data());
         }
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     gebd2_gebrd_initData<true, false, S, T>(handle, m, n, dA, lda, stA, dD, stD, dE, stE, dTauq,
@@ -382,16 +382,19 @@ void gebd2_gebrd_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
         gebd2_gebrd_initData<false, true, S, T>(handle, m, n, dA, lda, stA, dD, stD, dE, stE, dTauq,
                                                 stQ, dTaup, stP, bc, hA, hD, hE, hTauq, hTaup);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_gebd2_gebrd(STRIDED, GEBRD, handle, m, n, dA.data(), lda, stA, dD.data(), stD,
                               dE.data(), stE, dTauq.data(), stQ, dTaup.data(), stP, bc);
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -449,6 +452,27 @@ void testing_gebd2_gebrd(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        if(BATCHED)
+            CHECK_ALLOC_QUERY(rocsolver_gebd2_gebrd(STRIDED, GEBRD, handle, m, n,
+                                                        (T* const*)nullptr, lda, stA, (S*)nullptr,
+                                                        stD, (S*)nullptr, stE, (T*)nullptr, stQ,
+                                                        (T*)nullptr, stP, bc));
+        else
+            CHECK_ALLOC_QUERY(rocsolver_gebd2_gebrd(STRIDED, GEBRD, handle, m, n, (T*)nullptr,
+                                                        lda, stA, (S*)nullptr, stD, (S*)nullptr,
+                                                        stE, (T*)nullptr, stQ, (T*)nullptr, stP, bc));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     if(BATCHED)

--- a/rocsolver/clients/include/testing_gebd2_gebrd.hpp
+++ b/rocsolver/clients/include/testing_gebd2_gebrd.hpp
@@ -469,9 +469,7 @@ void testing_gebd2_gebrd(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     if(BATCHED)

--- a/rocsolver/clients/include/testing_gelq2_gelqf.hpp
+++ b/rocsolver/clients/include/testing_gelq2_gelqf.hpp
@@ -288,7 +288,7 @@ void testing_gelq2_gelqf(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)

--- a/rocsolver/clients/include/testing_gelq2_gelqf.hpp
+++ b/rocsolver/clients/include/testing_gelq2_gelqf.hpp
@@ -229,7 +229,7 @@ void gelq2_gelqf_getPerfData(const rocblas_handle handle,
     hipStream_t stream;
     CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
-    
+
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
         gelq2_gelqf_initData<false, true, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
@@ -292,12 +292,11 @@ void testing_gelq2_gelqf(Arguments argus)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
-            CHECK_ALLOC_QUERY(rocsolver_gelq2_gelqf(STRIDED, GELQF, handle, m, n,
-                                                        (T* const*)nullptr, lda, stA, (T*)nullptr,
-                                                        stP, bc));
+            CHECK_ALLOC_QUERY(rocsolver_gelq2_gelqf(STRIDED, GELQF, handle, m, n, (T* const*)nullptr,
+                                                    lda, stA, (T*)nullptr, stP, bc));
         else
-            CHECK_ALLOC_QUERY(rocsolver_gelq2_gelqf(STRIDED, GELQF, handle, m, n, (T*)nullptr,
-                                                        lda, stA, (T*)nullptr, stP, bc));
+            CHECK_ALLOC_QUERY(rocsolver_gelq2_gelqf(STRIDED, GELQF, handle, m, n, (T*)nullptr, lda,
+                                                    stA, (T*)nullptr, stP, bc));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_gelq2_gelqf.hpp
+++ b/rocsolver/clients/include/testing_gelq2_gelqf.hpp
@@ -205,13 +205,13 @@ void gelq2_gelqf_getPerfData(const rocblas_handle handle,
         gelq2_gelqf_initData<true, false, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
 
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         for(rocblas_int b = 0; b < bc; ++b)
         {
             GELQF ? cblas_gelqf<T>(m, n, hA[b], lda, hIpiv[b], hW.data(), m)
                   : cblas_gelq2<T>(m, n, hA[b], lda, hIpiv[b], hW.data());
         }
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     gelq2_gelqf_initData<true, false, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
@@ -226,15 +226,18 @@ void gelq2_gelqf_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+    
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
         gelq2_gelqf_initData<false, true, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_gelq2_gelqf(STRIDED, GELQF, handle, m, n, dA.data(), lda, stA, dIpiv.data(), stP,
                               bc);
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -282,6 +285,25 @@ void testing_gelq2_gelqf(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        if(BATCHED)
+            CHECK_ALLOC_QUERY(rocsolver_gelq2_gelqf(STRIDED, GELQF, handle, m, n,
+                                                        (T* const*)nullptr, lda, stA, (T*)nullptr,
+                                                        stP, bc));
+        else
+            CHECK_ALLOC_QUERY(rocsolver_gelq2_gelqf(STRIDED, GELQF, handle, m, n, (T*)nullptr,
+                                                        lda, stA, (T*)nullptr, stP, bc));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     if(BATCHED)

--- a/rocsolver/clients/include/testing_gelq2_gelqf.hpp
+++ b/rocsolver/clients/include/testing_gelq2_gelqf.hpp
@@ -300,9 +300,7 @@ void testing_gelq2_gelqf(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     if(BATCHED)

--- a/rocsolver/clients/include/testing_gels.hpp
+++ b/rocsolver/clients/include/testing_gels.hpp
@@ -371,9 +371,7 @@ void testing_gels(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     if(BATCHED)

--- a/rocsolver/clients/include/testing_gels.hpp
+++ b/rocsolver/clients/include/testing_gels.hpp
@@ -282,7 +282,7 @@ void gels_getPerfData(const rocblas_handle handle,
     hipStream_t stream;
     CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
-    
+
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
         gels_initData<false, true, T>(handle, trans, m, n, nrhs, dA, lda, stA, dB, ldb, stB, dInfo,
@@ -362,13 +362,12 @@ void testing_gels(Arguments argus)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
-            CHECK_ALLOC_QUERY(rocsolver_gels(STRIDED, handle, trans, m, n, nrhs,
-                                                 (T* const*)nullptr, lda, stA, (T* const*)nullptr,
-                                                 ldb, stB, (rocblas_int*)nullptr, bc));
+            CHECK_ALLOC_QUERY(rocsolver_gels(STRIDED, handle, trans, m, n, nrhs, (T* const*)nullptr,
+                                             lda, stA, (T* const*)nullptr, ldb, stB,
+                                             (rocblas_int*)nullptr, bc));
         else
-            CHECK_ALLOC_QUERY(rocsolver_gels(STRIDED, handle, trans, m, n, nrhs, (T*)nullptr,
-                                                 lda, stA, (T*)nullptr, ldb, stB,
-                                                 (rocblas_int*)nullptr, bc));
+            CHECK_ALLOC_QUERY(rocsolver_gels(STRIDED, handle, trans, m, n, nrhs, (T*)nullptr, lda,
+                                             stA, (T*)nullptr, ldb, stB, (rocblas_int*)nullptr, bc));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_gels.hpp
+++ b/rocsolver/clients/include/testing_gels.hpp
@@ -358,7 +358,7 @@ void testing_gels(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)

--- a/rocsolver/clients/include/testing_gels.hpp
+++ b/rocsolver/clients/include/testing_gels.hpp
@@ -260,12 +260,12 @@ void gels_getPerfData(const rocblas_handle handle,
         gels_initData<true, false, T>(handle, trans, m, n, nrhs, dA, lda, stA, dB, ldb, stB, dInfo,
                                       bc, hA, hB, hInfo);
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         for(rocblas_int b = 0; b < bc; ++b)
         {
             cblas_gels<T>(trans, m, n, nrhs, hA[b], lda, hB[b], ldb, hW.data(), sizeW);
         }
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
     gels_initData<true, false, T>(handle, trans, m, n, nrhs, dA, lda, stA, dB, ldb, stB, dInfo, bc,
                                   hA, hB, hInfo);
@@ -279,16 +279,19 @@ void gels_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+    
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
         gels_initData<false, true, T>(handle, trans, m, n, nrhs, dA, lda, stA, dB, ldb, stB, dInfo,
                                       bc, hA, hB, hInfo);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_gels(STRIDED, handle, trans, m, n, nrhs, dA.data(), lda, stA, dB.data(), ldb, stB,
                        dInfo.data(), bc);
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -296,13 +299,8 @@ void gels_getPerfData(const rocblas_handle handle,
 template <bool BATCHED, bool STRIDED, typename T>
 void testing_gels(Arguments argus)
 {
-    rocblas_local_handle handle;
-    // Set handle memory size to a large enough value for all tests to pass.
-    //(TODO: Investigate why rocblas is not automatically increasing the size of
-    //the memory stack in rocblas_handle)
-    rocblas_set_device_memory_size(handle, 80000000);
-
     // get arguments
+    rocblas_local_handle handle;
     rocblas_int m = argus.M;
     rocblas_int n = argus.N;
     rocblas_int nrhs = argus.K;
@@ -357,6 +355,26 @@ void testing_gels(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        if(BATCHED)
+            CHECK_ALLOC_QUERY(rocsolver_gels(STRIDED, handle, trans, m, n, nrhs,
+                                                 (T* const*)nullptr, lda, stA, (T* const*)nullptr,
+                                                 ldb, stB, (rocblas_int*)nullptr, bc));
+        else
+            CHECK_ALLOC_QUERY(rocsolver_gels(STRIDED, handle, trans, m, n, nrhs, (T*)nullptr,
+                                                 lda, stA, (T*)nullptr, ldb, stB,
+                                                 (rocblas_int*)nullptr, bc));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     if(BATCHED)

--- a/rocsolver/clients/include/testing_geql2_geqlf.hpp
+++ b/rocsolver/clients/include/testing_geql2_geqlf.hpp
@@ -288,7 +288,7 @@ void testing_geql2_geqlf(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)

--- a/rocsolver/clients/include/testing_geql2_geqlf.hpp
+++ b/rocsolver/clients/include/testing_geql2_geqlf.hpp
@@ -205,13 +205,13 @@ void geql2_geqlf_getPerfData(const rocblas_handle handle,
         geql2_geqlf_initData<true, false, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
 
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         for(rocblas_int b = 0; b < bc; ++b)
         {
             GEQLF ? cblas_geqlf<T>(m, n, hA[b], lda, hIpiv[b], hW.data(), n)
                   : cblas_geql2<T>(m, n, hA[b], lda, hIpiv[b], hW.data());
         }
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     geql2_geqlf_initData<true, false, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
@@ -226,15 +226,18 @@ void geql2_geqlf_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+    
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
         geql2_geqlf_initData<false, true, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_geql2_geqlf(STRIDED, GEQLF, handle, m, n, dA.data(), lda, stA, dIpiv.data(), stP,
                               bc);
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -282,6 +285,25 @@ void testing_geql2_geqlf(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        if(BATCHED)
+            CHECK_ALLOC_QUERY(rocsolver_geql2_geqlf(STRIDED, GEQLF, handle, m, n,
+                                                        (T* const*)nullptr, lda, stA, (T*)nullptr,
+                                                        stP, bc));
+        else
+            CHECK_ALLOC_QUERY(rocsolver_geql2_geqlf(STRIDED, GEQLF, handle, m, n, (T*)nullptr,
+                                                        lda, stA, (T*)nullptr, stP, bc));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     if(BATCHED)

--- a/rocsolver/clients/include/testing_geql2_geqlf.hpp
+++ b/rocsolver/clients/include/testing_geql2_geqlf.hpp
@@ -300,9 +300,7 @@ void testing_geql2_geqlf(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     if(BATCHED)

--- a/rocsolver/clients/include/testing_geql2_geqlf.hpp
+++ b/rocsolver/clients/include/testing_geql2_geqlf.hpp
@@ -229,7 +229,7 @@ void geql2_geqlf_getPerfData(const rocblas_handle handle,
     hipStream_t stream;
     CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
-    
+
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
         geql2_geqlf_initData<false, true, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
@@ -292,12 +292,11 @@ void testing_geql2_geqlf(Arguments argus)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
-            CHECK_ALLOC_QUERY(rocsolver_geql2_geqlf(STRIDED, GEQLF, handle, m, n,
-                                                        (T* const*)nullptr, lda, stA, (T*)nullptr,
-                                                        stP, bc));
+            CHECK_ALLOC_QUERY(rocsolver_geql2_geqlf(STRIDED, GEQLF, handle, m, n, (T* const*)nullptr,
+                                                    lda, stA, (T*)nullptr, stP, bc));
         else
-            CHECK_ALLOC_QUERY(rocsolver_geql2_geqlf(STRIDED, GEQLF, handle, m, n, (T*)nullptr,
-                                                        lda, stA, (T*)nullptr, stP, bc));
+            CHECK_ALLOC_QUERY(rocsolver_geql2_geqlf(STRIDED, GEQLF, handle, m, n, (T*)nullptr, lda,
+                                                    stA, (T*)nullptr, stP, bc));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_geqr2_geqrf.hpp
+++ b/rocsolver/clients/include/testing_geqr2_geqrf.hpp
@@ -229,7 +229,7 @@ void geqr2_geqrf_getPerfData(const rocblas_handle handle,
     hipStream_t stream;
     CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
-    
+
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
         geqr2_geqrf_initData<false, true, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
@@ -292,12 +292,11 @@ void testing_geqr2_geqrf(Arguments argus)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
-            CHECK_ALLOC_QUERY(rocsolver_geqr2_geqrf(STRIDED, GEQRF, handle, m, n,
-                                                        (T* const*)nullptr, lda, stA, (T*)nullptr,
-                                                        stP, bc));
+            CHECK_ALLOC_QUERY(rocsolver_geqr2_geqrf(STRIDED, GEQRF, handle, m, n, (T* const*)nullptr,
+                                                    lda, stA, (T*)nullptr, stP, bc));
         else
-            CHECK_ALLOC_QUERY(rocsolver_geqr2_geqrf(STRIDED, GEQRF, handle, m, n, (T*)nullptr,
-                                                        lda, stA, (T*)nullptr, stP, bc));
+            CHECK_ALLOC_QUERY(rocsolver_geqr2_geqrf(STRIDED, GEQRF, handle, m, n, (T*)nullptr, lda,
+                                                    stA, (T*)nullptr, stP, bc));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_geqr2_geqrf.hpp
+++ b/rocsolver/clients/include/testing_geqr2_geqrf.hpp
@@ -288,7 +288,7 @@ void testing_geqr2_geqrf(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)

--- a/rocsolver/clients/include/testing_geqr2_geqrf.hpp
+++ b/rocsolver/clients/include/testing_geqr2_geqrf.hpp
@@ -205,13 +205,13 @@ void geqr2_geqrf_getPerfData(const rocblas_handle handle,
         geqr2_geqrf_initData<true, false, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
 
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         for(rocblas_int b = 0; b < bc; ++b)
         {
             GEQRF ? cblas_geqrf<T>(m, n, hA[b], lda, hIpiv[b], hW.data(), n)
                   : cblas_geqr2<T>(m, n, hA[b], lda, hIpiv[b], hW.data());
         }
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     geqr2_geqrf_initData<true, false, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
@@ -226,15 +226,18 @@ void geqr2_geqrf_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+    
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
         geqr2_geqrf_initData<false, true, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_geqr2_geqrf(STRIDED, GEQRF, handle, m, n, dA.data(), lda, stA, dIpiv.data(), stP,
                               bc);
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -282,6 +285,25 @@ void testing_geqr2_geqrf(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        if(BATCHED)
+            CHECK_ALLOC_QUERY(rocsolver_geqr2_geqrf(STRIDED, GEQRF, handle, m, n,
+                                                        (T* const*)nullptr, lda, stA, (T*)nullptr,
+                                                        stP, bc));
+        else
+            CHECK_ALLOC_QUERY(rocsolver_geqr2_geqrf(STRIDED, GEQRF, handle, m, n, (T*)nullptr,
+                                                        lda, stA, (T*)nullptr, stP, bc));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     if(BATCHED && STRIDED)

--- a/rocsolver/clients/include/testing_geqr2_geqrf.hpp
+++ b/rocsolver/clients/include/testing_geqr2_geqrf.hpp
@@ -300,9 +300,7 @@ void testing_geqr2_geqrf(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     if(BATCHED && STRIDED)

--- a/rocsolver/clients/include/testing_gesvd.hpp
+++ b/rocsolver/clients/include/testing_gesvd.hpp
@@ -438,7 +438,7 @@ void gesvd_getPerfData(const rocblas_handle handle,
     hipStream_t stream;
     CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
-    
+
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
         gesvd_initData<false, true, T>(handle, left_svect, right_svect, m, n, dA, lda, bc, hA, A, 0);
@@ -626,24 +626,24 @@ void testing_gesvd(Arguments argus)
         if(BATCHED)
         {
             CHECK_ALLOC_QUERY(rocsolver_gesvd(STRIDED, handle, leftv, rightv, m, n,
-                                                  (T* const*)nullptr, lda, stA, (S*)nullptr, stS,
-                                                  (T*)nullptr, ldu, stU, (T*)nullptr, ldv, stV,
-                                                  (S*)nullptr, stE, fa, (rocblas_int*)nullptr, bc));
+                                              (T* const*)nullptr, lda, stA, (S*)nullptr, stS,
+                                              (T*)nullptr, ldu, stU, (T*)nullptr, ldv, stV,
+                                              (S*)nullptr, stE, fa, (rocblas_int*)nullptr, bc));
             CHECK_ALLOC_QUERY(rocsolver_gesvd(STRIDED, handle, leftvT, rightvT, mT, nT,
-                                                  (T* const*)nullptr, lda, stA, (S*)nullptr, stS,
-                                                  (T*)nullptr, lduT, stUT, (T*)nullptr, ldvT, stVT,
-                                                  (S*)nullptr, stE, fa, (rocblas_int*)nullptr, bc));
+                                              (T* const*)nullptr, lda, stA, (S*)nullptr, stS,
+                                              (T*)nullptr, lduT, stUT, (T*)nullptr, ldvT, stVT,
+                                              (S*)nullptr, stE, fa, (rocblas_int*)nullptr, bc));
         }
         else
         {
             CHECK_ALLOC_QUERY(rocsolver_gesvd(STRIDED, handle, leftv, rightv, m, n, (T*)nullptr,
-                                                  lda, stA, (S*)nullptr, stS, (T*)nullptr, ldu, stU,
-                                                  (T*)nullptr, ldv, stV, (S*)nullptr, stE, fa,
-                                                  (rocblas_int*)nullptr, bc));
+                                              lda, stA, (S*)nullptr, stS, (T*)nullptr, ldu, stU,
+                                              (T*)nullptr, ldv, stV, (S*)nullptr, stE, fa,
+                                              (rocblas_int*)nullptr, bc));
             CHECK_ALLOC_QUERY(rocsolver_gesvd(STRIDED, handle, leftvT, rightvT, mT, nT, (T*)nullptr,
-                                                  lda, stA, (S*)nullptr, stS, (T*)nullptr, lduT, stUT,
-                                                  (T*)nullptr, ldvT, stVT, (S*)nullptr, stE, fa,
-                                                  (rocblas_int*)nullptr, bc));
+                                              lda, stA, (S*)nullptr, stS, (T*)nullptr, lduT, stUT,
+                                              (T*)nullptr, ldvT, stVT, (S*)nullptr, stE, fa,
+                                              (rocblas_int*)nullptr, bc));
         }
 
         size_t size;

--- a/rocsolver/clients/include/testing_gesvd.hpp
+++ b/rocsolver/clients/include/testing_gesvd.hpp
@@ -620,7 +620,7 @@ void testing_gesvd(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)

--- a/rocsolver/clients/include/testing_gesvd.hpp
+++ b/rocsolver/clients/include/testing_gesvd.hpp
@@ -648,9 +648,7 @@ void testing_gesvd(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations (all cases)

--- a/rocsolver/clients/include/testing_getf2_getrf.hpp
+++ b/rocsolver/clients/include/testing_getf2_getrf.hpp
@@ -302,7 +302,7 @@ void getf2_getrf_getPerfData(const rocblas_handle handle,
     hipStream_t stream;
     CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
-    
+
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
         getf2_getrf_initData<false, true, T>(handle, m, n, dA, lda, stA, dIpiv, stP, dInfo, bc, hA,
@@ -369,12 +369,13 @@ void testing_getf2_getrf(Arguments argus)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
-            CHECK_ALLOC_QUERY(rocsolver_getf2_getrf(STRIDED, GETRF, handle, m, n, (T* const*)nullptr, lda, stA,
-                                      (rocblas_int*)nullptr, stP, (rocblas_int*)nullptr, bc));
+            CHECK_ALLOC_QUERY(rocsolver_getf2_getrf(STRIDED, GETRF, handle, m, n, (T* const*)nullptr,
+                                                    lda, stA, (rocblas_int*)nullptr, stP,
+                                                    (rocblas_int*)nullptr, bc));
         else
-            CHECK_ALLOC_QUERY(rocsolver_getf2_getrf(STRIDED, GETRF, handle, m, n, (T*)nullptr,
-                                                        lda, stA, (rocblas_int*)nullptr, stP,
-                                                        (rocblas_int*)nullptr, bc));
+            CHECK_ALLOC_QUERY(rocsolver_getf2_getrf(STRIDED, GETRF, handle, m, n, (T*)nullptr, lda,
+                                                    stA, (rocblas_int*)nullptr, stP,
+                                                    (rocblas_int*)nullptr, bc));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_getf2_getrf.hpp
+++ b/rocsolver/clients/include/testing_getf2_getrf.hpp
@@ -365,7 +365,7 @@ void testing_getf2_getrf(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)

--- a/rocsolver/clients/include/testing_getf2_getrf.hpp
+++ b/rocsolver/clients/include/testing_getf2_getrf.hpp
@@ -379,9 +379,7 @@ void testing_getf2_getrf(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     if(BATCHED)

--- a/rocsolver/clients/include/testing_getf2_getrf.hpp
+++ b/rocsolver/clients/include/testing_getf2_getrf.hpp
@@ -276,13 +276,13 @@ void getf2_getrf_getPerfData(const rocblas_handle handle,
                                              hIpiv, hInfo, singular);
 
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         for(rocblas_int b = 0; b < bc; ++b)
         {
             GETRF ? cblas_getrf<T>(m, n, hA[b], lda, hIpiv[b], hInfo[b])
                   : cblas_getf2<T>(m, n, hA[b], lda, hIpiv[b], hInfo[b]);
         }
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     getf2_getrf_initData<true, false, T>(handle, m, n, dA, lda, stA, dIpiv, stP, dInfo, bc, hA,
@@ -299,16 +299,19 @@ void getf2_getrf_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+    
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
         getf2_getrf_initData<false, true, T>(handle, m, n, dA, lda, stA, dIpiv, stP, dInfo, bc, hA,
                                              hIpiv, hInfo, singular);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_getf2_getrf(STRIDED, GETRF, handle, m, n, dA.data(), lda, stA, dIpiv.data(), stP,
                               dInfo.data(), bc);
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -359,6 +362,25 @@ void testing_getf2_getrf(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        if(BATCHED)
+            CHECK_ALLOC_QUERY(rocsolver_getf2_getrf(STRIDED, GETRF, handle, m, n, (T* const*)nullptr, lda, stA,
+                                      (rocblas_int*)nullptr, stP, (rocblas_int*)nullptr, bc));
+        else
+            CHECK_ALLOC_QUERY(rocsolver_getf2_getrf(STRIDED, GETRF, handle, m, n, (T*)nullptr,
+                                                        lda, stA, (rocblas_int*)nullptr, stP,
+                                                        (rocblas_int*)nullptr, bc));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     if(BATCHED)

--- a/rocsolver/clients/include/testing_getf2_getrf_npvt.hpp
+++ b/rocsolver/clients/include/testing_getf2_getrf_npvt.hpp
@@ -324,11 +324,11 @@ void testing_getf2_getrf_npvt(Arguments argus)
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
             CHECK_ALLOC_QUERY(rocsolver_getf2_getrf_npvt(STRIDED, GETRF, handle, m, n,
-                                                             (T* const*)nullptr, lda, stA,
-                                                             (rocblas_int*)nullptr, bc));
+                                                         (T* const*)nullptr, lda, stA,
+                                                         (rocblas_int*)nullptr, bc));
         else
             CHECK_ALLOC_QUERY(rocsolver_getf2_getrf_npvt(STRIDED, GETRF, handle, m, n, (T*)nullptr,
-                                                             lda, stA, (rocblas_int*)nullptr, bc));
+                                                         lda, stA, (rocblas_int*)nullptr, bc));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_getf2_getrf_npvt.hpp
+++ b/rocsolver/clients/include/testing_getf2_getrf_npvt.hpp
@@ -332,9 +332,7 @@ void testing_getf2_getrf_npvt(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     if(BATCHED)

--- a/rocsolver/clients/include/testing_getf2_getrf_npvt.hpp
+++ b/rocsolver/clients/include/testing_getf2_getrf_npvt.hpp
@@ -319,7 +319,7 @@ void testing_getf2_getrf_npvt(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)

--- a/rocsolver/clients/include/testing_getri.hpp
+++ b/rocsolver/clients/include/testing_getri.hpp
@@ -298,7 +298,7 @@ void getri_getPerfData(const rocblas_handle handle,
     hipStream_t stream;
     CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
-    
+
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
         getri_initData<false, true, T>(handle, n, dA1, dA, lda, stA, dIpiv, stP, dInfo, bc, hA1, hA,
@@ -362,12 +362,12 @@ void testing_getri(Arguments argus)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
-            CHECK_ALLOC_QUERY(rocsolver_getri(STRIDED, handle, n, (T* const*)nullptr, (T* const*)nullptr, lda,
-                                stA, (rocblas_int*)nullptr, stP, (rocblas_int*)nullptr, bc));
+            CHECK_ALLOC_QUERY(rocsolver_getri(STRIDED, handle, n, (T* const*)nullptr,
+                                              (T* const*)nullptr, lda, stA, (rocblas_int*)nullptr,
+                                              stP, (rocblas_int*)nullptr, bc));
         else
-            CHECK_ALLOC_QUERY(rocsolver_getri(STRIDED, handle, n, (T*)nullptr, (T*)nullptr, lda,
-                                                  stA, (rocblas_int*)nullptr, stP,
-                                                  (rocblas_int*)nullptr, bc));
+            CHECK_ALLOC_QUERY(rocsolver_getri(STRIDED, handle, n, (T*)nullptr, (T*)nullptr, lda, stA,
+                                              (rocblas_int*)nullptr, stP, (rocblas_int*)nullptr, bc));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_getri.hpp
+++ b/rocsolver/clients/include/testing_getri.hpp
@@ -358,7 +358,7 @@ void testing_getri(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)

--- a/rocsolver/clients/include/testing_getri.hpp
+++ b/rocsolver/clients/include/testing_getri.hpp
@@ -273,12 +273,12 @@ void getri_getPerfData(const rocblas_handle handle,
                                        hIpiv, hInfo, singular);
 
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         for(rocblas_int b = 0; b < bc; ++b)
         {
             cblas_getri<T>(n, hA[b], lda, hIpiv[b], hW.data(), sizeW, hInfo[b]);
         }
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     getri_initData<true, false, T>(handle, n, dA1, dA, lda, stA, dIpiv, stP, dInfo, bc, hA1, hA,
@@ -295,16 +295,19 @@ void getri_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+    
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
         getri_initData<false, true, T>(handle, n, dA1, dA, lda, stA, dIpiv, stP, dInfo, bc, hA1, hA,
                                        hIpiv, hInfo, singular);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_getri(STRIDED, handle, n, dA1.data(), dA.data(), lda, stA, dIpiv.data(), stP,
                         dInfo.data(), bc);
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -312,13 +315,8 @@ void getri_getPerfData(const rocblas_handle handle,
 template <bool BATCHED, bool STRIDED, typename T>
 void testing_getri(Arguments argus)
 {
-    rocblas_local_handle handle;
-    /* Set handle memory size to a large enough value for all tests to pass.
-     (TODO: Investigate why rocblas is not automatically increasing the size of
-     the memory stack in rocblas_handle)*/
-    rocblas_set_device_memory_size(handle, 80000000);
-
     // get arguments
+    rocblas_local_handle handle;
     rocblas_int n = argus.N;
     rocblas_int lda = argus.lda;
     rocblas_stride stA = argus.bsa;
@@ -357,6 +355,25 @@ void testing_getri(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        if(BATCHED)
+            CHECK_ALLOC_QUERY(rocsolver_getri(STRIDED, handle, n, (T* const*)nullptr, (T* const*)nullptr, lda,
+                                stA, (rocblas_int*)nullptr, stP, (rocblas_int*)nullptr, bc));
+        else
+            CHECK_ALLOC_QUERY(rocsolver_getri(STRIDED, handle, n, (T*)nullptr, (T*)nullptr, lda,
+                                                  stA, (rocblas_int*)nullptr, stP,
+                                                  (rocblas_int*)nullptr, bc));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     if(BATCHED && STRIDED)

--- a/rocsolver/clients/include/testing_getri.hpp
+++ b/rocsolver/clients/include/testing_getri.hpp
@@ -371,9 +371,7 @@ void testing_getri(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     if(BATCHED && STRIDED)

--- a/rocsolver/clients/include/testing_getrs.hpp
+++ b/rocsolver/clients/include/testing_getrs.hpp
@@ -268,7 +268,7 @@ void getrs_getPerfData(const rocblas_handle handle,
     hipStream_t stream;
     CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
-    
+
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
         getrs_initData<false, true, T>(handle, trans, m, nrhs, dA, lda, stA, dIpiv, stP, dB, ldb,
@@ -338,12 +338,12 @@ void testing_getrs(Arguments argus)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
-            CHECK_ALLOC_QUERY(rocsolver_getrs(STRIDED, handle, trans, m, nrhs, (T* const*)nullptr, lda, stA,
-                                (rocblas_int*)nullptr, stP, (T* const*)nullptr, ldb, stB, bc));
+            CHECK_ALLOC_QUERY(rocsolver_getrs(STRIDED, handle, trans, m, nrhs, (T* const*)nullptr,
+                                              lda, stA, (rocblas_int*)nullptr, stP,
+                                              (T* const*)nullptr, ldb, stB, bc));
         else
-            CHECK_ALLOC_QUERY(rocsolver_getrs(STRIDED, handle, trans, m, nrhs, (T*)nullptr, lda,
-                                                  stA, (rocblas_int*)nullptr, stP, (T*)nullptr, ldb,
-                                                  stB, bc));
+            CHECK_ALLOC_QUERY(rocsolver_getrs(STRIDED, handle, trans, m, nrhs, (T*)nullptr, lda, stA,
+                                              (rocblas_int*)nullptr, stP, (T*)nullptr, ldb, stB, bc));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
@@ -351,7 +351,7 @@ void testing_getrs(Arguments argus)
         if(size > DEFAULT_MEM)
             CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
-    
+
     if(BATCHED)
     {
         // memory allocations

--- a/rocsolver/clients/include/testing_getrs.hpp
+++ b/rocsolver/clients/include/testing_getrs.hpp
@@ -347,9 +347,7 @@ void testing_getrs(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     if(BATCHED)

--- a/rocsolver/clients/include/testing_getrs.hpp
+++ b/rocsolver/clients/include/testing_getrs.hpp
@@ -243,12 +243,12 @@ void getrs_getPerfData(const rocblas_handle handle,
                                        stB, bc, hA, hIpiv, hB);
 
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         for(rocblas_int b = 0; b < bc; ++b)
         {
             cblas_getrs<T>(trans, m, nrhs, hA[b], lda, hIpiv[b], hB[b], ldb);
         }
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     getrs_initData<true, false, T>(handle, trans, m, nrhs, dA, lda, stA, dIpiv, stP, dB, ldb, stB,
@@ -265,16 +265,19 @@ void getrs_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+    
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
         getrs_initData<false, true, T>(handle, trans, m, nrhs, dA, lda, stA, dIpiv, stP, dB, ldb,
                                        stB, bc, hA, hIpiv, hB);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_getrs(STRIDED, handle, trans, m, nrhs, dA.data(), lda, stA, dIpiv.data(), stP,
                         dB.data(), ldb, stB, bc);
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -282,13 +285,8 @@ void getrs_getPerfData(const rocblas_handle handle,
 template <bool BATCHED, bool STRIDED, typename T>
 void testing_getrs(Arguments argus)
 {
-    rocblas_local_handle handle;
-    /* Set handle memory size to a large enough value for all tests to pass.
-   (TODO: Investigate why rocblas is not automatically increasing the size of
-   the memory stack in rocblas_handle)*/
-    rocblas_set_device_memory_size(handle, 80000000);
-
     // get arguments
+    rocblas_local_handle handle;
     rocblas_int m = argus.M;
     rocblas_int nrhs = argus.N;
     rocblas_int lda = argus.lda;
@@ -335,6 +333,25 @@ void testing_getrs(Arguments argus)
         return;
     }
 
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        if(BATCHED)
+            CHECK_ALLOC_QUERY(rocsolver_getrs(STRIDED, handle, trans, m, nrhs, (T* const*)nullptr, lda, stA,
+                                (rocblas_int*)nullptr, stP, (T* const*)nullptr, ldb, stB, bc));
+        else
+            CHECK_ALLOC_QUERY(rocsolver_getrs(STRIDED, handle, trans, m, nrhs, (T*)nullptr, lda,
+                                                  stA, (rocblas_int*)nullptr, stP, (T*)nullptr, ldb,
+                                                  stB, bc));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+    
     if(BATCHED)
     {
         // memory allocations

--- a/rocsolver/clients/include/testing_getrs.hpp
+++ b/rocsolver/clients/include/testing_getrs.hpp
@@ -334,7 +334,7 @@ void testing_getrs(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)

--- a/rocsolver/clients/include/testing_labrd.hpp
+++ b/rocsolver/clients/include/testing_labrd.hpp
@@ -327,7 +327,7 @@ void testing_labrd(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_labrd(handle, m, n, nb, (T*)nullptr, lda, (S*)nullptr,

--- a/rocsolver/clients/include/testing_labrd.hpp
+++ b/rocsolver/clients/include/testing_labrd.hpp
@@ -336,9 +336,7 @@ void testing_labrd(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_labrd.hpp
+++ b/rocsolver/clients/include/testing_labrd.hpp
@@ -265,7 +265,7 @@ void labrd_getPerfData(const rocblas_handle handle,
     hipStream_t stream;
     CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
-    
+
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
         labrd_initData<false, true, S, T>(handle, m, n, nb, dA, lda, dD, dE, dTauq, dTaup, dX, ldx,
@@ -331,8 +331,8 @@ void testing_labrd(Arguments argus)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_labrd(handle, m, n, nb, (T*)nullptr, lda, (S*)nullptr,
-                                              (S*)nullptr, (T*)nullptr, (T*)nullptr, (T*)nullptr,
-                                              ldx, (T*)nullptr, ldy));
+                                          (S*)nullptr, (T*)nullptr, (T*)nullptr, (T*)nullptr, ldx,
+                                          (T*)nullptr, ldy));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_lacgv.hpp
+++ b/rocsolver/clients/include/testing_lacgv.hpp
@@ -170,7 +170,7 @@ void testing_lacgv(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_lacgv(handle, n, (T*)nullptr, inc));

--- a/rocsolver/clients/include/testing_lacgv.hpp
+++ b/rocsolver/clients/include/testing_lacgv.hpp
@@ -177,9 +177,7 @@ void testing_lacgv(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_lacgv.hpp
+++ b/rocsolver/clients/include/testing_lacgv.hpp
@@ -126,7 +126,7 @@ void lacgv_getPerfData(const rocblas_handle handle,
     hipStream_t stream;
     CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
-    
+
     for(int iter = 0; iter < hot_calls; iter++)
     {
         lacgv_initData<false, true, T>(handle, n, dA, inc, hA);

--- a/rocsolver/clients/include/testing_larf.hpp
+++ b/rocsolver/clients/include/testing_larf.hpp
@@ -176,9 +176,9 @@ void larf_getPerfData(const rocblas_handle handle,
         larf_initData<true, false, T>(handle, side, m, n, dx, inc, dt, dA, lda, xx, hx, ht, hA);
 
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         cblas_larf<T>(side, m, n, hx[0], inc, ht[0], hA[0], lda, hw.data());
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     larf_initData<true, false, T>(handle, side, m, n, dx, inc, dt, dA, lda, xx, hx, ht, hA);
@@ -193,14 +193,17 @@ void larf_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+    
     for(int iter = 0; iter < hot_calls; iter++)
     {
         larf_initData<false, true, T>(handle, side, m, n, dx, inc, dt, dA, lda, xx, hx, ht, hA);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_larf(handle, side, m, n, dx.data(), inc, dt.data(), dA.data(), lda);
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -252,6 +255,19 @@ void testing_larf(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        CHECK_ALLOC_QUERY(rocsolver_larf(handle, side, m, n, (T*)nullptr, inc, (T*)nullptr, (T*)nullptr, lda));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_larf.hpp
+++ b/rocsolver/clients/include/testing_larf.hpp
@@ -266,9 +266,7 @@ void testing_larf(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_larf.hpp
+++ b/rocsolver/clients/include/testing_larf.hpp
@@ -258,7 +258,7 @@ void testing_larf(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(

--- a/rocsolver/clients/include/testing_larf.hpp
+++ b/rocsolver/clients/include/testing_larf.hpp
@@ -196,7 +196,7 @@ void larf_getPerfData(const rocblas_handle handle,
     hipStream_t stream;
     CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
-    
+
     for(int iter = 0; iter < hot_calls; iter++)
     {
         larf_initData<false, true, T>(handle, side, m, n, dx, inc, dt, dA, lda, xx, hx, ht, hA);
@@ -261,7 +261,8 @@ void testing_larf(Arguments argus)
     if(!REALLOC)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
-        CHECK_ALLOC_QUERY(rocsolver_larf(handle, side, m, n, (T*)nullptr, inc, (T*)nullptr, (T*)nullptr, lda));
+        CHECK_ALLOC_QUERY(
+            rocsolver_larf(handle, side, m, n, (T*)nullptr, inc, (T*)nullptr, (T*)nullptr, lda));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_larfb.hpp
+++ b/rocsolver/clients/include/testing_larfb.hpp
@@ -301,10 +301,10 @@ void larfb_getPerfData(const rocblas_handle handle,
                                        ldt, dA, lda, hV, hT, hA, hW, sizeW);
 
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         cblas_larfb<T>(side, trans, direct, storev, m, n, k, hV[0], ldv, hT[0], ldt, hA[0], lda,
                        hW.data(), ldw);
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     larfb_initData<true, false, T>(handle, side, trans, direct, storev, m, n, k, dV, ldv, dT, ldt,
@@ -321,16 +321,19 @@ void larfb_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+    
     for(int iter = 0; iter < hot_calls; iter++)
     {
         larfb_initData<false, true, T>(handle, side, trans, direct, storev, m, n, k, dV, ldv, dT,
                                        ldt, dA, lda, hV, hT, hA, hW, sizeW);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_larfb(handle, side, trans, direct, storev, m, n, k, dV.data(), ldv, dT.data(),
                         ldt, dA.data(), lda);
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -396,6 +399,20 @@ void testing_larfb(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        CHECK_ALLOC_QUERY(rocsolver_larfb(handle, side, trans, direct, storev, m, n, k,
+                                              (T*)nullptr, ldv, (T*)nullptr, ldt, (T*)nullptr, lda));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_larfb.hpp
+++ b/rocsolver/clients/include/testing_larfb.hpp
@@ -402,7 +402,7 @@ void testing_larfb(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_larfb(handle, side, trans, direct, storev, m, n, k, (T*)nullptr,

--- a/rocsolver/clients/include/testing_larfb.hpp
+++ b/rocsolver/clients/include/testing_larfb.hpp
@@ -410,9 +410,7 @@ void testing_larfb(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_larfb.hpp
+++ b/rocsolver/clients/include/testing_larfb.hpp
@@ -324,7 +324,7 @@ void larfb_getPerfData(const rocblas_handle handle,
     hipStream_t stream;
     CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
-    
+
     for(int iter = 0; iter < hot_calls; iter++)
     {
         larfb_initData<false, true, T>(handle, side, trans, direct, storev, m, n, k, dV, ldv, dT,
@@ -405,8 +405,8 @@ void testing_larfb(Arguments argus)
     if(!REALLOC)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
-        CHECK_ALLOC_QUERY(rocsolver_larfb(handle, side, trans, direct, storev, m, n, k,
-                                              (T*)nullptr, ldv, (T*)nullptr, ldt, (T*)nullptr, lda));
+        CHECK_ALLOC_QUERY(rocsolver_larfb(handle, side, trans, direct, storev, m, n, k, (T*)nullptr,
+                                          ldv, (T*)nullptr, ldt, (T*)nullptr, lda));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_larfg.hpp
+++ b/rocsolver/clients/include/testing_larfg.hpp
@@ -201,7 +201,7 @@ void testing_larfg(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_larfg(handle, n, (T*)nullptr, (T*)nullptr, inc, (T*)nullptr));

--- a/rocsolver/clients/include/testing_larfg.hpp
+++ b/rocsolver/clients/include/testing_larfg.hpp
@@ -152,7 +152,7 @@ void larfg_getPerfData(const rocblas_handle handle,
     hipStream_t stream;
     CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
-    
+
     for(int iter = 0; iter < hot_calls; iter++)
     {
         larfg_initData<false, true, T>(handle, n, da, dx, inc, dt, ha, hx, ht);

--- a/rocsolver/clients/include/testing_larfg.hpp
+++ b/rocsolver/clients/include/testing_larfg.hpp
@@ -133,9 +133,9 @@ void larfg_getPerfData(const rocblas_handle handle,
         larfg_initData<true, false, T>(handle, n, da, dx, inc, dt, ha, hx, ht);
 
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         cblas_larfg<T>(n, ha[0], hx[0], inc, ht[0]);
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     larfg_initData<true, false, T>(handle, n, da, dx, inc, dt, ha, hx, ht);
@@ -149,14 +149,17 @@ void larfg_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+    
     for(int iter = 0; iter < hot_calls; iter++)
     {
         larfg_initData<false, true, T>(handle, n, da, dx, inc, dt, ha, hx, ht);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_larfg(handle, n, da.data(), dx.data(), inc, dt.data());
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -195,6 +198,19 @@ void testing_larfg(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        CHECK_ALLOC_QUERY(rocsolver_larfg(handle, n, (T*)nullptr, (T*)nullptr, inc, (T*)nullptr));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_larfg.hpp
+++ b/rocsolver/clients/include/testing_larfg.hpp
@@ -208,9 +208,7 @@ void testing_larfg(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_larft.hpp
+++ b/rocsolver/clients/include/testing_larft.hpp
@@ -290,7 +290,7 @@ void testing_larft(Arguments argus)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_larft(handle, direct, storev, n, k, (T*)nullptr, ldv,
-                                              (T*)nullptr, (T*)nullptr, ldt));
+                                          (T*)nullptr, (T*)nullptr, ldt));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_larft.hpp
+++ b/rocsolver/clients/include/testing_larft.hpp
@@ -209,9 +209,9 @@ void larft_getPerfData(const rocblas_handle handle,
                                        hT, hw, size_w);
 
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         cblas_larft<T>(direct, storev, n, k, hV[0], ldv, ht[0], hT[0], ldt);
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     larft_initData<true, false, T>(handle, direct, storev, n, k, dV, ldv, dt, dT, ldt, hV, ht, hT,
@@ -228,15 +228,18 @@ void larft_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+
     for(int iter = 0; iter < hot_calls; iter++)
     {
         larft_initData<false, true, T>(handle, direct, storev, n, k, dV, ldv, dt, dT, ldt, hV, ht,
                                        hT, hw, size_w);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_larft(handle, direct, storev, n, k, dV.data(), ldv, dt.data(), dT.data(), ldt);
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -280,6 +283,20 @@ void testing_larft(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        CHECK_ALLOC_QUERY(rocsolver_larft(handle, direct, storev, n, k, (T*)nullptr, ldv,
+                                              (T*)nullptr, (T*)nullptr, ldt));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_larft.hpp
+++ b/rocsolver/clients/include/testing_larft.hpp
@@ -294,9 +294,7 @@ void testing_larft(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_larft.hpp
+++ b/rocsolver/clients/include/testing_larft.hpp
@@ -286,7 +286,7 @@ void testing_larft(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_larft(handle, direct, storev, n, k, (T*)nullptr, ldv,

--- a/rocsolver/clients/include/testing_laswp.hpp
+++ b/rocsolver/clients/include/testing_laswp.hpp
@@ -217,7 +217,7 @@ void testing_laswp(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(

--- a/rocsolver/clients/include/testing_laswp.hpp
+++ b/rocsolver/clients/include/testing_laswp.hpp
@@ -225,9 +225,7 @@ void testing_laswp(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_laswp.hpp
+++ b/rocsolver/clients/include/testing_laswp.hpp
@@ -220,7 +220,8 @@ void testing_laswp(Arguments argus)
     if(!REALLOC)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
-        CHECK_ALLOC_QUERY(rocsolver_laswp(handle, n, (T*)nullptr, lda, k1, k2, (rocblas_int*)nullptr, inc));
+        CHECK_ALLOC_QUERY(
+            rocsolver_laswp(handle, n, (T*)nullptr, lda, k1, k2, (rocblas_int*)nullptr, inc));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_laswp.hpp
+++ b/rocsolver/clients/include/testing_laswp.hpp
@@ -149,9 +149,9 @@ void laswp_getPerfData(const rocblas_handle handle,
         laswp_initData<true, false, T>(handle, n, dA, lda, k1, k2, dIpiv, inc, hA, hIpiv);
 
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         cblas_laswp<T>(n, hA[0], lda, k1, k2, hIpiv[0], inc);
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     laswp_initData<true, false, T>(handle, n, dA, lda, k1, k2, dIpiv, inc, hA, hIpiv);
@@ -165,14 +165,17 @@ void laswp_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+
     for(int iter = 0; iter < hot_calls; iter++)
     {
         laswp_initData<false, true, T>(handle, n, dA, lda, k1, k2, dIpiv, inc, hA, hIpiv);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_laswp(handle, n, dA.data(), lda, k1, k2, dIpiv.data(), inc);
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -211,6 +214,19 @@ void testing_laswp(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        CHECK_ALLOC_QUERY(rocsolver_laswp(handle, n, (T*)nullptr, lda, k1, k2, (rocblas_int*)nullptr, inc));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_latrd.hpp
+++ b/rocsolver/clients/include/testing_latrd.hpp
@@ -293,7 +293,7 @@ void testing_latrd(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_latrd(handle, uplo, n, k, (T*)nullptr, lda, (S*)nullptr,

--- a/rocsolver/clients/include/testing_latrd.hpp
+++ b/rocsolver/clients/include/testing_latrd.hpp
@@ -301,9 +301,7 @@ void testing_latrd(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_latrd.hpp
+++ b/rocsolver/clients/include/testing_latrd.hpp
@@ -207,10 +207,10 @@ void latrd_getPerfData(const rocblas_handle handle,
         latrd_initData<true, false, T>(handle, n, dA, lda, hA);
 
         // cpu-lapack performance
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         memset(hW[0], 0, ldw * k * sizeof(T));
         cblas_latrd(uplo, n, k, hA[0], lda, hE[0], hTau[0], hW[0], ldw);
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     latrd_initData<true, false, T>(handle, n, dA, lda, hA);
@@ -225,14 +225,17 @@ void latrd_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
         latrd_initData<false, true, T>(handle, n, dA, lda, hA);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_latrd(handle, uplo, n, k, dA.data(), lda, dE.data(), dTau.data(), dW.data(), ldw);
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -287,6 +290,20 @@ void testing_latrd(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        CHECK_ALLOC_QUERY(rocsolver_latrd(handle, uplo, n, k, (T*)nullptr, lda, (S*)nullptr,
+                                              (T*)nullptr, (T*)nullptr, ldw));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_latrd.hpp
+++ b/rocsolver/clients/include/testing_latrd.hpp
@@ -297,7 +297,7 @@ void testing_latrd(Arguments argus)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_latrd(handle, uplo, n, k, (T*)nullptr, lda, (S*)nullptr,
-                                              (T*)nullptr, (T*)nullptr, ldw));
+                                          (T*)nullptr, (T*)nullptr, ldw));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_orgbr_ungbr.hpp
+++ b/rocsolver/clients/include/testing_orgbr_ungbr.hpp
@@ -273,7 +273,8 @@ void testing_orgbr_ungbr(Arguments argus)
     if(!REALLOC)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
-        CHECK_ALLOC_QUERY(rocsolver_orgbr_ungbr(handle, storev, m, n, k, (T*)nullptr, lda, (T*)nullptr));
+        CHECK_ALLOC_QUERY(
+            rocsolver_orgbr_ungbr(handle, storev, m, n, k, (T*)nullptr, lda, (T*)nullptr));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_orgbr_ungbr.hpp
+++ b/rocsolver/clients/include/testing_orgbr_ungbr.hpp
@@ -191,9 +191,9 @@ void orgbr_ungbr_getPerfData(const rocblas_handle handle,
                                              size_W);
 
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         cblas_orgbr_ungbr<T>(storev, m, n, k, hA[0], lda, hIpiv[0], hW.data(), size_W);
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     orgbr_ungbr_initData<true, false, T>(handle, storev, m, n, k, dA, lda, dIpiv, hA, hIpiv, hW,
@@ -210,15 +210,18 @@ void orgbr_ungbr_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+
     for(int iter = 0; iter < hot_calls; iter++)
     {
         orgbr_ungbr_initData<false, true, T>(handle, storev, m, n, k, dA, lda, dIpiv, hA, hIpiv, hW,
                                              size_W);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_orgbr_ungbr(handle, storev, m, n, k, dA.data(), lda, dIpiv.data());
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -264,6 +267,19 @@ void testing_orgbr_ungbr(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        CHECK_ALLOC_QUERY(rocsolver_orgbr_ungbr(handle, storev, m, n, k, (T*)nullptr, lda, (T*)nullptr));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_orgbr_ungbr.hpp
+++ b/rocsolver/clients/include/testing_orgbr_ungbr.hpp
@@ -278,9 +278,7 @@ void testing_orgbr_ungbr(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_orgbr_ungbr.hpp
+++ b/rocsolver/clients/include/testing_orgbr_ungbr.hpp
@@ -270,7 +270,7 @@ void testing_orgbr_ungbr(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(

--- a/rocsolver/clients/include/testing_orglx_unglx.hpp
+++ b/rocsolver/clients/include/testing_orglx_unglx.hpp
@@ -233,9 +233,7 @@ void testing_orglx_unglx(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_orglx_unglx.hpp
+++ b/rocsolver/clients/include/testing_orglx_unglx.hpp
@@ -158,10 +158,10 @@ void orglx_unglx_getPerfData(const rocblas_handle handle,
         orglx_unglx_initData<true, false, T>(handle, m, n, k, dA, lda, dIpiv, hA, hIpiv, hW, size_W);
 
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         GLQ ? cblas_orglq_unglq<T>(m, n, k, hA[0], lda, hIpiv[0], hW.data(), size_W)
             : cblas_orgl2_ungl2<T>(m, n, k, hA[0], lda, hIpiv[0], hW.data());
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     orglx_unglx_initData<true, false, T>(handle, m, n, k, dA, lda, dIpiv, hA, hIpiv, hW, size_W);
@@ -175,14 +175,17 @@ void orglx_unglx_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+
     for(int iter = 0; iter < hot_calls; iter++)
     {
         orglx_unglx_initData<false, true, T>(handle, m, n, k, dA, lda, dIpiv, hA, hIpiv, hW, size_W);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_orglx_unglx(GLQ, handle, m, n, k, dA.data(), lda, dIpiv.data());
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -220,6 +223,19 @@ void testing_orglx_unglx(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        CHECK_ALLOC_QUERY(rocsolver_orglx_unglx(GLQ, handle, m, n, k, (T*)nullptr, lda, (T*)nullptr));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_orglx_unglx.hpp
+++ b/rocsolver/clients/include/testing_orglx_unglx.hpp
@@ -226,7 +226,7 @@ void testing_orglx_unglx(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_orglx_unglx(GLQ, handle, m, n, k, (T*)nullptr, lda, (T*)nullptr));

--- a/rocsolver/clients/include/testing_orgtr_ungtr.hpp
+++ b/rocsolver/clients/include/testing_orgtr_ungtr.hpp
@@ -233,9 +233,7 @@ void testing_orgtr_ungtr(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_orgtr_ungtr.hpp
+++ b/rocsolver/clients/include/testing_orgtr_ungtr.hpp
@@ -156,9 +156,9 @@ void orgtr_ungtr_getPerfData(const rocblas_handle handle,
         orgtr_ungtr_initData<true, false, T>(handle, uplo, n, dA, lda, dIpiv, hA, hIpiv, hW, size_W);
 
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         cblas_orgtr_ungtr<T>(uplo, n, hA[0], lda, hIpiv[0], hW.data(), size_W);
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     orgtr_ungtr_initData<true, false, T>(handle, uplo, n, dA, lda, dIpiv, hA, hIpiv, hW, size_W);
@@ -172,14 +172,17 @@ void orgtr_ungtr_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+
     for(int iter = 0; iter < hot_calls; iter++)
     {
         orgtr_ungtr_initData<false, true, T>(handle, uplo, n, dA, lda, dIpiv, hA, hIpiv, hW, size_W);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_orgtr_ungtr(handle, uplo, n, dA.data(), lda, dIpiv.data());
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -220,6 +223,19 @@ void testing_orgtr_ungtr(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        CHECK_ALLOC_QUERY(rocsolver_orgtr_ungtr(handle, uplo, n, (T*)nullptr, lda, (T*)nullptr));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_orgtr_ungtr.hpp
+++ b/rocsolver/clients/include/testing_orgtr_ungtr.hpp
@@ -226,7 +226,7 @@ void testing_orgtr_ungtr(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_orgtr_ungtr(handle, uplo, n, (T*)nullptr, lda, (T*)nullptr));

--- a/rocsolver/clients/include/testing_orgxl_ungxl.hpp
+++ b/rocsolver/clients/include/testing_orgxl_ungxl.hpp
@@ -233,9 +233,7 @@ void testing_orgxl_ungxl(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_orgxl_ungxl.hpp
+++ b/rocsolver/clients/include/testing_orgxl_ungxl.hpp
@@ -226,7 +226,7 @@ void testing_orgxl_ungxl(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_orgxl_ungxl(GQL, handle, m, n, k, (T*)nullptr, lda, (T*)nullptr));

--- a/rocsolver/clients/include/testing_orgxl_ungxl.hpp
+++ b/rocsolver/clients/include/testing_orgxl_ungxl.hpp
@@ -158,10 +158,10 @@ void orgxl_ungxl_getPerfData(const rocblas_handle handle,
         orgxl_ungxl_initData<true, false, T>(handle, m, n, k, dA, lda, dIpiv, hA, hIpiv, hW, size_W);
 
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         GQL ? cblas_orgql_ungql<T>(m, n, k, hA[0], lda, hIpiv[0], hW.data(), size_W)
             : cblas_org2l_ung2l<T>(m, n, k, hA[0], lda, hIpiv[0], hW.data());
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     orgxl_ungxl_initData<true, false, T>(handle, m, n, k, dA, lda, dIpiv, hA, hIpiv, hW, size_W);
@@ -175,14 +175,17 @@ void orgxl_ungxl_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+
     for(int iter = 0; iter < hot_calls; iter++)
     {
         orgxl_ungxl_initData<false, true, T>(handle, m, n, k, dA, lda, dIpiv, hA, hIpiv, hW, size_W);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_orgxl_ungxl(GQL, handle, m, n, k, dA.data(), lda, dIpiv.data());
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -220,6 +223,19 @@ void testing_orgxl_ungxl(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        CHECK_ALLOC_QUERY(rocsolver_orgxl_ungxl(GQL, handle, m, n, k, (T*)nullptr, lda, (T*)nullptr));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_orgxr_ungxr.hpp
+++ b/rocsolver/clients/include/testing_orgxr_ungxr.hpp
@@ -233,9 +233,7 @@ void testing_orgxr_ungxr(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_orgxr_ungxr.hpp
+++ b/rocsolver/clients/include/testing_orgxr_ungxr.hpp
@@ -226,7 +226,7 @@ void testing_orgxr_ungxr(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_orgxr_ungxr(GQR, handle, m, n, k, (T*)nullptr, lda, (T*)nullptr));

--- a/rocsolver/clients/include/testing_orgxr_ungxr.hpp
+++ b/rocsolver/clients/include/testing_orgxr_ungxr.hpp
@@ -158,10 +158,10 @@ void orgxr_ungxr_getPerfData(const rocblas_handle handle,
         orgxr_ungxr_initData<true, false, T>(handle, m, n, k, dA, lda, dIpiv, hA, hIpiv, hW, size_W);
 
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         GQR ? cblas_orgqr_ungqr<T>(m, n, k, hA[0], lda, hIpiv[0], hW.data(), size_W)
             : cblas_org2r_ung2r<T>(m, n, k, hA[0], lda, hIpiv[0], hW.data());
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     orgxr_ungxr_initData<true, false, T>(handle, m, n, k, dA, lda, dIpiv, hA, hIpiv, hW, size_W);
@@ -175,14 +175,17 @@ void orgxr_ungxr_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+
     for(int iter = 0; iter < hot_calls; iter++)
     {
         orgxr_ungxr_initData<false, true, T>(handle, m, n, k, dA, lda, dIpiv, hA, hIpiv, hW, size_W);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_orgxr_ungxr(GQR, handle, m, n, k, dA.data(), lda, dIpiv.data());
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -220,6 +223,19 @@ void testing_orgxr_ungxr(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        CHECK_ALLOC_QUERY(rocsolver_orgxr_ungxr(GQR, handle, m, n, k, (T*)nullptr, lda, (T*)nullptr));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_ormbr_unmbr.hpp
+++ b/rocsolver/clients/include/testing_ormbr_unmbr.hpp
@@ -353,9 +353,7 @@ void testing_ormbr_unmbr(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_ormbr_unmbr.hpp
+++ b/rocsolver/clients/include/testing_ormbr_unmbr.hpp
@@ -345,7 +345,7 @@ void testing_ormbr_unmbr(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_ormbr_unmbr(handle, storev, side, trans, m, n, k, (T*)nullptr,

--- a/rocsolver/clients/include/testing_ormbr_unmbr.hpp
+++ b/rocsolver/clients/include/testing_ormbr_unmbr.hpp
@@ -246,10 +246,10 @@ void ormbr_unmbr_getPerfData(const rocblas_handle handle,
                                              dC, ldc, hA, hIpiv, hC, hW, size_W);
 
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         cblas_ormbr_unmbr<T>(storev, side, trans, m, n, k, hA[0], lda, hIpiv[0], hC[0], ldc,
                              hW.data(), size_W);
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     ormbr_unmbr_initData<true, false, T>(handle, storev, side, trans, m, n, k, dA, lda, dIpiv, dC,
@@ -266,16 +266,19 @@ void ormbr_unmbr_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+
     for(int iter = 0; iter < hot_calls; iter++)
     {
         ormbr_unmbr_initData<false, true, T>(handle, storev, side, trans, m, n, k, dA, lda, dIpiv,
                                              dC, ldc, hA, hIpiv, hC, hW, size_W);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_ormbr_unmbr(handle, storev, side, trans, m, n, k, dA.data(), lda, dIpiv.data(),
                               dC.data(), ldc);
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -339,6 +342,20 @@ void testing_ormbr_unmbr(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        CHECK_ALLOC_QUERY(rocsolver_ormbr_unmbr(handle, storev, side, trans, m, n, k,
+                                                    (T*)nullptr, lda, (T*)nullptr, (T*)nullptr, ldc));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_ormbr_unmbr.hpp
+++ b/rocsolver/clients/include/testing_ormbr_unmbr.hpp
@@ -348,8 +348,8 @@ void testing_ormbr_unmbr(Arguments argus)
     if(!REALLOC)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
-        CHECK_ALLOC_QUERY(rocsolver_ormbr_unmbr(handle, storev, side, trans, m, n, k,
-                                                    (T*)nullptr, lda, (T*)nullptr, (T*)nullptr, ldc));
+        CHECK_ALLOC_QUERY(rocsolver_ormbr_unmbr(handle, storev, side, trans, m, n, k, (T*)nullptr,
+                                                lda, (T*)nullptr, (T*)nullptr, ldc));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_ormlx_unmlx.hpp
+++ b/rocsolver/clients/include/testing_ormlx_unmlx.hpp
@@ -216,11 +216,11 @@ void ormlx_unmlx_getPerfData(const rocblas_handle handle,
                                              hA, hIpiv, hC, hW, size_W);
 
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         MLQ ? cblas_ormlq_unmlq<T>(side, trans, m, n, k, hA[0], lda, hIpiv[0], hC[0], ldc,
                                    hW.data(), size_W)
             : cblas_orml2_unml2<T>(side, trans, m, n, k, hA[0], lda, hIpiv[0], hC[0], ldc, hW.data());
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     ormlx_unmlx_initData<true, false, T>(handle, side, trans, m, n, k, dA, lda, dIpiv, dC, ldc, hA,
@@ -237,16 +237,19 @@ void ormlx_unmlx_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+
     for(int iter = 0; iter < hot_calls; iter++)
     {
         ormlx_unmlx_initData<false, true, T>(handle, side, trans, m, n, k, dA, lda, dIpiv, dC, ldc,
                                              hA, hIpiv, hC, hW, size_W);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_ormlx_unmlx(MLQ, handle, side, trans, m, n, k, dA.data(), lda, dIpiv.data(),
                               dC.data(), ldc);
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -305,6 +308,20 @@ void testing_ormlx_unmlx(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        CHECK_ALLOC_QUERY(rocsolver_ormlx_unmlx(MLQ, handle, side, trans, m, n, k, (T*)nullptr,
+                                                    lda, (T*)nullptr, (T*)nullptr, ldc));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_ormlx_unmlx.hpp
+++ b/rocsolver/clients/include/testing_ormlx_unmlx.hpp
@@ -319,9 +319,7 @@ void testing_ormlx_unmlx(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_ormlx_unmlx.hpp
+++ b/rocsolver/clients/include/testing_ormlx_unmlx.hpp
@@ -311,7 +311,7 @@ void testing_ormlx_unmlx(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_ormlx_unmlx(MLQ, handle, side, trans, m, n, k, (T*)nullptr, lda,

--- a/rocsolver/clients/include/testing_ormlx_unmlx.hpp
+++ b/rocsolver/clients/include/testing_ormlx_unmlx.hpp
@@ -314,8 +314,8 @@ void testing_ormlx_unmlx(Arguments argus)
     if(!REALLOC)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
-        CHECK_ALLOC_QUERY(rocsolver_ormlx_unmlx(MLQ, handle, side, trans, m, n, k, (T*)nullptr,
-                                                    lda, (T*)nullptr, (T*)nullptr, ldc));
+        CHECK_ALLOC_QUERY(rocsolver_ormlx_unmlx(MLQ, handle, side, trans, m, n, k, (T*)nullptr, lda,
+                                                (T*)nullptr, (T*)nullptr, ldc));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_ormtr_unmtr.hpp
+++ b/rocsolver/clients/include/testing_ormtr_unmtr.hpp
@@ -315,7 +315,7 @@ void testing_ormtr_unmtr(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_ormtr_unmtr(handle, side, uplo, trans, m, n, (T*)nullptr, lda,

--- a/rocsolver/clients/include/testing_ormtr_unmtr.hpp
+++ b/rocsolver/clients/include/testing_ormtr_unmtr.hpp
@@ -219,10 +219,10 @@ void ormtr_unmtr_getPerfData(const rocblas_handle handle,
                                              ldc, hA, hIpiv, hC, hW, size_W);
 
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         cblas_ormtr_unmtr<T>(side, uplo, trans, m, n, hA[0], lda, hIpiv[0], hC[0], ldc, hW.data(),
                              size_W);
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     ormtr_unmtr_initData<true, false, T>(handle, side, uplo, trans, m, n, dA, lda, dIpiv, dC, ldc,
@@ -239,16 +239,19 @@ void ormtr_unmtr_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+
     for(int iter = 0; iter < hot_calls; iter++)
     {
         ormtr_unmtr_initData<false, true, T>(handle, side, uplo, trans, m, n, dA, lda, dIpiv, dC,
                                              ldc, hA, hIpiv, hC, hW, size_W);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_ormtr_unmtr(handle, side, uplo, trans, m, n, dA.data(), lda, dIpiv.data(),
                               dC.data(), ldc);
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -309,6 +312,20 @@ void testing_ormtr_unmtr(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        CHECK_ALLOC_QUERY(rocsolver_ormtr_unmtr(handle, side, uplo, trans, m, n, (T*)nullptr,
+                                                    lda, (T*)nullptr, (T*)nullptr, ldc));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_ormtr_unmtr.hpp
+++ b/rocsolver/clients/include/testing_ormtr_unmtr.hpp
@@ -318,8 +318,8 @@ void testing_ormtr_unmtr(Arguments argus)
     if(!REALLOC)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
-        CHECK_ALLOC_QUERY(rocsolver_ormtr_unmtr(handle, side, uplo, trans, m, n, (T*)nullptr,
-                                                    lda, (T*)nullptr, (T*)nullptr, ldc));
+        CHECK_ALLOC_QUERY(rocsolver_ormtr_unmtr(handle, side, uplo, trans, m, n, (T*)nullptr, lda,
+                                                (T*)nullptr, (T*)nullptr, ldc));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_ormtr_unmtr.hpp
+++ b/rocsolver/clients/include/testing_ormtr_unmtr.hpp
@@ -323,9 +323,7 @@ void testing_ormtr_unmtr(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_ormxl_unmxl.hpp
+++ b/rocsolver/clients/include/testing_ormxl_unmxl.hpp
@@ -311,7 +311,7 @@ void testing_ormxl_unmxl(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_ormxl_unmxl(MQL, handle, side, trans, m, n, k, (T*)nullptr, lda,

--- a/rocsolver/clients/include/testing_ormxl_unmxl.hpp
+++ b/rocsolver/clients/include/testing_ormxl_unmxl.hpp
@@ -216,11 +216,11 @@ void ormxl_unmxl_getPerfData(const rocblas_handle handle,
                                              hA, hIpiv, hC, hW, size_W);
 
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         MQL ? cblas_ormql_unmql<T>(side, trans, m, n, k, hA[0], lda, hIpiv[0], hC[0], ldc,
                                    hW.data(), size_W)
             : cblas_orm2l_unm2l<T>(side, trans, m, n, k, hA[0], lda, hIpiv[0], hC[0], ldc, hW.data());
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     ormxl_unmxl_initData<true, false, T>(handle, side, trans, m, n, k, dA, lda, dIpiv, dC, ldc, hA,
@@ -237,16 +237,19 @@ void ormxl_unmxl_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+
     for(int iter = 0; iter < hot_calls; iter++)
     {
         ormxl_unmxl_initData<false, true, T>(handle, side, trans, m, n, k, dA, lda, dIpiv, dC, ldc,
                                              hA, hIpiv, hC, hW, size_W);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_ormxl_unmxl(MQL, handle, side, trans, m, n, k, dA.data(), lda, dIpiv.data(),
                               dC.data(), ldc);
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -305,6 +308,20 @@ void testing_ormxl_unmxl(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        CHECK_ALLOC_QUERY(rocsolver_ormxl_unmxl(MQL, handle, side, trans, m, n, k, (T*)nullptr,
+                                                    lda, (T*)nullptr, (T*)nullptr, ldc));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_ormxl_unmxl.hpp
+++ b/rocsolver/clients/include/testing_ormxl_unmxl.hpp
@@ -319,9 +319,7 @@ void testing_ormxl_unmxl(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_ormxl_unmxl.hpp
+++ b/rocsolver/clients/include/testing_ormxl_unmxl.hpp
@@ -314,8 +314,8 @@ void testing_ormxl_unmxl(Arguments argus)
     if(!REALLOC)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
-        CHECK_ALLOC_QUERY(rocsolver_ormxl_unmxl(MQL, handle, side, trans, m, n, k, (T*)nullptr,
-                                                    lda, (T*)nullptr, (T*)nullptr, ldc));
+        CHECK_ALLOC_QUERY(rocsolver_ormxl_unmxl(MQL, handle, side, trans, m, n, k, (T*)nullptr, lda,
+                                                (T*)nullptr, (T*)nullptr, ldc));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_ormxr_unmxr.hpp
+++ b/rocsolver/clients/include/testing_ormxr_unmxr.hpp
@@ -311,7 +311,7 @@ void testing_ormxr_unmxr(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_ormxr_unmxr(MQR, handle, side, trans, m, n, k, (T*)nullptr, lda,

--- a/rocsolver/clients/include/testing_ormxr_unmxr.hpp
+++ b/rocsolver/clients/include/testing_ormxr_unmxr.hpp
@@ -319,9 +319,7 @@ void testing_ormxr_unmxr(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_ormxr_unmxr.hpp
+++ b/rocsolver/clients/include/testing_ormxr_unmxr.hpp
@@ -240,7 +240,7 @@ void ormxr_unmxr_getPerfData(const rocblas_handle handle,
     hipStream_t stream;
     CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
-    
+
     for(int iter = 0; iter < hot_calls; iter++)
     {
         ormxr_unmxr_initData<false, true, T>(handle, side, trans, m, n, k, dA, lda, dIpiv, dC, ldc,
@@ -314,8 +314,8 @@ void testing_ormxr_unmxr(Arguments argus)
     if(!REALLOC)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
-        CHECK_ALLOC_QUERY(rocsolver_ormxr_unmxr(MQR, handle, side, trans, m, n, k, (T*)nullptr,
-                                                    lda, (T*)nullptr, (T*)nullptr, ldc));
+        CHECK_ALLOC_QUERY(rocsolver_ormxr_unmxr(MQR, handle, side, trans, m, n, k, (T*)nullptr, lda,
+                                                (T*)nullptr, (T*)nullptr, ldc));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_potf2_potrf.hpp
+++ b/rocsolver/clients/include/testing_potf2_potrf.hpp
@@ -345,9 +345,7 @@ void testing_potf2_potrf(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     if(BATCHED)

--- a/rocsolver/clients/include/testing_potf2_potrf.hpp
+++ b/rocsolver/clients/include/testing_potf2_potrf.hpp
@@ -337,11 +337,11 @@ void testing_potf2_potrf(Arguments argus)
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
             CHECK_ALLOC_QUERY(rocsolver_potf2_potrf(STRIDED, POTRF, handle, uplo, n,
-                                                        (T* const*)nullptr, lda, stA,
-                                                        (rocblas_int*)nullptr, bc));
+                                                    (T* const*)nullptr, lda, stA,
+                                                    (rocblas_int*)nullptr, bc));
         else
             CHECK_ALLOC_QUERY(rocsolver_potf2_potrf(STRIDED, POTRF, handle, uplo, n, (T*)nullptr,
-                                                        lda, stA, (rocblas_int*)nullptr, bc));
+                                                    lda, stA, (rocblas_int*)nullptr, bc));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_potf2_potrf.hpp
+++ b/rocsolver/clients/include/testing_potf2_potrf.hpp
@@ -332,7 +332,7 @@ void testing_potf2_potrf(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)

--- a/rocsolver/clients/include/testing_steqr.hpp
+++ b/rocsolver/clients/include/testing_steqr.hpp
@@ -312,9 +312,7 @@ void testing_steqr(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_steqr.hpp
+++ b/rocsolver/clients/include/testing_steqr.hpp
@@ -304,7 +304,7 @@ void testing_steqr(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_steqr(handle, compc, n, (S*)nullptr, (S*)nullptr, (T*)nullptr,

--- a/rocsolver/clients/include/testing_steqr.hpp
+++ b/rocsolver/clients/include/testing_steqr.hpp
@@ -307,8 +307,8 @@ void testing_steqr(Arguments argus)
     if(!REALLOC)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
-        CHECK_ALLOC_QUERY(rocsolver_steqr(handle, compc, n, (S*)nullptr, (S*)nullptr,
-                                              (T*)nullptr, ldc, (rocblas_int*)nullptr));
+        CHECK_ALLOC_QUERY(rocsolver_steqr(handle, compc, n, (S*)nullptr, (S*)nullptr, (T*)nullptr,
+                                          ldc, (rocblas_int*)nullptr));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_steqr.hpp
+++ b/rocsolver/clients/include/testing_steqr.hpp
@@ -231,9 +231,9 @@ void steqr_getPerfData(const rocblas_handle handle,
                                           hInfo);
 
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         cblas_steqr<S, T>(compc, n, hD[0], hE[0], hC[0], ldc, hW.data());
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     steqr_initData<true, false, S, T>(handle, compc, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo);
@@ -249,15 +249,18 @@ void steqr_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
         steqr_initData<false, true, S, T>(handle, compc, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
                                           hInfo);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_steqr(handle, compc, n, dD.data(), dE.data(), dC.data(), ldc, dInfo.data());
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -298,6 +301,20 @@ void testing_steqr(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        CHECK_ALLOC_QUERY(rocsolver_steqr(handle, compc, n, (S*)nullptr, (S*)nullptr,
+                                              (T*)nullptr, ldc, (rocblas_int*)nullptr));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_sterf.hpp
+++ b/rocsolver/clients/include/testing_sterf.hpp
@@ -207,9 +207,7 @@ void testing_sterf(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations

--- a/rocsolver/clients/include/testing_sterf.hpp
+++ b/rocsolver/clients/include/testing_sterf.hpp
@@ -154,7 +154,7 @@ void sterf_getPerfData(const rocblas_handle handle,
     hipStream_t stream;
     CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
-    
+
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
         sterf_initData<false, true, T>(handle, n, dD, dE, dInfo, hD, hE, hInfo);

--- a/rocsolver/clients/include/testing_sterf.hpp
+++ b/rocsolver/clients/include/testing_sterf.hpp
@@ -200,7 +200,7 @@ void testing_sterf(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_sterf(handle, n, (T*)nullptr, (T*)nullptr, (rocblas_int*)nullptr));

--- a/rocsolver/clients/include/testing_sytxx_hetxx.hpp
+++ b/rocsolver/clients/include/testing_sytxx_hetxx.hpp
@@ -339,14 +339,14 @@ void sytxx_hetxx_getPerfData(const rocblas_handle handle,
         sytxx_hetxx_initData<true, false, T>(handle, n, dA, lda, bc, hA);
 
         // cpu-lapack performance (only if not in perf mode)
-        *cpu_time_used = get_time_us();
+        *cpu_time_used = get_time_us_no_sync();
         for(rocblas_int b = 0; b < bc; ++b)
         {
             SYTRD ? cblas_sytrd_hetrd<S, T>(uplo, n, hA[b], lda, hD[b], hE[b], hTau[b], hW.data(),
                                             32 * n)
                   : cblas_sytd2_hetd2<S, T>(uplo, n, hA[b], lda, hD[b], hE[b], hTau[b]);
         }
-        *cpu_time_used = get_time_us() - *cpu_time_used;
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
     sytxx_hetxx_initData<true, false, T>(handle, n, dA, lda, bc, hA);
@@ -362,15 +362,18 @@ void sytxx_hetxx_getPerfData(const rocblas_handle handle,
     }
 
     // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
+    
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
         sytxx_hetxx_initData<false, true, T>(handle, n, dA, lda, bc, hA);
 
-        start = get_time_us();
+        start = get_time_us_sync(stream);
         rocsolver_sytxx_hetxx(STRIDED, SYTRD, handle, uplo, n, dA.data(), lda, stA, dD.data(), stD,
                               dE.data(), stE, dTau.data(), stP, bc);
-        *gpu_time_used += get_time_us() - start;
+        *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
@@ -443,6 +446,26 @@ void testing_sytxx_hetxx(Arguments argus)
             ROCSOLVER_BENCH_INFORM(1);
 
         return;
+    }
+
+    // memory size query is necessary
+    if(!REALLOC)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        if(BATCHED)
+            CHECK_ALLOC_QUERY(rocsolver_sytxx_hetxx(STRIDED, SYTRD, handle, uplo, n,
+                                                        (T* const*)nullptr, lda, stA, (S*)nullptr,
+                                                        stD, (S*)nullptr, stE, (T*)nullptr, stP, bc));
+        else
+            CHECK_ALLOC_QUERY(rocsolver_sytxx_hetxx(STRIDED, SYTRD, handle, uplo, n,
+                                                        (T*)nullptr, lda, stA, (S*)nullptr, stD,
+                                                        (S*)nullptr, stE, (T*)nullptr, stP, bc));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        if(size > DEFAULT_MEM)
+            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations (all cases)

--- a/rocsolver/clients/include/testing_sytxx_hetxx.hpp
+++ b/rocsolver/clients/include/testing_sytxx_hetxx.hpp
@@ -449,7 +449,7 @@ void testing_sytxx_hetxx(Arguments argus)
     }
 
     // memory size query is necessary
-    if(!REALLOC)
+    if(!USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)

--- a/rocsolver/clients/include/testing_sytxx_hetxx.hpp
+++ b/rocsolver/clients/include/testing_sytxx_hetxx.hpp
@@ -365,7 +365,7 @@ void sytxx_hetxx_getPerfData(const rocblas_handle handle,
     hipStream_t stream;
     CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
     double start;
-    
+
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
         sytxx_hetxx_initData<false, true, T>(handle, n, dA, lda, bc, hA);
@@ -454,12 +454,12 @@ void testing_sytxx_hetxx(Arguments argus)
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
             CHECK_ALLOC_QUERY(rocsolver_sytxx_hetxx(STRIDED, SYTRD, handle, uplo, n,
-                                                        (T* const*)nullptr, lda, stA, (S*)nullptr,
-                                                        stD, (S*)nullptr, stE, (T*)nullptr, stP, bc));
+                                                    (T* const*)nullptr, lda, stA, (S*)nullptr, stD,
+                                                    (S*)nullptr, stE, (T*)nullptr, stP, bc));
         else
-            CHECK_ALLOC_QUERY(rocsolver_sytxx_hetxx(STRIDED, SYTRD, handle, uplo, n,
-                                                        (T*)nullptr, lda, stA, (S*)nullptr, stD,
-                                                        (S*)nullptr, stE, (T*)nullptr, stP, bc));
+            CHECK_ALLOC_QUERY(rocsolver_sytxx_hetxx(STRIDED, SYTRD, handle, uplo, n, (T*)nullptr,
+                                                    lda, stA, (S*)nullptr, stD, (S*)nullptr, stE,
+                                                    (T*)nullptr, stP, bc));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));

--- a/rocsolver/clients/include/testing_sytxx_hetxx.hpp
+++ b/rocsolver/clients/include/testing_sytxx_hetxx.hpp
@@ -463,9 +463,7 @@ void testing_sytxx_hetxx(Arguments argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-
-        if(size > DEFAULT_MEM)
-            CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
     // memory allocations (all cases)


### PR DESCRIPTION
Now that we fixed the automatic reallocation in rocBLAS, and all our GPU operations are tied to the stream provided by the user, some updates are needed in the unit tests and bench:

1. Synchronization for timing is done on the provided stream; CPU operations don't need synchronization. 
2. Removed manual reallocation of workspace unless we set REALLOC=0. (rocBLAS owns the automatic reallocation switch, but in case it is disabled in the future, we can update our tests by simply setting REALLOC to zero). --We can also use the logic in the if statement to enable memory queries from rocsolver-bench in the future--.