### PR TITLE
Remove gfx1030 from target list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ if( COMMAND rocm_check_target_ids )
 endif( )
 # Set this before finding hip so that hip::device has the required arch flags
 # added as usage requirements on its interface
-set( AMDGPU_TARGETS "gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx1030;${OPTIONAL_AMDGPU_TARGETS}"
+set( AMDGPU_TARGETS "gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;${OPTIONAL_AMDGPU_TARGETS}"
   CACHE STRING "List of specific machine types for library to target" )
 
 # Find HIP dependencies


### PR DESCRIPTION
Temporarily remove gfx1030 from the target list while some build
failures are investigated, and to reduce the load on the CI.

Thanks to @tfalders for identifying that the build issues were specific to gfx1030.