### PR TITLE
Workaround for debug binary size on CI

### DIFF
--- a/.jenkins/debug.groovy
+++ b/.jenkins/debug.groovy
@@ -20,7 +20,7 @@ def runCI =
     prj.defaults.ccache = true
 
     // customize for project
-    prj.paths.build_command = './install.sh -c'
+    prj.paths.build_command = './install.sh -a "gfx900;gfx906:xnack-" -c'
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)


### PR DESCRIPTION
Building for all architectures results in a binary that is too large
(>2GB) and will fail to link. However, the debug build is only tested
for a couple architectures. For now, limit the build to those tested
architectures, until we can find a general solution for the binary
size problem.