### PR TITLE
Build system restructuring - 1/5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,30 +1,34 @@
 # ########################################################################
-# Copyright (c) 2019-2020 Advanced Micro Devices, Inc.
+# Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
 # ########################################################################
 
 cmake_minimum_required( VERSION 3.8 )
 
-# We use C++14 features, this will add compile option: -std=c++14
 set( CMAKE_CXX_STANDARD 14 )
-# Without this line, it will add -std=gnu++14 instead, which has some issues.
 set( CMAKE_CXX_EXTENSIONS OFF )
+set( CMAKE_CXX_STANDARD_REQUIRED ON )
 
 # This has to be initialized before the project() command appears
-# Set the default of CMAKE_BUILD_TYPE to be release, unless user specifies with -D.  MSVC_IDE does not use CMAKE_BUILD_TYPE
+# Set the default of CMAKE_BUILD_TYPE to Release
 if( NOT DEFINED CMAKE_CONFIGURATION_TYPES AND NOT DEFINED CMAKE_BUILD_TYPE )
-  set( CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." )
+  set( CMAKE_BUILD_TYPE Release CACHE STRING
+    "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
+  )
 endif()
 
 if ( NOT DEFINED CMAKE_Fortran_COMPILER AND NOT DEFINED ENV{FC} )
   set( CMAKE_Fortran_COMPILER  "gfortran" )
 endif()
 
-# this remove some of the known warnings from the build output
+# ROCM_BUILD_ID is added to the package name by rocm-cmake. Unsetting it prevents that.
 unset(ENV{ROCM_BUILD_ID})
-add_compile_options( -Wno-unused-command-line-argument )
-add_compile_options( -Wno-pass-failed )
 
 project( rocsolver LANGUAGES CXX )
+
+# Add our CMake helper files to the lookup path
+list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" )
+list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/rocblascommon/cmake" )
+list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/rocsolver/clients/cmake" )
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
@@ -95,53 +99,17 @@ elseif( CXX_VERSION_STRING MATCHES "HCC" )
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -hc")
 endif( )
 
-# This finds the rocm-cmake project, and installs it if not found
-# rocm-cmake contains common cmake code for rocm projects to help setup and install
-set( PROJECT_EXTERN_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern )
+# get rocm-cmake
+include( get-rocm-cmake )
 
-# by default, rocm software stack is expected at /opt/rocm
-# set environment variable ROCM_PATH to change location
-if( NOT ROCM_PATH )
-  set( ROCM_PATH /opt/rocm )
-endif( )
-
-find_package( ROCM CONFIG QUIET PATHS ${ROCM_PATH} )
-if( NOT ROCM_FOUND )
-  set( rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download" )
-  file( DOWNLOAD https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip
-      ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip STATUS status LOG log)
-
-  list(GET status 0 status_code)
-  list(GET status 1 status_string)
-
-  if(NOT status_code EQUAL 0)
-    message(FATAL_ERROR "error: downloading
-    'https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip' failed
-    status_code: ${status_code}
-    status_string: ${status_string}
-    log: ${log}
-    ")
-  endif()
-
-  message(STATUS "downloading... done")
-
-  execute_process( COMMAND ${CMAKE_COMMAND} -E tar xzvf ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip
-    WORKING_DIRECTORY ${PROJECT_EXTERN_DIR} )
-
-  find_package( ROCM REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag} )
-endif( )
-
+# include the rocm-cmake components we use
 include( ROCMSetupVersion )
 include( ROCMCreatePackage )
 include( ROCMInstallTargets )
 include( ROCMPackageConfigHelpers )
 include( ROCMInstallSymlinks )
 
-# Append our library helper cmake path and the cmake path for hip (for convenience)
-# Users may override HIP path by specifying their own in CMAKE_MODULE_PATH
-list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/rocblascommon/cmake )
-
-include (rocblascommon/cmake/os-detection.cmake)
+include( os-detection )
 get_os_id(OS_ID)
 message (STATUS "OS detected is ${OS_ID}")
 
@@ -163,20 +131,18 @@ endif( )
 set( ARMOR_LEVEL "${DEFAULT_ARMOR_LEVEL}" CACHE STRING "Enables increasingly expensive runtime correctness checks" )
 include( armor-config )
 
-# # set the optimization level for debug mode
-# if( CMAKE_BUILD_TYPE STREQUAL "Debug" )
-#   add_compile_options( -O0 )
-# endif( )
-
-# BUILD_SHARED_LIBS is a cmake built-in; we make it an explicit option such that it shows in cmake-gui
+# BUILD_SHARED_LIBS is a cmake built-in
+# make it an explicit option such that it shows in cmake-gui
 option( BUILD_SHARED_LIBS "Build rocSOLVER as a shared library" ON )
 
+# include helper functions and wrapper functions
+include( util )
+
 # by default, clients are not built
-include( rocsolver/clients/cmake/build-options.cmake )
+include( build-options )
 message(STATUS "Tests: ${BUILD_CLIENTS_TESTS}")
 message(STATUS "Benchmarks: ${BUILD_CLIENTS_BENCHMARKS}")
 message(STATUS "Samples: ${BUILD_CLIENTS_SAMPLES}")
-
 
 # force library install path to lib (CentOS 7 defaults to lib64)
 set(CMAKE_INSTALL_LIBDIR "lib" CACHE INTERNAL "Installation directory for libraries" FORCE)
@@ -191,10 +157,7 @@ if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
   find_package( hip REQUIRED CONFIG PATHS ${ROCM_PATH} )
 endif( )
 
-
 find_package( rocblas REQUIRED CONFIG PATHS ${ROCM_PATH} )
-include_directories( ${rocblas_INCLUDE_DIR} )
-
 
 add_subdirectory( rocsolver/library )
 
@@ -202,5 +165,3 @@ add_subdirectory( rocsolver/library )
 if( BUILD_CLIENTS_TESTS OR BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_SAMPLES )
   add_subdirectory( rocsolver/clients )
 endif( )
-
-target_compile_definitions( rocsolver PRIVATE ROCM_USE_FLOAT16 )

--- a/cmake/get-rocm-cmake.cmake
+++ b/cmake/get-rocm-cmake.cmake
@@ -1,0 +1,35 @@
+# This finds the rocm-cmake project, and installs it if not found
+# rocm-cmake contains common cmake code for rocm projects to help setup and install
+set( PROJECT_EXTERN_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern )
+
+# by default, rocm software stack is expected at /opt/rocm
+# set environment variable ROCM_PATH to change location
+if( NOT ROCM_PATH )
+  set( ROCM_PATH /opt/rocm )
+endif( )
+
+find_package( ROCM CONFIG QUIET PATHS ${ROCM_PATH} )
+if( NOT ROCM_FOUND )
+  set( rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download" )
+  set( rocm_cmake_url "https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip" )
+  set( rocm_cmake_path "${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}" )
+  set( rocm_cmake_archive "${rocm_cmake_path}.zip" )
+  file( DOWNLOAD "${rocm_cmake_url}" "${rocm_cmake_archive}" STATUS status LOG log)
+
+  list(GET status 0 status_code)
+  list(GET status 1 status_string)
+
+  if(status_code EQUAL 0)
+    message(STATUS "downloading... done")
+  else()
+    message(FATAL_ERROR "error: downloading\n'${rocm_cmake_url}' failed
+    status_code: ${status_code}
+    status_string: ${status_string}
+    log: ${log}\n")
+  endif()
+
+  execute_process( COMMAND ${CMAKE_COMMAND} -E tar xzvf "${rocm_cmake_archive}"
+    WORKING_DIRECTORY ${PROJECT_EXTERN_DIR} )
+
+  find_package( ROCM REQUIRED CONFIG PATHS "${rocm_cmake_path}" )
+endif( )

--- a/cmake/util.cmake
+++ b/cmake/util.cmake
@@ -1,0 +1,60 @@
+# ########################################################################
+# HELPER FUNCTIONS
+# ########################################################################
+
+# ########################################################################
+# target_compile_features() override
+# Wraps the normal cmake function to cope with hipcc/nvcc weirdness.
+# ########################################################################
+function( target_compile_features target_name )
+  # With Cmake v3.5, hipcc (with nvcc backend) does not work with target_compile_features
+  # Turn on -std=c++14 manually
+  if( CUDA_FOUND AND CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )
+    set_target_properties( ${target_name} PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED ON )
+  else( )
+    _target_compile_features( ${target_name} ${ARGN} )
+  endif( )
+endfunction( )
+
+# ########################################################################
+# target_link_libraries() override
+# Wraps the normal cmake function to cope with hipcc/nvcc weirdness.
+# ########################################################################
+function( target_link_libraries target_name )
+  # hipcc takes care of finding hip library dependencies internally; remove
+  # explicit mentions of them so cmake doesn't complain on nvcc path
+  # FIXME: This removes this target's hip libraries, even if this particular
+  #        target is not built using a compiler that can find its dependencies
+  #        internally (e.g. Fortran programs).
+  if( CUDA_FOUND AND CMAKE_CXX_COMPILER MATCHES ".*/hipcc$|.*/nvcc$" )
+    foreach( link_library ${ARGN} )
+      if( (link_library MATCHES "^hip::|^hcc::") )
+        message( DEBUG "Removing ${link_library} from ${target_name} library list" )
+      else( )
+        if( TARGET ${link_library} )
+          list( APPEND new_list -Xlinker ${link_library} )
+        else( )
+          list( APPEND new_list ${link_library} )
+        endif( )
+      endif( )
+    endforeach( )
+    _target_link_libraries( ${target_name} ${new_list} )
+  else( )
+    _target_link_libraries( ${target_name} ${ARGN} )
+  endif( )
+endfunction( )
+
+# ########################################################################
+# A helper function to prefix a source list of files with a common path into a new list (non-destructive)
+# ########################################################################
+function( prepend_path prefix source_list_of_files return_list_of_files )
+  foreach( file ${${source_list_of_files}} )
+    if(IS_ABSOLUTE ${file} )
+      list( APPEND new_list ${file} )
+    else( )
+      list( APPEND new_list ${prefix}/${file} )
+    endif( )
+  endforeach( )
+  set( ${return_list_of_files} ${new_list} PARENT_SCOPE )
+endfunction( )
+

--- a/rocblascommon/deps/CMakeLists.txt
+++ b/rocblascommon/deps/CMakeLists.txt
@@ -1,37 +1,27 @@
 # ########################################################################
-# Copyright (c) 2016-2020 Advanced Micro Devices, Inc.
+# Copyright (c) 2016-2021 Advanced Micro Devices, Inc.
 # ########################################################################
-# Helper cmake script to automate building dependencies for rocblas
+# Helper cmake script to automate building dependencies for rocsolver
 # This script can be invoked manually by the user with 'cmake -P'
 
-# The ROCm platform requires Ubuntu 16.04 or Fedora 24, which has cmake 3.5
-cmake_minimum_required( VERSION 3.5 )
+cmake_minimum_required( VERSION 3.8 )
 
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../cmake )
 
 # This has to be initialized before the project() command appears
-# Set the default of CMAKE_BUILD_TYPE to be release, unless user specifies with -D.  MSVC_IDE does not use CMAKE_BUILD_TYPE
+# Set the default of CMAKE_BUILD_TYPE to Release
 if( NOT DEFINED CMAKE_CONFIGURATION_TYPES AND NOT DEFINED CMAKE_BUILD_TYPE )
-  set( CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." )
+  set( CMAKE_BUILD_TYPE Release CACHE STRING
+    "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
+  )
 endif()
 
 # The superbuild does not build anything itself; all compiling is done in external projects
-project( rocblas-dependencies NONE )
+project( rocsolver-dependencies NONE )
 
 option( BUILD_BOOST "Download and build boost library" ON )
 option( BUILD_GTEST "Download and build googletest library" ON )
 option( BUILD_LAPACK "Download and build lapack library" ON )
-# option( BUILD_VERBOSE "Print helpful build debug information" OFF )
-
-# if( BUILD_VERBOSE )
-#   message( STATUS "CMAKE_MODULE_PATH: ${CMAKE_MODULE_PATH}" )
-#   message( STATUS "CMAKE_BINARY_DIR: ${CMAKE_BINARY_DIR}" )
-#   message( STATUS "CMAKE_SOURCE_DIR: ${CMAKE_SOURCE_DIR}" )
-#   message( STATUS "CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}" )
-#   message( STATUS "CMAKE_CURRENT_BINARY_DIR: ${CMAKE_CURRENT_BINARY_DIR}" )
-#   message( STATUS "CMAKE_CURRENT_LIST_DIR: ${CMAKE_CURRENT_LIST_DIR}" )
-#   message( STATUS "CMAKE_CURRENT_LIST_FILE: ${CMAKE_CURRENT_LIST_FILE}" )
-# endif( )
 
 # This module scrapes the CMakeCache.txt file and attempts to get all the cli options the user specified to cmake invocation
 include( get-cli-arguments )
@@ -40,21 +30,21 @@ include( get-cli-arguments )
 if( BUILD_GTEST )
   include( external-gtest )
 
-  list( APPEND rocblas_dependencies googletest )
+  list( APPEND rocsolver_dependencies googletest )
   set( gtest_custom_target COMMAND cd ${GTEST_BINARY_ROOT}$<SEMICOLON> ${CMAKE_COMMAND} --build . --target install )
 endif( )
 
 if( BUILD_LAPACK )
   include( external-lapack )
 
-  list( APPEND rocblas_dependencies lapack )
+  list( APPEND rocsolver_dependencies lapack )
   set( lapack_custom_target COMMAND cd ${LAPACK_BINARY_ROOT}$<SEMICOLON> ${CMAKE_COMMAND} --build . --target install )
 endif( )
 
 if( BUILD_BOOST )
   include( external-boost )
 
-  list( APPEND rocblas_dependencies boost )
+  list( APPEND rocsolver_dependencies boost )
   set( boost_custom_target COMMAND cd ${BOOST_BINARY_ROOT}$<SEMICOLON> ${Boost.Command} install )
 endif( )
 
@@ -68,5 +58,5 @@ add_custom_target( install
   ${boost_custom_target}
   ${gtest_custom_target}
   ${lapack_custom_target}
-  DEPENDS ${rocblas_dependencies}
+  DEPENDS ${rocsolver_dependencies}
 )

--- a/rocsolver/clients/CMakeLists.txt
+++ b/rocsolver/clients/CMakeLists.txt
@@ -1,14 +1,15 @@
 # ########################################################################
-# Copyright (c) 2019-2020 Advanced Micro Devices, Inc.
+# Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
 # ########################################################################
 
-# The ROCm platform requires Ubuntu 16.04 or Fedora 24, which has cmake 3.5
-cmake_minimum_required( VERSION 3.5 )
+cmake_minimum_required( VERSION 3.8 )
 
 # This has to be initialized before the project() command appears
-# Set the default of CMAKE_BUILD_TYPE to be release, unless user specifies with -D.  MSVC_IDE does not use CMAKE_BUILD_TYPE
+# Set the default of CMAKE_BUILD_TYPE to Release
 if( NOT DEFINED CMAKE_CONFIGURATION_TYPES AND NOT DEFINED CMAKE_BUILD_TYPE )
-  set( CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." )
+  set( CMAKE_BUILD_TYPE Release CACHE STRING
+    "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
+  )
 endif()
 
 # This project may compile dependencies for clients
@@ -19,7 +20,6 @@ if(OS_ID_rhel OR OS_ID_centos OR OS_ID_sles)
 else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp -pthread")
 endif()
-
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)

--- a/rocsolver/clients/benchmarks/CMakeLists.txt
+++ b/rocsolver/clients/benchmarks/CMakeLists.txt
@@ -50,22 +50,12 @@ add_executable( rocsolver-bench client.cpp ${rocsolver_benchmark_common} )
 
 add_armor_flags( rocsolver-bench "${ARMOR_LEVEL}" )
 
-
-#if( BUILD_WITH_TENSILE )
-#    target_compile_definitions( rocsolver-bench PRIVATE BUILD_WITH_TENSILE=1 )
-#else()
-#    target_compile_definitions( rocsolver-bench PRIVATE BUILD_WITH_TENSILE=0 )
-#endif()
-
 # Internal header includes
 target_include_directories( rocsolver-bench
   PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../library/include>
 )
-
-#set( BLIS_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/build/deps/blis/include/blis )
-#set( BLIS_LIBRARY ${CMAKE_SOURCE_DIR}/build/deps/blis/lib/libblis.so )
 
 if( OS_ID_rhel OR OS_ID_centos OR OS_ID_sles)
     if( OS_ID_rhel OR OS_ID_centos)
@@ -104,7 +94,6 @@ if( OS_ID_rhel OR OS_ID_centos OR OS_ID_sles)
     target_include_directories( rocsolver-bench
       SYSTEM PRIVATE
         $<BUILD_INTERFACE:${CLANG_INCLUDE_DIR}>
-#        $<BUILD_INTERFACE:${BLIS_INCLUDE_DIR}>
         $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
         $<BUILD_INTERFACE:${HCC_INCLUDE_DIRS}>
         $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>
@@ -122,13 +111,12 @@ else()
         $<BUILD_INTERFACE:${HCC_INCLUDE_DIRS}>
         $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>
         $<BUILD_INTERFACE:${CBLAS_INCLUDE_DIRS}>
-#        $<BUILD_INTERFACE:${BLIS_INCLUDE_DIR}>
         )
 
     target_link_libraries( rocsolver-bench PRIVATE ${Boost_LIBRARIES} cblas lapack roc::rocsolver )
 endif()
 
-target_link_libraries( rocsolver-bench PRIVATE roc::rocblas ) #${ROCBLAS_LIBRARY})
+target_link_libraries( rocsolver-bench PRIVATE roc::rocblas )
 
 if( CUDA_FOUND )
   target_include_directories( rocsolver-bench

--- a/rocsolver/clients/gtest/CMakeLists.txt
+++ b/rocsolver/clients/gtest/CMakeLists.txt
@@ -176,7 +176,7 @@ else()
     target_link_libraries( rocsolver-test PRIVATE ${GTEST_LIBRARIES} ${Boost_LIBRARIES} cblas lapack roc::rocsolver )
 endif()
 
-target_link_libraries( rocsolver-test PRIVATE roc::rocblas ) #${ROCBLAS_LIBRARY})
+target_link_libraries( rocsolver-test PRIVATE roc::rocblas )
 
 if( CUDA_FOUND )
   target_include_directories( rocsolver-test

--- a/rocsolver/library/CMakeLists.txt
+++ b/rocsolver/library/CMakeLists.txt
@@ -1,77 +1,16 @@
 # ########################################################################
-# Copyright (c) 2019-2020 Advanced Micro Devices, Inc.
+# Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
 # ########################################################################
-
-# The following helper functions wrap common cmake functions.  They are
-# used to cope with a few wierdnesses of hipcc/nvcc.
-# ########################################################################
-# HELPER FUNCTIONS
-# ########################################################################
-
-# ########################################################################
-# target_compile_features() override for CUDA
-# ########################################################################
-function( target_compile_features target_name )
-  # With Cmake v3.5, hipcc (with nvcc backend) does not work with target_compile_features
-  # Turn on -std=c++14 manually
-  if( CUDA_FOUND AND CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )
-    set_target_properties( ${target_name} PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED ON )
-  else( )
-    _target_compile_features( ${target_name} ${ARGN} )
-  endif( )
-endfunction( )
-
-# ########################################################################
-# target_link_libraries() override for CUDA
-# ########################################################################
-function( target_link_libraries target_name )
-  # hipcc takes care of finding hip library dependencies internally; remove
-  # explicit mentions of them so cmake doesn't complain on nvcc path
-  # FIXME: This removes this target's hip libraries, even if this particular
-  #        target is not built using a compiler that can find its dependencies
-  #        internally (e.g. Fortran programs).
-  if( CUDA_FOUND AND CMAKE_CXX_COMPILER MATCHES ".*/hipcc$|.*/nvcc$" )
-    foreach( link_library ${ARGN} )
-      if( (link_library MATCHES "^hip::|^hcc::") )
-        message( DEBUG "Removing ${link_library} from ${target_name} library list" )
-      else( )
-        if( TARGET ${link_library} )
-          list( APPEND new_list -Xlinker ${link_library} )
-        else( )
-          list( APPEND new_list ${link_library} )
-        endif( )
-      endif( )
-    endforeach( )
-    _target_link_libraries( ${target_name} ${new_list} )
-  else( )
-    _target_link_libraries( ${target_name} ${ARGN} )
-  endif( )
-endfunction( )
-
-# ########################################################################
-# Main
-# ########################################################################
-
-
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads REQUIRED)
 
 # This is incremented when the ABI to the library changes
 set( rocsolver_SOVERSION 0.1 )
 
-list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/rocblascommon/cmake )
-
-# This option only works for make/nmake and the ninja generators, but no reason it shouldn't be on all the time
-# This tells cmake to create a compile_commands.json file that can be used with clang tooling or vim
+# This option only works for make, nmake and ninja, but no reason it shouldn't be on all the time
+# It creates a compile_commands.json file for use with clang tooling or vim
 set( CMAKE_EXPORT_COMPILE_COMMANDS ON )
-
-# set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic")
-
-# include( build-bitness )
 
 # Print out compiler flags for viewing/debug
 if( BUILD_VERBOSE )
-  message( STATUS "rocfft_VERSION: ${rocfft_VERSION}" )
   message( STATUS "\t==>CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" )
   message( STATUS "\t==>BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}" )
   message( STATUS "\t==>CMAKE_INSTALL_PREFIX link: " ${CMAKE_INSTALL_PREFIX} )
@@ -94,8 +33,8 @@ if( BUILD_VERBOSE )
   message( STATUS "\t==>CMAKE_SHARED_LINKER_FLAGS_RELEASE: ${CMAKE_SHARED_LINKER_FLAGS_RELEASE}" )
 endif( )
 
-# configure a header file to pass the CMake version settings to the source, and package the header files in the output archive
-configure_file( "${CMAKE_CURRENT_SOURCE_DIR}/include/rocsolver-version.h.in" "${PROJECT_BINARY_DIR}/include/rocsolver-version.h" )
+# Create version header from templated .in file using CMake info
+configure_file( include/rocsolver-version.h.in "${PROJECT_BINARY_DIR}/include/rocsolver-version.h" )
 
 set( rocsolver_headers_public
   include/rocsolver.h
@@ -106,6 +45,7 @@ set( rocsolver_headers_public
   ${PROJECT_BINARY_DIR}/include/rocsolver-export.h
 )
 
+# For IDE integration
 source_group( "Header Files\\Public" FILES ${rocsolver_headers_public} )
 
 include( GNUInstallDirs )
@@ -116,16 +56,6 @@ set( INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR} )
 
 # Build into subdirectories
 add_subdirectory( src )
-
-# The following code is setting variables to control the behavior of CPack to generate our
-# if( WIN32 )
-#     set( CPACK_SOURCE_GENERATOR "ZIP" )
-#     set( CPACK_GENERATOR "ZIP" )
-# else( )
-#     set( CPACK_SOURCE_GENERATOR "TGZ" )
-#     set( CPACK_GENERATOR "DEB;RPM" CACHE STRING "cpack list: 7Z, DEB, IFW, NSIS, NSIS64, RPM, STGZ, TBZ2, TGZ, TXZ, TZ, ZIP" )
-#     # set( CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON )
-# endif( )
 
 # Package specific CPACK vars
 string( TOLOWER "${HIP_RUNTIME}" HIP_RUNTIME_LOWER )
@@ -145,13 +75,17 @@ if( OS_ID_sles )
 endif()
 set( CPACK_RPM_PACKAGE_REQUIRES ${RPM_REQUIREMENTS} )
 
-set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/../../LICENSE.md" )
+set( CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE.md" )
 
 if( NOT CPACK_PACKAGING_INSTALL_PREFIX )
   set( CPACK_PACKAGING_INSTALL_PREFIX "${ROCM_PATH}" )
 endif( )
 
-set( CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "\${CPACK_PACKAGING_INSTALL_PREFIX}" "\${CPACK_PACKAGING_INSTALL_PREFIX}/include" "\${CPACK_PACKAGING_INSTALL_PREFIX}/lib" )
+set( CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION
+  "\${CPACK_PACKAGING_INSTALL_PREFIX}"
+  "\${CPACK_PACKAGING_INSTALL_PREFIX}/include"
+  "\${CPACK_PACKAGING_INSTALL_PREFIX}/lib"
+)
 
 # Give rocsolver compiled for CUDA backend a different name
 if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" OR CXX_VERSION_STRING MATCHES "clang" )
@@ -160,11 +94,12 @@ else( )
     set( package_name rocsolver-alt )
 endif( )
 
-set( ROCSOLVER_CONFIG_DIR "\${CPACK_PACKAGING_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" CACHE PATH "Path placed into ldconfig file" )
+set( ROCSOLVER_CONFIG_DIR "\${CPACK_PACKAGING_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
+  CACHE PATH "Path placed into ldconfig file" )
 
 rocm_create_package(
     NAME ${package_name}
-    DESCRIPTION "Radeon Open Compute SOLVER library"
+    DESCRIPTION "AMD ROCm SOLVER library"
     MAINTAINER "RocSOLVER maintainer <rocsolver-maintainer@amd.com>"
     LDCONFIG
     LDCONFIG_DIR ${ROCSOLVER_CONFIG_DIR}

--- a/rocsolver/library/src/CMakeLists.txt
+++ b/rocsolver/library/src/CMakeLists.txt
@@ -1,23 +1,5 @@
 # ########################################################################
-# Copyright (c) 2019-2020 Advanced Micro Devices, Inc.
-# ########################################################################
-
-# ########################################################################
-# A helper function to prefix a source list of files with a common path into a new list (non-destructive)
-# ########################################################################
-function( prepend_path prefix source_list_of_files return_list_of_files )
-  foreach( file ${${source_list_of_files}} )
-    if(IS_ABSOLUTE ${file} )
-      list( APPEND new_list ${file} )
-    else( )
-      list( APPEND new_list ${prefix}/${file} )
-    endif( )
-  endforeach( )
-  set( ${return_list_of_files} ${new_list} PARENT_SCOPE )
-endfunction( )
-
-# ########################################################################
-# Main
+# Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
 # ########################################################################
 
 # package_targets is used as a list of install target
@@ -146,6 +128,9 @@ set_target_properties( rocsolver PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRE
 # In ROCm 4.0 and earlier, the default maximum threads per block is 256
 target_compile_options( rocsolver PRIVATE --gpu-max-threads-per-block=1024 )
 
+# Ignore loop unrolling failures
+target_compile_options( rocsolver PRIVATE -Wno-pass-failed )
+
 if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
   # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
   # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
@@ -166,8 +151,7 @@ set_target_properties( rocsolver PROPERTIES CXX_EXTENSIONS NO )
 set_target_properties( rocsolver PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
 rocm_set_soversion(rocsolver ${rocsolver_SOVERSION})
 
-
-# Package that helps me set visibility for function names exported from shared library
+# set visibility for function names exported from shared library
 include( GenerateExportHeader )
 set_target_properties( rocsolver PROPERTIES CXX_VISIBILITY_PRESET "hidden" VISIBILITY_INLINES_HIDDEN ON )
 generate_export_header( rocsolver EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/rocsolver-export.h )
@@ -181,6 +165,8 @@ if(OPTIMAL)
   target_compile_definitions(rocsolver PRIVATE OPTIMAL)
 endif( )
 
+target_compile_definitions( rocsolver PRIVATE ROCM_USE_FLOAT16 )
+
 add_armor_flags( rocsolver "${ARMOR_LEVEL}" )
 
 ############################################################
@@ -193,7 +179,6 @@ rocm_install_targets(
     ${CMAKE_BINARY_DIR}/include
   PREFIX rocsolver
 )
-#         PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ
 
 rocm_export_targets(
   TARGETS roc::rocsolver


### PR DESCRIPTION
This first step is some CMake cleanup. There's a lot of changes here,
but they should still result in more or less the same build commands
being generated. This particular commit is not terribly exciting stuff;
I'm just doing some tidying up:

- Cleanup CMake comments
- Reorganize helper functions
- Simplify function calls
- Update package description

The end goal is a cleaner, simpler build configuration. Step 2 is going
to be applying an auto-formatter. Step 3 is going to be porting some
changes rocBLAS has already made. Step 4 is going to be look at
how we handle our dependencies. And Step 5 is going to be some
more misc cleanup.

I split the changes into steps just for clarity, as it would be difficult to
follow what was done if they were all squashed together.