### PR TITLE
Cleanup clients build system - 5/5

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -43,7 +43,10 @@ find_package( CUDA QUIET )
 
 if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS )
   add_library( clients-common INTERFACE )
-  target_include_directories( clients-common INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+  target_include_directories( clients-common INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+  )
   set( common_source_files
     common/lapack_host_reference.cpp
     rocblascommon/utility.cpp

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -12,14 +12,7 @@ if( NOT DEFINED CMAKE_CONFIGURATION_TYPES AND NOT DEFINED CMAKE_BUILD_TYPE )
   )
 endif()
 
-# This project may compile dependencies for clients
 project( rocsolver-clients LANGUAGES C CXX Fortran )
-
-if(OS_ID_rhel OR OS_ID_centos OR OS_ID_sles)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp=libgomp -pthread")
-else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp -pthread")
-endif()
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -10,12 +10,6 @@ add_executable( rocsolver-bench client.cpp )
 
 add_armor_flags( rocsolver-bench "${ARMOR_LEVEL}" )
 
-# Internal header includes
-target_include_directories( rocsolver-bench
-  PRIVATE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
-)
-
 # External header includes
 target_include_directories( rocsolver-bench
   SYSTEM PRIVATE

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -2,9 +2,6 @@
 # Copyright (c) 2016-2021 Advanced Micro Devices, Inc.
 # ########################################################################
 
-set( THREADS_PREFER_PTHREAD_FLAG ON )
-find_package( Threads REQUIRED )
-
 # Linking lapack library requires fortran flags
 enable_language( Fortran )
 find_package( cblas REQUIRED CONFIG )

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -2,25 +2,12 @@
 # Copyright (c) 2016-2021 Advanced Micro Devices, Inc.
 # ########################################################################
 
-if(EXISTS /etc/redhat-release)
-    if(CXX_VERSION_STRING MATCHES "clang")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp=libgomp -pthread -stdlib=libstdc++ -std=c++14")
-    else()
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp=libgomp -pthread")
-    endif()
-else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp -pthread")
-endif()
-
 set( THREADS_PREFER_PTHREAD_FLAG ON )
 find_package( Threads REQUIRED )
 
 # Linking lapack library requires fortran flags
 enable_language( Fortran )
-find_package( cblas CONFIG REQUIRED )
-if( NOT cblas_FOUND )
-  message( FATAL_ERROR "cblas is a required dependency and is not found;  try adding cblas path to CMAKE_PREFIX_PATH" )
-endif( )
+find_package( cblas REQUIRED CONFIG )
 
 add_executable( rocsolver-bench client.cpp )
 
@@ -32,58 +19,19 @@ target_include_directories( rocsolver-bench
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
 )
 
-if( OS_ID_rhel OR OS_ID_centos OR OS_ID_sles)
-    if( OS_ID_rhel OR OS_ID_centos)
-        if( EXISTS "/usr/lib/gcc/x86_64-redhat-linux/8/" )
-            set( ROCM_OPENMP_PATH /usr/lib/gcc/x86_64-redhat-linux/8 )
-        else()
-            set( ROCM_OPENMP_PATH /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7 )
-        endif()
+# External header includes
+target_include_directories( rocsolver-bench
+  SYSTEM PRIVATE
+    $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
+    $<BUILD_INTERFACE:${CBLAS_INCLUDE_DIRS}>
+    )
 
-        # defer OpenMP include as search order must come after clang
-        set( XXX_OPENMP_INCLUDE_DIR ${ROCM_OPENMP_PATH}/include )
-        set( OPENMP_LIBRARY ${ROCM_OPENMP_PATH}/libgomp.so )
-        if( CXX_VERSION_STRING MATCHES "clang")
-            set( XXX_OPENMP_INCLUDE_DIR ${ROCM_OPENMP_PATH}/include )
-        endif()
-    else()
-    #SLES
-        set( XXX_OPENMP_INCLUDE_DIR /usr/lib64/gcc/x86_64-suse-linux/7/include/ )
-        set( OPENMP_LIBRARY /usr/lib64/gcc/x86_64-suse-linux/7/libgomp.so )
-    endif()
-
-    message(STATUS "RocmPath: ${ROCM_PATH}")
-    if(EXISTS ${ROCM_PATH}/llvm/lib/clang/13.0.0/include/immintrin.h AND CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
-        set( CLANG_INCLUDE_DIR ${ROCM_PATH}/llvm/lib/clang/13.0.0/include )
-    elseif(EXISTS ${ROCM_PATH}/llvm/lib/clang/12.0.0/include/immintrin.h AND CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
-        set( CLANG_INCLUDE_DIR ${ROCM_PATH}/llvm/lib/clang/12.0.0/include )
-    elseif(EXISTS ${ROCM_PATH}/llvm/lib/clang/11.0.0/include/immintrin.h AND CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
-        set( CLANG_INCLUDE_DIR ${ROCM_PATH}/llvm/lib/clang/11.0.0/include )
-    else()
-        set( CLANG_INCLUDE_DIR )
-    endif()
-
-    # External header includes included as system files
-    target_include_directories( rocsolver-bench
-      SYSTEM PRIVATE
-        $<BUILD_INTERFACE:${CLANG_INCLUDE_DIR}>
-        $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
-        $<BUILD_INTERFACE:${CBLAS_INCLUDE_DIRS}>
-        $<BUILD_INTERFACE:${OPENMP_INCLUDE_DIR}>
-        )
-
-    target_link_libraries( rocsolver-bench PRIVATE ${OPENMP_LIBRARY} cblas lapack roc::rocsolver )
-
-else()
-    # External header includes included as system files
-    target_include_directories( rocsolver-bench
-      SYSTEM PRIVATE
-        $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
-        $<BUILD_INTERFACE:${CBLAS_INCLUDE_DIRS}>
-        )
-
-    target_link_libraries( rocsolver-bench PRIVATE cblas lapack roc::rocsolver )
-endif()
+target_link_libraries( rocsolver-bench PRIVATE
+  cblas
+  lapack
+  Threads::Threads
+  roc::rocsolver
+)
 
 if( CUDA_FOUND )
   target_include_directories( rocsolver-bench
@@ -102,20 +50,12 @@ if( CMAKE_COMPILER_IS_GNUCXX OR CXX_VERSION_STRING MATCHES "clang")
   target_compile_options( rocsolver-bench PRIVATE -mf16c )
 endif( )
 
-if( CXX_VERSION_STRING MATCHES "clang" )
-  target_link_libraries( rocsolver-bench PRIVATE -lpthread -lstdc++ -lm )
-  if(OS_ID_rhel OR OS_ID_centos OR OS_ID_sles)
-    set(CMAKE_CXX_FLAGS "-isystem ${CLANG_INCLUDE_DIR} -isystem ${XXX_OPENMP_INCLUDE_DIR} ${CMAKE_CXX_FLAGS}")
-  endif( )
-else( )
-  if(OS_ID_rhel OR OS_ID_centos OR OS_ID_sles)
-    set(CMAKE_CXX_FLAGS "-isystem ${CLANG_INCLUDE_DIR} -isystem ${XXX_OPENMP_INCLUDE_DIR} ${CMAKE_CXX_FLAGS}")
-  endif( )
-  set(CMAKE_CXX_FLAGS "-isystem ${ROCM_PATH}/include ${CMAKE_CXX_FLAGS}")
-endif( )
-
-set_target_properties( rocsolver-bench PROPERTIES CXX_EXTENSIONS NO )
-set_target_properties( rocsolver-bench PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
+set_target_properties( rocsolver-bench PROPERTIES
+  CXX_STANDARD 14
+  CXX_STANDARD_REQUIRED ON
+  CXX_EXTENSIONS OFF
+  RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging"
+)
 target_compile_definitions( rocsolver-bench PRIVATE ROCM_USE_FLOAT16 )
 
 target_link_libraries( rocsolver-bench PRIVATE rocsolver-common clients-common )

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -79,12 +79,6 @@ add_armor_flags( rocsolver-test "${ARMOR_LEVEL}" )
 
 target_compile_definitions( rocsolver-test PRIVATE GOOGLE_TEST )
 
-# Internal header includes
-target_include_directories( rocsolver-test
-  PRIVATE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
-)
-
 # External header includes included as system files
 target_include_directories( rocsolver-test
   SYSTEM PRIVATE

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -5,22 +5,9 @@
 # For debugging, uncomment this
 # set( CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -g -O0" )
 
-if(EXISTS /etc/redhat-release)
-    if(CXX_VERSION_STRING MATCHES "clang")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp=libgomp -pthread -stdlib=libstdc++ -std=c++14")
-    else()
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp=libgomp -pthread")
-    endif()
-else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp -pthread")
-endif()
-
 # Linking lapack library requires fortran flags
 enable_language( Fortran )
-find_package( cblas CONFIG REQUIRED )
-if( NOT cblas_FOUND )
-  message( FATAL_ERROR "cblas is a required dependency and is not found;  try adding cblas path to CMAKE_PREFIX_PATH" )
-endif( )
+find_package( cblas REQUIRED CONFIG )
 
 find_package( GTest REQUIRED )
 
@@ -101,65 +88,19 @@ target_include_directories( rocsolver-test
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
 )
 
-#set( BLIS_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/build/deps/blis/include/blis )
-#set( BLIS_LIBRARY ${CMAKE_SOURCE_DIR}/build/deps/blis/lib/libblis.so )
+# External header includes included as system files
+target_include_directories( rocsolver-test
+  SYSTEM PRIVATE
+    $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
+    $<BUILD_INTERFACE:${CBLAS_INCLUDE_DIRS}>
+    )
 
-if( OS_ID_rhel OR OS_ID_centos OR OS_ID_sles)
-    if( OS_ID_rhel OR OS_ID_centos)
-        if( EXISTS "/usr/lib/gcc/x86_64-redhat-linux/8/" )
-            set( ROCM_OPENMP_PATH /usr/lib/gcc/x86_64-redhat-linux/8 )
-        else()
-            set( ROCM_OPENMP_PATH /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7 )
-        endif()
-
-        # defer OpenMP include as search order must come after clang
-        set( XXX_OPENMP_INCLUDE_DIR ${ROCM_OPENMP_PATH}/include )
-        set( OPENMP_LIBRARY ${ROCM_OPENMP_PATH}/libgomp.so )
-        if( CXX_VERSION_STRING MATCHES "clang")
-            set( XXX_OPENMP_INCLUDE_DIR ${ROCM_OPENMP_PATH}/include )
-        endif()
-    else()
-    #SLES
-        set( XXX_OPENMP_INCLUDE_DIR /usr/lib64/gcc/x86_64-suse-linux/7/include/ )
-        set( OPENMP_LIBRARY /usr/lib64/gcc/x86_64-suse-linux/7/libgomp.so )
-    endif()
-
-    message(STATUS "RocmPath: ${ROCM_PATH}")
-    if(EXISTS ${ROCM_PATH}/llvm/lib/clang/13.0.0/include/immintrin.h AND CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
-        set( CLANG_INCLUDE_DIR ${ROCM_PATH}/llvm/lib/clang/13.0.0/include )
-    elseif(EXISTS ${ROCM_PATH}/llvm/lib/clang/12.0.0/include/immintrin.h AND CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
-        set( CLANG_INCLUDE_DIR ${ROCM_PATH}/llvm/lib/clang/12.0.0/include )
-    elseif(EXISTS ${ROCM_PATH}/llvm/lib/clang/11.0.0/include/immintrin.h AND CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
-        set( CLANG_INCLUDE_DIR ${ROCM_PATH}/llvm/lib/clang/11.0.0/include )
-    else()
-        set( CLANG_INCLUDE_DIR )
-    endif()
-
-    # External header includes included as system files
-    target_include_directories( rocsolver-test
-      SYSTEM PRIVATE
-        $<BUILD_INTERFACE:${CLANG_INCLUDE_DIR}>
-#        $<BUILD_INTERFACE:${BLIS_INCLUDE_DIR}>
-        $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
-        $<BUILD_INTERFACE:${GTEST_INCLUDE_DIRS}>
-        $<BUILD_INTERFACE:${CBLAS_INCLUDE_DIRS}>
-        $<BUILD_INTERFACE:${OPENMP_INCLUDE_DIR}>
-        )
-
-    target_link_libraries( rocsolver-test PRIVATE ${GTEST_LIBRARIES} ${OPENMP_LIBRARY} cblas lapack roc::rocsolver )
-
-else()
-    # External header includes included as system files
-    target_include_directories( rocsolver-test
-      SYSTEM PRIVATE
-        $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
-        $<BUILD_INTERFACE:${GTEST_INCLUDE_DIRS}>
-        $<BUILD_INTERFACE:${CBLAS_INCLUDE_DIRS}>
-#        $<BUILD_INTERFACE:${BLIS_INCLUDE_DIR}>
-        )
-
-    target_link_libraries( rocsolver-test PRIVATE ${GTEST_LIBRARIES} cblas lapack roc::rocsolver )
-endif()
+target_link_libraries( rocsolver-test PRIVATE
+  cblas
+  lapack
+  GTest::GTest
+  roc::rocsolver
+)
 
 if( CUDA_FOUND )
   target_include_directories( rocsolver-test
@@ -178,20 +119,13 @@ if( CMAKE_COMPILER_IS_GNUCXX OR CXX_VERSION_STRING MATCHES "clang")
   target_compile_options( rocsolver-test PRIVATE -mf16c )
 endif( )
 
-if( CXX_VERSION_STRING MATCHES "clang" )
-  target_link_libraries( rocsolver-test PRIVATE -lpthread -lstdc++ -lm )
-  if(OS_ID_rhel OR OS_ID_centos OR OS_ID_sles)
-    set(CMAKE_CXX_FLAGS "-isystem ${CLANG_INCLUDE_DIR} -isystem ${XXX_OPENMP_INCLUDE_DIR} ${CMAKE_CXX_FLAGS}")
-  endif( )
-else( )
-  if(OS_ID_rhel OR OS_ID_centos OR OS_ID_sles)
-    set(CMAKE_CXX_FLAGS "-isystem ${CLANG_INCLUDE_DIR} -isystem ${XXX_OPENMP_INCLUDE_DIR} ${CMAKE_CXX_FLAGS}")
-  endif( )
-  set(CMAKE_CXX_FLAGS "-isystem ${ROCM_PATH}/include ${CMAKE_CXX_FLAGS}")
-endif( )
-
-set_target_properties( rocsolver-test PROPERTIES CXX_EXTENSIONS NO )
-set_target_properties( rocsolver-test PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
+target_link_libraries( rocsolver-test PRIVATE m )
+set_target_properties( rocsolver-test PROPERTIES
+  CXX_STANDARD 14
+  CXX_STANDARD_REQUIRED ON
+  CXX_EXTENSIONS OFF
+  RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging"
+)
 target_compile_definitions( rocsolver-test PRIVATE ROCM_USE_FLOAT16 )
 
 target_link_libraries( rocsolver-test PRIVATE rocsolver-common clients-common )

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -11,9 +11,6 @@ find_package( cblas REQUIRED CONFIG )
 
 find_package( GTest REQUIRED )
 
-set( THREADS_PREFER_PTHREAD_FLAG ON )
-find_package( Threads REQUIRED )
-
 set(roclapack_test_source
     # linear systems solvers
     getrs_gtest.cpp

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -42,13 +42,17 @@ set( fortran_samples
 foreach( exe ${c_samples} ${cpp_samples} ${fortran_samples} )
   target_link_libraries( ${exe} PRIVATE roc::rocsolver )
 
-  set_target_properties( ${exe} PROPERTIES CXX_EXTENSIONS NO )
-  set_target_properties( ${exe} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
+  set_target_properties( ${exe} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging"
+  )
+endforeach( )
 
-  if( CMAKE_COMPILER_IS_GNUCXX OR CXX_VERSION_STRING MATCHES "clang" )
-    # GCC or hip-clang needs specific flags to turn on f16c intrinsics
-    target_compile_options( ${exe} PRIVATE -mf16c )
-  endif( )
+foreach( exe ${cpp_samples} )
+  set_target_properties( ${exe} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+  )
 endforeach( )
 
 foreach( exe ${c_samples} )

--- a/cmake/util.cmake
+++ b/cmake/util.cmake
@@ -3,20 +3,6 @@
 # ########################################################################
 
 # ########################################################################
-# target_compile_features() override
-# Wraps the normal cmake function to cope with hipcc/nvcc weirdness.
-# ########################################################################
-function( target_compile_features target_name )
-  # With Cmake v3.5, hipcc (with nvcc backend) does not work with target_compile_features
-  # Turn on -std=c++14 manually
-  if( CUDA_FOUND AND CMAKE_CXX_COMPILER MATCHES ".*/hipcc$|.*/nvcc$" )
-    set_target_properties( ${target_name} PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED ON )
-  else( )
-    _target_compile_features( ${target_name} ${ARGN} )
-  endif( )
-endfunction( )
-
-# ########################################################################
 # target_link_libraries() override
 # Wraps the normal cmake function to cope with hipcc/nvcc weirdness.
 # ########################################################################

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -147,7 +147,6 @@ target_link_libraries( rocsolver
     --rtlib=compiler-rt
     --unwindlib=libgcc
 )
-set_target_properties( rocsolver PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED ON )
 
 # In ROCm 4.0 and earlier, the default maximum threads per block is 256
 target_compile_options( rocsolver PRIVATE --gpu-max-threads-per-block=1024 )
@@ -164,7 +163,6 @@ target_include_directories( rocsolver
           ${CMAKE_CURRENT_SOURCE_DIR}
           )
 
-set_target_properties( rocsolver PROPERTIES CXX_EXTENSIONS NO )
 set_target_properties( rocsolver PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
 rocm_set_soversion(rocsolver ${rocsolver_SOVERSION})
 


### PR DESCRIPTION
This is basically updating the clients CMake to a more modern style. It follows more or less the same pattern as Torre did in [his change](https://github.com/ROCmSoftwarePlatform/rocBLAS/commit/d197906e6ce579032660ef67977674dbc9348375). However, we don't actually use OpenMP, so we can cut more and we don't need to bump the minimum version. (At some point this iteration we may want to bump to match rocBLAS, but this is already a lot in one PR.)

I thought I saw some issues with librt, but I'd been having trouble reproducing them. I'll leave this in draft until I'm sure they're not a problem.