### PR TITLE
Fix gesvd tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 
 ### Known Issues
 
+### Deprecated
+
+### Removed
+
+### Fixed
+- Thin-SVD failing tests. 
+
+### Known Issues
+
+### Security
 
 ## [rocSOLVER 3.12.0 for ROCm 4.2.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 ### Removed
 
 ### Fixed
-- Thin-SVD known failing tests. 
+- Fixed known Thin-SVD failing tests.
 
 ### Known Issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 ### Removed
 
 ### Fixed
-- Fixed known Thin-SVD failing tests.
+- Fixed known issues with Thin-SVD. The problem was identified in the test specification, not in the thin-SVD
+  implementation or the rocBLAS gemm\_batched routines.
 
 ### Known Issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,19 +12,10 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 ### Removed
 
 ### Fixed
+- Thin-SVD known failing tests. 
 
 ### Known Issues
 
-### Deprecated
-
-### Removed
-
-### Fixed
-- Thin-SVD failing tests. 
-
-### Known Issues
-
-### Security
 
 ## [rocSOLVER 3.12.0 for ROCm 4.2.0]
 ### Added

--- a/clients/gtest/gesvd_gtest.cpp
+++ b/clients/gtest/gesvd_gtest.cpp
@@ -53,31 +53,31 @@ const vector<vector<int>> opt_range = {
     {-1, 0, 0, 2, 2},
     {0, -1, 0, 1, 2},
     {0, 0, -1, 2, 1},
-    {0, -1, 0, 2, 2},
-    {0, 0, -1, 2, 2},
+    {0, 0, 0, 0, 0},
     // normal (valid) samples
     {1, 1, 1, 3, 3},
-    {0, 0, 0, 3, 1},
-    {0, 0, 0, 3, 0},
+    {0, 0, 1, 3, 2},
+    {0, 1, 0, 3, 1},
+    {0, 1, 1, 3, 0},
+    {1, 0, 0, 2, 3},
+    {1, 0, 1, 2, 2},
+    {1, 1, 0, 2, 1},
+    {0, 0, 0, 2, 0},
     {0, 0, 0, 1, 3},
-    {0, 1, 0, 1, 1},
+    {0, 0, 0, 1, 2},
+    {0, 0, 0, 1, 1},
     {0, 0, 0, 1, 0},
     {0, 0, 0, 0, 3},
-    {0, 0, 0, 0, 1},
-    {1, 0, 0, 0, 2},
-    {0, 0, 0, 2, 0},
-    {0, 0, 1, 2, 2}};
+    {0, 0, 0, 0, 2},
+    {0, 0, 0, 0, 1}};
 
 // for daily_lapack tests
-const vector<vector<int>> large_size_range = {{120, 100, 0}, {100, 120, 0}};
+const vector<vector<int>> large_size_range
+    = {{120, 100, 0}, {300, 120, 0}, {300, 120, 1}, {100, 120, 1}, {120, 300, 0}, {120, 300, 1}};
 
 const vector<vector<int>> large_opt_range
     = {{0, 0, 0, 3, 3}, {1, 0, 0, 0, 1}, {0, 1, 0, 1, 0}, {0, 0, 1, 1, 1},
        {0, 0, 0, 3, 0}, {0, 0, 0, 1, 3}, {0, 0, 0, 3, 2}};
-
-// known-bugs tests
-const vector<vector<int>> knownbug_size_range
-    = {{300, 120, 0}, {300, 120, 1}, {120, 300, 0}, {120, 300, 1}};
 
 Arguments gesvd_setup_arguments(gesvd_tuple tup)
 {
@@ -230,8 +230,3 @@ INSTANTIATE_TEST_SUITE_P(daily_lapack,
 // checkin_lapack tests normal execution with small sizes, invalid sizes,
 // quick returns, and corner cases
 INSTANTIATE_TEST_SUITE_P(checkin_lapack, GESVD, Combine(ValuesIn(size_range), ValuesIn(opt_range)));
-
-// known-bugs tests
-INSTANTIATE_TEST_SUITE_P(known_bug_lapack,
-                         GESVD,
-                         Combine(ValuesIn(knownbug_size_range), ValuesIn(large_opt_range)));

--- a/clients/include/testing_gesvd.hpp
+++ b/clients/include/testing_gesvd.hpp
@@ -280,7 +280,7 @@ void gesvd_getError(const rocblas_handle handle,
     // complementary execution (to compute all singular vectors if needed)
     CHECK_ROCBLAS_ERROR(rocsolver_gesvd(
         STRIDED, handle, left_svectT, right_svectT, mT, nT, dA.data(), lda, stA, dS.data(), stS,
-        dUT.data(), lduT, stUT, dVT.data(), ldvT, stVT, dE.data(), stE, fa, dinfo.data(), bc));
+        dUT.data(), lduT, stUT, dVT.data(), ldvT, stVT, dE.data(), stE, rocblas_inplace, dinfo.data(), bc)); 
 
     if(left_svect == rocblas_svect_none && right_svect != rocblas_svect_none)
         CHECK_HIP_ERROR(Ures.transfer_from(dUT));
@@ -514,6 +514,7 @@ void testing_gesvd(Arguments argus)
     rocblas_int mT = 0;
     rocblas_int nT = 0;
     bool svects = (leftv != rocblas_svect_none || rightv != rocblas_svect_none);
+
     if(svects)
     {
         if(leftv == rocblas_svect_none)
@@ -522,6 +523,8 @@ void testing_gesvd(Arguments argus)
             lduT = m;
             mT = m;
             nT = n;
+            if((n > m && fa == rocblas_outofplace) || (n > m && rightv == rocblas_svect_overwrite))
+                rightvT = rocblas_svect_overwrite;
         }
         if(rightv == rocblas_svect_none)
         {
@@ -529,6 +532,8 @@ void testing_gesvd(Arguments argus)
             ldvT = n;
             mT = m;
             nT = n;
+            if((m >= n && fa == rocblas_outofplace) || (m >= n && leftv == rocblas_svect_overwrite))
+                leftvT = rocblas_svect_overwrite;
         }
     }
 
@@ -783,10 +788,11 @@ void testing_gesvd(Arguments argus)
     // output results for rocsolver-bench
     if(argus.timing)
     {
+        if(svects)
+            max_error = (max_error >= max_errorv) ? max_error : max_errorv;
+       
         if(!argus.perf)
         {
-            if(svects)
-                max_error = (max_error >= max_errorv) ? max_error : max_errorv;
             rocsolver_cout << "\n============================================\n";
             rocsolver_cout << "Arguments:\n";
             rocsolver_cout << "============================================\n";

--- a/clients/include/testing_gesvd.hpp
+++ b/clients/include/testing_gesvd.hpp
@@ -278,7 +278,7 @@ void gesvd_getError(const rocblas_handle handle,
 
     // execute computations:
     // complementary execution to compute all singular vectors if needed (always in-place to ensure
-    // we don't combine results computed by gemm_bacthed with results computed by gemm_strided_batched)
+    // we don't combine results computed by gemm_batched with results computed by gemm_strided_batched)
     CHECK_ROCBLAS_ERROR(rocsolver_gesvd(STRIDED, handle, left_svectT, right_svectT, mT, nT,
                                         dA.data(), lda, stA, dS.data(), stS, dUT.data(), lduT, stUT,
                                         dVT.data(), ldvT, stVT, dE.data(), stE, rocblas_inplace,


### PR DESCRIPTION
Fix GESVD tests marked as "known bugs" by re-organizing the implicit test to avoid combining  gemm_strided_batched- with gemm_bached- based computations, which seems to be producing numerical artifacts.  