### PR TITLE
Workaround for static library size on CI

### DIFF
--- a/.jenkins/staticlibrary.groovy
+++ b/.jenkins/staticlibrary.groovy
@@ -20,7 +20,7 @@ def runCI =
     prj.defaults.ccache = true
 
     // customize for project
-    prj.paths.build_command = './install.sh -c --static'
+    prj.paths.build_command = './install.sh -a "gfx900;gfx906:xnack-" -c --static'
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)


### PR DESCRIPTION
Building for all architectures results in a binary that is too large
to link into our test clients. However, the static build is only
tested for a couple architectures. For now, limit the build to those
tested architectures, until we can find a general solution for the
binary size problem.