### PR TITLE
Print assumption failures using __assert_fail

### DIFF
--- a/rocsolver/library/src/include/common_host_helpers.hpp
+++ b/rocsolver/library/src/include/common_host_helpers.hpp
@@ -129,26 +129,47 @@ void print_device_matrix(const std::string name,
     }
 }
 
+#ifdef ROCSOLVER_VERIFY_ASSUMPTIONS
+// Ensure __assert_fail is declared.
+#if !__is_identifier(__assert_fail)
+extern "C" [[noreturn]] void __assert_fail(const char* assertion,
+                                           const char* file,
+                                           unsigned int line,
+                                           const char* function) noexcept;
+#endif
+// ROCSOLVER_FAIL(msg) is called with a string literal to print a message and abort the program.
+// By default, it calls __assert_fail, but can be defined to something else.
+#ifndef ROCSOLVER_FAIL
+#define ROCSOLVER_FAIL(msg) __assert_fail(msg, __FILE__, __LINE__, __PRETTY_FUNCTION__)
+#endif
+#endif
+
 // ROCSOLVER_UNREACHABLE is an alternative to __builtin_unreachable that verifies that the path is
 // actually unreachable if ROCSOLVER_VERIFY_ASSUMPTIONS is defined.
 #ifdef ROCSOLVER_VERIFY_ASSUMPTIONS
-#define ROCSOLVER_UNREACHABLE std::abort
+#define ROCSOLVER_UNREACHABLE() ROCSOLVER_FAIL("unreachable statement")
 #else
-#define ROCSOLVER_UNREACHABLE __builtin_unreachable
+#define ROCSOLVER_UNREACHABLE() __builtin_unreachable()
 #endif
 
 // ROCSOLVER_UNREACHABLE_X is a variant of ROCSOLVER_UNREACHABLE that takes a string as a parameter,
 // which should explain why this path is believed to be unreachable.
-#define ROCSOLVER_UNREACHABLE_X(message) ROCSOLVER_UNREACHABLE()
+#ifdef ROCSOLVER_VERIFY_ASSUMPTIONS
+#define ROCSOLVER_UNREACHABLE_X(msg) ROCSOLVER_FAIL("unreachable statement (assumed " msg ")")
+#else
+#define ROCSOLVER_UNREACHABLE_X(msg) __builtin_unreachable()
+#endif
 
 // ROCSOLVER_ASSUME is an alternative to __builtin_assume that verifies that the assumption is
 // actually true if ROCSOLVER_VERIFY_ASSUMPTIONS is defined.
 #ifdef ROCSOLVER_VERIFY_ASSUMPTIONS
-#define ROCSOLVER_ASSUME(invariant) \
-    do                              \
-    {                               \
-        if(!(invariant))            \
-            std::abort();           \
+#define ROCSOLVER_ASSUME(invariant)     \
+    do                                  \
+    {                                   \
+        if(!(invariant))                \
+        {                               \
+            ROCSOLVER_FAIL(#invariant); \
+        }                               \
     } while(0)
 #else
 #define ROCSOLVER_ASSUME(invariant) __builtin_assume(invariant)
@@ -156,4 +177,15 @@ void print_device_matrix(const std::string name,
 
 // ROCSOLVER_ASSUME_X is a variant of ROCSOLVER_ASSUME that takes a string as a second parameter,
 // which should explain why this invariant is believed to be guaranteed.
-#define ROCSOLVER_ASSUME_X(invariant, message) ROCSOLVER_ASSUME(invariant)
+#ifdef ROCSOLVER_VERIFY_ASSUMPTIONS
+#define ROCSOLVER_ASSUME_X(invariant, msg)                   \
+    do                                                       \
+    {                                                        \
+        if(!(invariant))                                     \
+        {                                                    \
+            ROCSOLVER_FAIL(#invariant " (assumed " msg ")"); \
+        }                                                    \
+    } while(0)
+#else
+#define ROCSOLVER_ASSUME_X(invariant, msg) __builtin_assume(invariant)
+#endif


### PR DESCRIPTION
The initial implementation of the rocsolver assumption macros would abort the program without message upon failure (in debug mode). With this change, they now use the POSIX `__assert_fail` function to explain what assumption was violated before exiting the program.