### PR TITLE
fix getri-out-of-place tests

### DIFF
--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -13,8 +13,8 @@ find_package( GTest REQUIRED )
 
 set(roclapack_test_source
     # linear systems solvers
-    getrs_gtest.cpp
     getri_gtest.cpp
+    getrs_gtest.cpp
     trtri_gtest.cpp
     # least squares solvers
     gels_gtest.cpp


### PR DESCRIPTION
As per discussion in rocSOLVER's teams channel. 
(I tested it with the `compute-rocm-rel-4.2:21-STG1` container on a gfx900 machine and it worked)