### PR TITLE
Update to LAPACK v3.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 ### Added
 ### Optimizations
 ### Changed
+- Raised reference LAPACK version used for rocSOLVER test and benchmark clients to v3.9.1
+
 ### Removed
 ### Fixed
 ### Known Issues

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -10,14 +10,10 @@ add_executable(rocsolver-bench client.cpp)
 
 add_armor_flags(rocsolver-bench "${ARMOR_LEVEL}")
 
-# External header includes
-target_include_directories(rocsolver-bench SYSTEM PRIVATE
-  ${CBLAS_INCLUDE_DIRS}
-)
-
 target_link_libraries(rocsolver-bench PRIVATE
   cblas
   lapack
+  blas
   Threads::Threads
   hip::device
   rocsolver-common

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -84,14 +84,10 @@ add_armor_flags(rocsolver-test "${ARMOR_LEVEL}")
 
 target_compile_definitions(rocsolver-test PRIVATE GOOGLE_TEST)
 
-# External header includes included as system files
-target_include_directories(rocsolver-test SYSTEM PRIVATE
-  ${CBLAS_INCLUDE_DIRS}
-)
-
 target_link_libraries(rocsolver-test PRIVATE
   cblas
   lapack
+  blas
   GTest::GTest
   hip::device
   rocsolver-common

--- a/deps/external-lapack.cmake
+++ b/deps/external-lapack.cmake
@@ -10,8 +10,8 @@ set( PREFIX_LAPACK ${CMAKE_INSTALL_PREFIX} CACHE PATH "Location where lapack sho
 set( lapack_cmake_args -DCMAKE_INSTALL_PREFIX=${PREFIX_LAPACK} )
 append_cmake_cli_arguments( lapack_cmake_args lapack_cmake_args )
 
-set( lapack_git_repository "https://github.com/Reference-LAPACK/lapack-release" CACHE STRING "URL to download lapack from" )
-set( lapack_git_tag "lapack-3.7.1" CACHE STRING "git branch" )
+set( lapack_git_repository "https://github.com/Reference-LAPACK/lapack.git" CACHE STRING "URL to download lapack from" )
+set( lapack_git_tag "v3.9.1" CACHE STRING "git branch" )
 
 # message( STATUS "lapack_make ( " ${lapack_make} " ) " )
 # message( STATUS "lapack_cmake_args ( " ${lapack_cmake_args} " ) " )


### PR DESCRIPTION
Switched to download tagged versions from the main lapack repository,
as the lapack-release repository has not been updated in several years.
    
There have been improvements in the LAPACK CMake such that special
handling for CBLAS_INCLUDE_DIRS is no longer needed.
    
It should not be necessary to specify lapack or blas if cblas has been
specified, but the lapack targets do not fully specify their library
dependencies. We build lapack with the reference blas, so we specify
that explicitly in the clients. (Explicitly specifying that blas should be
linked is not strictly necessary on Linux, but is required on Windows.)

(The Windows CI is using prebuilt copies of LAPACK 3.9.0.)