### PR TITLE
Minor code coverage build modifications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,8 +94,8 @@ option( BUILD_CLIENTS_SAMPLES "Build rocSOLVER samples" OFF )
 # FOR OPTIONAL CODE COVERAGE
 option(BUILD_CODE_COVERAGE "Build rocSOLVER with code coverage enabled" OFF)
 if(BUILD_CODE_COVERAGE)
-  add_compile_options(-g -fprofile-arcs -ftest-coverage)
-  add_link_options(-g --coverage)
+  add_compile_options(-fprofile-arcs -ftest-coverage)
+  add_link_options(--coverage)
 endif()
 
 message(STATUS "Tests: ${BUILD_CLIENTS_TESTS}")
@@ -194,5 +194,5 @@ add_custom_target(coverage_cleanup
     COMMAND find ${CMAKE_BINARY_DIR} -name *.gcda -delete
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )
-  
+
 endif()

--- a/install.sh
+++ b/install.sh
@@ -302,7 +302,7 @@ build_docs=false
 optimal=true
 cleanup=false
 architecture=
-build_coverage=false
+build_codecoverage=false
 
 
 # #################################################
@@ -388,7 +388,7 @@ while true; do
         build_relocatable=true
         shift ;;
     --codecoverage)
-        build_coverage=true
+        build_codecoverage=true
         shift ;;
     -k|--relwithdebinfo)
         build_type=RelWithDebInfo
@@ -543,9 +543,9 @@ case "${ID}" in
     ;;
 esac
 
-if [[ "${build_coverage}" == true ]]; then
+if [[ "${build_codecoverage}" == true ]]; then
     if [[ "${build_type}" == Release ]]; then
-        echo "Code coverage is not supported in Release mode, to enable code coverage select either Debug mode (-g | --debug) or RelWithDebInfo mode (-k | --relwithdebinfo); aborting";
+        echo "Code coverage is chosen to be disabled in Release mode, to enable code coverage select either Debug mode (-g | --debug) or RelWithDebInfo mode (-k | --relwithdebinfo); aborting";
         exit 1
     fi
     cmake_common_options="${cmake_common_options} -DBUILD_CODE_COVERAGE=ON"


### PR DESCRIPTION
make things standard across libraries. remove g option since it's already automatically added in the allowed modes.