### PR TITLE
add gfx1030 to target list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ set(CMAKE_INSTALL_LIBDIR "lib" CACHE INTERNAL "Installation directory for librar
 
 # Set this before finding hip so that hip::device has the required arch flags
 # added as usage requirements on its interface
-set( AMDGPU_TARGETS "gfx803;gfx900;gfx906:xnack-;gfx908:xnack-" CACHE STRING "List of specific machine types for library to target" )
+set( AMDGPU_TARGETS "gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx1030" CACHE STRING "List of specific machine types for library to target" )
 
 # Find HIP dependencies
 find_package( hip REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm )


### PR DESCRIPTION
This is the only real difference in gfx1030 branch. The version string is not applicable, and the workaround for the compiler bug is not needed anymore (the bug was fixed by compiler team). 