### PR TITLE
Fix rocSOLVER static library build

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -139,7 +139,7 @@ target_link_libraries( rocsolver
   PUBLIC
     roc::rocblas
   PRIVATE
-    rocsolver-common
+    $<BUILD_INTERFACE:rocsolver-common> # https://gitlab.kitware.com/cmake/cmake/-/issues/15415
     hip::device
     --rtlib=compiler-rt
     --unwindlib=libgcc


### PR DESCRIPTION
CMake will add an INTERFACE library as a link dependency of a static
library even when linked privately. That dependency is unnecessary,
but it appears to be the result of some internal CMake limitations.
The dependency causes problems when the rocsolver target is installed,
since the rocsolver-common target is not. We work around that by
specifying rocsolver-common should only be used during the build, not
during install.

In short, the CMake PUBLIC/PRIVATE/INTERFACE model is a bit of a leaky
abstraction. We need a minor workaround to plug the leak. It shouldn't
be necessary, but it is.