### PR TITLE
Minor build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,12 @@ option( BUILD_CLIENTS_BENCHMARKS "Build rocSOLVER benchmarks" OFF )
 option( BUILD_CLIENTS_SAMPLES "Build rocSOLVER samples" OFF )
 option(BUILD_ADDRESS_SANITIZER "Build with address sanitizer enabled" OFF)
 
+if(BUILD_ADDRESS_SANITIZER)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -shared-libasan")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -shared-libasan")
+  add_link_options(-fuse-ld=lld)
+endif()
+
 # FOR OPTIONAL CODE COVERAGE
 option(BUILD_CODE_COVERAGE "Build rocSOLVER with code coverage enabled" OFF)
 if(BUILD_CODE_COVERAGE)
@@ -135,12 +141,6 @@ add_subdirectory( common )
 if( BUILD_LIBRARY )
   add_subdirectory( library )
 endif( )
-
-if(BUILD_ADDRESS_SANITIZER)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -shared-libasan")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -shared-libasan")
-  add_link_options(-fuse-ld=lld)
-endif()
 
 # Build clients of the library
 if( BUILD_CLIENTS_TESTS OR BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_SAMPLES )

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -10,4 +10,3 @@ set( source_files
 prepend_path( "${CMAKE_CURRENT_SOURCE_DIR}/src/" source_files source_paths )
 target_sources( rocsolver-common INTERFACE ${source_paths} )
 target_compile_definitions( rocsolver-common INTERFACE __HIP_HCC_COMPAT_MODE__=1 )
-target_link_libraries( rocsolver-common INTERFACE fmt::fmt )


### PR DESCRIPTION
Address sanitizer should be enabled before the rocsolver target is
created, so that the flags are enabled when building the library
itself.

fmt::fmt should not be on rocsolver-common. The library and the client
each handle linking it themselves. That snippet was added in error while
resolving a merge conflict.