### PR TITLE
Use clang directly when building C sources

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -402,9 +402,9 @@ case "${ID}" in
   ;;
 esac
 
-cxx="hipcc"
-cc="clang"
-fc="gfortran"
+export CXX="hipcc"
+export CC="clang"
+export FC="gfortran"
 
 # We append customary rocm path; if user provides custom rocm path in ${path}, our
 # hard-coded path has lesser priority
@@ -421,7 +421,7 @@ if [[ "${install_dependencies}" == true ]]; then
     pushd .
     printf "\033[32mBuilding \033[33mgoogletest & lapack\033[32m from source; installing into \033[33m/usr/local\033[0m\n"
     mkdir -p "${build_dir}/deps" && cd "${build_dir}/deps"
-    CXX=${cxx} CC=${cc} FC=${fc} ${cmake_executable} -lpthread -DBUILD_BOOST=OFF "${main}/deps"
+    ${cmake_executable} -lpthread -DBUILD_BOOST=OFF "${main}/deps"
     make -j$(nproc)
     elevate_if_not_root make install
     popd
@@ -499,7 +499,7 @@ case "${ID}" in
     ;;
 esac
 
-CXX=${cxx} CC=${cc} ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCMAKE_SHARED_LINKER_FLAGS="${rocm_rpath}" "${main}"
+${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCMAKE_SHARED_LINKER_FLAGS="${rocm_rpath}" "${main}"
 check_exit_code "$?"
 
 make -j$(nproc) install

--- a/install.sh
+++ b/install.sh
@@ -405,9 +405,6 @@ esac
 export CXX="hipcc"
 export CC="clang"
 export FC="gfortran"
-
-# We append customary rocm path; if user provides custom rocm path in ${path}, our
-# hard-coded path has lesser priority
 export PATH="${rocm_path}/bin:${rocm_path}/hip/bin:${rocm_path}/llvm/bin:${PATH}"
 
 # #################################################

--- a/install.sh
+++ b/install.sh
@@ -403,7 +403,7 @@ case "${ID}" in
 esac
 
 cxx="hipcc"
-cc="hipcc"
+cc="clang"
 fc="gfortran"
 
 # We append customary rocm path; if user provides custom rocm path in ${path}, our


### PR DESCRIPTION
The C source files in rocSOLVER are all standard C code and do not need any particular compiler. The ROCm version of clang is just a convenient compiler that is guaranteed to be available wherever rocSOLVER is being built.

The hipcc wrapper is able to build both C and C++, but there are some bugs in its interpretation of command-line options, which can sometimes cause issues when building C sources. For more details, see  https://github.com/ROCm-Developer-Tools/HIP/issues/2246

In particular, this problem is a barrier for building rocSOLVER with Ninja, as some of the C configure checks will fail with hipcc. We do not need the extra ROCm-related flags that the hipcc wrapper would add, so we might as well keep things simple by cutting out the middleman.