### PR TITLE
Enable ccache on the CI

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -7,7 +7,6 @@ def runCompileCommand(platform, project, jobName, boolean sameOrg=false)
 
     String compiler = 'hipcc'
     String hipClang = ''
-    String sles = platform.jenkinsLabel.contains('sles') ? '/usr/bin/sudo --preserve-env' : ''
     String debug = project.buildName.contains('Debug') ? '-g' : ''
     String centos = platform.jenkinsLabel.contains('centos') ? 'source scl_source enable devtoolset-7' : ''
     String noOptimizations = ''
@@ -30,7 +29,7 @@ def runCompileCommand(platform, project, jobName, boolean sameOrg=false)
                 ${getRocBLAS}
                 ${auxiliary.exitIfNotSuccess()}
                 ${centos}
-                ${sles} ${project.paths.build_command} ${hipClang} ${debug} ${noOptimizations}
+                ${project.paths.build_command} ${hipClang} ${debug} ${noOptimizations}
                 ${auxiliary.exitIfNotSuccess()}
                 """
     platform.runCommand(this, command)

--- a/.jenkins/debug.groovy
+++ b/.jenkins/debug.groovy
@@ -17,6 +17,7 @@ def runCI =
     def prj = new rocProject('rocSOLVER', 'Debug')
 
     prj.timeout.compile = 600
+    prj.defaults.ccache = true
 
     // customize for project
     prj.paths.build_command = './install.sh -c'

--- a/.jenkins/extended.groovy
+++ b/.jenkins/extended.groovy
@@ -17,6 +17,7 @@ def runCI =
     def prj = new rocProject('rocSOLVER', 'Extended')
 
     prj.timeout.compile = 600
+    prj.defaults.ccache = true
     
     // customize for project
     prj.paths.build_command = './install.sh -c'

--- a/.jenkins/precheckin.groovy
+++ b/.jenkins/precheckin.groovy
@@ -16,6 +16,7 @@ def runCI =
     def prj = new rocProject('rocSOLVER', 'PreCheckin')
 
     prj.timeout.compile = 600
+    prj.defaults.ccache = true
     // customize for project
     prj.paths.build_command = './install.sh -c'
 

--- a/.jenkins/staticlibrary.groovy
+++ b/.jenkins/staticlibrary.groovy
@@ -17,6 +17,7 @@ def runCI =
     def prj = new rocProject('rocSOLVER', 'StaticLibrary')
 
     prj.timeout.compile = 600
+    prj.defaults.ccache = true
     
     // customize for project
     prj.paths.build_command = './install.sh -c --static'


### PR DESCRIPTION
This PR makes use of ccache the default setting for rocSOLVER builds on
the CI. It can be disabled for PRs using the label `ci:no-ccache`.