### PR TITLE
Use standard library timer functions

### DIFF
--- a/clients/rocblascommon/utility.cpp
+++ b/clients/rocblascommon/utility.cpp
@@ -8,7 +8,6 @@
 #include <cstdlib>
 #include <cstring>
 //#include <regex>
-#include <sys/time.h>
 
 // Random number generator
 // Note: We do not use random_device to initialize the RNG, because we want

--- a/common/src/common_host_helpers.cpp
+++ b/common/src/common_host_helpers.cpp
@@ -2,36 +2,35 @@
  * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
+#include <chrono>
+
 #include "common_host_helpers.hpp"
 
 /***********************************************************************
  * timing functions                                                    *
  ***********************************************************************/
 
-/*! \brief  CPU Timer(in microsecond): synchronize with the default device and
- * return wall time */
+/* CPU Timer (in microseconds): no GPU synchronization
+ */
+double get_time_us_no_sync()
+{
+    namespace sc = std::chrono;
+    const sc::steady_clock::time_point t = sc::steady_clock::now();
+    return double(sc::duration_cast<sc::microseconds>(t.time_since_epoch()).count());
+}
+
+/* CPU Timer (in microseconds): synchronize with the default device and return wall time
+ */
 double get_time_us()
 {
     hipDeviceSynchronize();
-    struct timespec tv;
-    clock_gettime(CLOCK_MONOTONIC, &tv);
-    return tv.tv_sec * 1'000'000llu + (tv.tv_nsec + 500llu) / 1000;
+    return get_time_us_no_sync();
 }
 
-/*! \brief  CPU Timer(in microsecond): synchronize with given queue/stream and
- * return wall time */
+/* CPU Timer (in microseconds): synchronize with given queue/stream and return wall time
+ */
 double get_time_us_sync(hipStream_t stream)
 {
     hipStreamSynchronize(stream);
-    struct timespec tv;
-    clock_gettime(CLOCK_MONOTONIC, &tv);
-    return tv.tv_sec * 1'000'000llu + (tv.tv_nsec + 500llu) / 1000;
-}
-
-/*! \brief  CPU Timer(in microsecond): no GPU synchronization */
-double get_time_us_no_sync()
-{
-    struct timespec tv;
-    clock_gettime(CLOCK_MONOTONIC, &tv);
-    return tv.tv_sec * 1'000'000llu + (tv.tv_nsec + 500llu) / 1000;
+    return get_time_us_no_sync();
 }

--- a/library/src/common/rocsolver_logger.cpp
+++ b/library/src/common/rocsolver_logger.cpp
@@ -7,7 +7,6 @@
 #include <cerrno>
 #include <climits>
 #include <cstdlib>
-#include <sys/time.h>
 
 #define STRINGIFY(s) STRINGIFY_HELPER(s)
 #define STRINGIFY_HELPER(s) #s


### PR DESCRIPTION
This PR replaces [`clock_gettime`](https://linux.die.net/man/3/clock_gettime) with [`std::chrono::steady_clock`](https://en.cppreference.com/w/cpp/chrono/steady_clock) for portability. When running the rocsolver-bench, I'm seeing a modest change of ~10% in the reported time for the CPU implementation, but the GPU time remains unchanged.

As far as I can tell, the change in CPU time is an actual change in the time taken to perform the benchmarked operation, and not a result of measurement error. The CPU benchmaking time also varies when I make unrelated changes, so I suspect that our benchmarking of the CPU implementation is just not as robust as the GPU benchmarking.