### PR TITLE
Add dlopen fix to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 - Error when calling STEQR with n=1 from batched routines
 - Added `roc::rocblas` to the `roc::rocsolver` CMake usage requirements
 - Added rocblas to the dependency list of the rocsolver deb and rpm packages
+- Fixed rocblas symbol loading with dlopen and the `RTLD_NOW | RTLD_LOCAL` options
 
 ### Known Issues
 - Thin-SVD implementation is failing in some cases (in particular m=300, n=120) due to a possible


### PR DESCRIPTION
Issue #230 was fixed in 5004d4e8d2c0ec5c392f0256d10b8a1d59c2121b, though it was not known at the time. This PR just adds it to the CHANGELOG.

Colin was looking at putting together a common testing strategy for this requirement that would verify all the math libraries, so I figured we could defer adding a test for now.