### PR TITLE
Use -h to print install.sh help message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,14 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
     - HEGVD (with batched and strided\_batched versions)
 
 ### Optimizations
+
 ### Changed
+- The -h option of install.sh now prints a help message, instead of doing nothing.
+
 ### Removed
+
 ### Fixed
+
 ### Known Issues
 
 

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@ Usage:
   $0 <options> (modify default behavior according to the following flags)
 
 Options:
-  --help                      Print this help message.
+  -h | --help                 Print this help message.
 
   --build_dir <builddir>      Specify path to the configure & build process output directory.
                               Relative paths are relative to the current directory.
@@ -53,7 +53,7 @@ Options:
 
   --clients-only              Pass this flag to skip building the library and only build the clients.
 
-  -h | --hip-clang            Pass this flag to build using the hip-clang compiler.
+  --hip-clang                 Pass this flag to build using the hip-clang compiler.
                               hip-clang is currently the only supported compiler, so this flag has no effect.
 
   -s | --static               Pass this flag to build rocsolver as a static library.
@@ -327,7 +327,7 @@ eval set -- "${GETOPT_PARSE}"
 
 while true; do
   case "${1}" in
-    --help)
+    -h|--help)
         display_help
         exit 0
         ;;
@@ -354,7 +354,7 @@ while true; do
     -s|--static)
         static_lib=true
         shift ;;
-    -h | --hip-clang)
+    --hip-clang)
         # flag has no effect; hip-clang is the default
         shift ;;
     -n | --no-optimizations)


### PR DESCRIPTION
install.sh is very unusual in that it uses the -h flag to specify that the library should be compiled using hip-clang, instead of the standard behaviour of printing the help message. Since hip-clang is now the default compiler and the -h flag currently does nothing, I think we should change it to fit the standard behaviour.