### PR TITLE
Remove unnecessary ROCSOLVER_COMMON namespace

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -27,10 +27,6 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS )
   )
   prepend_path( "${CMAKE_CURRENT_SOURCE_DIR}/" common_source_files common_source_paths )
   target_sources( clients-common INTERFACE ${common_source_paths} )
-  target_compile_definitions( clients-common
-    INTERFACE
-      ROCSOLVER_COMMON_NAMESPACE=rocsolver_clients
-  )
 
   if( BUILD_CLIENTS_BENCHMARKS )
     add_subdirectory( benchmarks )

--- a/common/include/common_host_helpers.hpp
+++ b/common/include/common_host_helpers.hpp
@@ -6,8 +6,6 @@
 
 #include "rocsolver_ostream.hpp"
 
-namespace ROCSOLVER_COMMON_NAMESPACE
-{
 /*
  * ===========================================================================
  *    common location for functions that are used by both the rocSOLVER
@@ -220,7 +218,3 @@ void print_host_matrix(rocsolver_ostream& os,
     }
     os << std::endl;
 }
-
-}
-
-using namespace ROCSOLVER_COMMON_NAMESPACE;

--- a/common/include/rocsolver_ostream.hpp
+++ b/common/include/rocsolver_ostream.hpp
@@ -27,8 +27,6 @@
 #include <unistd.h>
 #include <utility>
 
-namespace ROCSOLVER_COMMON_NAMESPACE
-{
 /*****************************************************************************
  * rocBLAS output streams                                                    *
  *****************************************************************************/
@@ -428,7 +426,3 @@ public:
     static std::ostream& yaml_on(std::ostream& os);
     static std::ostream& yaml_off(std::ostream& os);
 };
-
-}
-
-using namespace ROCSOLVER_COMMON_NAMESPACE;

--- a/common/src/common_host_helpers.cpp
+++ b/common/src/common_host_helpers.cpp
@@ -8,8 +8,6 @@
  * timing functions                                                    *
  ***********************************************************************/
 
-namespace ROCSOLVER_COMMON_NAMESPACE
-{
 /*! \brief  CPU Timer(in microsecond): synchronize with the default device and
  * return wall time */
 double get_time_us()
@@ -36,6 +34,4 @@ double get_time_us_no_sync()
     struct timespec tv;
     clock_gettime(CLOCK_MONOTONIC, &tv);
     return tv.tv_sec * 1'000'000llu + (tv.tv_nsec + 500llu) / 1000;
-}
-
 }

--- a/common/src/rocsolver_ostream.cpp
+++ b/common/src/rocsolver_ostream.cpp
@@ -4,18 +4,13 @@
 
 // Predeclare rocsolver_abort_once() for friend declaration in
 // rocsolver_ostream.hpp
-namespace ROCSOLVER_COMMON_NAMESPACE
-{
 static void rocsolver_abort_once [[noreturn]] ();
-}
 
 #include "rocsolver_ostream.hpp"
 #include <csignal>
 #include <fcntl.h>
 #include <type_traits>
 
-namespace ROCSOLVER_COMMON_NAMESPACE
-{
 /***********************************************************************
  * rocsolver_ostream functions                                           *
  ***********************************************************************/
@@ -358,6 +353,4 @@ rocsolver_ostream::worker::worker(int fd)
 
     // Detatch from the worker thread
     thread.detach();
-}
-
 }

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -177,11 +177,7 @@ if(OPTIMAL)
   target_compile_definitions(rocsolver PRIVATE OPTIMAL)
 endif( )
 
-target_compile_definitions( rocsolver
-  PRIVATE
-    ROCM_USE_FLOAT16
-    ROCSOLVER_COMMON_NAMESPACE=rocsolver_lib
-)
+target_compile_definitions( rocsolver PRIVATE ROCM_USE_FLOAT16 )
 
 add_armor_flags( rocsolver "${ARMOR_LEVEL}" )
 


### PR DESCRIPTION
Symbols marked as hidden can be repeated in another library / executable, and both sets of symbols will be considered distinct from each other. This namespace is therefore unnecessary.

See the algorithm for symbol resolution: https://www.airs.com/blog/archives/49