### PR TITLE
Increase compile stage timeout on CI

### DIFF
--- a/.jenkins/debug.groovy
+++ b/.jenkins/debug.groovy
@@ -16,6 +16,8 @@ def runCI =
 
     def prj = new rocProject('rocSOLVER', 'Debug')
 
+    prj.timeout.compile = 600
+
     // customize for project
     prj.paths.build_command = './install.sh -c'
 

--- a/.jenkins/extended.groovy
+++ b/.jenkins/extended.groovy
@@ -15,6 +15,9 @@ def runCI =
     nodeDetails, jobName->
 
     def prj = new rocProject('rocSOLVER', 'Extended')
+
+    prj.timeout.compile = 600
+    
     // customize for project
     prj.paths.build_command = './install.sh -c'
 

--- a/.jenkins/precheckin.groovy
+++ b/.jenkins/precheckin.groovy
@@ -14,6 +14,8 @@ def runCI =
     nodeDetails, jobName->
 
     def prj = new rocProject('rocSOLVER', 'PreCheckin')
+
+    prj.timeout.compile = 600
     // customize for project
     prj.paths.build_command = './install.sh -c'
 

--- a/.jenkins/staticlibrary.groovy
+++ b/.jenkins/staticlibrary.groovy
@@ -15,6 +15,9 @@ def runCI =
     nodeDetails, jobName->
 
     def prj = new rocProject('rocSOLVER', 'StaticLibrary')
+
+    prj.timeout.compile = 600
+    
     // customize for project
     prj.paths.build_command = './install.sh -c --static'
 


### PR DESCRIPTION
With the addition of gfx90a targets, compiles times are in excess of 7 hours on some CI nodes. 

http://math-ci.rocm.amd.com/blue/organizations/jenkins/hipclang-bleeding-edge%2Fprecheckin%2FrocSOLVER/detail/develop/19/pipeline

This will allow CI to complete compilation without timing out but will need to investigate gfx90a long compile times