### PR TITLE
Fix GESVD for 1x1 matrices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 - Fixed runtime errors in debug mode caused by incorrect kernel launch bounds
 - Fixed complex unit test bug caused by incorrect zaxpy function signature
 - Eliminated a small memory transfer that was being done on the default stream
+- Fixed GESVD right singular vectors for 1x1 matrices
 
 
 

--- a/rocsolver/clients/gtest/gesvd_gtest.cpp
+++ b/rocsolver/clients/gtest/gesvd_gtest.cpp
@@ -39,6 +39,7 @@ const vector<vector<int>> size_range = {
     {-1, 1, 0},
     {1, -1, 0},
     // normal (valid) samples
+    {1, 1, 0},
     {20, 20, 0},
     {40, 30, 0},
     {60, 30, 0},

--- a/rocsolver/clients/include/rocsolver_test.hpp
+++ b/rocsolver/clients/include/rocsolver_test.hpp
@@ -32,13 +32,11 @@ constexpr double get_epsilon()
     return std::numeric_limits<S>::epsilon();
 }
 
-template <typename T>
-inline void rocsolver_test_check(double max_error, int tol)
-{
 #ifdef GOOGLE_TEST
-    ASSERT_LE(max_error, tol * get_epsilon<T>());
+#define ROCSOLVER_TEST_CHECK(T, max_error, tol) ASSERT_LE((max_error), (tol)*get_epsilon<T>())
+#else
+#define ROCSOLVER_TEST_CHECK(T, max_error, tol)
 #endif
-}
 
 inline void rocsolver_bench_output()
 {

--- a/rocsolver/clients/include/testing_bdsqr.hpp
+++ b/rocsolver/clients/include/testing_bdsqr.hpp
@@ -574,9 +574,9 @@ void testing_bdsqr(Arguments argus)
     // using n * machine_precision as tolerance
     if(argus.unit_check)
     {
-        rocsolver_test_check<T>(max_error, n);
+        ROCSOLVER_TEST_CHECK(T, max_error, n);
         if(nv || nu || nc)
-            rocsolver_test_check<T>(max_errorv, n);
+            ROCSOLVER_TEST_CHECK(T, max_errorv, n);
     }
 
     // output results for rocsolver-bench

--- a/rocsolver/clients/include/testing_gebd2_gebrd.hpp
+++ b/rocsolver/clients/include/testing_gebd2_gebrd.hpp
@@ -579,7 +579,7 @@ void testing_gebd2_gebrd(Arguments argus)
     // validate results for rocsolver-test
     // using m*n * machine_precision as tolerance
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, m * n);
+        ROCSOLVER_TEST_CHECK(T, max_error, m * n);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_gelq2_gelqf.hpp
+++ b/rocsolver/clients/include/testing_gelq2_gelqf.hpp
@@ -383,7 +383,7 @@ void testing_gelq2_gelqf(Arguments argus)
     // using n * machine_precision as tolerance
     // (for possibly singular of ill-conditioned matrices we could use n*min(m,n))
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, n);
+        ROCSOLVER_TEST_CHECK(T, max_error, n);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_gels.hpp
+++ b/rocsolver/clients/include/testing_gels.hpp
@@ -459,7 +459,7 @@ void testing_gels(Arguments argus)
     // validate results for rocsolver-test
     // using max(m,n) * machine_precision as tolerance
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, max(m, n));
+        ROCSOLVER_TEST_CHECK(T, max_error, max(m, n));
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_geql2_geqlf.hpp
+++ b/rocsolver/clients/include/testing_geql2_geqlf.hpp
@@ -383,7 +383,7 @@ void testing_geql2_geqlf(Arguments argus)
     // using m * machine_precision as tolerance
     // (for possibly singular of ill-conditioned matrices we could use m*min(m,n))
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, m);
+        ROCSOLVER_TEST_CHECK(T, max_error, m);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_geqr2_geqrf.hpp
+++ b/rocsolver/clients/include/testing_geqr2_geqrf.hpp
@@ -420,7 +420,7 @@ void testing_geqr2_geqrf(Arguments argus)
     // using m * machine_precision as tolerance
     // (for possibly singular of ill-conditioned matrices we could use m*min(m,n))
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, m);
+        ROCSOLVER_TEST_CHECK(T, max_error, m);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_gesvd.hpp
+++ b/rocsolver/clients/include/testing_gesvd.hpp
@@ -771,12 +771,14 @@ void testing_gesvd(Arguments argus)
     }
 
     // validate results for rocsolver-test
-    // using min(m,n) * machine_precision as tolerance
+    // using k * min(m,n) * machine_precision as tolerance
+    // where k is 1 for reals and 2 for complex numbers
     if(argus.unit_check)
     {
-        rocsolver_test_check<T>(max_error, min(m, n));
+        const int k = is_complex<T> ? 2 : 1;
+        rocsolver_test_check<T>(max_error, k * min(m, n));
         if(svects)
-            rocsolver_test_check<T>(max_errorv, min(m, n));
+            rocsolver_test_check<T>(max_errorv, k * min(m, n));
     }
 
     // output results for rocsolver-bench

--- a/rocsolver/clients/include/testing_gesvd.hpp
+++ b/rocsolver/clients/include/testing_gesvd.hpp
@@ -344,7 +344,6 @@ void gesvd_getError(const rocblas_handle handle,
     // down to essentially run the algorithm again and until convergence is achieved).
 
     double err;
-    T tmp;
     *max_errv = 0;
 
     for(rocblas_int b = 0; b < bc; ++b)
@@ -362,7 +361,7 @@ void gesvd_getError(const rocblas_handle handle,
             {
                 for(rocblas_int i = 0; i < m; ++i)
                 {
-                    tmp = 0;
+                    T tmp = 0;
                     for(rocblas_int j = 0; j < n; ++j)
                         tmp += A[b * lda * n + i + j * lda] * sconj(Vres[b][k + j * ldvres]);
                     tmp -= hSres[b][k] * Ures[b][i + k * ldures];

--- a/rocsolver/clients/include/testing_gesvd.hpp
+++ b/rocsolver/clients/include/testing_gesvd.hpp
@@ -774,9 +774,9 @@ void testing_gesvd(Arguments argus)
     // using 2 * min(m,n) * machine_precision as tolerance
     if(argus.unit_check)
     {
-        rocsolver_test_check<T>(max_error, 2 * min(m, n));
+        ROCSOLVER_TEST_CHECK(T, max_error, 2 * min(m, n));
         if(svects)
-            rocsolver_test_check<T>(max_errorv, 2 * min(m, n));
+            ROCSOLVER_TEST_CHECK(T, max_errorv, 2 * min(m, n));
     }
 
     // output results for rocsolver-bench

--- a/rocsolver/clients/include/testing_gesvd.hpp
+++ b/rocsolver/clients/include/testing_gesvd.hpp
@@ -771,14 +771,12 @@ void testing_gesvd(Arguments argus)
     }
 
     // validate results for rocsolver-test
-    // using k * min(m,n) * machine_precision as tolerance
-    // where k is 1 for reals and 2 for complex numbers
+    // using 2 * min(m,n) * machine_precision as tolerance
     if(argus.unit_check)
     {
-        const int k = is_complex<T> ? 2 : 1;
-        rocsolver_test_check<T>(max_error, k * min(m, n));
+        rocsolver_test_check<T>(max_error, 2 * min(m, n));
         if(svects)
-            rocsolver_test_check<T>(max_errorv, k * min(m, n));
+            rocsolver_test_check<T>(max_errorv, 2 * min(m, n));
     }
 
     // output results for rocsolver-bench

--- a/rocsolver/clients/include/testing_gesvd.hpp
+++ b/rocsolver/clients/include/testing_gesvd.hpp
@@ -333,14 +333,14 @@ void gesvd_getError(const rocblas_handle handle,
         }
     }
 
-    // Check info for non-covergence
+    // Check info for non-convergence
     *max_err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
         if(hinfo[b][0] != hinfoRes[b][0])
             *max_err += 1;
 
     // (We expect the used input matrices to always converge. Testing
-    // implicitely the equivalent non-converged matrix is very complicated and it boils
+    // implicitly the equivalent non-converged matrix is very complicated and it boils
     // down to essentially run the algorithm again and until convergence is achieved).
 
     double err;
@@ -357,7 +357,7 @@ void gesvd_getError(const rocblas_handle handle,
         if(hinfo[b][0] == 0 && (left_svect != rocblas_svect_none || right_svect != rocblas_svect_none))
         {
             err = 0;
-            // check singular vectors implicitely (A*v_k = s_k*u_k)
+            // check singular vectors implicitly (A*v_k = s_k*u_k)
             for(rocblas_int k = 0; k < min(m, n); ++k)
             {
                 for(rocblas_int i = 0; i < m; ++i)

--- a/rocsolver/clients/include/testing_getf2_getrf.hpp
+++ b/rocsolver/clients/include/testing_getf2_getrf.hpp
@@ -473,7 +473,7 @@ void testing_getf2_getrf(Arguments argus)
     // validate results for rocsolver-test
     // using min(m,n) * machine_precision as tolerance
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, min(m, n));
+        ROCSOLVER_TEST_CHECK(T, max_error, min(m, n));
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_getf2_getrf_npvt.hpp
+++ b/rocsolver/clients/include/testing_getf2_getrf_npvt.hpp
@@ -418,7 +418,7 @@ void testing_getf2_getrf_npvt(Arguments argus)
     // validate results for rocsolver-test
     // using min(m,n) * machine_precision as tolerance
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, min(m, n));
+        ROCSOLVER_TEST_CHECK(T, max_error, min(m, n));
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_getri.hpp
+++ b/rocsolver/clients/include/testing_getri.hpp
@@ -508,7 +508,7 @@ void testing_getri(Arguments argus)
     // validate results for rocsolver-test
     // using n * machine_precision as tolerance
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, n);
+        ROCSOLVER_TEST_CHECK(T, max_error, n);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_getrs.hpp
+++ b/rocsolver/clients/include/testing_getrs.hpp
@@ -437,7 +437,7 @@ void testing_getrs(Arguments argus)
     // validate results for rocsolver-test
     // using m * machine_precision as tolerance
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, m);
+        ROCSOLVER_TEST_CHECK(T, max_error, m);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_labrd.hpp
+++ b/rocsolver/clients/include/testing_labrd.hpp
@@ -401,7 +401,7 @@ void testing_labrd(Arguments argus)
     // validate results for rocsolver-test
     // using nb * max(m,n) * machine_precision as tolerance
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, nb * max(m, n));
+        ROCSOLVER_TEST_CHECK(T, max_error, nb * max(m, n));
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_lacgv.hpp
+++ b/rocsolver/clients/include/testing_lacgv.hpp
@@ -212,7 +212,7 @@ void testing_lacgv(Arguments argus)
     // validate results for rocsolver-test
     // no tolerance
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, 0);
+        ROCSOLVER_TEST_CHECK(T, max_error, 0);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_larf.hpp
+++ b/rocsolver/clients/include/testing_larf.hpp
@@ -311,7 +311,7 @@ void testing_larf(Arguments argus)
     // validate results for rocsolver-test
     // using size_x * machine_precision as tolerance
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, size_x);
+        ROCSOLVER_TEST_CHECK(T, max_error, size_x);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_larfb.hpp
+++ b/rocsolver/clients/include/testing_larfb.hpp
@@ -457,7 +457,7 @@ void testing_larfb(Arguments argus)
     // using s * machine_precision as tolerance
     rocblas_int s = left ? m : n;
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, s);
+        ROCSOLVER_TEST_CHECK(T, max_error, s);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_larfg.hpp
+++ b/rocsolver/clients/include/testing_larfg.hpp
@@ -250,7 +250,7 @@ void testing_larfg(Arguments argus)
     // validate results for rocsolver-test
     // using n * machine_precision as tolerance
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, n);
+        ROCSOLVER_TEST_CHECK(T, max_error, n);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_larft.hpp
+++ b/rocsolver/clients/include/testing_larft.hpp
@@ -340,7 +340,7 @@ void testing_larft(Arguments argus)
     // validate results for rocsolver-test
     // using n * machine_precision as tolerance
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, n);
+        ROCSOLVER_TEST_CHECK(T, max_error, n);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_laswp.hpp
+++ b/rocsolver/clients/include/testing_laswp.hpp
@@ -265,7 +265,7 @@ void testing_laswp(Arguments argus)
     // validate results for rocsolver-test
     // no tolerance
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, 0);
+        ROCSOLVER_TEST_CHECK(T, max_error, 0);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_latrd.hpp
+++ b/rocsolver/clients/include/testing_latrd.hpp
@@ -351,7 +351,7 @@ void testing_latrd(Arguments argus)
     // validate results for rocsolver-test
     // using k*n * machine_precision as tolerance
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, k * n);
+        ROCSOLVER_TEST_CHECK(T, max_error, k * n);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_managed_malloc.hpp
+++ b/rocsolver/clients/include/testing_managed_malloc.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -273,7 +273,7 @@ void testing_managed_malloc(Arguments argus)
     // validate results for rocsolver-test
     // using nb * max(m,n) * machine_precision as tolerance
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, nb * max(m, n));
+        ROCSOLVER_TEST_CHECK(T, max_error, nb * max(m, n));
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_orgbr_ungbr.hpp
+++ b/rocsolver/clients/include/testing_orgbr_ungbr.hpp
@@ -320,7 +320,7 @@ void testing_orgbr_ungbr(Arguments argus)
     // using s * machine_precision as tolerance
     rocblas_int s = row ? n : m;
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, s);
+        ROCSOLVER_TEST_CHECK(T, max_error, s);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_orglx_unglx.hpp
+++ b/rocsolver/clients/include/testing_orglx_unglx.hpp
@@ -274,7 +274,7 @@ void testing_orglx_unglx(Arguments argus)
     // validate results for rocsolver-test
     // using n * machine_precision as tolerance
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, n);
+        ROCSOLVER_TEST_CHECK(T, max_error, n);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_orgtr_ungtr.hpp
+++ b/rocsolver/clients/include/testing_orgtr_ungtr.hpp
@@ -273,7 +273,7 @@ void testing_orgtr_ungtr(Arguments argus)
     // validate results for rocsolver-test
     // using n * machine_precision as tolerance
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, n);
+        ROCSOLVER_TEST_CHECK(T, max_error, n);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_orgxl_ungxl.hpp
+++ b/rocsolver/clients/include/testing_orgxl_ungxl.hpp
@@ -274,7 +274,7 @@ void testing_orgxl_ungxl(Arguments argus)
     // validate results for rocsolver-test
     // using n * machine_precision as tolerance
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, n);
+        ROCSOLVER_TEST_CHECK(T, max_error, n);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_orgxr_ungxr.hpp
+++ b/rocsolver/clients/include/testing_orgxr_ungxr.hpp
@@ -274,7 +274,7 @@ void testing_orgxr_ungxr(Arguments argus)
     // validate results for rocsolver-test
     // using m * machine_precision as tolerance
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, m);
+        ROCSOLVER_TEST_CHECK(T, max_error, m);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_ormbr_unmbr.hpp
+++ b/rocsolver/clients/include/testing_ormbr_unmbr.hpp
@@ -400,7 +400,7 @@ void testing_ormbr_unmbr(Arguments argus)
     // using n * machine_precision as tolerance
     rocblas_int s = left ? m : n;
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, s);
+        ROCSOLVER_TEST_CHECK(T, max_error, s);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_ormlx_unmlx.hpp
+++ b/rocsolver/clients/include/testing_ormlx_unmlx.hpp
@@ -367,7 +367,7 @@ void testing_ormlx_unmlx(Arguments argus)
     // using s * machine_precision as tolerance
     rocblas_int s = left ? m : n;
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, s);
+        ROCSOLVER_TEST_CHECK(T, max_error, s);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_ormtr_unmtr.hpp
+++ b/rocsolver/clients/include/testing_ormtr_unmtr.hpp
@@ -370,7 +370,7 @@ void testing_ormtr_unmtr(Arguments argus)
     // using n * machine_precision as tolerance
     rocblas_int s = left ? m : n;
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, s);
+        ROCSOLVER_TEST_CHECK(T, max_error, s);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_ormxl_unmxl.hpp
+++ b/rocsolver/clients/include/testing_ormxl_unmxl.hpp
@@ -367,7 +367,7 @@ void testing_ormxl_unmxl(Arguments argus)
     // using s * machine_precision as tolerance
     rocblas_int s = left ? m : n;
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, s);
+        ROCSOLVER_TEST_CHECK(T, max_error, s);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_ormxr_unmxr.hpp
+++ b/rocsolver/clients/include/testing_ormxr_unmxr.hpp
@@ -367,7 +367,7 @@ void testing_ormxr_unmxr(Arguments argus)
     // using s * machine_precision as tolerance
     rocblas_int s = left ? m : n;
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, s);
+        ROCSOLVER_TEST_CHECK(T, max_error, s);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_potf2_potrf.hpp
+++ b/rocsolver/clients/include/testing_potf2_potrf.hpp
@@ -429,7 +429,7 @@ void testing_potf2_potrf(Arguments argus)
     // validate results for rocsolver-test
     // using n * machine_precision as tolerance
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, n);
+        ROCSOLVER_TEST_CHECK(T, max_error, n);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_steqr.hpp
+++ b/rocsolver/clients/include/testing_steqr.hpp
@@ -362,7 +362,7 @@ void testing_steqr(Arguments argus)
     // validate results for rocsolver-test
     // using n * machine_precision as tolerance
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, n);
+        ROCSOLVER_TEST_CHECK(T, max_error, n);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_sterf.hpp
+++ b/rocsolver/clients/include/testing_sterf.hpp
@@ -250,7 +250,7 @@ void testing_sterf(Arguments argus)
     // validate results for rocsolver-test
     // using n * machine_precision as tolerance
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, n);
+        ROCSOLVER_TEST_CHECK(T, max_error, n);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/clients/include/testing_sytxx_hetxx.hpp
+++ b/rocsolver/clients/include/testing_sytxx_hetxx.hpp
@@ -557,7 +557,7 @@ void testing_sytxx_hetxx(Arguments argus)
     // validate results for rocsolver-test
     // using n * machine_precision as tolerance
     if(argus.unit_check)
-        rocsolver_test_check<T>(max_error, n);
+        ROCSOLVER_TEST_CHECK(T, max_error, n);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgbr_ungbr.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgbr_ungbr.hpp
@@ -158,10 +158,6 @@ rocblas_status rocsolver_orgbr_ungbr_template(rocblas_handle handle,
             rocblas_int ldw = m - 1;
             rocblas_int blocks = (m - 2) / BS + 1;
 
-            // set A(0,0) = 1
-            hipLaunchKernelGGL(reset_batch_info<T>, dim3(1, batch_count, 1), dim3(1, 1, 1), 0,
-                               stream, A, strideA, 1, 1);
-
             // copy
             hipLaunchKernelGGL(copyshift_right<T>, dim3(blocks, blocks, batch_count), dim3(BS, BS), 0,
                                stream, true, m - 1, A, shiftA, lda, strideA, work, 0, ldw, strideW);
@@ -194,10 +190,6 @@ rocblas_status rocsolver_orgbr_ungbr_template(rocblas_handle handle,
             rocblas_stride strideW = rocblas_stride(n - 1) * n / 2; // number of elements to copy
             rocblas_int ldw = n - 1;
             rocblas_int blocks = (n - 2) / BS + 1;
-
-            // set A(0,0) = 1
-            hipLaunchKernelGGL(reset_batch_info<T>, dim3(1, batch_count, 1), dim3(1, 1, 1), 0,
-                               stream, A, strideA, 1, 1);
 
             // copy
             hipLaunchKernelGGL(copyshift_down<T>, dim3(blocks, blocks, batch_count), dim3(BS, BS), 0,

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgbr_ungbr.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgbr_ungbr.hpp
@@ -159,7 +159,8 @@ rocblas_status rocsolver_orgbr_ungbr_template(rocblas_handle handle,
             rocblas_int blocks = (m - 2) / BS + 1;
 
             // set A(0,0) = 1
-            hipLaunchKernelGGL(reset_batch_info<T>, dim3(1,batch_count,1), dim3(1,1,1), 0, stream, A, strideA, 1, 1);
+            hipLaunchKernelGGL(reset_batch_info<T>, dim3(1, batch_count, 1), dim3(1, 1, 1), 0,
+                               stream, A, strideA, 1, 1);
 
             // copy
             hipLaunchKernelGGL(copyshift_right<T>, dim3(blocks, blocks, batch_count), dim3(BS, BS), 0,
@@ -195,7 +196,8 @@ rocblas_status rocsolver_orgbr_ungbr_template(rocblas_handle handle,
             rocblas_int blocks = (n - 2) / BS + 1;
 
             // set A(0,0) = 1
-            hipLaunchKernelGGL(reset_batch_info<T>, dim3(1,batch_count,1), dim3(1,1,1), 0, stream, A, strideA, 1, 1);
+            hipLaunchKernelGGL(reset_batch_info<T>, dim3(1, batch_count, 1), dim3(1, 1, 1), 0,
+                               stream, A, strideA, 1, 1);
 
             // copy
             hipLaunchKernelGGL(copyshift_down<T>, dim3(blocks, blocks, batch_count), dim3(BS, BS), 0,

--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgbr_ungbr.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgbr_ungbr.hpp
@@ -158,6 +158,9 @@ rocblas_status rocsolver_orgbr_ungbr_template(rocblas_handle handle,
             rocblas_int ldw = m - 1;
             rocblas_int blocks = (m - 2) / BS + 1;
 
+            // set A(0,0) = 1
+            hipLaunchKernelGGL(reset_batch_info<T>, dim3(1,batch_count,1), dim3(1,1,1), 0, stream, A, strideA, 1, 1);
+
             // copy
             hipLaunchKernelGGL(copyshift_right<T>, dim3(blocks, blocks, batch_count), dim3(BS, BS), 0,
                                stream, true, m - 1, A, shiftA, lda, strideA, work, 0, ldw, strideW);
@@ -173,7 +176,7 @@ rocblas_status rocsolver_orgbr_ungbr_template(rocblas_handle handle,
         }
     }
 
-    // if row-wise, compute orthonormal rowss of matrix P' in the
+    // if row-wise, compute orthonormal rows of matrix P' in the
     // bi-diagonalization of a k-by-n matrix A (given by gebrd)
     else
     {
@@ -190,6 +193,9 @@ rocblas_status rocsolver_orgbr_ungbr_template(rocblas_handle handle,
             rocblas_stride strideW = rocblas_stride(n - 1) * n / 2; // number of elements to copy
             rocblas_int ldw = n - 1;
             rocblas_int blocks = (n - 2) / BS + 1;
+
+            // set A(0,0) = 1
+            hipLaunchKernelGGL(reset_batch_info<T>, dim3(1,batch_count,1), dim3(1,1,1), 0, stream, A, strideA, 1, 1);
 
             // copy
             hipLaunchKernelGGL(copyshift_down<T>, dim3(blocks, blocks, batch_count), dim3(BS, BS), 0,

--- a/rocsolver/library/src/include/common_device_helpers.hpp
+++ b/rocsolver/library/src/include/common_device_helpers.hpp
@@ -340,7 +340,6 @@ __global__ void copyshift_left(const bool copy,
     {
         rocblas_int offset = j * ldw - j * (j + 1) / 2; // to acommodate in smaller array W
 
-
         if(copy)
         {
             // copy columns
@@ -376,11 +375,11 @@ __global__ void copyshift_down(const bool copy,
 
     T* Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
     T* Wp = load_ptr_batch<T>(W, b, shiftW, strideW);
-                
+
     // make first column the identity
     if(i == 0 && j == 0 && !copy)
         Ap[0] = 1.0;
-    
+
     if(i < dim && j < dim && i <= j)
     {
         rocblas_int offset = j * ldw - j * (j + 1) / 2; // to acommodate in smaller array W

--- a/rocsolver/library/src/include/common_device_helpers.hpp
+++ b/rocsolver/library/src/include/common_device_helpers.hpp
@@ -285,12 +285,16 @@ __global__ void copyshift_right(const bool copy,
     const auto j = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
     const auto i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
 
+    T* Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
+    T* Wp = load_ptr_batch<T>(W, b, shiftW, strideW);
+
+    // make first row the identity
+    if(i == 0 && j == 0 && !copy)
+        Ap[0] = 1.0;
+
     if(i < dim && j < dim && j <= i)
     {
         rocblas_int offset = j * (j + 1) / 2; // to acommodate in smaller array W
-
-        T* Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
-        T* Wp = load_ptr_batch<T>(W, b, shiftW, strideW);
 
         if(copy)
         {
@@ -304,11 +308,7 @@ __global__ void copyshift_right(const bool copy,
 
             // make first row the identity
             if(i == j)
-            {
                 Ap[(j + 1) * lda] = 0.0;
-                if(i == 0)
-                    Ap[0] = 1.0;
-            }
         }
     }
 }
@@ -329,12 +329,17 @@ __global__ void copyshift_left(const bool copy,
     const auto j = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
     const auto i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
 
+    T* Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
+    T* Wp = load_ptr_batch<T>(W, b, shiftW, strideW);
+
+    // make last row the identity
+    if(i == 0 && j == 0 && !copy)
+        Ap[dim + dim * lda] = 1.0;
+
     if(i < dim && j < dim && i <= j)
     {
         rocblas_int offset = j * ldw - j * (j + 1) / 2; // to acommodate in smaller array W
 
-        T* Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
-        T* Wp = load_ptr_batch<T>(W, b, shiftW, strideW);
 
         if(copy)
         {
@@ -348,11 +353,7 @@ __global__ void copyshift_left(const bool copy,
 
             // make last row the identity
             if(i == j)
-            {
                 Ap[dim + j * lda] = 0.0;
-                if(i == 0)
-                    Ap[dim + dim * lda] = 1.0;
-            }
         }
     }
 }
@@ -373,12 +374,16 @@ __global__ void copyshift_down(const bool copy,
     const auto j = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
     const auto i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
 
+    T* Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
+    T* Wp = load_ptr_batch<T>(W, b, shiftW, strideW);
+                
+    // make first column the identity
+    if(i == 0 && j == 0 && !copy)
+        Ap[0] = 1.0;
+    
     if(i < dim && j < dim && i <= j)
     {
         rocblas_int offset = j * ldw - j * (j + 1) / 2; // to acommodate in smaller array W
-
-        T* Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
-        T* Wp = load_ptr_batch<T>(W, b, shiftW, strideW);
 
         if(copy)
         {
@@ -392,11 +397,7 @@ __global__ void copyshift_down(const bool copy,
 
             // make first column the identity
             if(i == j)
-            {
                 Ap[i + 1] = 0.0;
-                if(j == 0)
-                    Ap[0] = 1.0;
-            }
         }
     }
 }


### PR DESCRIPTION
This change fixes the problem described in #197, correcting the GESVD output for V when processing 1x1 matrices.

I've added a test case for GESVD that matched the problem described, but there are probably more tests that should be added (e.g. for ORGBR itself). Given my limited experience in this part of the codebase, perhaps @jzuniga-amd or @tfalders could contribute them, if needed. My branch for this PR is open to edits.