### PR TITLE
Remove compiler version parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,69 +33,8 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
 # ########################################################################
-# NOTE:  CUDA compiling path
-# ########################################################################
-# I have tried compiling rocBLAS library source with multiple methods,
-# and ended up using the approach where we set the CXX compiler to hipcc.
-# I didn't like using the HIP_ADD_LIBRARY or CUDA_ADD_LIBRARY approaches,
-# for the reasons I list here.
-# 1.  Adding header include directories is through HIP_INCLUDE_DIRECTORIES(), which
-# is global to a directory and affects all targets
-# 2.  You must add HIP_SOURCE_PROPERTY_FORMAT OBJ properties to .cpp files
-# to get HIP_ADD_LIBRARY to recognize the file
-# 3.  HIP_ADD_LIBRARY invokes a call to add_custom_command() to compile files,
-# and rocBLAS does the same.  The order in which custom commands execute is
-# undefined, and sometimes a file is attempted to be compiled before it has
-# been generated.  The fix for this is to create 'PHONY' targets, which I
-# don't desire.
-
-# Using hipcc allows us to avoid the above problems, with two primary costs:
-# 1.  The cmake logic to detect compiler features fails with nvcc backend
-# 2.  Upfront cost to figure out all the strange compiler/linker flags I define
-# below.
-
-# Hopefully, cost #2 is already paid.  All in all, I want to get rid of the
-# need for hipcc, and hope that at some point of time in the future we
-# can use the export config files from hip for both ROCm & nvcc backends.
-# ########################################################################
-
-# ########################################################################
 # Main
 # ########################################################################
-
-if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$")
-  # Determine if CXX Compiler is hip-clang or nvcc
-  execute_process(COMMAND ${CMAKE_CXX_COMPILER} "--version" OUTPUT_VARIABLE CXX_OUTPUT
-                  OUTPUT_STRIP_TRAILING_WHITESPACE
-                  ERROR_STRIP_TRAILING_WHITESPACE)
-  string(REGEX MATCH "[A-Za-z]* ?clang version" TMP_CXX_VERSION ${CXX_OUTPUT})
-  string(REGEX MATCH "[A-Za-z]+" CXX_VERSION_STRING ${TMP_CXX_VERSION})
-endif()
-
-if( CXX_VERSION_STRING MATCHES "clang" )
-  message( STATUS "Use hip-clang to build for amdgpu backend" )
-# set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xclang -fallow-half-arguments-and-returns" )
-  set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__HIP_HCC_COMPAT_MODE__=1" )
-elseif( CXX_VERSION_STRING MATCHES "nvcc" )
-  message( STATUS "HIPCC nvcc compiler detected; CUDA backend selected" )
-
-  set( CMAKE_C_COMPILE_OPTIONS_PIC "-Xcompiler ${CMAKE_C_COMPILE_OPTIONS_PIC}" )
-  set( CMAKE_CXX_COMPILE_OPTIONS_PIC "-Xcompiler ${CMAKE_CXX_COMPILE_OPTIONS_PIC}" )
-  set( CMAKE_SHARED_LIBRARY_C_FLAGS "-Xlinker ${CMAKE_SHARED_LIBRARY_C_FLAGS}" )
-  set( CMAKE_SHARED_LIBRARY_CXX_FLAGS "-Xlinker ${CMAKE_SHARED_LIBRARY_CXX_FLAGS}" )
-  set( CMAKE_SHARED_LIBRARY_SONAME_C_FLAG "-Xlinker -soname," )
-  set( CMAKE_SHARED_LIBRARY_SONAME_CXX_FLAG "-Xlinker -soname," )
-  set( CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG "-Xlinker -rpath," )
-  set( CMAKE_SHARED_LIBRARY_RUNTIME_CXX_FLAG "-Xlinker -rpath," )
-  set( CMAKE_EXECUTABLE_RUNTIME_C_FLAG "-Xlinker -rpath," )
-  set( CMAKE_EXECUTABLE_RUNTIME_CXX_FLAG "-Xlinker -rpath," )
-  set( CMAKE_C_COMPILE_OPTIONS_VISIBILITY "-Xcompiler ${CMAKE_C_COMPILE_OPTIONS_VISIBILITY}" )
-  set( CMAKE_CXX_COMPILE_OPTIONS_VISIBILITY "-Xcompiler ${CMAKE_CXX_COMPILE_OPTIONS_VISIBILITY}" )
-  set( CMAKE_C_COMPILE_OPTIONS_VISIBILITY_INLINES_HIDDEN "-Xcompiler ${CMAKE_C_COMPILE_OPTIONS_VISIBILITY_INLINES_HIDDEN}" )
-  set( CMAKE_CXX_COMPILE_OPTIONS_VISIBILITY_INLINES_HIDDEN "-Xcompiler ${CMAKE_CXX_COMPILE_OPTIONS_VISIBILITY_INLINES_HIDDEN}" )
-elseif( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
-  message( SEND_ERROR "HCC compiler is no longer supported!" )
-endif( )
 
 # get rocm-cmake
 include( get-rocm-cmake )
@@ -149,9 +88,7 @@ set(CMAKE_INSTALL_LIBDIR "lib" CACHE INTERNAL "Installation directory for librar
 set( AMDGPU_TARGETS "gfx803;gfx900;gfx906:xnack-;gfx908:xnack-" CACHE STRING "List of specific machine types for library to target" )
 
 # Find HIP dependencies
-if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
-  find_package( hip REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm )
-endif( )
+find_package( hip REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm )
 
 find_package( rocblas REQUIRED CONFIG PATHS ${ROCM_PATH} )
 get_imported_target_location( location roc::rocblas )

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -37,10 +37,6 @@ if(NOT hip_FOUND)
   find_package( hip REQUIRED CONFIG PATHS ${ROCM_PATH} )
 endif()
 
-# Quietly look for CUDA, but if not found it's not an error
-# The presense of hip is not sufficient to determine if we want a rocm or cuda backend
-find_package( CUDA QUIET )
-
 if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS )
   add_library( clients-common INTERFACE )
   target_include_directories( clients-common INTERFACE

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -21,20 +21,11 @@ target_link_libraries( rocsolver-bench PRIVATE
   cblas
   lapack
   Threads::Threads
+  hip::device
+  rocsolver-common
+  clients-common
   roc::rocsolver
 )
-
-if( CUDA_FOUND )
-  target_include_directories( rocsolver-bench
-    PRIVATE
-      $<BUILD_INTERFACE:${CUDA_INCLUDE_DIRS}>
-      $<BUILD_INTERFACE:${hip_INCLUDE_DIRS}>
-    )
-  target_compile_definitions( rocsolver-bench PRIVATE __HIP_PLATFORM_NVCC__ )
-  target_link_libraries( rocsolver-bench PRIVATE ${CUDA_LIBRARIES} )
-else( )
-  target_link_libraries( rocsolver-bench PRIVATE hip::device )
-endif( )
 
 # Turn on f16c intrinsics
 target_compile_options( rocsolver-bench PRIVATE -mf16c )
@@ -46,5 +37,3 @@ set_target_properties( rocsolver-bench PROPERTIES
   CXX_EXTENSIONS OFF
   RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging"
 )
-
-target_link_libraries( rocsolver-bench PRIVATE rocsolver-common clients-common )

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -36,10 +36,9 @@ else( )
   target_link_libraries( rocsolver-bench PRIVATE hip::device )
 endif( )
 
-if( CMAKE_COMPILER_IS_GNUCXX OR CXX_VERSION_STRING MATCHES "clang")
-  # GCC or hip-clang needs specific flags to turn on f16c intrinsics
-  target_compile_options( rocsolver-bench PRIVATE -mf16c )
-endif( )
+# Turn on f16c intrinsics
+target_compile_options( rocsolver-bench PRIVATE -mf16c )
+target_compile_definitions( rocsolver-bench PRIVATE ROCM_USE_FLOAT16 )
 
 set_target_properties( rocsolver-bench PROPERTIES
   CXX_STANDARD 14
@@ -47,6 +46,5 @@ set_target_properties( rocsolver-bench PROPERTIES
   CXX_EXTENSIONS OFF
   RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging"
 )
-target_compile_definitions( rocsolver-bench PRIVATE ROCM_USE_FLOAT16 )
 
 target_link_libraries( rocsolver-bench PRIVATE rocsolver-common clients-common )

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -105,10 +105,9 @@ else( )
   target_link_libraries( rocsolver-test PRIVATE hip::device )
 endif( )
 
-if( CMAKE_COMPILER_IS_GNUCXX OR CXX_VERSION_STRING MATCHES "clang")
-  # GCC or hip-clang needs specific flags to turn on f16c intrinsics
-  target_compile_options( rocsolver-test PRIVATE -mf16c )
-endif( )
+# Turn on f16c intrinsics
+target_compile_options( rocsolver-test PRIVATE -mf16c )
+target_compile_definitions( rocsolver-test PRIVATE ROCM_USE_FLOAT16 )
 
 target_link_libraries( rocsolver-test PRIVATE m )
 set_target_properties( rocsolver-test PROPERTIES
@@ -117,6 +116,5 @@ set_target_properties( rocsolver-test PROPERTIES
   CXX_EXTENSIONS OFF
   RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging"
 )
-target_compile_definitions( rocsolver-test PRIVATE ROCM_USE_FLOAT16 )
 
 target_link_libraries( rocsolver-test PRIVATE rocsolver-common clients-common )

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -90,31 +90,20 @@ target_link_libraries( rocsolver-test PRIVATE
   cblas
   lapack
   GTest::GTest
+  hip::device
+  rocsolver-common
+  clients-common
+  m
   roc::rocsolver
 )
-
-if( CUDA_FOUND )
-  target_include_directories( rocsolver-test
-    PRIVATE
-      $<BUILD_INTERFACE:${CUDA_INCLUDE_DIRS}>
-      $<BUILD_INTERFACE:${hip_INCLUDE_DIRS}>
-    )
-  target_compile_definitions( rocsolver-test PRIVATE __HIP_PLATFORM_NVCC__ )
-  target_link_libraries( rocsolver-test PRIVATE ${CUDA_LIBRARIES} )
-else( )
-  target_link_libraries( rocsolver-test PRIVATE hip::device )
-endif( )
 
 # Turn on f16c intrinsics
 target_compile_options( rocsolver-test PRIVATE -mf16c )
 target_compile_definitions( rocsolver-test PRIVATE ROCM_USE_FLOAT16 )
 
-target_link_libraries( rocsolver-test PRIVATE m )
 set_target_properties( rocsolver-test PROPERTIES
   CXX_STANDARD 14
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging"
 )
-
-target_link_libraries( rocsolver-test PRIVATE rocsolver-common clients-common )

--- a/cmake/util.cmake
+++ b/cmake/util.cmake
@@ -3,34 +3,6 @@
 # ########################################################################
 
 # ########################################################################
-# target_link_libraries() override
-# Wraps the normal cmake function to cope with hipcc/nvcc weirdness.
-# ########################################################################
-function( target_link_libraries target_name )
-  # hipcc takes care of finding hip library dependencies internally; remove
-  # explicit mentions of them so cmake doesn't complain on nvcc path
-  # FIXME: This removes this target's hip libraries, even if this particular
-  #        target is not built using a compiler that can find its dependencies
-  #        internally (e.g. Fortran programs).
-  if( CUDA_FOUND AND CMAKE_CXX_COMPILER MATCHES ".*/hipcc$|.*/nvcc$" )
-    foreach( link_library ${ARGN} )
-      if( (link_library MATCHES "^hip::") )
-        message( DEBUG "Removing ${link_library} from ${target_name} library list" )
-      else( )
-        if( TARGET ${link_library} )
-          list( APPEND new_list -Xlinker ${link_library} )
-        else( )
-          list( APPEND new_list ${link_library} )
-        endif( )
-      endif( )
-    endforeach( )
-    _target_link_libraries( ${target_name} ${new_list} )
-  else( )
-    _target_link_libraries( ${target_name} ${ARGN} )
-  endif( )
-endfunction( )
-
-# ########################################################################
 # A helper function to prefix a source list of files with a common path
 # into a new list (non-destructive)
 # ########################################################################

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -10,3 +10,4 @@ set( source_files
 )
 prepend_path( "${CMAKE_CURRENT_SOURCE_DIR}/src/" source_files source_paths )
 target_sources( rocsolver-common INTERFACE ${source_paths} )
+target_compile_definitions( rocsolver-common INTERFACE __HIP_HCC_COMPAT_MODE__=1 )

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -78,18 +78,11 @@ set( CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION
   "\${CPACK_PACKAGING_INSTALL_PREFIX}/lib"
 )
 
-# Give rocsolver compiled for CUDA backend a different name
-if( CXX_VERSION_STRING MATCHES "clang" )
-    set( package_name rocsolver )
-else( )
-    set( package_name rocsolver-alt )
-endif( )
-
 set( ROCSOLVER_CONFIG_DIR "\${CPACK_PACKAGING_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
   CACHE PATH "Path placed into ldconfig file" )
 
 rocm_create_package(
-    NAME ${package_name}
+    NAME rocsolver
     DESCRIPTION "AMD ROCm SOLVER library"
     MAINTAINER "RocSOLVER maintainer <rocsolver-maintainer@amd.com>"
     LDCONFIG


### PR DESCRIPTION
We were parsing the output of `hipcc --version` to detect whether the compiler was ultimately going to be nvcc or hip-clang. However, the ROCmCC compiler is going to identify itself as "AMD clang" and `CXX_VERSION_STRING` is only populated with the first word, so the parsing code needs to be updated.

My proposal is to just delete all that code. Updating the check would be a smaller change, but the nvcc build doesn't actually work anyways so why bother maintaining code that exists to support a feature that wasn't implemented? This will also make it easier to use hip-clang directly, rather than relying on hipcc, as all the `if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$")` checks will go away with it.