### PR TITLE
Consistent ordering for template arguments

### DIFF
--- a/clients/common/lapack_host_reference.cpp
+++ b/clients/common/lapack_host_reference.cpp
@@ -2288,7 +2288,7 @@ void cblas_latrd<double, double>(rocblas_fill uplo,
 }
 
 template <>
-void cblas_latrd<float, rocblas_float_complex>(rocblas_fill uplo,
+void cblas_latrd<rocblas_float_complex, float>(rocblas_fill uplo,
                                                rocblas_int n,
                                                rocblas_int k,
                                                rocblas_float_complex* A,
@@ -2303,7 +2303,7 @@ void cblas_latrd<float, rocblas_float_complex>(rocblas_fill uplo,
 }
 
 template <>
-void cblas_latrd<double, rocblas_double_complex>(rocblas_fill uplo,
+void cblas_latrd<rocblas_double_complex, double>(rocblas_fill uplo,
                                                  rocblas_int n,
                                                  rocblas_int k,
                                                  rocblas_double_complex* A,
@@ -2357,7 +2357,7 @@ void cblas_labrd<double, double>(rocblas_int m,
 }
 
 template <>
-void cblas_labrd<float, rocblas_float_complex>(rocblas_int m,
+void cblas_labrd<rocblas_float_complex, float>(rocblas_int m,
                                                rocblas_int n,
                                                rocblas_int nb,
                                                rocblas_float_complex* A,
@@ -2376,7 +2376,7 @@ void cblas_labrd<float, rocblas_float_complex>(rocblas_int m,
 }
 
 template <>
-void cblas_labrd<double, rocblas_double_complex>(rocblas_int m,
+void cblas_labrd<rocblas_double_complex, double>(rocblas_int m,
                                                  rocblas_int n,
                                                  rocblas_int nb,
                                                  rocblas_double_complex* A,
@@ -5075,7 +5075,7 @@ void cblas_gebd2<double, double>(rocblas_int m,
 }
 
 template <>
-void cblas_gebd2<float, rocblas_float_complex>(rocblas_int m,
+void cblas_gebd2<rocblas_float_complex, float>(rocblas_int m,
                                                rocblas_int n,
                                                rocblas_float_complex* A,
                                                rocblas_int lda,
@@ -5090,7 +5090,7 @@ void cblas_gebd2<float, rocblas_float_complex>(rocblas_int m,
 }
 
 template <>
-void cblas_gebd2<double, rocblas_double_complex>(rocblas_int m,
+void cblas_gebd2<rocblas_double_complex, double>(rocblas_int m,
                                                  rocblas_int n,
                                                  rocblas_double_complex* A,
                                                  rocblas_int lda,
@@ -5138,7 +5138,7 @@ void cblas_gebrd<double, double>(rocblas_int m,
 }
 
 template <>
-void cblas_gebrd<float, rocblas_float_complex>(rocblas_int m,
+void cblas_gebrd<rocblas_float_complex, float>(rocblas_int m,
                                                rocblas_int n,
                                                rocblas_float_complex* A,
                                                rocblas_int lda,
@@ -5154,7 +5154,7 @@ void cblas_gebrd<float, rocblas_float_complex>(rocblas_int m,
 }
 
 template <>
-void cblas_gebrd<double, rocblas_double_complex>(rocblas_int m,
+void cblas_gebrd<rocblas_double_complex, double>(rocblas_int m,
                                                  rocblas_int n,
                                                  rocblas_double_complex* A,
                                                  rocblas_int lda,
@@ -5203,7 +5203,7 @@ void cblas_sytrd_hetrd<double, double>(rocblas_fill uplo,
 }
 
 template <>
-void cblas_sytrd_hetrd<float, rocblas_float_complex>(rocblas_fill uplo,
+void cblas_sytrd_hetrd<rocblas_float_complex, float>(rocblas_fill uplo,
                                                      rocblas_int n,
                                                      rocblas_float_complex* A,
                                                      rocblas_int lda,
@@ -5219,7 +5219,7 @@ void cblas_sytrd_hetrd<float, rocblas_float_complex>(rocblas_fill uplo,
 }
 
 template <>
-void cblas_sytrd_hetrd<double, rocblas_double_complex>(rocblas_fill uplo,
+void cblas_sytrd_hetrd<rocblas_double_complex, double>(rocblas_fill uplo,
                                                        rocblas_int n,
                                                        rocblas_double_complex* A,
                                                        rocblas_int lda,
@@ -5264,7 +5264,7 @@ void cblas_sytd2_hetd2<double, double>(rocblas_fill uplo,
 }
 
 template <>
-void cblas_sytd2_hetd2<float, rocblas_float_complex>(rocblas_fill uplo,
+void cblas_sytd2_hetd2<rocblas_float_complex, float>(rocblas_fill uplo,
                                                      rocblas_int n,
                                                      rocblas_float_complex* A,
                                                      rocblas_int lda,
@@ -5278,7 +5278,7 @@ void cblas_sytd2_hetd2<float, rocblas_float_complex>(rocblas_fill uplo,
 }
 
 template <>
-void cblas_sytd2_hetd2<double, rocblas_double_complex>(rocblas_fill uplo,
+void cblas_sytd2_hetd2<rocblas_double_complex, double>(rocblas_fill uplo,
                                                        rocblas_int n,
                                                        rocblas_double_complex* A,
                                                        rocblas_int lda,
@@ -5335,7 +5335,7 @@ void cblas_steqr<double, double>(rocblas_evect evect,
     dsteqr_(&evectC, &n, D, E, C, &ldc, work, info);
 }
 template <>
-void cblas_steqr<float, rocblas_float_complex>(rocblas_evect evect,
+void cblas_steqr<rocblas_float_complex, float>(rocblas_evect evect,
                                                rocblas_int n,
                                                float* D,
                                                float* E,
@@ -5349,7 +5349,7 @@ void cblas_steqr<float, rocblas_float_complex>(rocblas_evect evect,
 }
 
 template <>
-void cblas_steqr<double, rocblas_double_complex>(rocblas_evect evect,
+void cblas_steqr<rocblas_double_complex, double>(rocblas_evect evect,
                                                  rocblas_int n,
                                                  double* D,
                                                  double* E,
@@ -5401,7 +5401,7 @@ void cblas_stedc<double, double>(rocblas_evect evect,
     dstedc_(&evectC, &n, D, E, C, &ldc, rwork, &lrwork, iwork, &liwork, info);
 }
 template <>
-void cblas_stedc<float, rocblas_float_complex>(rocblas_evect evect,
+void cblas_stedc<rocblas_float_complex, float>(rocblas_evect evect,
                                                rocblas_int n,
                                                float* D,
                                                float* E,
@@ -5420,7 +5420,7 @@ void cblas_stedc<float, rocblas_float_complex>(rocblas_evect evect,
 }
 
 template <>
-void cblas_stedc<double, rocblas_double_complex>(rocblas_evect evect,
+void cblas_stedc<rocblas_double_complex, double>(rocblas_evect evect,
                                                  rocblas_int n,
                                                  double* D,
                                                  double* E,
@@ -5758,7 +5758,7 @@ void cblas_sygv_hegv<double, double>(rocblas_eform itype,
 }
 
 template <>
-void cblas_sygv_hegv<float, rocblas_float_complex>(rocblas_eform itype,
+void cblas_sygv_hegv<rocblas_float_complex, float>(rocblas_eform itype,
                                                    rocblas_evect evect,
                                                    rocblas_fill uplo,
                                                    rocblas_int n,
@@ -5779,7 +5779,7 @@ void cblas_sygv_hegv<float, rocblas_float_complex>(rocblas_eform itype,
 }
 
 template <>
-void cblas_sygv_hegv<double, rocblas_double_complex>(rocblas_eform itype,
+void cblas_sygv_hegv<rocblas_double_complex, double>(rocblas_eform itype,
                                                      rocblas_evect evect,
                                                      rocblas_fill uplo,
                                                      rocblas_int n,
@@ -5849,7 +5849,7 @@ void cblas_sygvd_hegvd<double, double>(rocblas_eform itype,
 }
 
 template <>
-void cblas_sygvd_hegvd<float, rocblas_float_complex>(rocblas_eform itype,
+void cblas_sygvd_hegvd<rocblas_float_complex, float>(rocblas_eform itype,
                                                      rocblas_evect evect,
                                                      rocblas_fill uplo,
                                                      rocblas_int n,
@@ -5874,7 +5874,7 @@ void cblas_sygvd_hegvd<float, rocblas_float_complex>(rocblas_eform itype,
 }
 
 template <>
-void cblas_sygvd_hegvd<double, rocblas_double_complex>(rocblas_eform itype,
+void cblas_sygvd_hegvd<rocblas_double_complex, double>(rocblas_eform itype,
                                                        rocblas_evect evect,
                                                        rocblas_fill uplo,
                                                        rocblas_int n,

--- a/clients/include/lapack_host_reference.hpp
+++ b/clients/include/lapack_host_reference.hpp
@@ -212,7 +212,7 @@ void cblas_larfb(rocblas_side side,
                  T* W,
                  rocblas_int ldw);
 
-template <typename S, typename T>
+template <typename T, typename S>
 void cblas_latrd(rocblas_fill uplo,
                  rocblas_int n,
                  rocblas_int k,
@@ -223,7 +223,7 @@ void cblas_latrd(rocblas_fill uplo,
                  T* W,
                  rocblas_int ldw);
 
-template <typename S, typename T>
+template <typename T, typename S>
 void cblas_labrd(rocblas_int m,
                  rocblas_int n,
                  rocblas_int nb,
@@ -478,10 +478,10 @@ void cblas_ormtr_unmtr(rocblas_side side,
                        T* work,
                        rocblas_int sizeW);
 
-template <typename S, typename T>
+template <typename T, typename S>
 void cblas_gebd2(rocblas_int m, rocblas_int n, T* A, rocblas_int lda, S* D, S* E, T* tauq, T* taup, T* work);
 
-template <typename S, typename T>
+template <typename T, typename S>
 void cblas_gebrd(rocblas_int m,
                  rocblas_int n,
                  T* A,
@@ -493,7 +493,7 @@ void cblas_gebrd(rocblas_int m,
                  T* work,
                  rocblas_int size_w);
 
-template <typename S, typename T>
+template <typename T, typename S>
 void cblas_sytrd_hetrd(rocblas_fill uplo,
                        rocblas_int n,
                        T* A,
@@ -504,7 +504,7 @@ void cblas_sytrd_hetrd(rocblas_fill uplo,
                        T* work,
                        rocblas_int size_w);
 
-template <typename S, typename T>
+template <typename T, typename S>
 void cblas_sytd2_hetd2(rocblas_fill uplo, rocblas_int n, T* A, rocblas_int lda, S* D, S* E, T* tau);
 
 template <typename T, typename W>
@@ -527,7 +527,7 @@ void cblas_gesvd(rocblas_svect leftv,
 template <typename T>
 void cblas_sterf(rocblas_int n, T* D, T* E);
 
-template <typename S, typename T>
+template <typename T, typename S>
 void cblas_steqr(rocblas_evect evect,
                  rocblas_int n,
                  S* D,
@@ -537,7 +537,7 @@ void cblas_steqr(rocblas_evect evect,
                  S* work,
                  rocblas_int* info);
 
-template <typename S, typename T>
+template <typename T, typename S>
 void cblas_stedc(rocblas_evect evect,
                  rocblas_int n,
                  S* D,
@@ -598,7 +598,7 @@ void cblas_syevd_heevd(rocblas_evect evect,
                        rocblas_int liwork,
                        rocblas_int* info);
 
-template <typename S, typename T>
+template <typename T, typename S>
 void cblas_sygv_hegv(rocblas_eform itype,
                      rocblas_evect evect,
                      rocblas_fill uplo,
@@ -613,7 +613,7 @@ void cblas_sygv_hegv(rocblas_eform itype,
                      S* rwork,
                      rocblas_int* info);
 
-template <typename S, typename T>
+template <typename T, typename S>
 void cblas_sygvd_hegvd(rocblas_eform itype,
                        rocblas_evect evect,
                        rocblas_fill uplo,

--- a/clients/include/testing_bdsqr.hpp
+++ b/clients/include/testing_bdsqr.hpp
@@ -11,7 +11,7 @@
 #include "rocsolver_arguments.hpp"
 #include "rocsolver_test.hpp"
 
-template <typename S, typename T>
+template <typename T, typename S>
 void bdsqr_checkBadArgs(const rocblas_handle handle,
                         const rocblas_fill uplo,
                         const rocblas_int n,
@@ -99,7 +99,7 @@ void testing_bdsqr_bad_arg()
                        ldu, dC.data(), ldc, dinfo.data());
 }
 
-template <bool CPU, bool GPU, typename S, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+template <bool CPU, bool GPU, typename T, typename S, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
 void bdsqr_initData(const rocblas_handle handle,
                     const rocblas_fill uplo,
                     const rocblas_int n,
@@ -223,8 +223,8 @@ void bdsqr_getError(const rocblas_handle handle,
     std::vector<S> E(nv);
 
     // input data initialization
-    bdsqr_initData<true, true, S, T>(handle, uplo, n, nv, nu, nc, dD, dE, dV, ldv, dU, ldu, dC, ldc,
-                                     dInfo, hD, hE, hV, hU, hC, hInfo, D, E);
+    bdsqr_initData<true, true, T>(handle, uplo, n, nv, nu, nc, dD, dE, dV, ldv, dU, ldu, dC, ldc,
+                                  dInfo, hD, hE, hV, hU, hC, hInfo, D, E);
 
     // execute computations
     // CPU lapack
@@ -358,8 +358,8 @@ void bdsqr_getPerfData(const rocblas_handle handle,
 
     if(!perf)
     {
-        bdsqr_initData<true, false, S, T>(handle, uplo, n, nv, nu, nc, dD, dE, dV, ldv, dU, ldu, dC,
-                                          ldc, dInfo, hD, hE, hV, hU, hC, hInfo, D, E);
+        bdsqr_initData<true, false, T>(handle, uplo, n, nv, nu, nc, dD, dE, dV, ldv, dU, ldu, dC,
+                                       ldc, dInfo, hD, hE, hV, hU, hC, hInfo, D, E);
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
@@ -368,14 +368,14 @@ void bdsqr_getPerfData(const rocblas_handle handle,
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
-    bdsqr_initData<true, false, S, T>(handle, uplo, n, nv, nu, nc, dD, dE, dV, ldv, dU, ldu, dC,
-                                      ldc, dInfo, hD, hE, hV, hU, hC, hInfo, D, E);
+    bdsqr_initData<true, false, T>(handle, uplo, n, nv, nu, nc, dD, dE, dV, ldv, dU, ldu, dC, ldc,
+                                   dInfo, hD, hE, hV, hU, hC, hInfo, D, E);
 
     // cold calls
     for(int iter = 0; iter < 2; iter++)
     {
-        bdsqr_initData<false, true, S, T>(handle, uplo, n, nv, nu, nc, dD, dE, dV, ldv, dU, ldu, dC,
-                                          ldc, dInfo, hD, hE, hV, hU, hC, hInfo, D, E);
+        bdsqr_initData<false, true, T>(handle, uplo, n, nv, nu, nc, dD, dE, dV, ldv, dU, ldu, dC,
+                                       ldc, dInfo, hD, hE, hV, hU, hC, hInfo, D, E);
 
         CHECK_ROCBLAS_ERROR(rocsolver_bdsqr(handle, uplo, n, nv, nu, nc, dD.data(), dE.data(),
                                             dV.data(), ldv, dU.data(), ldu, dC.data(), ldc,
@@ -395,8 +395,8 @@ void bdsqr_getPerfData(const rocblas_handle handle,
 
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
-        bdsqr_initData<false, true, S, T>(handle, uplo, n, nv, nu, nc, dD, dE, dV, ldv, dU, ldu, dC,
-                                          ldc, dInfo, hD, hE, hV, hU, hC, hInfo, D, E);
+        bdsqr_initData<false, true, T>(handle, uplo, n, nv, nu, nc, dD, dE, dV, ldv, dU, ldu, dC,
+                                       ldc, dInfo, hD, hE, hV, hU, hC, hInfo, D, E);
 
         start = get_time_us_sync(stream);
         rocsolver_bdsqr(handle, uplo, n, nv, nu, nc, dD.data(), dE.data(), dV.data(), ldv,

--- a/clients/include/testing_gebd2_gebrd.hpp
+++ b/clients/include/testing_gebd2_gebrd.hpp
@@ -235,9 +235,9 @@ void gebd2_gebrd_getError(const rocblas_handle handle,
         {
             memcpy(hARes[b], hA[b], lda * n * sizeof(T));
             GEBRD
-            ? cblas_gebrd<S, T>(m, n, hARes[b], lda, hD[b], hE[b], hTauq[b], hTaup[b], hW.data(),
-                                max(m, n))
-            : cblas_gebd2<S, T>(m, n, hARes[b], lda, hD[b], hE[b], hTauq[b], hTaup[b], hW.data());
+            ? cblas_gebrd<T>(m, n, hARes[b], lda, hD[b], hE[b], hTauq[b], hTaup[b], hW.data(),
+                             max(m, n))
+            : cblas_gebd2<T>(m, n, hARes[b], lda, hD[b], hE[b], hTauq[b], hTaup[b], hW.data());
         }
     }
 
@@ -363,9 +363,9 @@ void gebd2_gebrd_getPerfData(const rocblas_handle handle,
         *cpu_time_used = get_time_us_no_sync();
         for(rocblas_int b = 0; b < bc; ++b)
         {
-            GEBRD ? cblas_gebrd<S, T>(m, n, hA[b], lda, hD[b], hE[b], hTauq[b], hTaup[b], hW.data(),
-                                      max(m, n))
-                  : cblas_gebd2<S, T>(m, n, hA[b], lda, hD[b], hE[b], hTauq[b], hTaup[b], hW.data());
+            GEBRD ? cblas_gebrd<T>(m, n, hA[b], lda, hD[b], hE[b], hTauq[b], hTaup[b], hW.data(),
+                                   max(m, n))
+                  : cblas_gebd2<T>(m, n, hA[b], lda, hD[b], hE[b], hTauq[b], hTaup[b], hW.data());
         }
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }

--- a/clients/include/testing_gebd2_gebrd.hpp
+++ b/clients/include/testing_gebd2_gebrd.hpp
@@ -11,7 +11,7 @@
 #include "rocsolver_arguments.hpp"
 #include "rocsolver_test.hpp"
 
-template <bool STRIDED, bool GEBRD, typename S, typename T, typename U>
+template <bool STRIDED, bool GEBRD, typename T, typename S, typename U>
 void gebd2_gebrd_checkBadArgs(const rocblas_handle handle,
                               const rocblas_int m,
                               const rocblas_int n,
@@ -133,7 +133,7 @@ void testing_gebd2_gebrd_bad_arg()
     }
 }
 
-template <bool CPU, bool GPU, typename S, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
 void gebd2_gebrd_initData(const rocblas_handle handle,
                           const rocblas_int m,
                           const rocblas_int n,
@@ -182,7 +182,7 @@ void gebd2_gebrd_initData(const rocblas_handle handle,
     }
 }
 
-template <bool STRIDED, bool GEBRD, typename S, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+template <bool STRIDED, bool GEBRD, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
 void gebd2_gebrd_getError(const rocblas_handle handle,
                           const rocblas_int m,
                           const rocblas_int n,
@@ -212,8 +212,8 @@ void gebd2_gebrd_getError(const rocblas_handle handle,
     std::vector<T> hW(max(m, n));
 
     // input data initialization
-    gebd2_gebrd_initData<true, true, S, T>(handle, m, n, dA, lda, stA, dD, stD, dE, stE, dTauq, stQ,
-                                           dTaup, stP, bc, hA, hD, hE, hTauq, hTaup);
+    gebd2_gebrd_initData<true, true, T>(handle, m, n, dA, lda, stA, dD, stD, dE, stE, dTauq, stQ,
+                                        dTaup, stP, bc, hA, hD, hE, hTauq, hTaup);
 
     // execute computations
     // use verify_implicit_test to check correctness of the implicit test using
@@ -325,7 +325,7 @@ void gebd2_gebrd_getError(const rocblas_handle handle,
     }
 }
 
-template <bool STRIDED, bool GEBRD, typename S, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+template <bool STRIDED, bool GEBRD, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
 void gebd2_gebrd_getPerfData(const rocblas_handle handle,
                              const rocblas_int m,
                              const rocblas_int n,
@@ -356,8 +356,8 @@ void gebd2_gebrd_getPerfData(const rocblas_handle handle,
 
     if(!perf)
     {
-        gebd2_gebrd_initData<true, false, S, T>(handle, m, n, dA, lda, stA, dD, stD, dE, stE, dTauq,
-                                                stQ, dTaup, stP, bc, hA, hD, hE, hTauq, hTaup);
+        gebd2_gebrd_initData<true, false, T>(handle, m, n, dA, lda, stA, dD, stD, dE, stE, dTauq,
+                                             stQ, dTaup, stP, bc, hA, hD, hE, hTauq, hTaup);
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
@@ -370,14 +370,14 @@ void gebd2_gebrd_getPerfData(const rocblas_handle handle,
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
-    gebd2_gebrd_initData<true, false, S, T>(handle, m, n, dA, lda, stA, dD, stD, dE, stE, dTauq,
-                                            stQ, dTaup, stP, bc, hA, hD, hE, hTauq, hTaup);
+    gebd2_gebrd_initData<true, false, T>(handle, m, n, dA, lda, stA, dD, stD, dE, stE, dTauq, stQ,
+                                         dTaup, stP, bc, hA, hD, hE, hTauq, hTaup);
 
     // cold calls
     for(int iter = 0; iter < 2; iter++)
     {
-        gebd2_gebrd_initData<false, true, S, T>(handle, m, n, dA, lda, stA, dD, stD, dE, stE, dTauq,
-                                                stQ, dTaup, stP, bc, hA, hD, hE, hTauq, hTaup);
+        gebd2_gebrd_initData<false, true, T>(handle, m, n, dA, lda, stA, dD, stD, dE, stE, dTauq,
+                                             stQ, dTaup, stP, bc, hA, hD, hE, hTauq, hTaup);
 
         CHECK_ROCBLAS_ERROR(rocsolver_gebd2_gebrd(STRIDED, GEBRD, handle, m, n, dA.data(), lda, stA,
                                                   dD.data(), stD, dE.data(), stE, dTauq.data(), stQ,
@@ -397,8 +397,8 @@ void gebd2_gebrd_getPerfData(const rocblas_handle handle,
 
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
-        gebd2_gebrd_initData<false, true, S, T>(handle, m, n, dA, lda, stA, dD, stD, dE, stE, dTauq,
-                                                stQ, dTaup, stP, bc, hA, hD, hE, hTauq, hTaup);
+        gebd2_gebrd_initData<false, true, T>(handle, m, n, dA, lda, stA, dD, stD, dE, stE, dTauq,
+                                             stQ, dTaup, stP, bc, hA, hD, hE, hTauq, hTaup);
 
         start = get_time_us_sync(stream);
         rocsolver_gebd2_gebrd(STRIDED, GEBRD, handle, m, n, dA.data(), lda, stA, dD.data(), stD,
@@ -528,15 +528,16 @@ void testing_gebd2_gebrd(Arguments& argus)
 
         // check computations
         if(argus.unit_check || argus.norm_check)
-            gebd2_gebrd_getError<STRIDED, GEBRD, S, T>(handle, m, n, dA, lda, stA, dD, stD, dE, stE,
-                                                       dTauq, stQ, dTaup, stP, bc, hA, hARes, hD,
-                                                       hE, hTauq, hTaup, &max_error);
+            gebd2_gebrd_getError<STRIDED, GEBRD, T>(handle, m, n, dA, lda, stA, dD, stD, dE, stE,
+                                                    dTauq, stQ, dTaup, stP, bc, hA, hARes, hD, hE,
+                                                    hTauq, hTaup, &max_error);
 
         // collect performance data
         if(argus.timing)
-            gebd2_gebrd_getPerfData<STRIDED, GEBRD, S, T>(
-                handle, m, n, dA, lda, stA, dD, stD, dE, stE, dTauq, stQ, dTaup, stP, bc, hA, hD, hE,
-                hTauq, hTaup, &gpu_time_used, &cpu_time_used, hot_calls, argus.profile, argus.perf);
+            gebd2_gebrd_getPerfData<STRIDED, GEBRD, T>(handle, m, n, dA, lda, stA, dD, stD, dE, stE,
+                                                       dTauq, stQ, dTaup, stP, bc, hA, hD, hE,
+                                                       hTauq, hTaup, &gpu_time_used, &cpu_time_used,
+                                                       hot_calls, argus.profile, argus.perf);
     }
 
     else
@@ -579,15 +580,16 @@ void testing_gebd2_gebrd(Arguments& argus)
 
         // check computations
         if(argus.unit_check || argus.norm_check)
-            gebd2_gebrd_getError<STRIDED, GEBRD, S, T>(handle, m, n, dA, lda, stA, dD, stD, dE, stE,
-                                                       dTauq, stQ, dTaup, stP, bc, hA, hARes, hD,
-                                                       hE, hTauq, hTaup, &max_error);
+            gebd2_gebrd_getError<STRIDED, GEBRD, T>(handle, m, n, dA, lda, stA, dD, stD, dE, stE,
+                                                    dTauq, stQ, dTaup, stP, bc, hA, hARes, hD, hE,
+                                                    hTauq, hTaup, &max_error);
 
         // collect performance data
         if(argus.timing)
-            gebd2_gebrd_getPerfData<STRIDED, GEBRD, S, T>(
-                handle, m, n, dA, lda, stA, dD, stD, dE, stE, dTauq, stQ, dTaup, stP, bc, hA, hD, hE,
-                hTauq, hTaup, &gpu_time_used, &cpu_time_used, hot_calls, argus.profile, argus.perf);
+            gebd2_gebrd_getPerfData<STRIDED, GEBRD, T>(handle, m, n, dA, lda, stA, dD, stD, dE, stE,
+                                                       dTauq, stQ, dTaup, stP, bc, hA, hD, hE,
+                                                       hTauq, hTaup, &gpu_time_used, &cpu_time_used,
+                                                       hot_calls, argus.profile, argus.perf);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_labrd.hpp
+++ b/clients/include/testing_labrd.hpp
@@ -193,7 +193,7 @@ void labrd_getError(const rocblas_handle handle,
     CHECK_HIP_ERROR(hYRes.transfer_from(dY));
 
     // CPU lapack
-    cblas_labrd<S, T>(m, n, nb, hA[0], lda, hD[0], hE[0], hTauq[0], hTaup[0], hX[0], ldx, hY[0], ldy);
+    cblas_labrd<T>(m, n, nb, hA[0], lda, hD[0], hE[0], hTauq[0], hTaup[0], hX[0], ldx, hY[0], ldy);
 
     // error is max(||hA - hARes|| / ||hA||, ||hX - hXRes|| / ||hX||, ||hY -
     // hYRes|| / ||hY||) (THIS DOES NOT ACCOUNT FOR NUMERICAL REPRODUCIBILITY
@@ -245,8 +245,8 @@ void labrd_getPerfData(const rocblas_handle handle,
         *cpu_time_used = get_time_us_no_sync();
         memset(hX[0], 0, ldx * nb * sizeof(T));
         memset(hY[0], 0, ldy * nb * sizeof(T));
-        cblas_labrd<S, T>(m, n, nb, hA[0], lda, hD[0], hE[0], hTauq[0], hTaup[0], hX[0], ldx, hY[0],
-                          ldy);
+        cblas_labrd<T>(m, n, nb, hA[0], lda, hD[0], hE[0], hTauq[0], hTaup[0], hX[0], ldx, hY[0],
+                       ldy);
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 

--- a/clients/include/testing_labrd.hpp
+++ b/clients/include/testing_labrd.hpp
@@ -11,7 +11,7 @@
 #include "rocsolver_arguments.hpp"
 #include "rocsolver_test.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 void labrd_checkBadArgs(const rocblas_handle handle,
                         const rocblas_int m,
                         const rocblas_int n,
@@ -106,7 +106,7 @@ void testing_labrd_bad_arg()
                        dTaup.data(), dX.data(), ldx, dY.data(), ldy);
 }
 
-template <bool CPU, bool GPU, typename S, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
 void labrd_initData(const rocblas_handle handle,
                     const rocblas_int m,
                     const rocblas_int n,
@@ -153,7 +153,7 @@ void labrd_initData(const rocblas_handle handle,
     }
 }
 
-template <typename S, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+template <typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
 void labrd_getError(const rocblas_handle handle,
                     const rocblas_int m,
                     const rocblas_int n,
@@ -181,8 +181,8 @@ void labrd_getError(const rocblas_handle handle,
                     double* max_err)
 {
     // input data initialization
-    labrd_initData<true, true, S, T>(handle, m, n, nb, dA, lda, dD, dE, dTauq, dTaup, dX, ldx, dY,
-                                     ldy, hA, hD, hE, hTauq, hTaup, hX, hY);
+    labrd_initData<true, true, T>(handle, m, n, nb, dA, lda, dD, dE, dTauq, dTaup, dX, ldx, dY, ldy,
+                                  hA, hD, hE, hTauq, hTaup, hX, hY);
 
     // execute computations
     // GPU lapack
@@ -208,7 +208,7 @@ void labrd_getError(const rocblas_handle handle,
     *max_err = err > *max_err ? err : *max_err;
 }
 
-template <typename S, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+template <typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
 void labrd_getPerfData(const rocblas_handle handle,
                        const rocblas_int m,
                        const rocblas_int n,
@@ -238,8 +238,8 @@ void labrd_getPerfData(const rocblas_handle handle,
 {
     if(!perf)
     {
-        labrd_initData<true, false, S, T>(handle, m, n, nb, dA, lda, dD, dE, dTauq, dTaup, dX, ldx,
-                                          dY, ldy, hA, hD, hE, hTauq, hTaup, hX, hY);
+        labrd_initData<true, false, T>(handle, m, n, nb, dA, lda, dD, dE, dTauq, dTaup, dX, ldx, dY,
+                                       ldy, hA, hD, hE, hTauq, hTaup, hX, hY);
 
         // cpu-lapack performance
         *cpu_time_used = get_time_us_no_sync();
@@ -250,14 +250,14 @@ void labrd_getPerfData(const rocblas_handle handle,
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
-    labrd_initData<true, false, S, T>(handle, m, n, nb, dA, lda, dD, dE, dTauq, dTaup, dX, ldx, dY,
-                                      ldy, hA, hD, hE, hTauq, hTaup, hX, hY);
+    labrd_initData<true, false, T>(handle, m, n, nb, dA, lda, dD, dE, dTauq, dTaup, dX, ldx, dY,
+                                   ldy, hA, hD, hE, hTauq, hTaup, hX, hY);
 
     // cold calls
     for(int iter = 0; iter < 2; iter++)
     {
-        labrd_initData<false, true, S, T>(handle, m, n, nb, dA, lda, dD, dE, dTauq, dTaup, dX, ldx,
-                                          dY, ldy, hA, hD, hE, hTauq, hTaup, hX, hY);
+        labrd_initData<false, true, T>(handle, m, n, nb, dA, lda, dD, dE, dTauq, dTaup, dX, ldx, dY,
+                                       ldy, hA, hD, hE, hTauq, hTaup, hX, hY);
 
         CHECK_ROCBLAS_ERROR(rocsolver_labrd(handle, m, n, nb, dA.data(), lda, dD.data(), dE.data(),
                                             dTauq.data(), dTaup.data(), dX.data(), ldx, dY.data(),
@@ -277,8 +277,8 @@ void labrd_getPerfData(const rocblas_handle handle,
 
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
-        labrd_initData<false, true, S, T>(handle, m, n, nb, dA, lda, dD, dE, dTauq, dTaup, dX, ldx,
-                                          dY, ldy, hA, hD, hE, hTauq, hTaup, hX, hY);
+        labrd_initData<false, true, T>(handle, m, n, nb, dA, lda, dD, dE, dTauq, dTaup, dX, ldx, dY,
+                                       ldy, hA, hD, hE, hTauq, hTaup, hX, hY);
 
         start = get_time_us_sync(stream);
         rocsolver_labrd(handle, m, n, nb, dA.data(), lda, dD.data(), dE.data(), dTauq.data(),
@@ -403,14 +403,14 @@ void testing_labrd(Arguments& argus)
 
     // check computations
     if(argus.unit_check || argus.norm_check)
-        labrd_getError<S, T>(handle, m, n, nb, dA, lda, dD, dE, dTauq, dTaup, dX, ldx, dY, ldy, hA,
-                             hARes, hD, hE, hTauq, hTaup, hX, hXRes, hY, hYRes, &max_error);
+        labrd_getError<T>(handle, m, n, nb, dA, lda, dD, dE, dTauq, dTaup, dX, ldx, dY, ldy, hA,
+                          hARes, hD, hE, hTauq, hTaup, hX, hXRes, hY, hYRes, &max_error);
 
     // collect performance data
     if(argus.timing)
-        labrd_getPerfData<S, T>(handle, m, n, nb, dA, lda, dD, dE, dTauq, dTaup, dX, ldx, dY, ldy,
-                                hA, hD, hE, hTauq, hTaup, hX, hY, &gpu_time_used, &cpu_time_used,
-                                hot_calls, argus.profile, argus.perf);
+        labrd_getPerfData<T>(handle, m, n, nb, dA, lda, dD, dE, dTauq, dTaup, dX, ldx, dY, ldy, hA,
+                             hD, hE, hTauq, hTaup, hX, hY, &gpu_time_used, &cpu_time_used,
+                             hot_calls, argus.profile, argus.perf);
 
     // validate results for rocsolver-test
     // using nb * max(m,n) * machine_precision as tolerance

--- a/clients/include/testing_latrd.hpp
+++ b/clients/include/testing_latrd.hpp
@@ -11,7 +11,7 @@
 #include "rocsolver_arguments.hpp"
 #include "rocsolver_test.hpp"
 
-template <typename S, typename T>
+template <typename T, typename S>
 void latrd_checkBadArgs(const rocblas_handle handle,
                         const rocblas_fill uplo,
                         const rocblas_int n,

--- a/clients/include/testing_managed_malloc.hpp
+++ b/clients/include/testing_managed_malloc.hpp
@@ -58,7 +58,7 @@ void managed_malloc_initData(const rocblas_handle handle,
     }
 }
 
-template <typename S, typename T>
+template <typename T, typename S>
 void managed_malloc_getError(const rocblas_handle handle,
                              const rocblas_int m,
                              const rocblas_int n,
@@ -103,7 +103,7 @@ void managed_malloc_getError(const rocblas_handle handle,
     *max_err = err > *max_err ? err : *max_err;
 }
 
-template <typename S, typename T>
+template <typename T, typename S>
 void managed_malloc_getPerfData(const rocblas_handle handle,
                                 const rocblas_int m,
                                 const rocblas_int n,
@@ -274,14 +274,14 @@ void testing_managed_malloc(Arguments& argus)
 
     // check computations
     if(argus.unit_check || argus.norm_check)
-        managed_malloc_getError<S, T>(handle, m, n, nb, dA, dARes, lda, dD, dE, dTauq, dTaup, dX,
-                                      dXRes, ldx, dY, dYRes, ldy, &max_error);
+        managed_malloc_getError<T>(handle, m, n, nb, dA, dARes, lda, dD, dE, dTauq, dTaup, dX,
+                                   dXRes, ldx, dY, dYRes, ldy, &max_error);
 
     // collect performance data
     if(argus.timing)
-        managed_malloc_getPerfData<S, T>(handle, m, n, nb, dA, dARes, lda, dD, dE, dTauq, dTaup, dX,
-                                         dXRes, ldx, dY, dYRes, ldy, &gpu_time_used, &cpu_time_used,
-                                         hot_calls, argus.profile, argus.perf);
+        managed_malloc_getPerfData<T>(handle, m, n, nb, dA, dARes, lda, dD, dE, dTauq, dTaup, dX,
+                                      dXRes, ldx, dY, dYRes, ldy, &gpu_time_used, &cpu_time_used,
+                                      hot_calls, argus.profile, argus.perf);
 
     // free memory
     hipFree(dA);

--- a/clients/include/testing_managed_malloc.hpp
+++ b/clients/include/testing_managed_malloc.hpp
@@ -88,7 +88,7 @@ void managed_malloc_getError(const rocblas_handle handle,
     hipDeviceSynchronize();
 
     // CPU lapack
-    cblas_labrd<S, T>(m, n, nb, dA, lda, dD, dE, dTauq, dTaup, dX, ldx, dY, ldy);
+    cblas_labrd<T>(m, n, nb, dA, lda, dD, dE, dTauq, dTaup, dX, ldx, dY, ldy);
 
     // error is max(||hA - hARes|| / ||hA||, ||hX - hXRes|| / ||hX||, ||hY -
     // hYRes|| / ||hY||) (THIS DOES NOT ACCOUNT FOR NUMERICAL REPRODUCIBILITY
@@ -133,7 +133,7 @@ void managed_malloc_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance
         *cpu_time_used = get_time_us_no_sync();
-        cblas_labrd<S, T>(m, n, nb, dA, lda, dD, dE, dTauq, dTaup, dX, ldx, dY, ldy);
+        cblas_labrd<T>(m, n, nb, dA, lda, dD, dE, dTauq, dTaup, dX, ldx, dY, ldy);
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 

--- a/clients/include/testing_orgbr_ungbr.hpp
+++ b/clients/include/testing_orgbr_ungbr.hpp
@@ -104,8 +104,8 @@ void orgbr_ungbr_initData(const rocblas_handle handle,
                         hA[0][i + j * lda] -= 4;
                 }
             }
-            cblas_gebrd<S, T>(m, k, hA[0], lda, D.data(), E.data(), hIpiv[0], P.data(), hW.data(),
-                              size_W);
+            cblas_gebrd<T>(m, k, hA[0], lda, D.data(), E.data(), hIpiv[0], P.data(), hW.data(),
+                           size_W);
         }
         else
         {
@@ -119,8 +119,8 @@ void orgbr_ungbr_initData(const rocblas_handle handle,
                         hA[0][i + j * lda] -= 4;
                 }
             }
-            cblas_gebrd<S, T>(k, n, hA[0], lda, D.data(), E.data(), P.data(), hIpiv[0], hW.data(),
-                              size_W);
+            cblas_gebrd<T>(k, n, hA[0], lda, D.data(), E.data(), P.data(), hIpiv[0], hW.data(),
+                           size_W);
         }
     }
 

--- a/clients/include/testing_orgtr_ungtr.hpp
+++ b/clients/include/testing_orgtr_ungtr.hpp
@@ -92,7 +92,7 @@ void orgtr_ungtr_initData(const rocblas_handle handle,
         }
 
         // compute sytrd/hetrd
-        cblas_sytrd_hetrd<S, T>(uplo, n, hA[0], lda, D.data(), E.data(), hIpiv[0], hW.data(), size_W);
+        cblas_sytrd_hetrd<T>(uplo, n, hA[0], lda, D.data(), E.data(), hIpiv[0], hW.data(), size_W);
     }
 
     if(GPU)

--- a/clients/include/testing_ormbr_unmbr.hpp
+++ b/clients/include/testing_ormbr_unmbr.hpp
@@ -146,8 +146,8 @@ void ormbr_unmbr_initData(const rocblas_handle handle,
                         hA[0][i + j * lda] -= 4;
                 }
             }
-            cblas_gebrd<S, T>(nq, s, hA[0], lda, D.data(), E.data(), hIpiv[0], P.data(), hW.data(),
-                              size_W);
+            cblas_gebrd<T>(nq, s, hA[0], lda, D.data(), E.data(), hIpiv[0], P.data(), hW.data(),
+                           size_W);
         }
         else
         {
@@ -161,8 +161,8 @@ void ormbr_unmbr_initData(const rocblas_handle handle,
                         hA[0][i + j * lda] -= 4;
                 }
             }
-            cblas_gebrd<S, T>(s, nq, hA[0], lda, D.data(), E.data(), P.data(), hIpiv[0], hW.data(),
-                              size_W);
+            cblas_gebrd<T>(s, nq, hA[0], lda, D.data(), E.data(), P.data(), hIpiv[0], hW.data(),
+                           size_W);
         }
     }
 

--- a/clients/include/testing_ormtr_unmtr.hpp
+++ b/clients/include/testing_ormtr_unmtr.hpp
@@ -137,8 +137,7 @@ void ormtr_unmtr_initData(const rocblas_handle handle,
         }
 
         // compute sytrd/hetrd
-        cblas_sytrd_hetrd<S, T>(uplo, nq, hA[0], lda, D.data(), E.data(), hIpiv[0], hW.data(),
-                                size_W);
+        cblas_sytrd_hetrd<T>(uplo, nq, hA[0], lda, D.data(), E.data(), hIpiv[0], hW.data(), size_W);
     }
 
     if(GPU)

--- a/clients/include/testing_stedc.hpp
+++ b/clients/include/testing_stedc.hpp
@@ -192,8 +192,8 @@ void stedc_getError(const rocblas_handle handle,
     }
 
     // CPU lapack
-    cblas_stedc<S, T>(evect, n, hD[0], hE[0], hC[0], ldc, work.data(), lwork, rwork.data(), lrwork,
-                      iwork.data(), liwork, hInfo[0]);
+    cblas_stedc<T>(evect, n, hD[0], hE[0], hC[0], ldc, work.data(), lwork, rwork.data(), lrwork,
+                   iwork.data(), liwork, hInfo[0]);
 
     // check info
     if(hInfo[0][0] != hInfoRes[0][0])
@@ -273,8 +273,8 @@ void stedc_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        cblas_stedc<S, T>(evect, n, hD[0], hE[0], hC[0], ldc, work.data(), lwork, rwork.data(),
-                          lrwork, iwork.data(), liwork, hInfo[0]);
+        cblas_stedc<T>(evect, n, hD[0], hE[0], hC[0], ldc, work.data(), lwork, rwork.data(), lrwork,
+                       iwork.data(), liwork, hInfo[0]);
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 

--- a/clients/include/testing_stedc.hpp
+++ b/clients/include/testing_stedc.hpp
@@ -11,7 +11,7 @@
 #include "rocsolver_arguments.hpp"
 #include "rocsolver_test.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 void stedc_checkBadArgs(const rocblas_handle handle,
                         const rocblas_evect evect,
                         const rocblas_int n,
@@ -70,7 +70,7 @@ void testing_stedc_bad_arg()
     stedc_checkBadArgs(handle, evect, n, dD.data(), dE.data(), dC.data(), ldc, dInfo.data());
 }
 
-template <bool CPU, bool GPU, typename S, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
 void stedc_initData(const rocblas_handle handle,
                     const rocblas_evect evect,
                     const rocblas_int n,
@@ -86,6 +86,7 @@ void stedc_initData(const rocblas_handle handle,
 {
     if(CPU)
     {
+        using S = decltype(std::real(T{}));
         rocblas_init<S>(hD, true);
         rocblas_init<S>(hE, true);
 
@@ -159,7 +160,7 @@ void stedc_getError(const rocblas_handle handle,
     std::vector<rocblas_int> iwork(liwork);
 
     // input data initialization
-    stedc_initData<true, true, S, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo);
+    stedc_initData<true, true, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo);
 
     // execute computations
     // GPU lapack
@@ -268,8 +269,7 @@ void stedc_getPerfData(const rocblas_handle handle,
 
     if(!perf)
     {
-        stedc_initData<true, false, S, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
-                                          hInfo);
+        stedc_initData<true, false, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo);
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
@@ -278,13 +278,12 @@ void stedc_getPerfData(const rocblas_handle handle,
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
-    stedc_initData<true, false, S, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo);
+    stedc_initData<true, false, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo);
 
     // cold calls
     for(int iter = 0; iter < 2; iter++)
     {
-        stedc_initData<false, true, S, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
-                                          hInfo);
+        stedc_initData<false, true, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo);
 
         CHECK_ROCBLAS_ERROR(
             rocsolver_stedc(handle, evect, n, dD.data(), dE.data(), dC.data(), ldc, dInfo.data()));
@@ -303,8 +302,7 @@ void stedc_getPerfData(const rocblas_handle handle,
 
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
-        stedc_initData<false, true, S, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
-                                          hInfo);
+        stedc_initData<false, true, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo);
 
         start = get_time_us_sync(stream);
         rocsolver_stedc(handle, evect, n, dD.data(), dE.data(), dC.data(), ldc, dInfo.data());

--- a/clients/include/testing_steqr.hpp
+++ b/clients/include/testing_steqr.hpp
@@ -11,7 +11,7 @@
 #include "rocsolver_arguments.hpp"
 #include "rocsolver_test.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 void steqr_checkBadArgs(const rocblas_handle handle,
                         const rocblas_evect evect,
                         const rocblas_int n,
@@ -70,7 +70,7 @@ void testing_steqr_bad_arg()
     steqr_checkBadArgs(handle, evect, n, dD.data(), dE.data(), dC.data(), ldc, dInfo.data());
 }
 
-template <bool CPU, bool GPU, typename S, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
 void steqr_initData(const rocblas_handle handle,
                     const rocblas_evect evect,
                     const rocblas_int n,
@@ -86,6 +86,7 @@ void steqr_initData(const rocblas_handle handle,
 {
     if(CPU)
     {
+        using S = decltype(std::real(T{}));
         rocblas_init<S>(hD, true);
         rocblas_init<S>(hE, true);
 
@@ -153,7 +154,7 @@ void steqr_getError(const rocblas_handle handle,
     std::vector<S> work(lwork);
 
     // input data initialization
-    steqr_initData<true, true, S, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo);
+    steqr_initData<true, true, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo);
 
     // execute computations
     // GPU lapack
@@ -255,8 +256,7 @@ void steqr_getPerfData(const rocblas_handle handle,
 
     if(!perf)
     {
-        steqr_initData<true, false, S, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
-                                          hInfo);
+        steqr_initData<true, false, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo);
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
@@ -264,13 +264,12 @@ void steqr_getPerfData(const rocblas_handle handle,
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
-    steqr_initData<true, false, S, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo);
+    steqr_initData<true, false, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo);
 
     // cold calls
     for(int iter = 0; iter < 2; iter++)
     {
-        steqr_initData<false, true, S, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
-                                          hInfo);
+        steqr_initData<false, true, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo);
 
         CHECK_ROCBLAS_ERROR(
             rocsolver_steqr(handle, evect, n, dD.data(), dE.data(), dC.data(), ldc, dInfo.data()));
@@ -289,8 +288,7 @@ void steqr_getPerfData(const rocblas_handle handle,
 
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
-        steqr_initData<false, true, S, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
-                                          hInfo);
+        steqr_initData<false, true, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo);
 
         start = get_time_us_sync(stream);
         rocsolver_steqr(handle, evect, n, dD.data(), dE.data(), dC.data(), ldc, dInfo.data());

--- a/clients/include/testing_steqr.hpp
+++ b/clients/include/testing_steqr.hpp
@@ -186,7 +186,7 @@ void steqr_getError(const rocblas_handle handle,
     }
 
     // CPU lapack
-    cblas_steqr<S, T>(evect, n, hD[0], hE[0], hC[0], ldc, work.data(), hInfo[0]);
+    cblas_steqr<T>(evect, n, hD[0], hE[0], hC[0], ldc, work.data(), hInfo[0]);
 
     // check info
     if(hInfo[0][0] != hInfoRes[0][0])
@@ -260,7 +260,7 @@ void steqr_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        cblas_steqr<S, T>(evect, n, hD[0], hE[0], hC[0], ldc, work.data(), hInfo[0]);
+        cblas_steqr<T>(evect, n, hD[0], hE[0], hC[0], ldc, work.data(), hInfo[0]);
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 

--- a/clients/include/testing_sygv_hegv.hpp
+++ b/clients/include/testing_sygv_hegv.hpp
@@ -291,8 +291,8 @@ void sygv_hegv_getError(const rocblas_handle handle,
     // CPU lapack
     for(rocblas_int b = 0; b < bc; ++b)
     {
-        cblas_sygv_hegv(itype, evect, uplo, n, hA[b], lda, hB[b], ldb, hD[b], work.data(), lwork,
-                        rwork.data(), hInfo[b]);
+        cblas_sygv_hegv<T>(itype, evect, uplo, n, hA[b], lda, hB[b], ldb, hD[b], work.data(), lwork,
+                           rwork.data(), hInfo[b]);
     }
 
     // (We expect the used input matrices to always converge. Testing
@@ -427,8 +427,8 @@ void sygv_hegv_getPerfData(const rocblas_handle handle,
         *cpu_time_used = get_time_us_no_sync();
         for(rocblas_int b = 0; b < bc; ++b)
         {
-            cblas_sygv_hegv<S, T>(itype, evect, uplo, n, hA[b], lda, hB[b], ldb, hD[b], work.data(),
-                                  lwork, rwork.data(), hInfo[b]);
+            cblas_sygv_hegv<T>(itype, evect, uplo, n, hA[b], lda, hB[b], ldb, hD[b], work.data(),
+                               lwork, rwork.data(), hInfo[b]);
         }
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }

--- a/clients/include/testing_sygvd_hegvd.hpp
+++ b/clients/include/testing_sygvd_hegvd.hpp
@@ -306,8 +306,8 @@ void sygvd_hegvd_getError(const rocblas_handle handle,
     // CPU lapack
     for(rocblas_int b = 0; b < bc; ++b)
     {
-        cblas_sygvd_hegvd(itype, evect, uplo, n, hA[b], lda, hB[b], ldb, hD[b], work.data(), lwork,
-                          rwork.data(), lrwork, iwork.data(), liwork, hInfo[b]);
+        cblas_sygvd_hegvd<T>(itype, evect, uplo, n, hA[b], lda, hB[b], ldb, hD[b], work.data(),
+                             lwork, rwork.data(), lrwork, iwork.data(), liwork, hInfo[b]);
     }
 
     // (We expect the used input matrices to always converge. Testing
@@ -454,8 +454,8 @@ void sygvd_hegvd_getPerfData(const rocblas_handle handle,
         *cpu_time_used = get_time_us_no_sync();
         for(rocblas_int b = 0; b < bc; ++b)
         {
-            cblas_sygvd_hegvd<S, T>(itype, evect, uplo, n, hA[b], lda, hB[b], ldb, hD[b], work.data(),
-                                    lwork, rwork.data(), lrwork, iwork.data(), liwork, hInfo[b]);
+            cblas_sygvd_hegvd<T>(itype, evect, uplo, n, hA[b], lda, hB[b], ldb, hD[b], work.data(),
+                                 lwork, rwork.data(), lrwork, iwork.data(), liwork, hInfo[b]);
         }
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }

--- a/clients/include/testing_sytxx_hetxx.hpp
+++ b/clients/include/testing_sytxx_hetxx.hpp
@@ -345,9 +345,9 @@ void sytxx_hetxx_getPerfData(const rocblas_handle handle,
         *cpu_time_used = get_time_us_no_sync();
         for(rocblas_int b = 0; b < bc; ++b)
         {
-            SYTRD ? cblas_sytrd_hetrd<S, T>(uplo, n, hA[b], lda, hD[b], hE[b], hTau[b], hW.data(),
-                                            32 * n)
-                  : cblas_sytd2_hetd2<S, T>(uplo, n, hA[b], lda, hD[b], hE[b], hTau[b]);
+            SYTRD
+                ? cblas_sytrd_hetrd<T>(uplo, n, hA[b], lda, hD[b], hE[b], hTau[b], hW.data(), 32 * n)
+                : cblas_sytd2_hetd2<T>(uplo, n, hA[b], lda, hD[b], hE[b], hTau[b]);
         }
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }

--- a/clients/include/testing_sytxx_hetxx.hpp
+++ b/clients/include/testing_sytxx_hetxx.hpp
@@ -212,7 +212,6 @@ void sytxx_hetxx_getError(const rocblas_handle handle,
                           Uh& hTau,
                           double* max_err)
 {
-    using S = decltype(std::real(T{}));
     constexpr bool COMPLEX = is_complex<T>;
 
     std::vector<T> hW(32 * n);
@@ -333,8 +332,6 @@ void sytxx_hetxx_getPerfData(const rocblas_handle handle,
                              const int profile,
                              const bool perf)
 {
-    using S = decltype(std::real(T{}));
-
     std::vector<T> hW(32 * n);
 
     if(!perf)
@@ -346,8 +343,8 @@ void sytxx_hetxx_getPerfData(const rocblas_handle handle,
         for(rocblas_int b = 0; b < bc; ++b)
         {
             SYTRD
-                ? cblas_sytrd_hetrd<T>(uplo, n, hA[b], lda, hD[b], hE[b], hTau[b], hW.data(), 32 * n)
-                : cblas_sytd2_hetd2<T>(uplo, n, hA[b], lda, hD[b], hE[b], hTau[b]);
+            ? cblas_sytrd_hetrd<T>(uplo, n, hA[b], lda, hD[b], hE[b], hTau[b], hW.data(), 32 * n)
+            : cblas_sytd2_hetd2<T>(uplo, n, hA[b], lda, hD[b], hE[b], hTau[b]);
         }
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }

--- a/library/src/auxiliary/rocauxiliary_labrd.cpp
+++ b/library/src/auxiliary/rocauxiliary_labrd.cpp
@@ -4,7 +4,7 @@
 
 #include "rocauxiliary_labrd.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_labrd_impl(rocblas_handle handle,
                                     const rocblas_int m,
                                     const rocblas_int n,
@@ -74,10 +74,10 @@ rocblas_status rocsolver_labrd_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_labrd_template<S, T>(handle, m, n, k, A, shiftA, lda, strideA, D, strideD, E,
-                                          strideE, tauq, strideQ, taup, strideP, X, shiftX, ldx,
-                                          strideX, Y, shiftY, ldy, strideY, batch_count,
-                                          (T*)scalars, work_workArr, (T*)norms);
+    return rocsolver_labrd_template<T>(handle, m, n, k, A, shiftA, lda, strideA, D, strideD, E,
+                                       strideE, tauq, strideQ, taup, strideP, X, shiftX, ldx,
+                                       strideX, Y, shiftY, ldy, strideY, batch_count, (T*)scalars,
+                                       work_workArr, (T*)norms);
 }
 
 /*
@@ -103,8 +103,7 @@ rocblas_status rocsolver_slabrd(rocblas_handle handle,
                                 float* Y,
                                 const rocblas_int ldy)
 {
-    return rocsolver_labrd_impl<float, float>(handle, m, n, k, A, lda, D, E, tauq, taup, X, ldx, Y,
-                                              ldy);
+    return rocsolver_labrd_impl<float>(handle, m, n, k, A, lda, D, E, tauq, taup, X, ldx, Y, ldy);
 }
 
 rocblas_status rocsolver_dlabrd(rocblas_handle handle,
@@ -122,8 +121,7 @@ rocblas_status rocsolver_dlabrd(rocblas_handle handle,
                                 double* Y,
                                 const rocblas_int ldy)
 {
-    return rocsolver_labrd_impl<double, double>(handle, m, n, k, A, lda, D, E, tauq, taup, X, ldx,
-                                                Y, ldy);
+    return rocsolver_labrd_impl<double>(handle, m, n, k, A, lda, D, E, tauq, taup, X, ldx, Y, ldy);
 }
 
 rocblas_status rocsolver_clabrd(rocblas_handle handle,
@@ -141,8 +139,8 @@ rocblas_status rocsolver_clabrd(rocblas_handle handle,
                                 rocblas_float_complex* Y,
                                 const rocblas_int ldy)
 {
-    return rocsolver_labrd_impl<float, rocblas_float_complex>(handle, m, n, k, A, lda, D, E, tauq,
-                                                              taup, X, ldx, Y, ldy);
+    return rocsolver_labrd_impl<rocblas_float_complex>(handle, m, n, k, A, lda, D, E, tauq, taup, X,
+                                                       ldx, Y, ldy);
 }
 
 rocblas_status rocsolver_zlabrd(rocblas_handle handle,
@@ -160,8 +158,8 @@ rocblas_status rocsolver_zlabrd(rocblas_handle handle,
                                 rocblas_double_complex* Y,
                                 const rocblas_int ldy)
 {
-    return rocsolver_labrd_impl<double, rocblas_double_complex>(handle, m, n, k, A, lda, D, E, tauq,
-                                                                taup, X, ldx, Y, ldy);
+    return rocsolver_labrd_impl<rocblas_double_complex>(handle, m, n, k, A, lda, D, E, tauq, taup,
+                                                        X, ldx, Y, ldy);
 }
 
 } // extern C

--- a/library/src/auxiliary/rocauxiliary_labrd.cpp
+++ b/library/src/auxiliary/rocauxiliary_labrd.cpp
@@ -53,7 +53,7 @@ rocblas_status rocsolver_labrd_impl(rocblas_handle handle,
     size_t size_work_workArr;
     // extra requirements for calling LARFG
     size_t size_norms;
-    rocsolver_labrd_getMemorySize<T, false>(m, n, k, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_labrd_getMemorySize<false, T>(m, n, k, batch_count, &size_scalars, &size_work_workArr,
                                             &size_norms);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/auxiliary/rocauxiliary_labrd.hpp
+++ b/library/src/auxiliary/rocauxiliary_labrd.hpp
@@ -14,7 +14,7 @@
 #include "rocblas.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_labrd_getMemorySize(const rocblas_int m,
                                    const rocblas_int n,
                                    const rocblas_int k,

--- a/library/src/auxiliary/rocauxiliary_labrd.hpp
+++ b/library/src/auxiliary/rocauxiliary_labrd.hpp
@@ -50,7 +50,7 @@ void rocsolver_labrd_getMemorySize(const rocblas_int m,
     *size_work_workArr = max(s1, s2);
 }
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_labrd_argCheck(rocblas_handle handle,
                                         const rocblas_int m,
                                         const rocblas_int n,
@@ -88,7 +88,7 @@ rocblas_status rocsolver_labrd_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename S, typename T, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename S, typename U, bool COMPLEX = is_complex<T>>
 rocblas_status rocsolver_labrd_template(rocblas_handle handle,
                                         const rocblas_int m,
                                         const rocblas_int n,

--- a/library/src/auxiliary/rocauxiliary_larf.cpp
+++ b/library/src/auxiliary/rocauxiliary_larf.cpp
@@ -42,7 +42,7 @@ rocblas_status rocsolver_larf_impl(rocblas_handle handle,
     size_t size_Abyx;
     // size of arrays of pointers (for batched cases)
     size_t size_workArr;
-    rocsolver_larf_getMemorySize<T, false>(side, m, n, batch_count, &size_scalars, &size_Abyx,
+    rocsolver_larf_getMemorySize<false, T>(side, m, n, batch_count, &size_scalars, &size_Abyx,
                                            &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/auxiliary/rocauxiliary_larf.hpp
+++ b/library/src/auxiliary/rocauxiliary_larf.hpp
@@ -12,7 +12,7 @@
 #include "rocblas.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_larf_getMemorySize(const rocblas_side side,
                                   const rocblas_int m,
                                   const rocblas_int n,

--- a/library/src/auxiliary/rocauxiliary_larfb.cpp
+++ b/library/src/auxiliary/rocauxiliary_larfb.cpp
@@ -49,7 +49,7 @@ rocblas_status rocsolver_larfb_impl(rocblas_handle handle,
     size_t size_tmptr;
     // size of arrays of pointers (for batched cases)
     size_t size_workArr;
-    rocsolver_larfb_getMemorySize<T, false>(side, m, n, k, batch_count, &size_tmptr, &size_workArr);
+    rocsolver_larfb_getMemorySize<false, T>(side, m, n, k, batch_count, &size_tmptr, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_tmptr, size_workArr);

--- a/library/src/auxiliary/rocauxiliary_larfb.hpp
+++ b/library/src/auxiliary/rocauxiliary_larfb.hpp
@@ -64,7 +64,7 @@ __global__ void addmatA1(const rocblas_int ldw,
     }
 }
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_larfb_getMemorySize(const rocblas_side side,
                                    const rocblas_int m,
                                    const rocblas_int n,

--- a/library/src/auxiliary/rocauxiliary_larft.cpp
+++ b/library/src/auxiliary/rocauxiliary_larft.cpp
@@ -43,7 +43,7 @@ rocblas_status rocsolver_larft_impl(rocblas_handle handle,
     size_t size_work;
     // size of arrays of pointers (for batched cases)
     size_t size_workArr;
-    rocsolver_larft_getMemorySize<T, false>(n, k, batch_count, &size_scalars, &size_work,
+    rocsolver_larft_getMemorySize<false, T>(n, k, batch_count, &size_scalars, &size_work,
                                             &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/auxiliary/rocauxiliary_larft.hpp
+++ b/library/src/auxiliary/rocauxiliary_larft.hpp
@@ -136,7 +136,7 @@ __global__ void set_tau(const rocblas_int k, T* tau, const rocblas_stride stride
     }
 }
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_larft_getMemorySize(const rocblas_int n,
                                    const rocblas_int k,
                                    const rocblas_int batch_count,

--- a/library/src/auxiliary/rocauxiliary_latrd.cpp
+++ b/library/src/auxiliary/rocauxiliary_latrd.cpp
@@ -4,7 +4,7 @@
 
 #include "rocauxiliary_latrd.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_latrd_impl(rocblas_handle handle,
                                     const rocblas_fill uplo,
                                     const rocblas_int n,
@@ -66,9 +66,9 @@ rocblas_status rocsolver_latrd_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_latrd_template(handle, uplo, n, k, A, shiftA, lda, strideA, E, strideE, tau,
-                                    strideP, W, shiftW, ldw, strideW, batch_count, (T*)scalars,
-                                    (T*)work, (T*)norms, (T**)workArr);
+    return rocsolver_latrd_template<T>(handle, uplo, n, k, A, shiftA, lda, strideA, E, strideE, tau,
+                                       strideP, W, shiftW, ldw, strideW, batch_count, (T*)scalars,
+                                       (T*)work, (T*)norms, (T**)workArr);
 }
 
 /*
@@ -90,7 +90,7 @@ rocblas_status rocsolver_slatrd(rocblas_handle handle,
                                 float* W,
                                 const rocblas_int ldw)
 {
-    return rocsolver_latrd_impl<float, float>(handle, uplo, n, k, A, lda, E, tau, W, ldw);
+    return rocsolver_latrd_impl<float>(handle, uplo, n, k, A, lda, E, tau, W, ldw);
 }
 
 rocblas_status rocsolver_dlatrd(rocblas_handle handle,
@@ -104,7 +104,7 @@ rocblas_status rocsolver_dlatrd(rocblas_handle handle,
                                 double* W,
                                 const rocblas_int ldw)
 {
-    return rocsolver_latrd_impl<double, double>(handle, uplo, n, k, A, lda, E, tau, W, ldw);
+    return rocsolver_latrd_impl<double>(handle, uplo, n, k, A, lda, E, tau, W, ldw);
 }
 
 rocblas_status rocsolver_clatrd(rocblas_handle handle,
@@ -118,8 +118,7 @@ rocblas_status rocsolver_clatrd(rocblas_handle handle,
                                 rocblas_float_complex* W,
                                 const rocblas_int ldw)
 {
-    return rocsolver_latrd_impl<float, rocblas_float_complex>(handle, uplo, n, k, A, lda, E, tau, W,
-                                                              ldw);
+    return rocsolver_latrd_impl<rocblas_float_complex>(handle, uplo, n, k, A, lda, E, tau, W, ldw);
 }
 
 rocblas_status rocsolver_zlatrd(rocblas_handle handle,
@@ -133,8 +132,7 @@ rocblas_status rocsolver_zlatrd(rocblas_handle handle,
                                 rocblas_double_complex* W,
                                 const rocblas_int ldw)
 {
-    return rocsolver_latrd_impl<double, rocblas_double_complex>(handle, uplo, n, k, A, lda, E, tau,
-                                                                W, ldw);
+    return rocsolver_latrd_impl<rocblas_double_complex>(handle, uplo, n, k, A, lda, E, tau, W, ldw);
 }
 
 } // extern C

--- a/library/src/auxiliary/rocauxiliary_latrd.cpp
+++ b/library/src/auxiliary/rocauxiliary_latrd.cpp
@@ -44,7 +44,7 @@ rocblas_status rocsolver_latrd_impl(rocblas_handle handle,
     size_t size_workArr;
     // extra requirements for calling LARFG
     size_t size_work, size_norms;
-    rocsolver_latrd_getMemorySize<T, false>(n, k, batch_count, &size_scalars, &size_work,
+    rocsolver_latrd_getMemorySize<false, T>(n, k, batch_count, &size_scalars, &size_work,
                                             &size_norms, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/auxiliary/rocauxiliary_latrd.hpp
+++ b/library/src/auxiliary/rocauxiliary_latrd.hpp
@@ -46,7 +46,7 @@ void rocsolver_latrd_getMemorySize(const rocblas_int n,
     rocsolver_larfg_getMemorySize<T>(n, batch_count, size_work, size_norms);
 }
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_latrd_argCheck(rocblas_handle handle,
                                         const rocblas_fill uplo,
                                         const rocblas_int n,
@@ -80,7 +80,7 @@ rocblas_status rocsolver_latrd_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename S, typename T, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename S, typename U, bool COMPLEX = is_complex<T>>
 rocblas_status rocsolver_latrd_template(rocblas_handle handle,
                                         const rocblas_fill uplo,
                                         const rocblas_int n,

--- a/library/src/auxiliary/rocauxiliary_latrd.hpp
+++ b/library/src/auxiliary/rocauxiliary_latrd.hpp
@@ -14,7 +14,7 @@
 #include "rocblas.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_latrd_getMemorySize(const rocblas_int n,
                                    const rocblas_int k,
                                    const rocblas_int batch_count,

--- a/library/src/auxiliary/rocauxiliary_org2l_ung2l.cpp
+++ b/library/src/auxiliary/rocauxiliary_org2l_ung2l.cpp
@@ -39,7 +39,7 @@ rocblas_status rocsolver_org2l_ung2l_impl(rocblas_handle handle,
     size_t size_workArr;
     // extra requirements for calling LARF
     size_t size_Abyx;
-    rocsolver_org2l_ung2l_getMemorySize<T, false>(m, n, batch_count, &size_scalars, &size_Abyx,
+    rocsolver_org2l_ung2l_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_Abyx,
                                                   &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/auxiliary/rocauxiliary_org2l_ung2l.hpp
+++ b/library/src/auxiliary/rocauxiliary_org2l_ung2l.hpp
@@ -43,7 +43,7 @@ __global__ void org2l_init_ident(const rocblas_int m,
     }
 }
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_org2l_ung2l_getMemorySize(const rocblas_int m,
                                          const rocblas_int n,
                                          const rocblas_int batch_count,
@@ -61,7 +61,7 @@ void rocsolver_org2l_ung2l_getMemorySize(const rocblas_int m,
     }
 
     // memory requirements to call larf
-    rocsolver_larf_getMemorySize<T, BATCHED>(rocblas_side_left, m, n, batch_count, size_scalars,
+    rocsolver_larf_getMemorySize<BATCHED, T>(rocblas_side_left, m, n, batch_count, size_scalars,
                                              size_Abyx, size_workArr);
 }
 

--- a/library/src/auxiliary/rocauxiliary_org2r_ung2r.cpp
+++ b/library/src/auxiliary/rocauxiliary_org2r_ung2r.cpp
@@ -39,7 +39,7 @@ rocblas_status rocsolver_org2r_ung2r_impl(rocblas_handle handle,
     size_t size_workArr;
     // extra requirements for calling LARF
     size_t size_Abyx;
-    rocsolver_org2r_ung2r_getMemorySize<T, false>(m, n, batch_count, &size_scalars, &size_Abyx,
+    rocsolver_org2r_ung2r_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_Abyx,
                                                   &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/auxiliary/rocauxiliary_org2r_ung2r.hpp
+++ b/library/src/auxiliary/rocauxiliary_org2r_ung2r.hpp
@@ -44,7 +44,7 @@ __global__ void org2r_init_ident(const rocblas_int m,
     }
 }
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_org2r_ung2r_getMemorySize(const rocblas_int m,
                                          const rocblas_int n,
                                          const rocblas_int batch_count,
@@ -62,7 +62,7 @@ void rocsolver_org2r_ung2r_getMemorySize(const rocblas_int m,
     }
 
     // memory requirements to call larf
-    rocsolver_larf_getMemorySize<T, BATCHED>(rocblas_side_left, m, n, batch_count, size_scalars,
+    rocsolver_larf_getMemorySize<BATCHED, T>(rocblas_side_left, m, n, batch_count, size_scalars,
                                              size_Abyx, size_workArr);
 }
 

--- a/library/src/auxiliary/rocauxiliary_orgbr_ungbr.cpp
+++ b/library/src/auxiliary/rocauxiliary_orgbr_ungbr.cpp
@@ -40,7 +40,7 @@ rocblas_status rocsolver_orgbr_ungbr_impl(rocblas_handle handle,
     size_t size_work;
     size_t size_Abyx_tmptr;
     size_t size_trfact;
-    rocsolver_orgbr_ungbr_getMemorySize<T, false>(storev, m, n, k, batch_count, &size_scalars,
+    rocsolver_orgbr_ungbr_getMemorySize<false, T>(storev, m, n, k, batch_count, &size_scalars,
                                                   &size_work, &size_Abyx_tmptr, &size_trfact,
                                                   &size_workArr);
 

--- a/library/src/auxiliary/rocauxiliary_orgbr_ungbr.hpp
+++ b/library/src/auxiliary/rocauxiliary_orgbr_ungbr.hpp
@@ -14,7 +14,7 @@
 #include "rocblas.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_orgbr_ungbr_getMemorySize(const rocblas_storev storev,
                                          const rocblas_int m,
                                          const rocblas_int n,
@@ -42,7 +42,7 @@ void rocsolver_orgbr_ungbr_getMemorySize(const rocblas_storev storev,
         // requirements for calling orgqr/ungqr
         if(m >= k)
         {
-            rocsolver_orgqr_ungqr_getMemorySize<T, BATCHED>(m, n, k, batch_count, size_scalars,
+            rocsolver_orgqr_ungqr_getMemorySize<BATCHED, T>(m, n, k, batch_count, size_scalars,
                                                             size_work, size_Abyx_tmptr, size_trfact,
                                                             size_workArr);
         }
@@ -50,7 +50,7 @@ void rocsolver_orgbr_ungbr_getMemorySize(const rocblas_storev storev,
         {
             size_t s1 = sizeof(T) * batch_count * (m - 1) * m / 2;
             size_t s2;
-            rocsolver_orgqr_ungqr_getMemorySize<T, BATCHED>(m - 1, m - 1, m - 1, batch_count,
+            rocsolver_orgqr_ungqr_getMemorySize<BATCHED, T>(m - 1, m - 1, m - 1, batch_count,
                                                             size_scalars, &s2, size_Abyx_tmptr,
                                                             size_trfact, size_workArr);
             *size_work = max(s1, s2);
@@ -62,7 +62,7 @@ void rocsolver_orgbr_ungbr_getMemorySize(const rocblas_storev storev,
         // requirements for calling orglq/unglq
         if(n > k)
         {
-            rocsolver_orglq_unglq_getMemorySize<T, BATCHED>(m, n, k, batch_count, size_scalars,
+            rocsolver_orglq_unglq_getMemorySize<BATCHED, T>(m, n, k, batch_count, size_scalars,
                                                             size_work, size_Abyx_tmptr, size_trfact,
                                                             size_workArr);
         }
@@ -70,7 +70,7 @@ void rocsolver_orgbr_ungbr_getMemorySize(const rocblas_storev storev,
         {
             size_t s1 = sizeof(T) * batch_count * (n - 1) * n / 2;
             size_t s2;
-            rocsolver_orglq_unglq_getMemorySize<T, BATCHED>(n - 1, n - 1, n - 1, batch_count,
+            rocsolver_orglq_unglq_getMemorySize<BATCHED, T>(n - 1, n - 1, n - 1, batch_count,
                                                             size_scalars, &s2, size_Abyx_tmptr,
                                                             size_trfact, size_workArr);
             *size_work = max(s1, s2);

--- a/library/src/auxiliary/rocauxiliary_orgl2_ungl2.cpp
+++ b/library/src/auxiliary/rocauxiliary_orgl2_ungl2.cpp
@@ -39,7 +39,7 @@ rocblas_status rocsolver_orgl2_ungl2_impl(rocblas_handle handle,
     size_t size_workArr;
     // extra requirements for calling LARF
     size_t size_Abyx;
-    rocsolver_orgl2_ungl2_getMemorySize<T, false>(m, n, batch_count, &size_scalars, &size_Abyx,
+    rocsolver_orgl2_ungl2_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_Abyx,
                                                   &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/auxiliary/rocauxiliary_orgl2_ungl2.hpp
+++ b/library/src/auxiliary/rocauxiliary_orgl2_ungl2.hpp
@@ -45,7 +45,7 @@ __global__ void orgl2_init_ident(const rocblas_int m,
     }
 }
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_orgl2_ungl2_getMemorySize(const rocblas_int m,
                                          const rocblas_int n,
                                          const rocblas_int batch_count,
@@ -63,7 +63,7 @@ void rocsolver_orgl2_ungl2_getMemorySize(const rocblas_int m,
     }
 
     // memory requirements to call larf
-    rocsolver_larf_getMemorySize<T, BATCHED>(rocblas_side_right, m, n, batch_count, size_scalars,
+    rocsolver_larf_getMemorySize<BATCHED, T>(rocblas_side_right, m, n, batch_count, size_scalars,
                                              size_Abyx, size_workArr);
 }
 

--- a/library/src/auxiliary/rocauxiliary_orglq_unglq.cpp
+++ b/library/src/auxiliary/rocauxiliary_orglq_unglq.cpp
@@ -43,7 +43,7 @@ rocblas_status rocsolver_orglq_unglq_impl(rocblas_handle handle,
     size_t size_Abyx_tmptr;
     // size of temporary array for triangular factor
     size_t size_trfact;
-    rocsolver_orglq_unglq_getMemorySize<T, false>(m, n, k, batch_count, &size_scalars, &size_work,
+    rocsolver_orglq_unglq_getMemorySize<false, T>(m, n, k, batch_count, &size_scalars, &size_work,
                                                   &size_Abyx_tmptr, &size_trfact, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/auxiliary/rocauxiliary_orglq_unglq.hpp
+++ b/library/src/auxiliary/rocauxiliary_orglq_unglq.hpp
@@ -15,7 +15,7 @@
 #include "rocblas.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_orglq_unglq_getMemorySize(const rocblas_int m,
                                          const rocblas_int n,
                                          const rocblas_int k,
@@ -38,7 +38,7 @@ void rocsolver_orglq_unglq_getMemorySize(const rocblas_int m,
     }
 
     size_t temp, unused;
-    rocsolver_orgl2_ungl2_getMemorySize<T, BATCHED>(m, n, batch_count, size_scalars,
+    rocsolver_orgl2_ungl2_getMemorySize<BATCHED, T>(m, n, batch_count, size_scalars,
                                                     size_Abyx_tmptr, size_workArr);
 
     if(k <= ORGxx_UNGxx_SWITCHSIZE)
@@ -55,8 +55,8 @@ void rocsolver_orglq_unglq_getMemorySize(const rocblas_int m,
 
         // size of workspace is maximum of what is needed by larft and larfb.
         // size of Abyx_tmptr is maximum of what is needed by orgl2/ungl2 and larfb.
-        rocsolver_larft_getMemorySize<T, BATCHED>(n, jb, batch_count, &unused, size_work, &unused);
-        rocsolver_larfb_getMemorySize<T, BATCHED>(rocblas_side_left, m - jb, n, jb, batch_count,
+        rocsolver_larft_getMemorySize<BATCHED, T>(n, jb, batch_count, &unused, size_work, &unused);
+        rocsolver_larfb_getMemorySize<BATCHED, T>(rocblas_side_left, m - jb, n, jb, batch_count,
                                                   &temp, &unused);
 
         *size_Abyx_tmptr = *size_Abyx_tmptr >= temp ? *size_Abyx_tmptr : temp;

--- a/library/src/auxiliary/rocauxiliary_orgql_ungql.cpp
+++ b/library/src/auxiliary/rocauxiliary_orgql_ungql.cpp
@@ -43,7 +43,7 @@ rocblas_status rocsolver_orgql_ungql_impl(rocblas_handle handle,
     size_t size_Abyx_tmptr;
     // size of temporary array for triangular factor
     size_t size_trfact;
-    rocsolver_orgql_ungql_getMemorySize<T, false>(m, n, k, batch_count, &size_scalars, &size_work,
+    rocsolver_orgql_ungql_getMemorySize<false, T>(m, n, k, batch_count, &size_scalars, &size_work,
                                                   &size_Abyx_tmptr, &size_trfact, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/auxiliary/rocauxiliary_orgql_ungql.hpp
+++ b/library/src/auxiliary/rocauxiliary_orgql_ungql.hpp
@@ -15,7 +15,7 @@
 #include "rocblas.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_orgql_ungql_getMemorySize(const rocblas_int m,
                                          const rocblas_int n,
                                          const rocblas_int k,
@@ -38,7 +38,7 @@ void rocsolver_orgql_ungql_getMemorySize(const rocblas_int m,
     }
 
     size_t temp, unused;
-    rocsolver_org2l_ung2l_getMemorySize<T, BATCHED>(m, n, batch_count, size_scalars,
+    rocsolver_org2l_ung2l_getMemorySize<BATCHED, T>(m, n, batch_count, size_scalars,
                                                     size_Abyx_tmptr, size_workArr);
 
     if(k <= ORGxx_UNGxx_SWITCHSIZE)
@@ -55,8 +55,8 @@ void rocsolver_orgql_ungql_getMemorySize(const rocblas_int m,
 
         // size of workspace is maximum of what is needed by larft and larfb.
         // size of Abyx_tmptr is maximum of what is needed by org2r/ung2r and larfb.
-        rocsolver_larft_getMemorySize<T, BATCHED>(m, jb, batch_count, &unused, size_work, &unused);
-        rocsolver_larfb_getMemorySize<T, BATCHED>(rocblas_side_left, m, n - jb, jb, batch_count,
+        rocsolver_larft_getMemorySize<BATCHED, T>(m, jb, batch_count, &unused, size_work, &unused);
+        rocsolver_larfb_getMemorySize<BATCHED, T>(rocblas_side_left, m, n - jb, jb, batch_count,
                                                   &temp, &unused);
 
         *size_Abyx_tmptr = *size_Abyx_tmptr >= temp ? *size_Abyx_tmptr : temp;

--- a/library/src/auxiliary/rocauxiliary_orgqr_ungqr.cpp
+++ b/library/src/auxiliary/rocauxiliary_orgqr_ungqr.cpp
@@ -43,7 +43,7 @@ rocblas_status rocsolver_orgqr_ungqr_impl(rocblas_handle handle,
     size_t size_Abyx_tmptr;
     // size of temporary array for triangular factor
     size_t size_trfact;
-    rocsolver_orgqr_ungqr_getMemorySize<T, false>(m, n, k, batch_count, &size_scalars, &size_work,
+    rocsolver_orgqr_ungqr_getMemorySize<false, T>(m, n, k, batch_count, &size_scalars, &size_work,
                                                   &size_Abyx_tmptr, &size_trfact, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/auxiliary/rocauxiliary_orgqr_ungqr.hpp
+++ b/library/src/auxiliary/rocauxiliary_orgqr_ungqr.hpp
@@ -15,7 +15,7 @@
 #include "rocblas.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_orgqr_ungqr_getMemorySize(const rocblas_int m,
                                          const rocblas_int n,
                                          const rocblas_int k,
@@ -38,7 +38,7 @@ void rocsolver_orgqr_ungqr_getMemorySize(const rocblas_int m,
     }
 
     size_t temp, unused;
-    rocsolver_org2r_ung2r_getMemorySize<T, BATCHED>(m, n, batch_count, size_scalars,
+    rocsolver_org2r_ung2r_getMemorySize<BATCHED, T>(m, n, batch_count, size_scalars,
                                                     size_Abyx_tmptr, size_workArr);
 
     if(k <= ORGxx_UNGxx_SWITCHSIZE)
@@ -55,8 +55,8 @@ void rocsolver_orgqr_ungqr_getMemorySize(const rocblas_int m,
 
         // size of workspace is maximum of what is needed by larft and larfb.
         // size of Abyx_tmptr is maximum of what is needed by org2r/ung2r and larfb.
-        rocsolver_larft_getMemorySize<T, BATCHED>(m, jb, batch_count, &unused, size_work, &unused);
-        rocsolver_larfb_getMemorySize<T, BATCHED>(rocblas_side_left, m, n - jb, jb, batch_count,
+        rocsolver_larft_getMemorySize<BATCHED, T>(m, jb, batch_count, &unused, size_work, &unused);
+        rocsolver_larfb_getMemorySize<BATCHED, T>(rocblas_side_left, m, n - jb, jb, batch_count,
                                                   &temp, &unused);
 
         *size_Abyx_tmptr = *size_Abyx_tmptr >= temp ? *size_Abyx_tmptr : temp;

--- a/library/src/auxiliary/rocauxiliary_orgtr_ungtr.cpp
+++ b/library/src/auxiliary/rocauxiliary_orgtr_ungtr.cpp
@@ -42,7 +42,7 @@ rocblas_status rocsolver_orgtr_ungtr_impl(rocblas_handle handle,
     size_t size_Abyx_tmptr;
     // size of temporary array for triangular factor
     size_t size_trfact;
-    rocsolver_orgtr_ungtr_getMemorySize<T, false>(uplo, n, batch_count, &size_scalars, &size_work,
+    rocsolver_orgtr_ungtr_getMemorySize<false, T>(uplo, n, batch_count, &size_scalars, &size_work,
                                                   &size_Abyx_tmptr, &size_trfact, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/auxiliary/rocauxiliary_orgtr_ungtr.hpp
+++ b/library/src/auxiliary/rocauxiliary_orgtr_ungtr.hpp
@@ -14,7 +14,7 @@
 #include "rocblas.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_orgtr_ungtr_getMemorySize(const rocblas_fill uplo,
                                          const rocblas_int n,
                                          const rocblas_int batch_count,
@@ -40,7 +40,7 @@ void rocsolver_orgtr_ungtr_getMemorySize(const rocblas_fill uplo,
     if(uplo == rocblas_fill_upper)
     {
         // requirements for calling orgql/ungql
-        rocsolver_orgql_ungql_getMemorySize<T, BATCHED>(n - 1, n - 1, n - 1, batch_count,
+        rocsolver_orgql_ungql_getMemorySize<BATCHED, T>(n - 1, n - 1, n - 1, batch_count,
                                                         size_scalars, &w2, size_Abyx_tmptr,
                                                         size_trfact, size_workArr);
     }
@@ -48,7 +48,7 @@ void rocsolver_orgtr_ungtr_getMemorySize(const rocblas_fill uplo,
     else
     {
         // requirements for calling orgqr/ungqr
-        rocsolver_orgqr_ungqr_getMemorySize<T, BATCHED>(n - 1, n - 1, n - 1, batch_count,
+        rocsolver_orgqr_ungqr_getMemorySize<BATCHED, T>(n - 1, n - 1, n - 1, batch_count,
                                                         size_scalars, &w2, size_Abyx_tmptr,
                                                         size_trfact, size_workArr);
     }

--- a/library/src/auxiliary/rocauxiliary_orm2l_unm2l.cpp
+++ b/library/src/auxiliary/rocauxiliary_orm2l_unm2l.cpp
@@ -49,7 +49,7 @@ rocblas_status rocsolver_orm2l_unm2l_impl(rocblas_handle handle,
     size_t size_diag;
     // size of arrays of pointers (for batched cases)
     size_t size_workArr;
-    rocsolver_orm2l_unm2l_getMemorySize<T, false>(side, m, n, k, batch_count, &size_scalars,
+    rocsolver_orm2l_unm2l_getMemorySize<false, T>(side, m, n, k, batch_count, &size_scalars,
                                                   &size_Abyx, &size_diag, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/auxiliary/rocauxiliary_orm2l_unm2l.hpp
+++ b/library/src/auxiliary/rocauxiliary_orm2l_unm2l.hpp
@@ -14,7 +14,7 @@
 #include "rocblas.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_orm2l_unm2l_getMemorySize(const rocblas_side side,
                                          const rocblas_int m,
                                          const rocblas_int n,
@@ -39,7 +39,7 @@ void rocsolver_orm2l_unm2l_getMemorySize(const rocblas_side side,
     *size_diag = sizeof(T) * batch_count;
 
     // memory requirements to call larf
-    rocsolver_larf_getMemorySize<T, BATCHED>(side, m, n, batch_count, size_scalars, size_Abyx,
+    rocsolver_larf_getMemorySize<BATCHED, T>(side, m, n, batch_count, size_scalars, size_Abyx,
                                              size_workArr);
 }
 

--- a/library/src/auxiliary/rocauxiliary_orm2r_unm2r.cpp
+++ b/library/src/auxiliary/rocauxiliary_orm2r_unm2r.cpp
@@ -49,7 +49,7 @@ rocblas_status rocsolver_orm2r_unm2r_impl(rocblas_handle handle,
     size_t size_diag;
     // size of arrays of pointers (for batched cases)
     size_t size_workArr;
-    rocsolver_orm2r_unm2r_getMemorySize<T, false>(side, m, n, k, batch_count, &size_scalars,
+    rocsolver_orm2r_unm2r_getMemorySize<false, T>(side, m, n, k, batch_count, &size_scalars,
                                                   &size_Abyx, &size_diag, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/auxiliary/rocauxiliary_orm2r_unm2r.hpp
+++ b/library/src/auxiliary/rocauxiliary_orm2r_unm2r.hpp
@@ -14,7 +14,7 @@
 #include "rocblas.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_orm2r_unm2r_getMemorySize(const rocblas_side side,
                                          const rocblas_int m,
                                          const rocblas_int n,
@@ -39,7 +39,7 @@ void rocsolver_orm2r_unm2r_getMemorySize(const rocblas_side side,
     *size_diag = sizeof(T) * batch_count;
 
     // extra memory requirements for calling LARF
-    rocsolver_larf_getMemorySize<T, BATCHED>(side, m, n, batch_count, size_scalars, size_Abyx,
+    rocsolver_larf_getMemorySize<BATCHED, T>(side, m, n, batch_count, size_scalars, size_Abyx,
                                              size_workArr);
 }
 

--- a/library/src/auxiliary/rocauxiliary_ormbr_unmbr.cpp
+++ b/library/src/auxiliary/rocauxiliary_ormbr_unmbr.cpp
@@ -47,7 +47,7 @@ rocblas_status rocsolver_ormbr_unmbr_impl(rocblas_handle handle,
     size_t size_AbyxORwork, size_diagORtmptr;
     size_t size_trfact;
     size_t size_workArr;
-    rocsolver_ormbr_unmbr_getMemorySize<T, false>(storev, side, m, n, k, batch_count, &size_scalars,
+    rocsolver_ormbr_unmbr_getMemorySize<false, T>(storev, side, m, n, k, batch_count, &size_scalars,
                                                   &size_AbyxORwork, &size_diagORtmptr, &size_trfact,
                                                   &size_workArr);
 

--- a/library/src/auxiliary/rocauxiliary_ormbr_unmbr.hpp
+++ b/library/src/auxiliary/rocauxiliary_ormbr_unmbr.hpp
@@ -14,7 +14,7 @@
 #include "rocblas.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_ormbr_unmbr_getMemorySize(const rocblas_storev storev,
                                          const rocblas_side side,
                                          const rocblas_int m,
@@ -42,12 +42,12 @@ void rocsolver_ormbr_unmbr_getMemorySize(const rocblas_storev storev,
 
     // requirements for calling ORMQR/UNMQR or ORMLQ/UNMLQ
     if(storev == rocblas_column_wise)
-        rocsolver_ormqr_unmqr_getMemorySize<T, BATCHED>(side, m, n, min(nq, k), batch_count,
+        rocsolver_ormqr_unmqr_getMemorySize<BATCHED, T>(side, m, n, min(nq, k), batch_count,
                                                         size_scalars, size_AbyxORwork,
                                                         size_diagORtmptr, size_trfact, size_workArr);
 
     else
-        rocsolver_ormlq_unmlq_getMemorySize<T, BATCHED>(side, m, n, min(nq, k), batch_count,
+        rocsolver_ormlq_unmlq_getMemorySize<BATCHED, T>(side, m, n, min(nq, k), batch_count,
                                                         size_scalars, size_AbyxORwork,
                                                         size_diagORtmptr, size_trfact, size_workArr);
 }

--- a/library/src/auxiliary/rocauxiliary_orml2_unml2.cpp
+++ b/library/src/auxiliary/rocauxiliary_orml2_unml2.cpp
@@ -49,7 +49,7 @@ rocblas_status rocsolver_orml2_unml2_impl(rocblas_handle handle,
     size_t size_diag;
     // size of arrays of pointers (for batched cases)
     size_t size_workArr;
-    rocsolver_orml2_unml2_getMemorySize<T, false>(side, m, n, k, batch_count, &size_scalars,
+    rocsolver_orml2_unml2_getMemorySize<false, T>(side, m, n, k, batch_count, &size_scalars,
                                                   &size_Abyx, &size_diag, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/auxiliary/rocauxiliary_orml2_unml2.hpp
+++ b/library/src/auxiliary/rocauxiliary_orml2_unml2.hpp
@@ -14,7 +14,7 @@
 #include "rocblas.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_orml2_unml2_getMemorySize(const rocblas_side side,
                                          const rocblas_int m,
                                          const rocblas_int n,
@@ -39,7 +39,7 @@ void rocsolver_orml2_unml2_getMemorySize(const rocblas_side side,
     *size_diag = sizeof(T) * batch_count;
 
     // memory requirements to call larf
-    rocsolver_larf_getMemorySize<T, BATCHED>(side, m, n, batch_count, size_scalars, size_Abyx,
+    rocsolver_larf_getMemorySize<BATCHED, T>(side, m, n, batch_count, size_scalars, size_Abyx,
                                              size_workArr);
 }
 

--- a/library/src/auxiliary/rocauxiliary_ormlq_unmlq.cpp
+++ b/library/src/auxiliary/rocauxiliary_ormlq_unmlq.cpp
@@ -49,7 +49,7 @@ rocblas_status rocsolver_ormlq_unmlq_impl(rocblas_handle handle,
     size_t size_trfact;
     // size of arrays of pointers (for batched cases)
     size_t size_workArr;
-    rocsolver_ormlq_unmlq_getMemorySize<T, false>(side, m, n, k, batch_count, &size_scalars,
+    rocsolver_ormlq_unmlq_getMemorySize<false, T>(side, m, n, k, batch_count, &size_scalars,
                                                   &size_AbyxORwork, &size_diagORtmptr, &size_trfact,
                                                   &size_workArr);
 

--- a/library/src/auxiliary/rocauxiliary_ormlq_unmlq.hpp
+++ b/library/src/auxiliary/rocauxiliary_ormlq_unmlq.hpp
@@ -15,7 +15,7 @@
 #include "rocblas.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_ormlq_unmlq_getMemorySize(const rocblas_side side,
                                          const rocblas_int m,
                                          const rocblas_int n,
@@ -39,7 +39,7 @@ void rocsolver_ormlq_unmlq_getMemorySize(const rocblas_side side,
     }
 
     size_t unused;
-    rocsolver_orml2_unml2_getMemorySize<T, BATCHED>(side, m, n, k, batch_count, size_scalars,
+    rocsolver_orml2_unml2_getMemorySize<BATCHED, T>(side, m, n, k, batch_count, size_scalars,
                                                     size_AbyxORwork, size_diagORtmptr, size_workArr);
 
     if(k > ORMxx_ORMxx_BLOCKSIZE)
@@ -47,11 +47,11 @@ void rocsolver_ormlq_unmlq_getMemorySize(const rocblas_side side,
         rocblas_int jb = ORMxx_ORMxx_BLOCKSIZE;
 
         // requirements for calling larft
-        rocsolver_larft_getMemorySize<T, BATCHED>(max(m, n), min(jb, k), batch_count, &unused,
+        rocsolver_larft_getMemorySize<BATCHED, T>(max(m, n), min(jb, k), batch_count, &unused,
                                                   size_AbyxORwork, &unused);
 
         // requirements for calling larfb
-        rocsolver_larfb_getMemorySize<T, BATCHED>(side, m, n, min(jb, k), batch_count,
+        rocsolver_larfb_getMemorySize<BATCHED, T>(side, m, n, min(jb, k), batch_count,
                                                   size_diagORtmptr, &unused);
 
         // size of temporary array for triangular factor

--- a/library/src/auxiliary/rocauxiliary_ormql_unmql.cpp
+++ b/library/src/auxiliary/rocauxiliary_ormql_unmql.cpp
@@ -49,7 +49,7 @@ rocblas_status rocsolver_ormql_unmql_impl(rocblas_handle handle,
     size_t size_trfact;
     // size of arrays of pointers (for batched cases)
     size_t size_workArr;
-    rocsolver_ormql_unmql_getMemorySize<T, false>(side, m, n, k, batch_count, &size_scalars,
+    rocsolver_ormql_unmql_getMemorySize<false, T>(side, m, n, k, batch_count, &size_scalars,
                                                   &size_AbyxORwork, &size_diagORtmptr, &size_trfact,
                                                   &size_workArr);
 

--- a/library/src/auxiliary/rocauxiliary_ormql_unmql.hpp
+++ b/library/src/auxiliary/rocauxiliary_ormql_unmql.hpp
@@ -15,7 +15,7 @@
 #include "rocblas.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_ormql_unmql_getMemorySize(const rocblas_side side,
                                          const rocblas_int m,
                                          const rocblas_int n,
@@ -39,7 +39,7 @@ void rocsolver_ormql_unmql_getMemorySize(const rocblas_side side,
     }
 
     size_t unused;
-    rocsolver_orm2l_unm2l_getMemorySize<T, BATCHED>(side, m, n, k, batch_count, size_scalars,
+    rocsolver_orm2l_unm2l_getMemorySize<BATCHED, T>(side, m, n, k, batch_count, size_scalars,
                                                     size_AbyxORwork, size_diagORtmptr, size_workArr);
 
     if(k > ORMxx_ORMxx_BLOCKSIZE)
@@ -47,11 +47,11 @@ void rocsolver_ormql_unmql_getMemorySize(const rocblas_side side,
         rocblas_int jb = ORMxx_ORMxx_BLOCKSIZE;
 
         // requirements for calling larft
-        rocsolver_larft_getMemorySize<T, BATCHED>(max(m, n), min(jb, k), batch_count, &unused,
+        rocsolver_larft_getMemorySize<BATCHED, T>(max(m, n), min(jb, k), batch_count, &unused,
                                                   size_AbyxORwork, &unused);
 
         // requirements for calling larfb
-        rocsolver_larfb_getMemorySize<T, BATCHED>(side, m, n, min(jb, k), batch_count,
+        rocsolver_larfb_getMemorySize<BATCHED, T>(side, m, n, min(jb, k), batch_count,
                                                   size_diagORtmptr, &unused);
 
         // size of temporary array for triangular factor

--- a/library/src/auxiliary/rocauxiliary_ormqr_unmqr.cpp
+++ b/library/src/auxiliary/rocauxiliary_ormqr_unmqr.cpp
@@ -49,7 +49,7 @@ rocblas_status rocsolver_ormqr_unmqr_impl(rocblas_handle handle,
     size_t size_trfact;
     // size of arrays of pointers (for batched cases)
     size_t size_workArr;
-    rocsolver_ormqr_unmqr_getMemorySize<T, false>(side, m, n, k, batch_count, &size_scalars,
+    rocsolver_ormqr_unmqr_getMemorySize<false, T>(side, m, n, k, batch_count, &size_scalars,
                                                   &size_AbyxORwork, &size_diagORtmptr, &size_trfact,
                                                   &size_workArr);
 

--- a/library/src/auxiliary/rocauxiliary_ormqr_unmqr.hpp
+++ b/library/src/auxiliary/rocauxiliary_ormqr_unmqr.hpp
@@ -15,7 +15,7 @@
 #include "rocblas.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_ormqr_unmqr_getMemorySize(const rocblas_side side,
                                          const rocblas_int m,
                                          const rocblas_int n,
@@ -39,7 +39,7 @@ void rocsolver_ormqr_unmqr_getMemorySize(const rocblas_side side,
     }
 
     size_t unused;
-    rocsolver_orm2r_unm2r_getMemorySize<T, BATCHED>(side, m, n, k, batch_count, size_scalars,
+    rocsolver_orm2r_unm2r_getMemorySize<BATCHED, T>(side, m, n, k, batch_count, size_scalars,
                                                     size_AbyxORwork, size_diagORtmptr, size_workArr);
 
     if(k > ORMxx_ORMxx_BLOCKSIZE)
@@ -47,11 +47,11 @@ void rocsolver_ormqr_unmqr_getMemorySize(const rocblas_side side,
         rocblas_int jb = ORMxx_ORMxx_BLOCKSIZE;
 
         // requirements for calling larft
-        rocsolver_larft_getMemorySize<T, BATCHED>(max(m, n), min(jb, k), batch_count, &unused,
+        rocsolver_larft_getMemorySize<BATCHED, T>(max(m, n), min(jb, k), batch_count, &unused,
                                                   size_AbyxORwork, &unused);
 
         // requirements for calling larfb
-        rocsolver_larfb_getMemorySize<T, BATCHED>(side, m, n, min(jb, k), batch_count,
+        rocsolver_larfb_getMemorySize<BATCHED, T>(side, m, n, min(jb, k), batch_count,
                                                   size_diagORtmptr, &unused);
 
         // size of temporary array for triangular factor

--- a/library/src/auxiliary/rocauxiliary_ormtr_unmtr.cpp
+++ b/library/src/auxiliary/rocauxiliary_ormtr_unmtr.cpp
@@ -46,7 +46,7 @@ rocblas_status rocsolver_ormtr_unmtr_impl(rocblas_handle handle,
     size_t size_AbyxORwork, size_diagORtmptr;
     size_t size_trfact;
     size_t size_workArr;
-    rocsolver_ormtr_unmtr_getMemorySize<T, false>(side, uplo, m, n, batch_count, &size_scalars,
+    rocsolver_ormtr_unmtr_getMemorySize<false, T>(side, uplo, m, n, batch_count, &size_scalars,
                                                   &size_AbyxORwork, &size_diagORtmptr, &size_trfact,
                                                   &size_workArr);
 

--- a/library/src/auxiliary/rocauxiliary_ormtr_unmtr.hpp
+++ b/library/src/auxiliary/rocauxiliary_ormtr_unmtr.hpp
@@ -14,7 +14,7 @@
 #include "rocblas.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_ormtr_unmtr_getMemorySize(const rocblas_side side,
                                          const rocblas_fill uplo,
                                          const rocblas_int m,
@@ -41,12 +41,12 @@ void rocsolver_ormtr_unmtr_getMemorySize(const rocblas_side side,
 
     // requirements for calling ORMQL/UNMQL or ORMQR/UNMQR
     if(uplo == rocblas_fill_upper)
-        rocsolver_ormql_unmql_getMemorySize<T, BATCHED>(side, m, n, nq, batch_count, size_scalars,
+        rocsolver_ormql_unmql_getMemorySize<BATCHED, T>(side, m, n, nq, batch_count, size_scalars,
                                                         size_AbyxORwork, size_diagORtmptr,
                                                         size_trfact, size_workArr);
 
     else
-        rocsolver_ormqr_unmqr_getMemorySize<T, BATCHED>(side, m, n, nq, batch_count, size_scalars,
+        rocsolver_ormqr_unmqr_getMemorySize<BATCHED, T>(side, m, n, nq, batch_count, size_scalars,
                                                         size_AbyxORwork, size_diagORtmptr,
                                                         size_trfact, size_workArr);
 }

--- a/library/src/include/lib_device_helpers.hpp
+++ b/library/src/include/lib_device_helpers.hpp
@@ -539,7 +539,7 @@ __global__ void copyshift_down(const bool copy,
 /** set_offdiag kernel copies the off-diagonal element of A, which is the non-zero element
     resulting by applying the Householder reflector to the working column, to E. Then set it
     to 1 to prepare for the application of the Householder reflector to the rest of the matrix **/
-template <typename T, typename U, typename S, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, typename S, typename U, std::enable_if_t<!is_complex<T>, int> = 0>
 __global__ void set_offdiag(const rocblas_int batch_count,
                             U A,
                             const rocblas_int shiftA,
@@ -559,7 +559,7 @@ __global__ void set_offdiag(const rocblas_int batch_count,
     }
 }
 
-template <typename T, typename U, typename S, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, typename S, typename U, std::enable_if_t<is_complex<T>, int> = 0>
 __global__ void set_offdiag(const rocblas_int batch_count,
                             U A,
                             const rocblas_int shiftA,

--- a/library/src/include/rocblas.hpp
+++ b/library/src/include/rocblas.hpp
@@ -1023,7 +1023,7 @@ rocblas_status rocblasCall_syr2_her2(rocblas_handle handle,
 }
 
 // syrk
-template <typename S, typename T, typename U, typename V, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, typename U, typename V, std::enable_if_t<!is_complex<T>, int> = 0>
 rocblas_status rocblasCall_syrk_herk(rocblas_handle handle,
                                      rocblas_fill uplo,
                                      rocblas_operation transA,
@@ -1045,13 +1045,15 @@ rocblas_status rocblasCall_syrk_herk(rocblas_handle handle,
     ROCBLAS_ENTER("syrk", "uplo:", uplo, "trans:", transA, "n:", n, "k:", k, "shiftA:", offsetA,
                   "lda:", lda, "shiftC:", offsetC, "ldc:", ldc, "bc:", batch_count);
 
+    using S = decltype(std::real(T{}));
+
     return rocblas_internal_syrk_template(
         handle, uplo, transA, n, k, cast2constType<S>(alpha), cast2constType<T>(A), offsetA, lda,
         strideA, cast2constType<S>(beta), C, offsetC, ldc, strideC, batch_count);
 }
 
 // herk
-template <typename S, typename T, typename U, typename V, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, typename U, typename V, std::enable_if_t<is_complex<T>, int> = 0>
 rocblas_status rocblasCall_syrk_herk(rocblas_handle handle,
                                      rocblas_fill uplo,
                                      rocblas_operation transA,
@@ -1072,6 +1074,8 @@ rocblas_status rocblasCall_syrk_herk(rocblas_handle handle,
     // TODO: How to get alpha and beta for trace logging
     ROCBLAS_ENTER("herk", "uplo:", uplo, "trans:", transA, "n:", n, "k:", k, "shiftA:", offsetA,
                   "lda:", lda, "shiftC:", offsetC, "ldc:", ldc, "bc:", batch_count);
+
+    using S = decltype(std::real(T{}));
 
     return rocblas_internal_herk_template(
         handle, uplo, transA, n, k, cast2constType<S>(alpha), cast2constType<T>(A), offsetA, lda,

--- a/library/src/lapack/roclapack_gebd2.cpp
+++ b/library/src/lapack/roclapack_gebd2.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_gebd2.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_gebd2_impl(rocblas_handle handle,
                                     const rocblas_int m,
                                     const rocblas_int n,
@@ -64,9 +64,9 @@ rocblas_status rocsolver_gebd2_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_gebd2_template<S, T>(handle, m, n, A, shiftA, lda, strideA, D, strideD, E,
-                                          strideE, tauq, strideQ, taup, strideP, batch_count,
-                                          (T*)scalars, work_workArr, (T*)Abyx_norms);
+    return rocsolver_gebd2_template<T>(handle, m, n, A, shiftA, lda, strideA, D, strideD, E,
+                                       strideE, tauq, strideQ, taup, strideP, batch_count,
+                                       (T*)scalars, work_workArr, (T*)Abyx_norms);
 }
 
 /*
@@ -87,7 +87,7 @@ rocblas_status rocsolver_sgebd2(rocblas_handle handle,
                                 float* tauq,
                                 float* taup)
 {
-    return rocsolver_gebd2_impl<float, float>(handle, m, n, A, lda, D, E, tauq, taup);
+    return rocsolver_gebd2_impl<float>(handle, m, n, A, lda, D, E, tauq, taup);
 }
 
 rocblas_status rocsolver_dgebd2(rocblas_handle handle,
@@ -100,7 +100,7 @@ rocblas_status rocsolver_dgebd2(rocblas_handle handle,
                                 double* tauq,
                                 double* taup)
 {
-    return rocsolver_gebd2_impl<double, double>(handle, m, n, A, lda, D, E, tauq, taup);
+    return rocsolver_gebd2_impl<double>(handle, m, n, A, lda, D, E, tauq, taup);
 }
 
 rocblas_status rocsolver_cgebd2(rocblas_handle handle,
@@ -113,7 +113,7 @@ rocblas_status rocsolver_cgebd2(rocblas_handle handle,
                                 rocblas_float_complex* tauq,
                                 rocblas_float_complex* taup)
 {
-    return rocsolver_gebd2_impl<float, rocblas_float_complex>(handle, m, n, A, lda, D, E, tauq, taup);
+    return rocsolver_gebd2_impl<rocblas_float_complex>(handle, m, n, A, lda, D, E, tauq, taup);
 }
 
 rocblas_status rocsolver_zgebd2(rocblas_handle handle,
@@ -126,8 +126,7 @@ rocblas_status rocsolver_zgebd2(rocblas_handle handle,
                                 rocblas_double_complex* tauq,
                                 rocblas_double_complex* taup)
 {
-    return rocsolver_gebd2_impl<double, rocblas_double_complex>(handle, m, n, A, lda, D, E, tauq,
-                                                                taup);
+    return rocsolver_gebd2_impl<rocblas_double_complex>(handle, m, n, A, lda, D, E, tauq, taup);
 }
 
 } // extern C

--- a/library/src/lapack/roclapack_gebd2.cpp
+++ b/library/src/lapack/roclapack_gebd2.cpp
@@ -43,7 +43,7 @@ rocblas_status rocsolver_gebd2_impl(rocblas_handle handle,
     size_t size_work_workArr;
     // extra requirements for calling LARF and LARFG
     size_t size_Abyx_norms;
-    rocsolver_gebd2_getMemorySize<T, false>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_gebd2_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                             &size_Abyx_norms);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_gebd2.hpp
+++ b/library/src/lapack/roclapack_gebd2.hpp
@@ -15,7 +15,7 @@
 #include "rocblas.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_gebd2_getMemorySize(const rocblas_int m,
                                    const rocblas_int n,
                                    const rocblas_int batch_count,
@@ -35,7 +35,7 @@ void rocsolver_gebd2_getMemorySize(const rocblas_int m,
     // size of Abyx_norms is maximum of what is needed by larf and larfg
     // size_work_workArr is maximum of re-usable work space and array of pointers to workspace
     size_t s1, s2, w1, w2;
-    rocsolver_larf_getMemorySize<T, BATCHED>(rocblas_side_both, m, n, batch_count, size_scalars,
+    rocsolver_larf_getMemorySize<BATCHED, T>(rocblas_side_both, m, n, batch_count, size_scalars,
                                              &s1, &w1);
     rocsolver_larfg_getMemorySize<T>(max(m, n), batch_count, &w2, &s2);
     *size_work_workArr = max(w1, w2);

--- a/library/src/lapack/roclapack_gebd2.hpp
+++ b/library/src/lapack/roclapack_gebd2.hpp
@@ -42,7 +42,7 @@ void rocsolver_gebd2_getMemorySize(const rocblas_int m,
     *size_Abyx_norms = max(s1, s2);
 }
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_gebd2_gebrd_argCheck(rocblas_handle handle,
                                               const rocblas_int m,
                                               const rocblas_int n,
@@ -74,7 +74,7 @@ rocblas_status rocsolver_gebd2_gebrd_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename S, typename T, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename S, typename U, bool COMPLEX = is_complex<T>>
 rocblas_status rocsolver_gebd2_template(rocblas_handle handle,
                                         const rocblas_int m,
                                         const rocblas_int n,

--- a/library/src/lapack/roclapack_gebd2_batched.cpp
+++ b/library/src/lapack/roclapack_gebd2_batched.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_gebd2.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_gebd2_batched_impl(rocblas_handle handle,
                                             const rocblas_int m,
                                             const rocblas_int n,
@@ -67,9 +67,9 @@ rocblas_status rocsolver_gebd2_batched_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_gebd2_template<S, T>(handle, m, n, A, shiftA, lda, strideA, D, strideD, E,
-                                          strideE, tauq, strideQ, taup, strideP, batch_count,
-                                          (T*)scalars, work_workArr, (T*)Abyx_norms);
+    return rocsolver_gebd2_template<T>(handle, m, n, A, shiftA, lda, strideA, D, strideD, E,
+                                       strideE, tauq, strideQ, taup, strideP, batch_count,
+                                       (T*)scalars, work_workArr, (T*)Abyx_norms);
 }
 
 /*
@@ -95,8 +95,8 @@ rocblas_status rocsolver_sgebd2_batched(rocblas_handle handle,
                                         const rocblas_stride strideP,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_gebd2_batched_impl<float, float>(handle, m, n, A, lda, D, strideD, E, strideE,
-                                                      tauq, strideQ, taup, strideP, batch_count);
+    return rocsolver_gebd2_batched_impl<float>(handle, m, n, A, lda, D, strideD, E, strideE, tauq,
+                                               strideQ, taup, strideP, batch_count);
 }
 
 rocblas_status rocsolver_dgebd2_batched(rocblas_handle handle,
@@ -114,8 +114,8 @@ rocblas_status rocsolver_dgebd2_batched(rocblas_handle handle,
                                         const rocblas_stride strideP,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_gebd2_batched_impl<double, double>(handle, m, n, A, lda, D, strideD, E, strideE,
-                                                        tauq, strideQ, taup, strideP, batch_count);
+    return rocsolver_gebd2_batched_impl<double>(handle, m, n, A, lda, D, strideD, E, strideE, tauq,
+                                                strideQ, taup, strideP, batch_count);
 }
 
 rocblas_status rocsolver_cgebd2_batched(rocblas_handle handle,
@@ -133,7 +133,7 @@ rocblas_status rocsolver_cgebd2_batched(rocblas_handle handle,
                                         const rocblas_stride strideP,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_gebd2_batched_impl<float, rocblas_float_complex>(
+    return rocsolver_gebd2_batched_impl<rocblas_float_complex>(
         handle, m, n, A, lda, D, strideD, E, strideE, tauq, strideQ, taup, strideP, batch_count);
 }
 
@@ -152,7 +152,7 @@ rocblas_status rocsolver_zgebd2_batched(rocblas_handle handle,
                                         const rocblas_stride strideP,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_gebd2_batched_impl<double, rocblas_double_complex>(
+    return rocsolver_gebd2_batched_impl<rocblas_double_complex>(
         handle, m, n, A, lda, D, strideD, E, strideE, tauq, strideQ, taup, strideP, batch_count);
 }
 

--- a/library/src/lapack/roclapack_gebd2_batched.cpp
+++ b/library/src/lapack/roclapack_gebd2_batched.cpp
@@ -46,7 +46,7 @@ rocblas_status rocsolver_gebd2_batched_impl(rocblas_handle handle,
     size_t size_work_workArr;
     // extra requirements for calling larf and larfg
     size_t size_Abyx_norms;
-    rocsolver_gebd2_getMemorySize<T, true>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_gebd2_getMemorySize<true, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                            &size_Abyx_norms);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_gebd2_strided_batched.cpp
+++ b/library/src/lapack/roclapack_gebd2_strided_batched.cpp
@@ -44,7 +44,7 @@ rocblas_status rocsolver_gebd2_strided_batched_impl(rocblas_handle handle,
     size_t size_work_workArr;
     // extra requirements for calling larf and larfg
     size_t size_Abyx_norms;
-    rocsolver_gebd2_getMemorySize<T, false>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_gebd2_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                             &size_Abyx_norms);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_gebd2_strided_batched.cpp
+++ b/library/src/lapack/roclapack_gebd2_strided_batched.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_gebd2.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_gebd2_strided_batched_impl(rocblas_handle handle,
                                                     const rocblas_int m,
                                                     const rocblas_int n,
@@ -65,9 +65,9 @@ rocblas_status rocsolver_gebd2_strided_batched_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_gebd2_template<S, T>(handle, m, n, A, shiftA, lda, strideA, D, strideD, E,
-                                          strideE, tauq, strideQ, taup, strideP, batch_count,
-                                          (T*)scalars, work_workArr, (T*)Abyx_norms);
+    return rocsolver_gebd2_template<T>(handle, m, n, A, shiftA, lda, strideA, D, strideD, E,
+                                       strideE, tauq, strideQ, taup, strideP, batch_count,
+                                       (T*)scalars, work_workArr, (T*)Abyx_norms);
 }
 
 /*
@@ -94,9 +94,9 @@ rocblas_status rocsolver_sgebd2_strided_batched(rocblas_handle handle,
                                                 const rocblas_stride strideP,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_gebd2_strided_batched_impl<float, float>(handle, m, n, A, lda, strideA, D,
-                                                              strideD, E, strideE, tauq, strideQ,
-                                                              taup, strideP, batch_count);
+    return rocsolver_gebd2_strided_batched_impl<float>(handle, m, n, A, lda, strideA, D, strideD, E,
+                                                       strideE, tauq, strideQ, taup, strideP,
+                                                       batch_count);
 }
 
 rocblas_status rocsolver_dgebd2_strided_batched(rocblas_handle handle,
@@ -115,9 +115,9 @@ rocblas_status rocsolver_dgebd2_strided_batched(rocblas_handle handle,
                                                 const rocblas_stride strideP,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_gebd2_strided_batched_impl<double, double>(handle, m, n, A, lda, strideA, D,
-                                                                strideD, E, strideE, tauq, strideQ,
-                                                                taup, strideP, batch_count);
+    return rocsolver_gebd2_strided_batched_impl<double>(handle, m, n, A, lda, strideA, D, strideD,
+                                                        E, strideE, tauq, strideQ, taup, strideP,
+                                                        batch_count);
 }
 
 rocblas_status rocsolver_cgebd2_strided_batched(rocblas_handle handle,
@@ -136,7 +136,7 @@ rocblas_status rocsolver_cgebd2_strided_batched(rocblas_handle handle,
                                                 const rocblas_stride strideP,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_gebd2_strided_batched_impl<float, rocblas_float_complex>(
+    return rocsolver_gebd2_strided_batched_impl<rocblas_float_complex>(
         handle, m, n, A, lda, strideA, D, strideD, E, strideE, tauq, strideQ, taup, strideP,
         batch_count);
 }
@@ -157,7 +157,7 @@ rocblas_status rocsolver_zgebd2_strided_batched(rocblas_handle handle,
                                                 const rocblas_stride strideP,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_gebd2_strided_batched_impl<double, rocblas_double_complex>(
+    return rocsolver_gebd2_strided_batched_impl<rocblas_double_complex>(
         handle, m, n, A, lda, strideA, D, strideD, E, strideE, tauq, strideQ, taup, strideP,
         batch_count);
 }

--- a/library/src/lapack/roclapack_gebrd.cpp
+++ b/library/src/lapack/roclapack_gebrd.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_gebrd.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_gebrd_impl(rocblas_handle handle,
                                     const rocblas_int m,
                                     const rocblas_int n,
@@ -74,7 +74,7 @@ rocblas_status rocsolver_gebrd_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_gebrd_template<false, false, S, T>(
+    return rocsolver_gebrd_template<false, false, T>(
         handle, m, n, A, shiftA, lda, strideA, D, strideD, E, strideE, tauq, strideQ, taup, strideP,
         (T*)X, shiftX, m, strideX, (T*)Y, shiftY, n, strideY, batch_count, (T*)scalars,
         work_workArr, (T*)Abyx_norms);
@@ -98,7 +98,7 @@ rocblas_status rocsolver_sgebrd(rocblas_handle handle,
                                 float* tauq,
                                 float* taup)
 {
-    return rocsolver_gebrd_impl<float, float>(handle, m, n, A, lda, D, E, tauq, taup);
+    return rocsolver_gebrd_impl<float>(handle, m, n, A, lda, D, E, tauq, taup);
 }
 
 rocblas_status rocsolver_dgebrd(rocblas_handle handle,
@@ -111,7 +111,7 @@ rocblas_status rocsolver_dgebrd(rocblas_handle handle,
                                 double* tauq,
                                 double* taup)
 {
-    return rocsolver_gebrd_impl<double, double>(handle, m, n, A, lda, D, E, tauq, taup);
+    return rocsolver_gebrd_impl<double>(handle, m, n, A, lda, D, E, tauq, taup);
 }
 
 rocblas_status rocsolver_cgebrd(rocblas_handle handle,
@@ -124,7 +124,7 @@ rocblas_status rocsolver_cgebrd(rocblas_handle handle,
                                 rocblas_float_complex* tauq,
                                 rocblas_float_complex* taup)
 {
-    return rocsolver_gebrd_impl<float, rocblas_float_complex>(handle, m, n, A, lda, D, E, tauq, taup);
+    return rocsolver_gebrd_impl<rocblas_float_complex>(handle, m, n, A, lda, D, E, tauq, taup);
 }
 
 rocblas_status rocsolver_zgebrd(rocblas_handle handle,
@@ -137,8 +137,7 @@ rocblas_status rocsolver_zgebrd(rocblas_handle handle,
                                 rocblas_double_complex* tauq,
                                 rocblas_double_complex* taup)
 {
-    return rocsolver_gebrd_impl<double, rocblas_double_complex>(handle, m, n, A, lda, D, E, tauq,
-                                                                taup);
+    return rocsolver_gebrd_impl<rocblas_double_complex>(handle, m, n, A, lda, D, E, tauq, taup);
 }
 
 } // extern C

--- a/library/src/lapack/roclapack_gebrd.cpp
+++ b/library/src/lapack/roclapack_gebrd.cpp
@@ -50,7 +50,7 @@ rocblas_status rocsolver_gebrd_impl(rocblas_handle handle,
     // size for temporary resulting orthogonal matrices when calling LABRD
     size_t size_X;
     size_t size_Y;
-    rocsolver_gebrd_getMemorySize<T, false>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_gebrd_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                             &size_Abyx_norms, &size_X, &size_Y);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_gebrd.hpp
+++ b/library/src/lapack/roclapack_gebrd.hpp
@@ -67,7 +67,7 @@ void rocsolver_gebrd_getMemorySize(const rocblas_int m,
     }
 }
 
-template <bool BATCHED, bool STRIDED, typename S, typename T, typename U, bool COMPLEX = is_complex<T>>
+template <bool BATCHED, bool STRIDED, typename T, typename S, typename U, bool COMPLEX = is_complex<T>>
 rocblas_status rocsolver_gebrd_template(rocblas_handle handle,
                                         const rocblas_int m,
                                         const rocblas_int n,
@@ -114,9 +114,9 @@ rocblas_status rocsolver_gebrd_template(rocblas_handle handle,
 
     // if the matrix is small, use the unblocked variant of the algorithm
     if(m <= k || n <= k)
-        return rocsolver_gebd2_template<S, T>(handle, m, n, A, shiftA, lda, strideA, D, strideD, E,
-                                              strideE, tauq, strideQ, taup, strideP, batch_count,
-                                              scalars, work_workArr, Abyx_norms);
+        return rocsolver_gebd2_template<T>(handle, m, n, A, shiftA, lda, strideA, D, strideD, E,
+                                           strideE, tauq, strideQ, taup, strideP, batch_count,
+                                           scalars, work_workArr, Abyx_norms);
 
     // everything must be executed with scalars on the host
     rocblas_pointer_mode old_mode;
@@ -127,10 +127,10 @@ rocblas_status rocsolver_gebrd_template(rocblas_handle handle,
     {
         // Reduce block to bidiagonal form
         jb = min(dim - j, k); // number of rows and columns in the block
-        rocsolver_labrd_template<S, T>(handle, m - j, n - j, jb, A, shiftA + idx2D(j, j, lda), lda,
-                                       strideA, D + j, strideD, E + j, strideE, tauq + j, strideQ,
-                                       taup + j, strideP, X, shiftX, ldx, strideX, Y, shiftY, ldy,
-                                       strideY, batch_count, scalars, work_workArr, Abyx_norms);
+        rocsolver_labrd_template<T>(handle, m - j, n - j, jb, A, shiftA + idx2D(j, j, lda), lda,
+                                    strideA, D + j, strideD, E + j, strideE, tauq + j, strideQ,
+                                    taup + j, strideP, X, shiftX, ldx, strideX, Y, shiftY, ldy,
+                                    strideY, batch_count, scalars, work_workArr, Abyx_norms);
 
         // update the rest of the matrix
         rocblasCall_gemm<BATCHED, STRIDED, T>(
@@ -168,10 +168,9 @@ rocblas_status rocsolver_gebrd_template(rocblas_handle handle,
 
     // factor last block
     if(j < dim)
-        rocsolver_gebd2_template<S, T>(handle, m - j, n - j, A, shiftA + idx2D(j, j, lda), lda,
-                                       strideA, D + j, strideD, E + j, strideE, tauq + j, strideQ,
-                                       taup + j, strideP, batch_count, scalars, work_workArr,
-                                       Abyx_norms);
+        rocsolver_gebd2_template<T>(handle, m - j, n - j, A, shiftA + idx2D(j, j, lda), lda, strideA,
+                                    D + j, strideD, E + j, strideE, tauq + j, strideQ, taup + j,
+                                    strideP, batch_count, scalars, work_workArr, Abyx_norms);
 
     rocblas_set_pointer_mode(handle, old_mode);
     return rocblas_status_success;

--- a/library/src/lapack/roclapack_gebrd.hpp
+++ b/library/src/lapack/roclapack_gebrd.hpp
@@ -14,7 +14,7 @@
 #include "roclapack_gebd2.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_gebrd_getMemorySize(const rocblas_int m,
                                    const rocblas_int n,
                                    const rocblas_int batch_count,
@@ -38,7 +38,7 @@ void rocsolver_gebrd_getMemorySize(const rocblas_int m,
     if(m <= GEBRD_GEBD2_SWITCHSIZE || n <= GEBRD_GEBD2_SWITCHSIZE)
     {
         // requirements for calling a single GEBD2
-        rocsolver_gebd2_getMemorySize<T, BATCHED>(m, n, batch_count, size_scalars,
+        rocsolver_gebd2_getMemorySize<BATCHED, T>(m, n, batch_count, size_scalars,
                                                   size_work_workArr, size_Abyx_norms);
         *size_X = 0;
         *size_Y = 0;
@@ -51,9 +51,9 @@ void rocsolver_gebrd_getMemorySize(const rocblas_int m,
         rocblas_int d = min(m / k, n / k);
 
         // sizes are maximum of what is required by GEBD2 and LABRD
-        rocsolver_gebd2_getMemorySize<T, BATCHED>(m - d * k, n - d * k, batch_count, &unused, &w1,
+        rocsolver_gebd2_getMemorySize<BATCHED, T>(m - d * k, n - d * k, batch_count, &unused, &w1,
                                                   &s1);
-        rocsolver_labrd_getMemorySize<T, BATCHED>(m, n, k, batch_count, size_scalars, &w2, &s2);
+        rocsolver_labrd_getMemorySize<BATCHED, T>(m, n, k, batch_count, size_scalars, &w2, &s2);
         *size_work_workArr = max(w1, w2);
         *size_Abyx_norms = max(s1, s2);
 

--- a/library/src/lapack/roclapack_gebrd_batched.cpp
+++ b/library/src/lapack/roclapack_gebrd_batched.cpp
@@ -53,7 +53,7 @@ rocblas_status rocsolver_gebrd_batched_impl(rocblas_handle handle,
     // size for temporary resulting orthogonal matrices when calling LABRD
     size_t size_X;
     size_t size_Y;
-    rocsolver_gebrd_getMemorySize<T, true>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_gebrd_getMemorySize<true, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                            &size_Abyx_norms, &size_X, &size_Y);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_gebrd_batched.cpp
+++ b/library/src/lapack/roclapack_gebrd_batched.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_gebrd.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_gebrd_batched_impl(rocblas_handle handle,
                                             const rocblas_int m,
                                             const rocblas_int n,
@@ -77,7 +77,7 @@ rocblas_status rocsolver_gebrd_batched_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_gebrd_template<true, false, S, T>(
+    return rocsolver_gebrd_template<true, false, T>(
         handle, m, n, A, shiftA, lda, strideA, D, strideD, E, strideE, tauq, strideQ, taup, strideP,
         (T*)X, shiftX, m, strideX, (T*)Y, shiftY, n, strideY, batch_count, (T*)scalars,
         work_workArr, (T*)Abyx_norms);
@@ -106,8 +106,8 @@ rocblas_status rocsolver_sgebrd_batched(rocblas_handle handle,
                                         const rocblas_stride strideP,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_gebrd_batched_impl<float, float>(handle, m, n, A, lda, D, strideD, E, strideE,
-                                                      tauq, strideQ, taup, strideP, batch_count);
+    return rocsolver_gebrd_batched_impl<float>(handle, m, n, A, lda, D, strideD, E, strideE, tauq,
+                                               strideQ, taup, strideP, batch_count);
 }
 
 rocblas_status rocsolver_dgebrd_batched(rocblas_handle handle,
@@ -125,8 +125,8 @@ rocblas_status rocsolver_dgebrd_batched(rocblas_handle handle,
                                         const rocblas_stride strideP,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_gebrd_batched_impl<double, double>(handle, m, n, A, lda, D, strideD, E, strideE,
-                                                        tauq, strideQ, taup, strideP, batch_count);
+    return rocsolver_gebrd_batched_impl<double>(handle, m, n, A, lda, D, strideD, E, strideE, tauq,
+                                                strideQ, taup, strideP, batch_count);
 }
 
 rocblas_status rocsolver_cgebrd_batched(rocblas_handle handle,
@@ -144,7 +144,7 @@ rocblas_status rocsolver_cgebrd_batched(rocblas_handle handle,
                                         const rocblas_stride strideP,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_gebrd_batched_impl<float, rocblas_float_complex>(
+    return rocsolver_gebrd_batched_impl<rocblas_float_complex>(
         handle, m, n, A, lda, D, strideD, E, strideE, tauq, strideQ, taup, strideP, batch_count);
 }
 
@@ -163,7 +163,7 @@ rocblas_status rocsolver_zgebrd_batched(rocblas_handle handle,
                                         const rocblas_stride strideP,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_gebrd_batched_impl<double, rocblas_double_complex>(
+    return rocsolver_gebrd_batched_impl<rocblas_double_complex>(
         handle, m, n, A, lda, D, strideD, E, strideE, tauq, strideQ, taup, strideP, batch_count);
 }
 

--- a/library/src/lapack/roclapack_gebrd_strided_batched.cpp
+++ b/library/src/lapack/roclapack_gebrd_strided_batched.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_gebrd.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_gebrd_strided_batched_impl(rocblas_handle handle,
                                                     const rocblas_int m,
                                                     const rocblas_int n,
@@ -77,7 +77,7 @@ rocblas_status rocsolver_gebrd_strided_batched_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_gebrd_template<false, true, S, T>(
+    return rocsolver_gebrd_template<false, true, T>(
         handle, m, n, A, shiftA, lda, strideA, D, strideD, E, strideE, tauq, strideQ, taup, strideP,
         (T*)X, shiftX, m, strideX, (T*)Y, shiftY, n, strideY, batch_count, (T*)scalars,
         work_workArr, (T*)Abyx_norms);
@@ -107,9 +107,9 @@ rocblas_status rocsolver_sgebrd_strided_batched(rocblas_handle handle,
                                                 const rocblas_stride strideP,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_gebrd_strided_batched_impl<float, float>(handle, m, n, A, lda, strideA, D,
-                                                              strideD, E, strideE, tauq, strideQ,
-                                                              taup, strideP, batch_count);
+    return rocsolver_gebrd_strided_batched_impl<float>(handle, m, n, A, lda, strideA, D, strideD, E,
+                                                       strideE, tauq, strideQ, taup, strideP,
+                                                       batch_count);
 }
 
 rocblas_status rocsolver_dgebrd_strided_batched(rocblas_handle handle,
@@ -128,9 +128,9 @@ rocblas_status rocsolver_dgebrd_strided_batched(rocblas_handle handle,
                                                 const rocblas_stride strideP,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_gebrd_strided_batched_impl<double, double>(handle, m, n, A, lda, strideA, D,
-                                                                strideD, E, strideE, tauq, strideQ,
-                                                                taup, strideP, batch_count);
+    return rocsolver_gebrd_strided_batched_impl<double>(handle, m, n, A, lda, strideA, D, strideD,
+                                                        E, strideE, tauq, strideQ, taup, strideP,
+                                                        batch_count);
 }
 
 rocblas_status rocsolver_cgebrd_strided_batched(rocblas_handle handle,
@@ -149,7 +149,7 @@ rocblas_status rocsolver_cgebrd_strided_batched(rocblas_handle handle,
                                                 const rocblas_stride strideP,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_gebrd_strided_batched_impl<float, rocblas_float_complex>(
+    return rocsolver_gebrd_strided_batched_impl<rocblas_float_complex>(
         handle, m, n, A, lda, strideA, D, strideD, E, strideE, tauq, strideQ, taup, strideP,
         batch_count);
 }
@@ -170,7 +170,7 @@ rocblas_status rocsolver_zgebrd_strided_batched(rocblas_handle handle,
                                                 const rocblas_stride strideP,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_gebrd_strided_batched_impl<double, rocblas_double_complex>(
+    return rocsolver_gebrd_strided_batched_impl<rocblas_double_complex>(
         handle, m, n, A, lda, strideA, D, strideD, E, strideE, tauq, strideQ, taup, strideP,
         batch_count);
 }

--- a/library/src/lapack/roclapack_gebrd_strided_batched.cpp
+++ b/library/src/lapack/roclapack_gebrd_strided_batched.cpp
@@ -53,7 +53,7 @@ rocblas_status rocsolver_gebrd_strided_batched_impl(rocblas_handle handle,
     // size for temporary resulting orthogonal matrices when calling LABRD
     size_t size_X;
     size_t size_Y;
-    rocsolver_gebrd_getMemorySize<T, false>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_gebrd_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                             &size_Abyx_norms, &size_X, &size_Y);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_gelq2.cpp
+++ b/library/src/lapack/roclapack_gelq2.cpp
@@ -39,7 +39,7 @@ rocblas_status rocsolver_gelq2_impl(rocblas_handle handle,
     size_t size_Abyx_norms;
     // size of temporary array to store diagonal elements
     size_t size_diag;
-    rocsolver_gelq2_getMemorySize<T, false>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_gelq2_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                             &size_Abyx_norms, &size_diag);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_gelq2.hpp
+++ b/library/src/lapack/roclapack_gelq2.hpp
@@ -15,7 +15,7 @@
 #include "rocblas.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_gelq2_getMemorySize(const rocblas_int m,
                                    const rocblas_int n,
                                    const rocblas_int batch_count,
@@ -37,7 +37,7 @@ void rocsolver_gelq2_getMemorySize(const rocblas_int m,
     // size of Abyx_norms is maximum of what is needed by larf and larfg
     // size_work_workArr is maximum of re-usable work space and array of pointers to workspace
     size_t s1, s2, w1, w2;
-    rocsolver_larf_getMemorySize<T, BATCHED>(rocblas_side_right, m, n, batch_count, size_scalars,
+    rocsolver_larf_getMemorySize<BATCHED, T>(rocblas_side_right, m, n, batch_count, size_scalars,
                                              &s1, &w1);
     rocsolver_larfg_getMemorySize<T>(n, batch_count, &w2, &s2);
     *size_work_workArr = max(w1, w2);

--- a/library/src/lapack/roclapack_gelq2_batched.cpp
+++ b/library/src/lapack/roclapack_gelq2_batched.cpp
@@ -40,7 +40,7 @@ rocblas_status rocsolver_gelq2_batched_impl(rocblas_handle handle,
     size_t size_Abyx_norms;
     // size of temporary array to store diagonal elements
     size_t size_diag;
-    rocsolver_gelq2_getMemorySize<T, true>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_gelq2_getMemorySize<true, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                            &size_Abyx_norms, &size_diag);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_gelq2_strided_batched.cpp
+++ b/library/src/lapack/roclapack_gelq2_strided_batched.cpp
@@ -38,7 +38,7 @@ rocblas_status rocsolver_gelq2_strided_batched_impl(rocblas_handle handle,
     size_t size_Abyx_norms;
     // size of temporary array to store diagonal elements
     size_t size_diag;
-    rocsolver_gelq2_getMemorySize<T, false>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_gelq2_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                             &size_Abyx_norms, &size_diag);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_gelqf.cpp
+++ b/library/src/lapack/roclapack_gelqf.cpp
@@ -39,7 +39,7 @@ rocblas_status rocsolver_gelqf_impl(rocblas_handle handle,
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GEQR2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_gelqf_getMemorySize<T, false>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_gelqf_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                             &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_gelqf.hpp
+++ b/library/src/lapack/roclapack_gelqf.hpp
@@ -15,7 +15,7 @@
 #include "roclapack_gelq2.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_gelqf_getMemorySize(const rocblas_int m,
                                    const rocblas_int n,
                                    const rocblas_int batch_count,
@@ -39,7 +39,7 @@ void rocsolver_gelqf_getMemorySize(const rocblas_int m,
     if(m <= GExQF_GExQ2_SWITCHSIZE || n <= GExQF_GExQ2_SWITCHSIZE)
     {
         // requirements for a single GELQ2 call
-        rocsolver_gelq2_getMemorySize<T, BATCHED>(m, n, batch_count, size_scalars, size_work_workArr,
+        rocsolver_gelq2_getMemorySize<BATCHED, T>(m, n, batch_count, size_scalars, size_work_workArr,
                                                   size_Abyx_norms_trfact, size_diag_tmptr);
         *size_workArr = 0;
     }
@@ -52,14 +52,14 @@ void rocsolver_gelqf_getMemorySize(const rocblas_int m,
         *size_Abyx_norms_trfact = sizeof(T) * jb * jb * batch_count;
 
         // requirements for calling GELQ2 with sub blocks
-        rocsolver_gelq2_getMemorySize<T, BATCHED>(jb, n, batch_count, size_scalars, &w1, &s2, &s1);
+        rocsolver_gelq2_getMemorySize<BATCHED, T>(jb, n, batch_count, size_scalars, &w1, &s2, &s1);
         *size_Abyx_norms_trfact = max(s2, *size_Abyx_norms_trfact);
 
         // requirements for calling LARFT
-        rocsolver_larft_getMemorySize<T, BATCHED>(n, jb, batch_count, &unused, &w2, size_workArr);
+        rocsolver_larft_getMemorySize<BATCHED, T>(n, jb, batch_count, &unused, &w2, size_workArr);
 
         // requirements for calling LARFB
-        rocsolver_larfb_getMemorySize<T, BATCHED>(rocblas_side_right, m - jb, n, jb, batch_count,
+        rocsolver_larfb_getMemorySize<BATCHED, T>(rocblas_side_right, m - jb, n, jb, batch_count,
                                                   &s2, &unused);
 
         *size_work_workArr = max(w1, w2);

--- a/library/src/lapack/roclapack_gelqf_batched.cpp
+++ b/library/src/lapack/roclapack_gelqf_batched.cpp
@@ -40,7 +40,7 @@ rocblas_status rocsolver_gelqf_batched_impl(rocblas_handle handle,
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GEQR2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_gelqf_getMemorySize<T, true>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_gelqf_getMemorySize<true, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                            &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_gelqf_strided_batched.cpp
+++ b/library/src/lapack/roclapack_gelqf_strided_batched.cpp
@@ -38,7 +38,7 @@ rocblas_status rocsolver_gelqf_strided_batched_impl(rocblas_handle handle,
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GEQR2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_gelqf_getMemorySize<T, false>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_gelqf_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                             &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_gels.hpp
+++ b/library/src/lapack/roclapack_gels.hpp
@@ -68,10 +68,10 @@ void rocsolver_gels_getMemorySize(const rocblas_int m,
 
     if(m >= n)
     {
-        rocsolver_geqrf_getMemorySize<T, BATCHED>(m, n, batch_count, &gexxf_scalars, &gexxf_work,
+        rocsolver_geqrf_getMemorySize<BATCHED, T>(m, n, batch_count, &gexxf_scalars, &gexxf_work,
                                                   &gexxf_workArr, &gexxf_diag, &gexxf_trfact);
 
-        rocsolver_ormqr_unmqr_getMemorySize<T, BATCHED>(rocblas_side_left, m, nrhs, n, batch_count,
+        rocsolver_ormqr_unmqr_getMemorySize<BATCHED, T>(rocblas_side_left, m, nrhs, n, batch_count,
                                                         &ormxx_scalars, &ormxx_work, &ormxx_workArr,
                                                         &ormxx_trfact, &ormxx_workTrmm);
 
@@ -79,10 +79,10 @@ void rocsolver_gels_getMemorySize(const rocblas_int m,
     }
     else
     {
-        rocsolver_gelqf_getMemorySize<T, BATCHED>(m, n, batch_count, &gexxf_scalars, &gexxf_work,
+        rocsolver_gelqf_getMemorySize<BATCHED, T>(m, n, batch_count, &gexxf_scalars, &gexxf_work,
                                                   &gexxf_workArr, &gexxf_diag, &gexxf_trfact);
 
-        rocsolver_ormlq_unmlq_getMemorySize<T, BATCHED>(rocblas_side_left, n, nrhs, m, batch_count,
+        rocsolver_ormlq_unmlq_getMemorySize<BATCHED, T>(rocblas_side_left, n, nrhs, m, batch_count,
                                                         &ormxx_scalars, &ormxx_work, &ormxx_workArr,
                                                         &ormxx_trfact, &ormxx_workTrmm);
 

--- a/library/src/lapack/roclapack_geql2.cpp
+++ b/library/src/lapack/roclapack_geql2.cpp
@@ -39,7 +39,7 @@ rocblas_status rocsolver_geql2_impl(rocblas_handle handle,
     size_t size_Abyx_norms;
     // size of temporary array to store diagonal elements
     size_t size_diag;
-    rocsolver_geql2_getMemorySize<T, false>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_geql2_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                             &size_Abyx_norms, &size_diag);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_geql2.hpp
+++ b/library/src/lapack/roclapack_geql2.hpp
@@ -15,7 +15,7 @@
 #include "rocblas.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_geql2_getMemorySize(const rocblas_int m,
                                    const rocblas_int n,
                                    const rocblas_int batch_count,
@@ -37,7 +37,7 @@ void rocsolver_geql2_getMemorySize(const rocblas_int m,
     // size of Abyx_norms is maximum of what is needed by larf and larfg
     // size_work_workArr is maximum of re-usable work space and array of pointers to workspace
     size_t s1, s2, w1, w2;
-    rocsolver_larf_getMemorySize<T, BATCHED>(rocblas_side_left, m, n, batch_count, size_scalars,
+    rocsolver_larf_getMemorySize<BATCHED, T>(rocblas_side_left, m, n, batch_count, size_scalars,
                                              &s1, &w1);
     rocsolver_larfg_getMemorySize<T>(m, batch_count, &w2, &s2);
     *size_work_workArr = max(w1, w2);

--- a/library/src/lapack/roclapack_geql2_batched.cpp
+++ b/library/src/lapack/roclapack_geql2_batched.cpp
@@ -40,7 +40,7 @@ rocblas_status rocsolver_geql2_batched_impl(rocblas_handle handle,
     size_t size_Abyx_norms;
     // size of temporary array to store diagonal elements
     size_t size_diag;
-    rocsolver_geql2_getMemorySize<T, true>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_geql2_getMemorySize<true, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                            &size_Abyx_norms, &size_diag);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_geql2_strided_batched.cpp
+++ b/library/src/lapack/roclapack_geql2_strided_batched.cpp
@@ -38,7 +38,7 @@ rocblas_status rocsolver_geql2_strided_batched_impl(rocblas_handle handle,
     size_t size_Abyx_norms;
     // size of temporary array to store diagonal elements
     size_t size_diag;
-    rocsolver_geql2_getMemorySize<T, false>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_geql2_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                             &size_Abyx_norms, &size_diag);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_geqlf.cpp
+++ b/library/src/lapack/roclapack_geqlf.cpp
@@ -39,7 +39,7 @@ rocblas_status rocsolver_geqlf_impl(rocblas_handle handle,
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GEQR2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_geqlf_getMemorySize<T, false>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_geqlf_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                             &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_geqlf.hpp
+++ b/library/src/lapack/roclapack_geqlf.hpp
@@ -15,7 +15,7 @@
 #include "roclapack_geql2.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_geqlf_getMemorySize(const rocblas_int m,
                                    const rocblas_int n,
                                    const rocblas_int batch_count,
@@ -39,7 +39,7 @@ void rocsolver_geqlf_getMemorySize(const rocblas_int m,
     if(m <= GEQxF_GEQx2_SWITCHSIZE || n <= GEQxF_GEQx2_SWITCHSIZE)
     {
         // requirements for a single GEQL2 call
-        rocsolver_geql2_getMemorySize<T, BATCHED>(m, n, batch_count, size_scalars, size_work_workArr,
+        rocsolver_geql2_getMemorySize<BATCHED, T>(m, n, batch_count, size_scalars, size_work_workArr,
                                                   size_Abyx_norms_trfact, size_diag_tmptr);
         *size_workArr = 0;
     }
@@ -52,14 +52,14 @@ void rocsolver_geqlf_getMemorySize(const rocblas_int m,
         *size_Abyx_norms_trfact = sizeof(T) * jb * jb * batch_count;
 
         // requirements for calling GEQL2 with sub blocks
-        rocsolver_geql2_getMemorySize<T, BATCHED>(m, jb, batch_count, size_scalars, &w1, &s2, &s1);
+        rocsolver_geql2_getMemorySize<BATCHED, T>(m, jb, batch_count, size_scalars, &w1, &s2, &s1);
         *size_Abyx_norms_trfact = max(s2, *size_Abyx_norms_trfact);
 
         // requirements for calling LARFT
-        rocsolver_larft_getMemorySize<T, BATCHED>(m, jb, batch_count, &unused, &w2, size_workArr);
+        rocsolver_larft_getMemorySize<BATCHED, T>(m, jb, batch_count, &unused, &w2, size_workArr);
 
         // requirements for calling LARFB
-        rocsolver_larfb_getMemorySize<T, BATCHED>(rocblas_side_left, m, n - jb, jb, batch_count,
+        rocsolver_larfb_getMemorySize<BATCHED, T>(rocblas_side_left, m, n - jb, jb, batch_count,
                                                   &s2, &unused);
 
         *size_work_workArr = max(w1, w2);

--- a/library/src/lapack/roclapack_geqlf_batched.cpp
+++ b/library/src/lapack/roclapack_geqlf_batched.cpp
@@ -40,7 +40,7 @@ rocblas_status rocsolver_geqlf_batched_impl(rocblas_handle handle,
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GEQR2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_geqlf_getMemorySize<T, true>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_geqlf_getMemorySize<true, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                            &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_geqlf_strided_batched.cpp
+++ b/library/src/lapack/roclapack_geqlf_strided_batched.cpp
@@ -38,7 +38,7 @@ rocblas_status rocsolver_geqlf_strided_batched_impl(rocblas_handle handle,
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GEQR2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_geqlf_getMemorySize<T, false>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_geqlf_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                             &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_geqr2.cpp
+++ b/library/src/lapack/roclapack_geqr2.cpp
@@ -39,7 +39,7 @@ rocblas_status rocsolver_geqr2_impl(rocblas_handle handle,
     size_t size_Abyx_norms;
     // size of temporary array to store diagonal elements
     size_t size_diag;
-    rocsolver_geqr2_getMemorySize<T, false>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_geqr2_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                             &size_Abyx_norms, &size_diag);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_geqr2.hpp
+++ b/library/src/lapack/roclapack_geqr2.hpp
@@ -15,7 +15,7 @@
 #include "rocblas.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_geqr2_getMemorySize(const rocblas_int m,
                                    const rocblas_int n,
                                    const rocblas_int batch_count,
@@ -37,7 +37,7 @@ void rocsolver_geqr2_getMemorySize(const rocblas_int m,
     // size of Abyx_norms is maximum of what is needed by larf and larfg
     // size_work_workArr is maximum of re-usable work space and array of pointers to workspace
     size_t s1, s2, w1, w2;
-    rocsolver_larf_getMemorySize<T, BATCHED>(rocblas_side_left, m, n, batch_count, size_scalars,
+    rocsolver_larf_getMemorySize<BATCHED, T>(rocblas_side_left, m, n, batch_count, size_scalars,
                                              &s1, &w1);
     rocsolver_larfg_getMemorySize<T>(m, batch_count, &w2, &s2);
     *size_work_workArr = max(w1, w2);

--- a/library/src/lapack/roclapack_geqr2_batched.cpp
+++ b/library/src/lapack/roclapack_geqr2_batched.cpp
@@ -40,7 +40,7 @@ rocblas_status rocsolver_geqr2_batched_impl(rocblas_handle handle,
     size_t size_Abyx_norms;
     // size of temporary array to store diagonal elements
     size_t size_diag;
-    rocsolver_geqr2_getMemorySize<T, true>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_geqr2_getMemorySize<true, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                            &size_Abyx_norms, &size_diag);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_geqr2_strided_batched.cpp
+++ b/library/src/lapack/roclapack_geqr2_strided_batched.cpp
@@ -38,7 +38,7 @@ rocblas_status rocsolver_geqr2_strided_batched_impl(rocblas_handle handle,
     size_t size_Abyx_norms;
     // size of temporary array to store diagonal elements
     size_t size_diag;
-    rocsolver_geqr2_getMemorySize<T, false>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_geqr2_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                             &size_Abyx_norms, &size_diag);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_geqrf.cpp
+++ b/library/src/lapack/roclapack_geqrf.cpp
@@ -39,7 +39,7 @@ rocblas_status rocsolver_geqrf_impl(rocblas_handle handle,
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GEQR2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_geqrf_getMemorySize<T, false>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_geqrf_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                             &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_geqrf.hpp
+++ b/library/src/lapack/roclapack_geqrf.hpp
@@ -15,7 +15,7 @@
 #include "roclapack_geqr2.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_geqrf_getMemorySize(const rocblas_int m,
                                    const rocblas_int n,
                                    const rocblas_int batch_count,
@@ -39,7 +39,7 @@ void rocsolver_geqrf_getMemorySize(const rocblas_int m,
     if(m <= GEQxF_GEQx2_SWITCHSIZE || n <= GEQxF_GEQx2_SWITCHSIZE)
     {
         // requirements for a single GEQR2 call
-        rocsolver_geqr2_getMemorySize<T, BATCHED>(m, n, batch_count, size_scalars, size_work_workArr,
+        rocsolver_geqr2_getMemorySize<BATCHED, T>(m, n, batch_count, size_scalars, size_work_workArr,
                                                   size_Abyx_norms_trfact, size_diag_tmptr);
         *size_workArr = 0;
     }
@@ -52,14 +52,14 @@ void rocsolver_geqrf_getMemorySize(const rocblas_int m,
         *size_Abyx_norms_trfact = sizeof(T) * jb * jb * batch_count;
 
         // requirements for calling GEQR2 with sub blocks
-        rocsolver_geqr2_getMemorySize<T, BATCHED>(m, jb, batch_count, size_scalars, &w1, &s2, &s1);
+        rocsolver_geqr2_getMemorySize<BATCHED, T>(m, jb, batch_count, size_scalars, &w1, &s2, &s1);
         *size_Abyx_norms_trfact = max(s2, *size_Abyx_norms_trfact);
 
         // requirements for calling LARFT
-        rocsolver_larft_getMemorySize<T, BATCHED>(m, jb, batch_count, &unused, &w2, size_workArr);
+        rocsolver_larft_getMemorySize<BATCHED, T>(m, jb, batch_count, &unused, &w2, size_workArr);
 
         // requirements for calling LARFB
-        rocsolver_larfb_getMemorySize<T, BATCHED>(rocblas_side_left, m, n - jb, jb, batch_count,
+        rocsolver_larfb_getMemorySize<BATCHED, T>(rocblas_side_left, m, n - jb, jb, batch_count,
                                                   &s2, &unused);
 
         *size_work_workArr = max(w1, w2);

--- a/library/src/lapack/roclapack_geqrf_batched.cpp
+++ b/library/src/lapack/roclapack_geqrf_batched.cpp
@@ -40,7 +40,7 @@ rocblas_status rocsolver_geqrf_batched_impl(rocblas_handle handle,
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GEQR2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_geqrf_getMemorySize<T, true>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_geqrf_getMemorySize<true, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                            &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_geqrf_ptr_batched.cpp
+++ b/library/src/lapack/roclapack_geqrf_ptr_batched.cpp
@@ -58,7 +58,7 @@ rocblas_status rocsolver_geqrf_ptr_batched_impl(rocblas_handle handle,
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GEQR2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_geqrf_getMemorySize<T, true>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_geqrf_getMemorySize<true, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                            &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr);
 
     // this is to mamange tau as a simple array ipiv

--- a/library/src/lapack/roclapack_geqrf_strided_batched.cpp
+++ b/library/src/lapack/roclapack_geqrf_strided_batched.cpp
@@ -38,7 +38,7 @@ rocblas_status rocsolver_geqrf_strided_batched_impl(rocblas_handle handle,
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GEQR2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_geqrf_getMemorySize<T, false>(m, n, batch_count, &size_scalars, &size_work_workArr,
+    rocsolver_geqrf_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
                                             &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_gesvd.hpp
+++ b/library/src/lapack/roclapack_gesvd.hpp
@@ -219,10 +219,10 @@ void rocsolver_gesvd_getMemorySize(const rocblas_svect left_svect,
 
     // workspace required for the bidiagonalization
     if(thinSVD)
-        rocsolver_gebrd_getMemorySize<T, BATCHED>(k, k, batch_count, size_scalars, &w[0], &a[0],
+        rocsolver_gebrd_getMemorySize<BATCHED, T>(k, k, batch_count, size_scalars, &w[0], &a[0],
                                                   &x[0], &y[0]);
     else
-        rocsolver_gebrd_getMemorySize<T, BATCHED>(m, n, batch_count, size_scalars, &w[0], &a[0],
+        rocsolver_gebrd_getMemorySize<BATCHED, T>(m, n, batch_count, size_scalars, &w[0], &a[0],
                                                   &x[0], &y[0]);
 
     // workspace required for the SVD of the bidiagonal form
@@ -232,45 +232,45 @@ void rocsolver_gesvd_getMemorySize(const rocblas_svect left_svect,
     if(thinSVD)
     {
         if(row)
-            rocsolver_geqrf_getMemorySize<T, BATCHED>(m, n, batch_count, &unused, &w[2], &x[1],
+            rocsolver_geqrf_getMemorySize<BATCHED, T>(m, n, batch_count, &unused, &w[2], &x[1],
                                                       &y[1], &unused);
         else
-            rocsolver_gelqf_getMemorySize<T, BATCHED>(m, n, batch_count, &unused, &w[2], &x[1],
+            rocsolver_gelqf_getMemorySize<BATCHED, T>(m, n, batch_count, &unused, &w[2], &x[1],
                                                       &y[1], &unused);
     }
 
     // extra requirements for orthonormal/unitary matrix generation
     // ormbr
     if(thinSVD && !fast_thinSVD && !leadvN)
-        rocsolver_ormbr_unmbr_getMemorySize<T, BATCHED>(storev_lead, side, m, n, k, batch_count,
+        rocsolver_ormbr_unmbr_getMemorySize<BATCHED, T>(storev_lead, side, m, n, k, batch_count,
                                                         &unused, &a[1], &y[2], &x[2], &unused);
     // orgbr
     if(thinSVD)
     {
         if(!othervN)
-            rocsolver_orgbr_ungbr_getMemorySize<T, BATCHED>(storev_other, k, k, k, batch_count,
+            rocsolver_orgbr_ungbr_getMemorySize<BATCHED, T>(storev_other, k, k, k, batch_count,
                                                             &unused, &w[3], &a[2], &x[3], &unused);
 
         if(fast_thinSVD && !leadvN)
-            rocsolver_orgbr_ungbr_getMemorySize<T, BATCHED>(storev_lead, k, k, k, batch_count,
+            rocsolver_orgbr_ungbr_getMemorySize<BATCHED, T>(storev_lead, k, k, k, batch_count,
                                                             &unused, &w[4], &a[3], &x[4], &unused);
     }
     else
     {
         mn = (row && leftvS) ? n : m;
         if(leftvS || leftvA)
-            rocsolver_orgbr_ungbr_getMemorySize<T, BATCHED>(
+            rocsolver_orgbr_ungbr_getMemorySize<BATCHED, T>(
                 rocblas_column_wise, m, mn, n, batch_count, &unused, &w[3], &a[2], &x[3], &unused);
         else if(leftvO)
-            rocsolver_orgbr_ungbr_getMemorySize<T, BATCHED>(
+            rocsolver_orgbr_ungbr_getMemorySize<BATCHED, T>(
                 rocblas_column_wise, m, k, n, batch_count, &unused, &w[3], &a[2], &x[3], &unused);
 
         mn = (!row && rightvS) ? m : n;
         if(rightvS || rightvA)
-            rocsolver_orgbr_ungbr_getMemorySize<T, BATCHED>(rocblas_row_wise, mn, n, m, batch_count,
+            rocsolver_orgbr_ungbr_getMemorySize<BATCHED, T>(rocblas_row_wise, mn, n, m, batch_count,
                                                             &unused, &w[4], &a[3], &x[4], &unused);
         else if(rightvO)
-            rocsolver_orgbr_ungbr_getMemorySize<T, BATCHED>(rocblas_row_wise, k, n, m, batch_count,
+            rocsolver_orgbr_ungbr_getMemorySize<BATCHED, T>(rocblas_row_wise, k, n, m, batch_count,
                                                             &unused, &w[4], &a[3], &x[4], &unused);
     }
     // orgqr/orglq
@@ -279,19 +279,19 @@ void rocsolver_gesvd_getMemorySize(const rocblas_svect left_svect,
         if(leadvA)
         {
             if(row)
-                rocsolver_orgqr_ungqr_getMemorySize<T, BATCHED>(kk, kk, k, batch_count, &unused,
+                rocsolver_orgqr_ungqr_getMemorySize<BATCHED, T>(kk, kk, k, batch_count, &unused,
                                                                 &w[5], &a[4], &x[5], &unused);
             else
-                rocsolver_orglq_unglq_getMemorySize<T, BATCHED>(kk, kk, k, batch_count, &unused,
+                rocsolver_orglq_unglq_getMemorySize<BATCHED, T>(kk, kk, k, batch_count, &unused,
                                                                 &w[5], &a[4], &x[5], &unused);
         }
         else
         {
             if(row)
-                rocsolver_orgqr_ungqr_getMemorySize<T, BATCHED>(m, n, k, batch_count, &unused,
+                rocsolver_orgqr_ungqr_getMemorySize<BATCHED, T>(m, n, k, batch_count, &unused,
                                                                 &w[5], &a[4], &x[5], &unused);
             else
-                rocsolver_orglq_unglq_getMemorySize<T, BATCHED>(m, n, k, batch_count, &unused,
+                rocsolver_orglq_unglq_getMemorySize<BATCHED, T>(m, n, k, batch_count, &unused,
                                                                 &w[5], &a[4], &x[5], &unused);
         }
     }

--- a/library/src/lapack/roclapack_potrf.cpp
+++ b/library/src/lapack/roclapack_potrf.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_potrf.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename U>
 rocblas_status rocsolver_potrf_impl(rocblas_handle handle,
                                     const rocblas_fill uplo,
                                     const rocblas_int n,
@@ -13,6 +13,8 @@ rocblas_status rocsolver_potrf_impl(rocblas_handle handle,
                                     rocblas_int* info)
 {
     ROCSOLVER_ENTER_TOP("potrf", "--uplo", uplo, "-n", n, "--lda", lda);
+
+    using S = decltype(std::real(T{}));
 
     if(!handle)
         return rocblas_status_invalid_handle;
@@ -69,7 +71,7 @@ rocblas_status rocsolver_potrf_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_potrf_template<false, S, T>(handle, uplo, n, A, shiftA, lda, strideA, info,
+    return rocsolver_potrf_template<false, T, S>(handle, uplo, n, A, shiftA, lda, strideA, info,
                                                  batch_count, (T*)scalars, work1, work2, work3,
                                                  work4, (T*)pivots, (rocblas_int*)iinfo, optim_mem);
 }
@@ -89,7 +91,7 @@ rocblas_status rocsolver_spotrf(rocblas_handle handle,
                                 const rocblas_int lda,
                                 rocblas_int* info)
 {
-    return rocsolver_potrf_impl<float, float>(handle, uplo, n, A, lda, info);
+    return rocsolver_potrf_impl<float>(handle, uplo, n, A, lda, info);
 }
 
 rocblas_status rocsolver_dpotrf(rocblas_handle handle,
@@ -99,7 +101,7 @@ rocblas_status rocsolver_dpotrf(rocblas_handle handle,
                                 const rocblas_int lda,
                                 rocblas_int* info)
 {
-    return rocsolver_potrf_impl<double, double>(handle, uplo, n, A, lda, info);
+    return rocsolver_potrf_impl<double>(handle, uplo, n, A, lda, info);
 }
 
 rocblas_status rocsolver_cpotrf(rocblas_handle handle,
@@ -109,7 +111,7 @@ rocblas_status rocsolver_cpotrf(rocblas_handle handle,
                                 const rocblas_int lda,
                                 rocblas_int* info)
 {
-    return rocsolver_potrf_impl<float, rocblas_float_complex>(handle, uplo, n, A, lda, info);
+    return rocsolver_potrf_impl<rocblas_float_complex>(handle, uplo, n, A, lda, info);
 }
 
 rocblas_status rocsolver_zpotrf(rocblas_handle handle,
@@ -119,6 +121,6 @@ rocblas_status rocsolver_zpotrf(rocblas_handle handle,
                                 const rocblas_int lda,
                                 rocblas_int* info)
 {
-    return rocsolver_potrf_impl<double, rocblas_double_complex>(handle, uplo, n, A, lda, info);
+    return rocsolver_potrf_impl<rocblas_double_complex>(handle, uplo, n, A, lda, info);
 }
 }

--- a/library/src/lapack/roclapack_potrf.hpp
+++ b/library/src/lapack/roclapack_potrf.hpp
@@ -79,7 +79,7 @@ void rocsolver_potrf_getMemorySize(const rocblas_int n,
     }
 }
 
-template <bool BATCHED, typename S, typename T, typename U, bool COMPLEX = is_complex<T>>
+template <bool BATCHED, typename T, typename S, typename U, bool COMPLEX = is_complex<T>>
 rocblas_status rocsolver_potrf_template(rocblas_handle handle,
                                         const rocblas_fill uplo,
                                         const rocblas_int n,
@@ -165,7 +165,7 @@ rocblas_status rocsolver_potrf_template(rocblas_handle handle,
                     shiftA + idx2D(j, j, lda), lda, strideA, A, shiftA + idx2D(j, j + jb, lda), lda,
                     strideA, batch_count, optim_mem, work1, work2, work3, work4);
 
-                rocblasCall_syrk_herk<S, T>(
+                rocblasCall_syrk_herk<T>(
                     handle, uplo, rocblas_operation_conjugate_transpose, n - j - jb, jb, &s_minone,
                     A, shiftA + idx2D(j, j + jb, lda), lda, strideA, &s_one, A,
                     shiftA + idx2D(j + jb, j + jb, lda), lda, strideA, batch_count);
@@ -196,10 +196,10 @@ rocblas_status rocsolver_potrf_template(rocblas_handle handle,
                     shiftA + idx2D(j, j, lda), lda, strideA, A, shiftA + idx2D(j + jb, j, lda), lda,
                     strideA, batch_count, optim_mem, work1, work2, work3, work4);
 
-                rocblasCall_syrk_herk<S, T>(handle, uplo, rocblas_operation_none, n - j - jb, jb,
-                                            &s_minone, A, shiftA + idx2D(j + jb, j, lda), lda,
-                                            strideA, &s_one, A, shiftA + idx2D(j + jb, j + jb, lda),
-                                            lda, strideA, batch_count);
+                rocblasCall_syrk_herk<T>(handle, uplo, rocblas_operation_none, n - j - jb, jb,
+                                         &s_minone, A, shiftA + idx2D(j + jb, j, lda), lda, strideA,
+                                         &s_one, A, shiftA + idx2D(j + jb, j + jb, lda), lda,
+                                         strideA, batch_count);
             }
         }
     }

--- a/library/src/lapack/roclapack_potrf_batched.cpp
+++ b/library/src/lapack/roclapack_potrf_batched.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_potrf.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename U>
 rocblas_status rocsolver_potrf_batched_impl(rocblas_handle handle,
                                             const rocblas_fill uplo,
                                             const rocblas_int n,
@@ -15,6 +15,8 @@ rocblas_status rocsolver_potrf_batched_impl(rocblas_handle handle,
 {
     ROCSOLVER_ENTER_TOP("potrf_batched", "--uplo", uplo, "-n", n, "--lda", lda, "--batch_count",
                         batch_count);
+
+    using S = decltype(std::real(T{}));
 
     if(!handle)
         return rocblas_status_invalid_handle;
@@ -70,7 +72,7 @@ rocblas_status rocsolver_potrf_batched_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_potrf_template<true, S, T>(handle, uplo, n, A, shiftA, lda, strideA, info,
+    return rocsolver_potrf_template<true, T, S>(handle, uplo, n, A, shiftA, lda, strideA, info,
                                                 batch_count, (T*)scalars, work1, work2, work3,
                                                 work4, (T*)pivots, (rocblas_int*)iinfo, optim_mem);
 }
@@ -91,7 +93,7 @@ rocblas_status rocsolver_spotrf_batched(rocblas_handle handle,
                                         rocblas_int* info,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_potrf_batched_impl<float, float>(handle, uplo, n, A, lda, info, batch_count);
+    return rocsolver_potrf_batched_impl<float>(handle, uplo, n, A, lda, info, batch_count);
 }
 
 rocblas_status rocsolver_dpotrf_batched(rocblas_handle handle,
@@ -102,7 +104,7 @@ rocblas_status rocsolver_dpotrf_batched(rocblas_handle handle,
                                         rocblas_int* info,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_potrf_batched_impl<double, double>(handle, uplo, n, A, lda, info, batch_count);
+    return rocsolver_potrf_batched_impl<double>(handle, uplo, n, A, lda, info, batch_count);
 }
 
 rocblas_status rocsolver_cpotrf_batched(rocblas_handle handle,
@@ -113,8 +115,8 @@ rocblas_status rocsolver_cpotrf_batched(rocblas_handle handle,
                                         rocblas_int* info,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_potrf_batched_impl<float, rocblas_float_complex>(handle, uplo, n, A, lda, info,
-                                                                      batch_count);
+    return rocsolver_potrf_batched_impl<rocblas_float_complex>(handle, uplo, n, A, lda, info,
+                                                               batch_count);
 }
 
 rocblas_status rocsolver_zpotrf_batched(rocblas_handle handle,
@@ -125,7 +127,7 @@ rocblas_status rocsolver_zpotrf_batched(rocblas_handle handle,
                                         rocblas_int* info,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_potrf_batched_impl<double, rocblas_double_complex>(handle, uplo, n, A, lda,
-                                                                        info, batch_count);
+    return rocsolver_potrf_batched_impl<rocblas_double_complex>(handle, uplo, n, A, lda, info,
+                                                                batch_count);
 }
 }

--- a/library/src/lapack/roclapack_potrf_strided_batched.cpp
+++ b/library/src/lapack/roclapack_potrf_strided_batched.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_potrf.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename U>
 rocblas_status rocsolver_potrf_strided_batched_impl(rocblas_handle handle,
                                                     const rocblas_fill uplo,
                                                     const rocblas_int n,
@@ -16,6 +16,8 @@ rocblas_status rocsolver_potrf_strided_batched_impl(rocblas_handle handle,
 {
     ROCSOLVER_ENTER_TOP("potrf_strided_batched", "--uplo", uplo, "-n", n, "--lda", lda, "--strideA",
                         strideA, "--batch_count", batch_count);
+
+    using S = decltype(std::real(T{}));
 
     if(!handle)
         return rocblas_status_invalid_handle;
@@ -68,7 +70,7 @@ rocblas_status rocsolver_potrf_strided_batched_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_potrf_template<false, S, T>(handle, uplo, n, A, shiftA, lda, strideA, info,
+    return rocsolver_potrf_template<false, T, S>(handle, uplo, n, A, shiftA, lda, strideA, info,
                                                  batch_count, (T*)scalars, work1, work2, work3,
                                                  work4, (T*)pivots, (rocblas_int*)iinfo, optim_mem);
 }
@@ -90,8 +92,8 @@ rocblas_status rocsolver_spotrf_strided_batched(rocblas_handle handle,
                                                 rocblas_int* info,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_potrf_strided_batched_impl<float, float>(handle, uplo, n, A, lda, strideA,
-                                                              info, batch_count);
+    return rocsolver_potrf_strided_batched_impl<float>(handle, uplo, n, A, lda, strideA, info,
+                                                       batch_count);
 }
 
 rocblas_status rocsolver_dpotrf_strided_batched(rocblas_handle handle,
@@ -103,8 +105,8 @@ rocblas_status rocsolver_dpotrf_strided_batched(rocblas_handle handle,
                                                 rocblas_int* info,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_potrf_strided_batched_impl<double, double>(handle, uplo, n, A, lda, strideA,
-                                                                info, batch_count);
+    return rocsolver_potrf_strided_batched_impl<double>(handle, uplo, n, A, lda, strideA, info,
+                                                        batch_count);
 }
 
 rocblas_status rocsolver_cpotrf_strided_batched(rocblas_handle handle,
@@ -116,8 +118,8 @@ rocblas_status rocsolver_cpotrf_strided_batched(rocblas_handle handle,
                                                 rocblas_int* info,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_potrf_strided_batched_impl<float, rocblas_float_complex>(
-        handle, uplo, n, A, lda, strideA, info, batch_count);
+    return rocsolver_potrf_strided_batched_impl<rocblas_float_complex>(handle, uplo, n, A, lda,
+                                                                       strideA, info, batch_count);
 }
 
 rocblas_status rocsolver_zpotrf_strided_batched(rocblas_handle handle,
@@ -129,7 +131,7 @@ rocblas_status rocsolver_zpotrf_strided_batched(rocblas_handle handle,
                                                 rocblas_int* info,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_potrf_strided_batched_impl<double, rocblas_double_complex>(
-        handle, uplo, n, A, lda, strideA, info, batch_count);
+    return rocsolver_potrf_strided_batched_impl<rocblas_double_complex>(handle, uplo, n, A, lda,
+                                                                        strideA, info, batch_count);
 }
 }

--- a/library/src/lapack/roclapack_syev_heev.hpp
+++ b/library/src/lapack/roclapack_syev_heev.hpp
@@ -60,12 +60,12 @@ __global__ void scalar_case(const rocblas_evect evect,
 }
 
 /** Argument checking **/
-template <typename W, typename S>
+template <typename T, typename S>
 rocblas_status rocsolver_syev_heev_argCheck(rocblas_handle handle,
                                             const rocblas_evect evect,
                                             const rocblas_fill uplo,
                                             const rocblas_int n,
-                                            W A,
+                                            T A,
                                             const rocblas_int lda,
                                             S* D,
                                             S* E,

--- a/library/src/lapack/roclapack_syev_heev.hpp
+++ b/library/src/lapack/roclapack_syev_heev.hpp
@@ -125,13 +125,13 @@ void rocsolver_syev_heev_getMemorySize(const rocblas_evect evect,
     size_t t1 = 0, t2 = 0;
 
     // requirements for tridiagonalization (sytrd/hetrd)
-    rocsolver_sytrd_hetrd_getMemorySize<T, BATCHED>(n, batch_count, size_scalars, &w1, &a1, &t1,
+    rocsolver_sytrd_hetrd_getMemorySize<BATCHED, T>(n, batch_count, size_scalars, &w1, &a1, &t1,
                                                     size_workArr);
 
     if(evect == rocblas_evect_original)
     {
         // extra requirements for orgtr/ungtr
-        rocsolver_orgtr_ungtr_getMemorySize<T, BATCHED>(uplo, n, batch_count, &unused, &w2, &a2,
+        rocsolver_orgtr_ungtr_getMemorySize<BATCHED, T>(uplo, n, batch_count, &unused, &w2, &a2,
                                                         &t2, &unused);
 
         // extra requirements for computing eigenvalues and vectors (steqr)

--- a/library/src/lapack/roclapack_syevd_heevd.hpp
+++ b/library/src/lapack/roclapack_syevd_heevd.hpp
@@ -51,7 +51,7 @@ void rocsolver_syevd_heevd_getMemorySize(const rocblas_evect evect,
     size_t t1 = 0, t2 = 0;
 
     // requirements for tridiagonalization (sytrd/hetrd)
-    rocsolver_sytrd_hetrd_getMemorySize<T, BATCHED>(n, batch_count, size_scalars, &w11, &w21, &t1,
+    rocsolver_sytrd_hetrd_getMemorySize<BATCHED, T>(n, batch_count, size_scalars, &w11, &w21, &t1,
                                                     &unused);
 
     if(evect == rocblas_evect_original)
@@ -61,7 +61,7 @@ void rocsolver_syevd_heevd_getMemorySize(const rocblas_evect evect,
                                                      &unused);
 
         // extra requirements for ormtr/unmtr
-        rocsolver_ormtr_unmtr_getMemorySize<T, BATCHED>(rocblas_side_left, uplo, n, n, batch_count,
+        rocsolver_ormtr_unmtr_getMemorySize<BATCHED, T>(rocblas_side_left, uplo, n, n, batch_count,
                                                         &unused, &w13, &w23, &w32, &unused);
 
         *size_work3 = std::max(w31, w32);

--- a/library/src/lapack/roclapack_sygs2_hegs2.cpp
+++ b/library/src/lapack/roclapack_sygs2_hegs2.cpp
@@ -41,7 +41,7 @@ rocblas_status rocsolver_sygs2_hegs2_impl(rocblas_handle handle,
     size_t size_work_wur, size_store_wcs;
     // size of array of pointers (only for batched case)
     size_t size_workArr;
-    rocsolver_sygs2_hegs2_getMemorySize<T, false>(itype, n, batch_count, &size_scalars,
+    rocsolver_sygs2_hegs2_getMemorySize<false, T>(itype, n, batch_count, &size_scalars,
                                                   &size_work_wur, &size_store_wcs, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_sygs2_hegs2.hpp
+++ b/library/src/lapack/roclapack_sygs2_hegs2.hpp
@@ -99,7 +99,7 @@ __global__ void sygs2_set_diag3(const rocblas_int k,
     }
 }
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_sygs2_hegs2_getMemorySize(const rocblas_eform itype,
                                          const rocblas_int n,
                                          const rocblas_int batch_count,

--- a/library/src/lapack/roclapack_sygs2_hegs2_batched.cpp
+++ b/library/src/lapack/roclapack_sygs2_hegs2_batched.cpp
@@ -43,7 +43,7 @@ rocblas_status rocsolver_sygs2_hegs2_batched_impl(rocblas_handle handle,
     size_t size_work_wur, size_store_wcs;
     // size of array of pointers (only for batched case)
     size_t size_workArr;
-    rocsolver_sygs2_hegs2_getMemorySize<T, true>(itype, n, batch_count, &size_scalars,
+    rocsolver_sygs2_hegs2_getMemorySize<true, T>(itype, n, batch_count, &size_scalars,
                                                  &size_work_wur, &size_store_wcs, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_sygs2_hegs2_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sygs2_hegs2_strided_batched.cpp
@@ -41,7 +41,7 @@ rocblas_status rocsolver_sygs2_hegs2_strided_batched_impl(rocblas_handle handle,
     size_t size_work_wur, size_store_wcs;
     // size of array of pointers (only for batched case)
     size_t size_workArr;
-    rocsolver_sygs2_hegs2_getMemorySize<T, false>(itype, n, batch_count, &size_scalars,
+    rocsolver_sygs2_hegs2_getMemorySize<false, T>(itype, n, batch_count, &size_scalars,
                                                   &size_work_wur, &size_store_wcs, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_sygst_hegst.cpp
+++ b/library/src/lapack/roclapack_sygst_hegst.cpp
@@ -41,7 +41,7 @@ rocblas_status rocsolver_sygst_hegst_impl(rocblas_handle handle,
     size_t size_scalars;
     // size of reusable workspace (and for calling TRSV or TRMV)
     size_t size_work_wur_x_temp, size_workArr_temp_arr, size_store_wcs_invA, size_invA_arr;
-    rocsolver_sygst_hegst_getMemorySize<T, false>(itype, n, batch_count, &size_scalars,
+    rocsolver_sygst_hegst_getMemorySize<false, T>(itype, n, batch_count, &size_scalars,
                                                   &size_work_wur_x_temp, &size_workArr_temp_arr,
                                                   &size_store_wcs_invA, &size_invA_arr);
 

--- a/library/src/lapack/roclapack_sygst_hegst.cpp
+++ b/library/src/lapack/roclapack_sygst_hegst.cpp
@@ -70,7 +70,7 @@ rocblas_status rocsolver_sygst_hegst_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_sygst_hegst_template<false, false, S, T>(
+    return rocsolver_sygst_hegst_template<false, false, T, S>(
         handle, itype, uplo, n, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, batch_count,
         (T*)scalars, work_wur_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr, optim_mem);
 }

--- a/library/src/lapack/roclapack_sygst_hegst.hpp
+++ b/library/src/lapack/roclapack_sygst_hegst.hpp
@@ -13,7 +13,7 @@
 #include "roclapack_sygs2_hegs2.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_sygst_hegst_getMemorySize(const rocblas_eform itype,
                                          const rocblas_int n,
                                          const rocblas_int batch_count,
@@ -37,7 +37,7 @@ void rocsolver_sygst_hegst_getMemorySize(const rocblas_eform itype,
     if(n < xxGST_xxGS2_BLOCKSIZE)
     {
         // requirements for calling a single SYGS2/HEGS2
-        rocsolver_sygs2_hegs2_getMemorySize<T, BATCHED>(itype, n, batch_count, size_scalars,
+        rocsolver_sygs2_hegs2_getMemorySize<BATCHED, T>(itype, n, batch_count, size_scalars,
                                                         size_work_wur_x_temp, size_store_wcs_invA,
                                                         size_workArr_temp_arr);
         *size_invA_arr = 0;
@@ -48,7 +48,7 @@ void rocsolver_sygst_hegst_getMemorySize(const rocblas_eform itype,
         size_t temp1, temp2, temp3, temp4, temp5, temp6, temp7, temp8;
 
         // requirements for calling SYGS2/HEGS2 for the subblocks
-        rocsolver_sygs2_hegs2_getMemorySize<T, BATCHED>(itype, kb, batch_count, size_scalars,
+        rocsolver_sygs2_hegs2_getMemorySize<BATCHED, T>(itype, kb, batch_count, size_scalars,
                                                         size_work_wur_x_temp, size_store_wcs_invA,
                                                         size_workArr_temp_arr);
         *size_invA_arr = 0;

--- a/library/src/lapack/roclapack_sygst_hegst.hpp
+++ b/library/src/lapack/roclapack_sygst_hegst.hpp
@@ -69,7 +69,7 @@ void rocsolver_sygst_hegst_getMemorySize(const rocblas_eform itype,
     }
 }
 
-template <bool BATCHED, bool STRIDED, typename S, typename T, typename U, bool COMPLEX = is_complex<T>>
+template <bool BATCHED, bool STRIDED, typename T, typename S, typename U, bool COMPLEX = is_complex<T>>
 rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                                               const rocblas_eform itype,
                                               const rocblas_fill uplo,

--- a/library/src/lapack/roclapack_sygst_hegst_batched.cpp
+++ b/library/src/lapack/roclapack_sygst_hegst_batched.cpp
@@ -72,7 +72,7 @@ rocblas_status rocsolver_sygst_hegst_batched_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_sygst_hegst_template<true, false, S, T>(
+    return rocsolver_sygst_hegst_template<true, false, T, S>(
         handle, itype, uplo, n, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, batch_count,
         (T*)scalars, work_x_temp, workArr_temp_arr, store_invA, invA_arr, optim_mem);
 }

--- a/library/src/lapack/roclapack_sygst_hegst_batched.cpp
+++ b/library/src/lapack/roclapack_sygst_hegst_batched.cpp
@@ -43,7 +43,7 @@ rocblas_status rocsolver_sygst_hegst_batched_impl(rocblas_handle handle,
     size_t size_scalars;
     // size of reusable workspace (and for calling TRSV or TRMV)
     size_t size_work_wur_x_temp, size_workArr_temp_arr, size_store_wcs_invA, size_invA_arr;
-    rocsolver_sygst_hegst_getMemorySize<T, true>(itype, n, batch_count, &size_scalars,
+    rocsolver_sygst_hegst_getMemorySize<true, T>(itype, n, batch_count, &size_scalars,
                                                  &size_work_wur_x_temp, &size_workArr_temp_arr,
                                                  &size_store_wcs_invA, &size_invA_arr);
 

--- a/library/src/lapack/roclapack_sygst_hegst_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sygst_hegst_strided_batched.cpp
@@ -70,7 +70,7 @@ rocblas_status rocsolver_sygst_hegst_strided_batched_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_sygst_hegst_template<false, true, S, T>(
+    return rocsolver_sygst_hegst_template<false, true, T, S>(
         handle, itype, uplo, n, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, batch_count,
         (T*)scalars, work_wur_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr, optim_mem);
 }

--- a/library/src/lapack/roclapack_sygst_hegst_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sygst_hegst_strided_batched.cpp
@@ -41,7 +41,7 @@ rocblas_status rocsolver_sygst_hegst_strided_batched_impl(rocblas_handle handle,
     size_t size_scalars;
     // size of reusable workspace (and for calling TRSV or TRMV)
     size_t size_work_wur_x_temp, size_workArr_temp_arr, size_store_wcs_invA, size_invA_arr;
-    rocsolver_sygst_hegst_getMemorySize<T, false>(itype, n, batch_count, &size_scalars,
+    rocsolver_sygst_hegst_getMemorySize<false, T>(itype, n, batch_count, &size_scalars,
                                                   &size_work_wur_x_temp, &size_workArr_temp_arr,
                                                   &size_store_wcs_invA, &size_invA_arr);
 

--- a/library/src/lapack/roclapack_sygv_hegv.cpp
+++ b/library/src/lapack/roclapack_sygv_hegv.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_sygv_hegv.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_sygv_hegv_impl(rocblas_handle handle,
                                         const rocblas_eform itype,
                                         const rocblas_evect evect,
@@ -109,8 +109,7 @@ rocblas_status rocsolver_ssygv(rocblas_handle handle,
                                float* E,
                                rocblas_int* info)
 {
-    return rocsolver_sygv_hegv_impl<float, float>(handle, itype, evect, uplo, n, A, lda, B, ldb, D,
-                                                  E, info);
+    return rocsolver_sygv_hegv_impl<float>(handle, itype, evect, uplo, n, A, lda, B, ldb, D, E, info);
 }
 
 rocblas_status rocsolver_dsygv(rocblas_handle handle,
@@ -126,8 +125,8 @@ rocblas_status rocsolver_dsygv(rocblas_handle handle,
                                double* E,
                                rocblas_int* info)
 {
-    return rocsolver_sygv_hegv_impl<double, double>(handle, itype, evect, uplo, n, A, lda, B, ldb,
-                                                    D, E, info);
+    return rocsolver_sygv_hegv_impl<double>(handle, itype, evect, uplo, n, A, lda, B, ldb, D, E,
+                                            info);
 }
 
 rocblas_status rocsolver_chegv(rocblas_handle handle,
@@ -143,8 +142,8 @@ rocblas_status rocsolver_chegv(rocblas_handle handle,
                                float* E,
                                rocblas_int* info)
 {
-    return rocsolver_sygv_hegv_impl<float, rocblas_float_complex>(handle, itype, evect, uplo, n, A,
-                                                                  lda, B, ldb, D, E, info);
+    return rocsolver_sygv_hegv_impl<rocblas_float_complex>(handle, itype, evect, uplo, n, A, lda, B,
+                                                           ldb, D, E, info);
 }
 
 rocblas_status rocsolver_zhegv(rocblas_handle handle,
@@ -160,8 +159,8 @@ rocblas_status rocsolver_zhegv(rocblas_handle handle,
                                double* E,
                                rocblas_int* info)
 {
-    return rocsolver_sygv_hegv_impl<double, rocblas_double_complex>(handle, itype, evect, uplo, n,
-                                                                    A, lda, B, ldb, D, E, info);
+    return rocsolver_sygv_hegv_impl<rocblas_double_complex>(handle, itype, evect, uplo, n, A, lda,
+                                                            B, ldb, D, E, info);
 }
 
 } // extern C

--- a/library/src/lapack/roclapack_sygv_hegv.hpp
+++ b/library/src/lapack/roclapack_sygv_hegv.hpp
@@ -96,7 +96,7 @@ void rocsolver_sygv_hegv_getMemorySize(const rocblas_eform itype,
     }
 }
 
-template <typename S, typename T>
+template <typename T, typename S>
 rocblas_status rocsolver_sygv_hegv_argCheck(rocblas_handle handle,
                                             const rocblas_eform itype,
                                             const rocblas_evect evect,
@@ -196,7 +196,7 @@ rocblas_status rocsolver_sygv_hegv_template(rocblas_handle handle,
     T one = 1;
 
     // perform Cholesky factorization of B
-    rocsolver_potrf_template<BATCHED, S, T>(handle, uplo, n, B, shiftB, ldb, strideB, info,
+    rocsolver_potrf_template<BATCHED, T, S>(handle, uplo, n, B, shiftB, ldb, strideB, info,
                                             batch_count, scalars, work1, work2, work3, work4,
                                             (T*)pivots_workArr, iinfo, optim_mem);
 
@@ -206,7 +206,7 @@ rocblas_status rocsolver_sygv_hegv_template(rocblas_handle handle,
         positive-definite case) **/
 
     // reduce to standard eigenvalue problem and solve
-    rocsolver_sygst_hegst_template<BATCHED, STRIDED, S, T>(
+    rocsolver_sygst_hegst_template<BATCHED, STRIDED, T, S>(
         handle, itype, uplo, n, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, batch_count,
         scalars, work1, work2, work3, work4, optim_mem);
 

--- a/library/src/lapack/roclapack_sygv_hegv.hpp
+++ b/library/src/lapack/roclapack_sygv_hegv.hpp
@@ -65,7 +65,7 @@ void rocsolver_sygv_hegv_getMemorySize(const rocblas_eform itype,
     *size_iinfo = max(*size_iinfo, sizeof(rocblas_int) * batch_count);
 
     // requirements for calling SYGST/HEGST
-    rocsolver_sygst_hegst_getMemorySize<T, BATCHED>(itype, n, batch_count, &unused, &temp1, &temp2,
+    rocsolver_sygst_hegst_getMemorySize<BATCHED, T>(itype, n, batch_count, &unused, &temp1, &temp2,
                                                     &temp3, &temp4);
     *size_work1 = max(*size_work1, temp1);
     *size_work2 = max(*size_work2, temp2);

--- a/library/src/lapack/roclapack_sygv_hegv_batched.cpp
+++ b/library/src/lapack/roclapack_sygv_hegv_batched.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_sygv_hegv.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_sygv_hegv_batched_impl(rocblas_handle handle,
                                                 const rocblas_eform itype,
                                                 const rocblas_evect evect,
@@ -113,8 +113,8 @@ rocblas_status rocsolver_ssygv_batched(rocblas_handle handle,
                                        rocblas_int* info,
                                        const rocblas_int batch_count)
 {
-    return rocsolver_sygv_hegv_batched_impl<float, float>(
-        handle, itype, evect, uplo, n, A, lda, B, ldb, D, strideD, E, strideE, info, batch_count);
+    return rocsolver_sygv_hegv_batched_impl<float>(handle, itype, evect, uplo, n, A, lda, B, ldb, D,
+                                                   strideD, E, strideE, info, batch_count);
 }
 
 rocblas_status rocsolver_dsygv_batched(rocblas_handle handle,
@@ -133,8 +133,8 @@ rocblas_status rocsolver_dsygv_batched(rocblas_handle handle,
                                        rocblas_int* info,
                                        const rocblas_int batch_count)
 {
-    return rocsolver_sygv_hegv_batched_impl<double, double>(
-        handle, itype, evect, uplo, n, A, lda, B, ldb, D, strideD, E, strideE, info, batch_count);
+    return rocsolver_sygv_hegv_batched_impl<double>(handle, itype, evect, uplo, n, A, lda, B, ldb,
+                                                    D, strideD, E, strideE, info, batch_count);
 }
 
 rocblas_status rocsolver_chegv_batched(rocblas_handle handle,
@@ -153,7 +153,7 @@ rocblas_status rocsolver_chegv_batched(rocblas_handle handle,
                                        rocblas_int* info,
                                        const rocblas_int batch_count)
 {
-    return rocsolver_sygv_hegv_batched_impl<float, rocblas_float_complex>(
+    return rocsolver_sygv_hegv_batched_impl<rocblas_float_complex>(
         handle, itype, evect, uplo, n, A, lda, B, ldb, D, strideD, E, strideE, info, batch_count);
 }
 
@@ -173,7 +173,7 @@ rocblas_status rocsolver_zhegv_batched(rocblas_handle handle,
                                        rocblas_int* info,
                                        const rocblas_int batch_count)
 {
-    return rocsolver_sygv_hegv_batched_impl<double, rocblas_double_complex>(
+    return rocsolver_sygv_hegv_batched_impl<rocblas_double_complex>(
         handle, itype, evect, uplo, n, A, lda, B, ldb, D, strideD, E, strideE, info, batch_count);
 }
 

--- a/library/src/lapack/roclapack_sygv_hegv_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sygv_hegv_strided_batched.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_sygv_hegv.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_sygv_hegv_strided_batched_impl(rocblas_handle handle,
                                                         const rocblas_eform itype,
                                                         const rocblas_evect evect,
@@ -113,9 +113,9 @@ rocblas_status rocsolver_ssygv_strided_batched(rocblas_handle handle,
                                                rocblas_int* info,
                                                const rocblas_int batch_count)
 {
-    return rocsolver_sygv_hegv_strided_batched_impl<float, float>(
-        handle, itype, evect, uplo, n, A, lda, strideA, B, ldb, strideB, D, strideD, E, strideE,
-        info, batch_count);
+    return rocsolver_sygv_hegv_strided_batched_impl<float>(handle, itype, evect, uplo, n, A, lda,
+                                                           strideA, B, ldb, strideB, D, strideD, E,
+                                                           strideE, info, batch_count);
 }
 
 rocblas_status rocsolver_dsygv_strided_batched(rocblas_handle handle,
@@ -136,9 +136,9 @@ rocblas_status rocsolver_dsygv_strided_batched(rocblas_handle handle,
                                                rocblas_int* info,
                                                const rocblas_int batch_count)
 {
-    return rocsolver_sygv_hegv_strided_batched_impl<double, double>(
-        handle, itype, evect, uplo, n, A, lda, strideA, B, ldb, strideB, D, strideD, E, strideE,
-        info, batch_count);
+    return rocsolver_sygv_hegv_strided_batched_impl<double>(handle, itype, evect, uplo, n, A, lda,
+                                                            strideA, B, ldb, strideB, D, strideD, E,
+                                                            strideE, info, batch_count);
 }
 
 rocblas_status rocsolver_chegv_strided_batched(rocblas_handle handle,
@@ -159,7 +159,7 @@ rocblas_status rocsolver_chegv_strided_batched(rocblas_handle handle,
                                                rocblas_int* info,
                                                const rocblas_int batch_count)
 {
-    return rocsolver_sygv_hegv_strided_batched_impl<float, rocblas_float_complex>(
+    return rocsolver_sygv_hegv_strided_batched_impl<rocblas_float_complex>(
         handle, itype, evect, uplo, n, A, lda, strideA, B, ldb, strideB, D, strideD, E, strideE,
         info, batch_count);
 }
@@ -182,7 +182,7 @@ rocblas_status rocsolver_zhegv_strided_batched(rocblas_handle handle,
                                                rocblas_int* info,
                                                const rocblas_int batch_count)
 {
-    return rocsolver_sygv_hegv_strided_batched_impl<double, rocblas_double_complex>(
+    return rocsolver_sygv_hegv_strided_batched_impl<rocblas_double_complex>(
         handle, itype, evect, uplo, n, A, lda, strideA, B, ldb, strideB, D, strideD, E, strideE,
         info, batch_count);
 }

--- a/library/src/lapack/roclapack_sygvd_hegvd.cpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_sygvd_hegvd.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_sygvd_hegvd_impl(rocblas_handle handle,
                                           const rocblas_eform itype,
                                           const rocblas_evect evect,
@@ -111,8 +111,8 @@ rocblas_status rocsolver_ssygvd(rocblas_handle handle,
                                 float* E,
                                 rocblas_int* info)
 {
-    return rocsolver_sygvd_hegvd_impl<float, float>(handle, itype, evect, uplo, n, A, lda, B, ldb,
-                                                    D, E, info);
+    return rocsolver_sygvd_hegvd_impl<float>(handle, itype, evect, uplo, n, A, lda, B, ldb, D, E,
+                                             info);
 }
 
 rocblas_status rocsolver_dsygvd(rocblas_handle handle,
@@ -128,8 +128,8 @@ rocblas_status rocsolver_dsygvd(rocblas_handle handle,
                                 double* E,
                                 rocblas_int* info)
 {
-    return rocsolver_sygvd_hegvd_impl<double, double>(handle, itype, evect, uplo, n, A, lda, B, ldb,
-                                                      D, E, info);
+    return rocsolver_sygvd_hegvd_impl<double>(handle, itype, evect, uplo, n, A, lda, B, ldb, D, E,
+                                              info);
 }
 
 rocblas_status rocsolver_chegvd(rocblas_handle handle,
@@ -145,8 +145,8 @@ rocblas_status rocsolver_chegvd(rocblas_handle handle,
                                 float* E,
                                 rocblas_int* info)
 {
-    return rocsolver_sygvd_hegvd_impl<float, rocblas_float_complex>(handle, itype, evect, uplo, n,
-                                                                    A, lda, B, ldb, D, E, info);
+    return rocsolver_sygvd_hegvd_impl<rocblas_float_complex>(handle, itype, evect, uplo, n, A, lda,
+                                                             B, ldb, D, E, info);
 }
 
 rocblas_status rocsolver_zhegvd(rocblas_handle handle,
@@ -162,8 +162,8 @@ rocblas_status rocsolver_zhegvd(rocblas_handle handle,
                                 double* E,
                                 rocblas_int* info)
 {
-    return rocsolver_sygvd_hegvd_impl<double, rocblas_double_complex>(handle, itype, evect, uplo, n,
-                                                                      A, lda, B, ldb, D, E, info);
+    return rocsolver_sygvd_hegvd_impl<rocblas_double_complex>(handle, itype, evect, uplo, n, A, lda,
+                                                              B, ldb, D, E, info);
 }
 
 } // extern C

--- a/library/src/lapack/roclapack_sygvd_hegvd.hpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd.hpp
@@ -54,7 +54,7 @@ void rocsolver_sygvd_hegvd_getMemorySize(const rocblas_eform itype,
     *size_iinfo = max(*size_iinfo, sizeof(rocblas_int) * batch_count);
 
     // requirements for calling SYGST/HEGST
-    rocsolver_sygst_hegst_getMemorySize<T, BATCHED>(itype, n, batch_count, &unused, &temp1, &temp2,
+    rocsolver_sygst_hegst_getMemorySize<BATCHED, T>(itype, n, batch_count, &unused, &temp1, &temp2,
                                                     &temp3, &temp4);
     *size_work1 = max(*size_work1, temp1);
     *size_work2 = max(*size_work2, temp2);

--- a/library/src/lapack/roclapack_sygvd_hegvd.hpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd.hpp
@@ -146,7 +146,7 @@ rocblas_status rocsolver_sygvd_hegvd_template(rocblas_handle handle,
     T one = 1;
 
     // perform Cholesky factorization of B
-    rocsolver_potrf_template<BATCHED, S, T>(handle, uplo, n, B, shiftB, ldb, strideB, info,
+    rocsolver_potrf_template<BATCHED, T, S>(handle, uplo, n, B, shiftB, ldb, strideB, info,
                                             batch_count, scalars, work1, work2, work3, work4,
                                             (T*)pivots_workArr, iinfo, optim_mem);
 
@@ -156,7 +156,7 @@ rocblas_status rocsolver_sygvd_hegvd_template(rocblas_handle handle,
         positive-definite case) **/
 
     // reduce to standard eigenvalue problem and solve
-    rocsolver_sygst_hegst_template<BATCHED, STRIDED, S, T>(
+    rocsolver_sygst_hegst_template<BATCHED, STRIDED, T, S>(
         handle, itype, uplo, n, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, batch_count,
         scalars, work1, work2, work3, work4, optim_mem);
 

--- a/library/src/lapack/roclapack_sygvd_hegvd_batched.cpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd_batched.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_sygvd_hegvd.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_sygvd_hegvd_batched_impl(rocblas_handle handle,
                                                   const rocblas_eform itype,
                                                   const rocblas_evect evect,
@@ -115,8 +115,8 @@ rocblas_status rocsolver_ssygvd_batched(rocblas_handle handle,
                                         rocblas_int* info,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_sygvd_hegvd_batched_impl<float, float>(
-        handle, itype, evect, uplo, n, A, lda, B, ldb, D, strideD, E, strideE, info, batch_count);
+    return rocsolver_sygvd_hegvd_batched_impl<float>(handle, itype, evect, uplo, n, A, lda, B, ldb,
+                                                     D, strideD, E, strideE, info, batch_count);
 }
 
 rocblas_status rocsolver_dsygvd_batched(rocblas_handle handle,
@@ -135,8 +135,8 @@ rocblas_status rocsolver_dsygvd_batched(rocblas_handle handle,
                                         rocblas_int* info,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_sygvd_hegvd_batched_impl<double, double>(
-        handle, itype, evect, uplo, n, A, lda, B, ldb, D, strideD, E, strideE, info, batch_count);
+    return rocsolver_sygvd_hegvd_batched_impl<double>(handle, itype, evect, uplo, n, A, lda, B, ldb,
+                                                      D, strideD, E, strideE, info, batch_count);
 }
 
 rocblas_status rocsolver_chegvd_batched(rocblas_handle handle,
@@ -155,7 +155,7 @@ rocblas_status rocsolver_chegvd_batched(rocblas_handle handle,
                                         rocblas_int* info,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_sygvd_hegvd_batched_impl<float, rocblas_float_complex>(
+    return rocsolver_sygvd_hegvd_batched_impl<rocblas_float_complex>(
         handle, itype, evect, uplo, n, A, lda, B, ldb, D, strideD, E, strideE, info, batch_count);
 }
 
@@ -175,7 +175,7 @@ rocblas_status rocsolver_zhegvd_batched(rocblas_handle handle,
                                         rocblas_int* info,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_sygvd_hegvd_batched_impl<double, rocblas_double_complex>(
+    return rocsolver_sygvd_hegvd_batched_impl<rocblas_double_complex>(
         handle, itype, evect, uplo, n, A, lda, B, ldb, D, strideD, E, strideE, info, batch_count);
 }
 

--- a/library/src/lapack/roclapack_sygvd_hegvd_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd_strided_batched.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_sygvd_hegvd.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_sygvd_hegvd_strided_batched_impl(rocblas_handle handle,
                                                           const rocblas_eform itype,
                                                           const rocblas_evect evect,
@@ -115,9 +115,9 @@ rocblas_status rocsolver_ssygvd_strided_batched(rocblas_handle handle,
                                                 rocblas_int* info,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_sygvd_hegvd_strided_batched_impl<float, float>(
-        handle, itype, evect, uplo, n, A, lda, strideA, B, ldb, strideB, D, strideD, E, strideE,
-        info, batch_count);
+    return rocsolver_sygvd_hegvd_strided_batched_impl<float>(handle, itype, evect, uplo, n, A, lda,
+                                                             strideA, B, ldb, strideB, D, strideD,
+                                                             E, strideE, info, batch_count);
 }
 
 rocblas_status rocsolver_dsygvd_strided_batched(rocblas_handle handle,
@@ -138,9 +138,9 @@ rocblas_status rocsolver_dsygvd_strided_batched(rocblas_handle handle,
                                                 rocblas_int* info,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_sygvd_hegvd_strided_batched_impl<double, double>(
-        handle, itype, evect, uplo, n, A, lda, strideA, B, ldb, strideB, D, strideD, E, strideE,
-        info, batch_count);
+    return rocsolver_sygvd_hegvd_strided_batched_impl<double>(handle, itype, evect, uplo, n, A, lda,
+                                                              strideA, B, ldb, strideB, D, strideD,
+                                                              E, strideE, info, batch_count);
 }
 
 rocblas_status rocsolver_chegvd_strided_batched(rocblas_handle handle,
@@ -161,7 +161,7 @@ rocblas_status rocsolver_chegvd_strided_batched(rocblas_handle handle,
                                                 rocblas_int* info,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_sygvd_hegvd_strided_batched_impl<float, rocblas_float_complex>(
+    return rocsolver_sygvd_hegvd_strided_batched_impl<rocblas_float_complex>(
         handle, itype, evect, uplo, n, A, lda, strideA, B, ldb, strideB, D, strideD, E, strideE,
         info, batch_count);
 }
@@ -184,7 +184,7 @@ rocblas_status rocsolver_zhegvd_strided_batched(rocblas_handle handle,
                                                 rocblas_int* info,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_sygvd_hegvd_strided_batched_impl<double, rocblas_double_complex>(
+    return rocsolver_sygvd_hegvd_strided_batched_impl<rocblas_double_complex>(
         handle, itype, evect, uplo, n, A, lda, strideA, B, ldb, strideB, D, strideD, E, strideE,
         info, batch_count);
 }

--- a/library/src/lapack/roclapack_sytd2_hetd2.cpp
+++ b/library/src/lapack/roclapack_sytd2_hetd2.cpp
@@ -44,7 +44,7 @@ rocblas_status rocsolver_sytd2_hetd2_impl(rocblas_handle handle,
     size_t size_tmptau;
     // size of array of pointers to workspace (batched case)
     size_t size_workArr;
-    rocsolver_sytd2_hetd2_getMemorySize<T, false>(n, batch_count, &size_scalars, &size_work,
+    rocsolver_sytd2_hetd2_getMemorySize<false, T>(n, batch_count, &size_scalars, &size_work,
                                                   &size_norms, &size_tmptau, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_sytd2_hetd2.cpp
+++ b/library/src/lapack/roclapack_sytd2_hetd2.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_sytd2_hetd2.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_sytd2_hetd2_impl(rocblas_handle handle,
                                           const rocblas_fill uplo,
                                           const rocblas_int n,
@@ -67,9 +67,9 @@ rocblas_status rocsolver_sytd2_hetd2_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_sytd2_hetd2_template(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,
-                                          strideE, tau, strideP, batch_count, (T*)scalars, (T*)work,
-                                          (T*)norms, (T*)tmptau, (T**)workArr);
+    return rocsolver_sytd2_hetd2_template<T>(handle, uplo, n, A, shiftA, lda, strideA, D, strideD,
+                                             E, strideE, tau, strideP, batch_count, (T*)scalars,
+                                             (T*)work, (T*)norms, (T*)tmptau, (T**)workArr);
 }
 
 /*
@@ -89,7 +89,7 @@ rocblas_status rocsolver_ssytd2(rocblas_handle handle,
                                 float* E,
                                 float* tau)
 {
-    return rocsolver_sytd2_hetd2_impl<float, float>(handle, uplo, n, A, lda, D, E, tau);
+    return rocsolver_sytd2_hetd2_impl<float>(handle, uplo, n, A, lda, D, E, tau);
 }
 
 rocblas_status rocsolver_dsytd2(rocblas_handle handle,
@@ -101,7 +101,7 @@ rocblas_status rocsolver_dsytd2(rocblas_handle handle,
                                 double* E,
                                 double* tau)
 {
-    return rocsolver_sytd2_hetd2_impl<double, double>(handle, uplo, n, A, lda, D, E, tau);
+    return rocsolver_sytd2_hetd2_impl<double>(handle, uplo, n, A, lda, D, E, tau);
 }
 
 rocblas_status rocsolver_chetd2(rocblas_handle handle,
@@ -113,8 +113,7 @@ rocblas_status rocsolver_chetd2(rocblas_handle handle,
                                 float* E,
                                 rocblas_float_complex* tau)
 {
-    return rocsolver_sytd2_hetd2_impl<float, rocblas_float_complex>(handle, uplo, n, A, lda, D, E,
-                                                                    tau);
+    return rocsolver_sytd2_hetd2_impl<rocblas_float_complex>(handle, uplo, n, A, lda, D, E, tau);
 }
 
 rocblas_status rocsolver_zhetd2(rocblas_handle handle,
@@ -126,8 +125,7 @@ rocblas_status rocsolver_zhetd2(rocblas_handle handle,
                                 double* E,
                                 rocblas_double_complex* tau)
 {
-    return rocsolver_sytd2_hetd2_impl<double, rocblas_double_complex>(handle, uplo, n, A, lda, D, E,
-                                                                      tau);
+    return rocsolver_sytd2_hetd2_impl<rocblas_double_complex>(handle, uplo, n, A, lda, D, E, tau);
 }
 
 } // extern C

--- a/library/src/lapack/roclapack_sytd2_hetd2.hpp
+++ b/library/src/lapack/roclapack_sytd2_hetd2.hpp
@@ -101,7 +101,7 @@ __global__ void set_tridiag(const rocblas_fill uplo,
     }
 }
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_sytd2_hetd2_getMemorySize(const rocblas_int n,
                                          const rocblas_int batch_count,
                                          size_t* size_scalars,

--- a/library/src/lapack/roclapack_sytd2_hetd2.hpp
+++ b/library/src/lapack/roclapack_sytd2_hetd2.hpp
@@ -29,7 +29,7 @@ __global__ void set_tau(const rocblas_int batch_count, T* tmptau, T* tau, const 
 
 /** set_tridiag kernel copies results to set tridiagonal form in A, diagonal elements in D
     and off-diagonal elements in E **/
-template <typename S, typename T, typename U, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, typename S, typename U, std::enable_if_t<!is_complex<T>, int> = 0>
 __global__ void set_tridiag(const rocblas_fill uplo,
                             const rocblas_int n,
                             U A,
@@ -65,7 +65,7 @@ __global__ void set_tridiag(const rocblas_fill uplo,
     }
 }
 
-template <typename S, typename T, typename U, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, typename S, typename U, std::enable_if_t<is_complex<T>, int> = 0>
 __global__ void set_tridiag(const rocblas_fill uplo,
                             const rocblas_int n,
                             U A,
@@ -137,7 +137,7 @@ void rocsolver_sytd2_hetd2_getMemorySize(const rocblas_int n,
     rocsolver_larfg_getMemorySize<T>(n, batch_count, size_work, size_norms);
 }
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_sytd2_hetd2_argCheck(rocblas_handle handle,
                                               const rocblas_fill uplo,
                                               const rocblas_int n,
@@ -169,7 +169,7 @@ rocblas_status rocsolver_sytd2_hetd2_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename S, typename T, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename S, typename U, bool COMPLEX = is_complex<T>>
 rocblas_status rocsolver_sytd2_hetd2_template(rocblas_handle handle,
                                               const rocblas_fill uplo,
                                               const rocblas_int n,
@@ -306,8 +306,8 @@ rocblas_status rocsolver_sytd2_hetd2_template(rocblas_handle handle,
     }
 
     // Copy results (set tridiagonal form in A)
-    hipLaunchKernelGGL((set_tridiag<S, T>), grid_n, threads, 0, stream, uplo, n, A, shiftA, lda,
-                       strideA, D, strideD, E, strideE);
+    hipLaunchKernelGGL(set_tridiag<T>, grid_n, threads, 0, stream, uplo, n, A, shiftA, lda, strideA,
+                       D, strideD, E, strideE);
 
     rocblas_set_pointer_mode(handle, old_mode);
     return rocblas_status_success;

--- a/library/src/lapack/roclapack_sytd2_hetd2_batched.cpp
+++ b/library/src/lapack/roclapack_sytd2_hetd2_batched.cpp
@@ -46,7 +46,7 @@ rocblas_status rocsolver_sytd2_hetd2_batched_impl(rocblas_handle handle,
     size_t size_tmptau;
     // size of array of pointers to workspace (batched case)
     size_t size_workArr;
-    rocsolver_sytd2_hetd2_getMemorySize<T, true>(n, batch_count, &size_scalars, &size_work,
+    rocsolver_sytd2_hetd2_getMemorySize<true, T>(n, batch_count, &size_scalars, &size_work,
                                                  &size_norms, &size_tmptau, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_sytd2_hetd2_batched.cpp
+++ b/library/src/lapack/roclapack_sytd2_hetd2_batched.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_sytd2_hetd2.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_sytd2_hetd2_batched_impl(rocblas_handle handle,
                                                   const rocblas_fill uplo,
                                                   const rocblas_int n,
@@ -69,9 +69,9 @@ rocblas_status rocsolver_sytd2_hetd2_batched_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_sytd2_hetd2_template(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,
-                                          strideE, tau, strideP, batch_count, (T*)scalars, (T*)work,
-                                          (T*)norms, (T*)tmptau, (T**)workArr);
+    return rocsolver_sytd2_hetd2_template<T>(handle, uplo, n, A, shiftA, lda, strideA, D, strideD,
+                                             E, strideE, tau, strideP, batch_count, (T*)scalars,
+                                             (T*)work, (T*)norms, (T*)tmptau, (T**)workArr);
 }
 
 /*
@@ -95,8 +95,8 @@ rocblas_status rocsolver_ssytd2_batched(rocblas_handle handle,
                                         const rocblas_stride strideP,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_sytd2_hetd2_batched_impl<float, float>(handle, uplo, n, A, lda, D, strideD, E,
-                                                            strideE, tau, strideP, batch_count);
+    return rocsolver_sytd2_hetd2_batched_impl<float>(handle, uplo, n, A, lda, D, strideD, E,
+                                                     strideE, tau, strideP, batch_count);
 }
 
 rocblas_status rocsolver_dsytd2_batched(rocblas_handle handle,
@@ -112,8 +112,8 @@ rocblas_status rocsolver_dsytd2_batched(rocblas_handle handle,
                                         const rocblas_stride strideP,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_sytd2_hetd2_batched_impl<double, double>(handle, uplo, n, A, lda, D, strideD,
-                                                              E, strideE, tau, strideP, batch_count);
+    return rocsolver_sytd2_hetd2_batched_impl<double>(handle, uplo, n, A, lda, D, strideD, E,
+                                                      strideE, tau, strideP, batch_count);
 }
 
 rocblas_status rocsolver_chetd2_batched(rocblas_handle handle,
@@ -129,7 +129,7 @@ rocblas_status rocsolver_chetd2_batched(rocblas_handle handle,
                                         const rocblas_stride strideP,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_sytd2_hetd2_batched_impl<float, rocblas_float_complex>(
+    return rocsolver_sytd2_hetd2_batched_impl<rocblas_float_complex>(
         handle, uplo, n, A, lda, D, strideD, E, strideE, tau, strideP, batch_count);
 }
 
@@ -146,7 +146,7 @@ rocblas_status rocsolver_zhetd2_batched(rocblas_handle handle,
                                         const rocblas_stride strideP,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_sytd2_hetd2_batched_impl<double, rocblas_double_complex>(
+    return rocsolver_sytd2_hetd2_batched_impl<rocblas_double_complex>(
         handle, uplo, n, A, lda, D, strideD, E, strideE, tau, strideP, batch_count);
 }
 

--- a/library/src/lapack/roclapack_sytd2_hetd2_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sytd2_hetd2_strided_batched.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_sytd2_hetd2.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_sytd2_hetd2_strided_batched_impl(rocblas_handle handle,
                                                           const rocblas_fill uplo,
                                                           const rocblas_int n,
@@ -68,9 +68,9 @@ rocblas_status rocsolver_sytd2_hetd2_strided_batched_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_sytd2_hetd2_template(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,
-                                          strideE, tau, strideP, batch_count, (T*)scalars, (T*)work,
-                                          (T*)norms, (T*)tmptau, (T**)workArr);
+    return rocsolver_sytd2_hetd2_template<T>(handle, uplo, n, A, shiftA, lda, strideA, D, strideD,
+                                             E, strideE, tau, strideP, batch_count, (T*)scalars,
+                                             (T*)work, (T*)norms, (T*)tmptau, (T**)workArr);
 }
 
 /*
@@ -95,7 +95,7 @@ rocblas_status rocsolver_ssytd2_strided_batched(rocblas_handle handle,
                                                 const rocblas_stride strideP,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_sytd2_hetd2_strided_batched_impl<float, float>(
+    return rocsolver_sytd2_hetd2_strided_batched_impl<float>(
         handle, uplo, n, A, lda, strideA, D, strideD, E, strideE, tau, strideP, batch_count);
 }
 
@@ -113,7 +113,7 @@ rocblas_status rocsolver_dsytd2_strided_batched(rocblas_handle handle,
                                                 const rocblas_stride strideP,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_sytd2_hetd2_strided_batched_impl<double, double>(
+    return rocsolver_sytd2_hetd2_strided_batched_impl<double>(
         handle, uplo, n, A, lda, strideA, D, strideD, E, strideE, tau, strideP, batch_count);
 }
 
@@ -131,7 +131,7 @@ rocblas_status rocsolver_chetd2_strided_batched(rocblas_handle handle,
                                                 const rocblas_stride strideP,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_sytd2_hetd2_strided_batched_impl<float, rocblas_float_complex>(
+    return rocsolver_sytd2_hetd2_strided_batched_impl<rocblas_float_complex>(
         handle, uplo, n, A, lda, strideA, D, strideD, E, strideE, tau, strideP, batch_count);
 }
 
@@ -149,7 +149,7 @@ rocblas_status rocsolver_zhetd2_strided_batched(rocblas_handle handle,
                                                 const rocblas_stride strideP,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_sytd2_hetd2_strided_batched_impl<double, rocblas_double_complex>(
+    return rocsolver_sytd2_hetd2_strided_batched_impl<rocblas_double_complex>(
         handle, uplo, n, A, lda, strideA, D, strideD, E, strideE, tau, strideP, batch_count);
 }
 

--- a/library/src/lapack/roclapack_sytd2_hetd2_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sytd2_hetd2_strided_batched.cpp
@@ -45,7 +45,7 @@ rocblas_status rocsolver_sytd2_hetd2_strided_batched_impl(rocblas_handle handle,
     size_t size_tmptau;
     // size of array of pointers to workspace (batched case)
     size_t size_workArr;
-    rocsolver_sytd2_hetd2_getMemorySize<T, false>(n, batch_count, &size_scalars, &size_work,
+    rocsolver_sytd2_hetd2_getMemorySize<false, T>(n, batch_count, &size_scalars, &size_work,
                                                   &size_norms, &size_tmptau, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_sytrd_hetrd.cpp
+++ b/library/src/lapack/roclapack_sytrd_hetrd.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_sytrd_hetrd.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_sytrd_hetrd_impl(rocblas_handle handle,
                                           const rocblas_fill uplo,
                                           const rocblas_int n,
@@ -66,9 +66,9 @@ rocblas_status rocsolver_sytrd_hetrd_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_sytrd_hetrd_template(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,
-                                          strideE, tau, strideP, batch_count, (T*)scalars, (T*)work,
-                                          (T*)norms, (T*)tmptau_W, (T**)workArr);
+    return rocsolver_sytrd_hetrd_template<T>(handle, uplo, n, A, shiftA, lda, strideA, D, strideD,
+                                             E, strideE, tau, strideP, batch_count, (T*)scalars,
+                                             (T*)work, (T*)norms, (T*)tmptau_W, (T**)workArr);
 }
 
 /*
@@ -88,7 +88,7 @@ rocblas_status rocsolver_ssytrd(rocblas_handle handle,
                                 float* E,
                                 float* tau)
 {
-    return rocsolver_sytrd_hetrd_impl<float, float>(handle, uplo, n, A, lda, D, E, tau);
+    return rocsolver_sytrd_hetrd_impl<float>(handle, uplo, n, A, lda, D, E, tau);
 }
 
 rocblas_status rocsolver_dsytrd(rocblas_handle handle,
@@ -100,7 +100,7 @@ rocblas_status rocsolver_dsytrd(rocblas_handle handle,
                                 double* E,
                                 double* tau)
 {
-    return rocsolver_sytrd_hetrd_impl<double, double>(handle, uplo, n, A, lda, D, E, tau);
+    return rocsolver_sytrd_hetrd_impl<double>(handle, uplo, n, A, lda, D, E, tau);
 }
 
 rocblas_status rocsolver_chetrd(rocblas_handle handle,
@@ -112,8 +112,7 @@ rocblas_status rocsolver_chetrd(rocblas_handle handle,
                                 float* E,
                                 rocblas_float_complex* tau)
 {
-    return rocsolver_sytrd_hetrd_impl<float, rocblas_float_complex>(handle, uplo, n, A, lda, D, E,
-                                                                    tau);
+    return rocsolver_sytrd_hetrd_impl<rocblas_float_complex>(handle, uplo, n, A, lda, D, E, tau);
 }
 
 rocblas_status rocsolver_zhetrd(rocblas_handle handle,
@@ -125,8 +124,7 @@ rocblas_status rocsolver_zhetrd(rocblas_handle handle,
                                 double* E,
                                 rocblas_double_complex* tau)
 {
-    return rocsolver_sytrd_hetrd_impl<double, rocblas_double_complex>(handle, uplo, n, A, lda, D, E,
-                                                                      tau);
+    return rocsolver_sytrd_hetrd_impl<rocblas_double_complex>(handle, uplo, n, A, lda, D, E, tau);
 }
 
 } // extern C

--- a/library/src/lapack/roclapack_sytrd_hetrd.cpp
+++ b/library/src/lapack/roclapack_sytrd_hetrd.cpp
@@ -42,7 +42,7 @@ rocblas_status rocsolver_sytrd_hetrd_impl(rocblas_handle handle,
     size_t size_norms, size_work, size_tmptau_W;
     // size of array of pointers to workspace (batched case)
     size_t size_workArr;
-    rocsolver_sytrd_hetrd_getMemorySize<T, false>(n, batch_count, &size_scalars, &size_work,
+    rocsolver_sytrd_hetrd_getMemorySize<false, T>(n, batch_count, &size_scalars, &size_work,
                                                   &size_norms, &size_tmptau_W, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_sytrd_hetrd.hpp
+++ b/library/src/lapack/roclapack_sytrd_hetrd.hpp
@@ -50,7 +50,7 @@ void rocsolver_sytrd_hetrd_getMemorySize(const rocblas_int n,
     *size_tmptau_W = max(s1, s2);
 }
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_sytrd_hetrd_argCheck(rocblas_handle handle,
                                               const rocblas_fill uplo,
                                               const rocblas_int n,
@@ -82,7 +82,7 @@ rocblas_status rocsolver_sytrd_hetrd_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename S, typename T, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename S, typename U, bool COMPLEX = is_complex<T>>
 rocblas_status rocsolver_sytrd_hetrd_template(rocblas_handle handle,
                                               const rocblas_fill uplo,
                                               const rocblas_int n,
@@ -144,9 +144,9 @@ rocblas_status rocsolver_sytrd_hetrd_template(rocblas_handle handle,
         while(j < n - kk)
         {
             // reduce columns j:j+k-1
-            rocsolver_latrd_template(handle, uplo, n - j, k, A, shiftA + idx2D(j, j, lda), lda,
-                                     strideA, (E + j), strideE, (tau + j), strideP, tmptau_W, 0,
-                                     ldw, strideW, batch_count, scalars, work, norms, workArr);
+            rocsolver_latrd_template<T>(handle, uplo, n - j, k, A, shiftA + idx2D(j, j, lda), lda,
+                                        strideA, (E + j), strideE, (tau + j), strideP, tmptau_W, 0,
+                                        ldw, strideW, batch_count, scalars, work, norms, workArr);
 
             // update unreduced block as a rank-2k update
             // A = A - V*W' - W*V'
@@ -160,9 +160,10 @@ rocblas_status rocsolver_sytrd_hetrd_template(rocblas_handle handle,
         }
 
         // reduce last columns of A
-        rocsolver_sytd2_hetd2_template(handle, uplo, n - j, A, shiftA + idx2D(j, j, lda), lda,
-                                       strideA, (D + j), strideD, (E + j), strideE, (tau + j),
-                                       strideP, batch_count, scalars, work, norms, tmptau_W, workArr);
+        rocsolver_sytd2_hetd2_template<T>(handle, uplo, n - j, A, shiftA + idx2D(j, j, lda), lda,
+                                          strideA, (D + j), strideD, (E + j), strideE, (tau + j),
+                                          strideP, batch_count, scalars, work, norms, tmptau_W,
+                                          workArr);
     }
 
     else
@@ -175,9 +176,9 @@ rocblas_status rocsolver_sytrd_hetrd_template(rocblas_handle handle,
         while(j >= upkk)
         {
             // reduce columns j:j+k-1
-            rocsolver_latrd_template(handle, uplo, j + k, k, A, shiftA, lda, strideA, E, strideE,
-                                     tau, strideP, tmptau_W, 0, ldw, strideW, batch_count, scalars,
-                                     work, norms, workArr);
+            rocsolver_latrd_template<T>(handle, uplo, j + k, k, A, shiftA, lda, strideA, E, strideE,
+                                        tau, strideP, tmptau_W, 0, ldw, strideW, batch_count,
+                                        scalars, work, norms, workArr);
 
             // update unreduced block as a rank-2k update
             // A = A - V*W' - W*V'
@@ -188,15 +189,15 @@ rocblas_status rocsolver_sytrd_hetrd_template(rocblas_handle handle,
         }
 
         // reduce first columns of A
-        rocsolver_sytd2_hetd2_template(handle, uplo, upkk, A, shiftA, lda, strideA, D, strideD, E,
-                                       strideE, tau, strideP, batch_count, scalars, work, norms,
-                                       tmptau_W, workArr);
+        rocsolver_sytd2_hetd2_template<T>(handle, uplo, upkk, A, shiftA, lda, strideA, D, strideD,
+                                          E, strideE, tau, strideP, batch_count, scalars, work,
+                                          norms, tmptau_W, workArr);
     }
 
     // Copy results (set tridiagonal form in A)
     rocblas_int blocks = (n - 1) / BLOCKSIZE + 1;
-    hipLaunchKernelGGL((set_tridiag<S, T>), dim3(blocks, batch_count), dim3(BLOCKSIZE), 0, stream,
-                       uplo, n, A, shiftA, lda, strideA, D, strideD, E, strideE);
+    hipLaunchKernelGGL(set_tridiag<T>, dim3(blocks, batch_count), dim3(BLOCKSIZE), 0, stream, uplo,
+                       n, A, shiftA, lda, strideA, D, strideD, E, strideE);
 
     rocblas_set_pointer_mode(handle, old_mode);
     return rocblas_status_success;

--- a/library/src/lapack/roclapack_sytrd_hetrd.hpp
+++ b/library/src/lapack/roclapack_sytrd_hetrd.hpp
@@ -14,7 +14,7 @@
 #include "roclapack_sytd2_hetd2.hpp"
 #include "rocsolver.h"
 
-template <typename T, bool BATCHED>
+template <bool BATCHED, typename T>
 void rocsolver_sytrd_hetrd_getMemorySize(const rocblas_int n,
                                          const rocblas_int batch_count,
                                          size_t* size_scalars,
@@ -44,7 +44,7 @@ void rocsolver_sytrd_hetrd_getMemorySize(const rocblas_int n,
     }
 
     // extra requirements to call SYTD2/HETD2
-    rocsolver_sytd2_hetd2_getMemorySize<T, BATCHED>(n, batch_count, size_scalars, size_work,
+    rocsolver_sytd2_hetd2_getMemorySize<BATCHED, T>(n, batch_count, size_scalars, size_work,
                                                     size_norms, &s2, size_workArr);
 
     *size_tmptau_W = max(s1, s2);

--- a/library/src/lapack/roclapack_sytrd_hetrd_batched.cpp
+++ b/library/src/lapack/roclapack_sytrd_hetrd_batched.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_sytrd_hetrd.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_sytrd_hetrd_batched_impl(rocblas_handle handle,
                                                   const rocblas_fill uplo,
                                                   const rocblas_int n,
@@ -68,9 +68,9 @@ rocblas_status rocsolver_sytrd_hetrd_batched_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_sytrd_hetrd_template(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,
-                                          strideE, tau, strideP, batch_count, (T*)scalars, (T*)work,
-                                          (T*)norms, (T*)tmptau_W, (T**)workArr);
+    return rocsolver_sytrd_hetrd_template<T>(handle, uplo, n, A, shiftA, lda, strideA, D, strideD,
+                                             E, strideE, tau, strideP, batch_count, (T*)scalars,
+                                             (T*)work, (T*)norms, (T*)tmptau_W, (T**)workArr);
 }
 
 /*
@@ -94,8 +94,8 @@ rocblas_status rocsolver_ssytrd_batched(rocblas_handle handle,
                                         const rocblas_stride strideP,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_sytrd_hetrd_batched_impl<float, float>(handle, uplo, n, A, lda, D, strideD, E,
-                                                            strideE, tau, strideP, batch_count);
+    return rocsolver_sytrd_hetrd_batched_impl<float>(handle, uplo, n, A, lda, D, strideD, E,
+                                                     strideE, tau, strideP, batch_count);
 }
 
 rocblas_status rocsolver_dsytrd_batched(rocblas_handle handle,
@@ -111,8 +111,8 @@ rocblas_status rocsolver_dsytrd_batched(rocblas_handle handle,
                                         const rocblas_stride strideP,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_sytrd_hetrd_batched_impl<double, double>(handle, uplo, n, A, lda, D, strideD,
-                                                              E, strideE, tau, strideP, batch_count);
+    return rocsolver_sytrd_hetrd_batched_impl<double>(handle, uplo, n, A, lda, D, strideD, E,
+                                                      strideE, tau, strideP, batch_count);
 }
 
 rocblas_status rocsolver_chetrd_batched(rocblas_handle handle,
@@ -128,7 +128,7 @@ rocblas_status rocsolver_chetrd_batched(rocblas_handle handle,
                                         const rocblas_stride strideP,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_sytrd_hetrd_batched_impl<float, rocblas_float_complex>(
+    return rocsolver_sytrd_hetrd_batched_impl<rocblas_float_complex>(
         handle, uplo, n, A, lda, D, strideD, E, strideE, tau, strideP, batch_count);
 }
 
@@ -145,7 +145,7 @@ rocblas_status rocsolver_zhetrd_batched(rocblas_handle handle,
                                         const rocblas_stride strideP,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_sytrd_hetrd_batched_impl<double, rocblas_double_complex>(
+    return rocsolver_sytrd_hetrd_batched_impl<rocblas_double_complex>(
         handle, uplo, n, A, lda, D, strideD, E, strideE, tau, strideP, batch_count);
 }
 

--- a/library/src/lapack/roclapack_sytrd_hetrd_batched.cpp
+++ b/library/src/lapack/roclapack_sytrd_hetrd_batched.cpp
@@ -44,7 +44,7 @@ rocblas_status rocsolver_sytrd_hetrd_batched_impl(rocblas_handle handle,
     size_t size_norms, size_work, size_tmptau_W;
     // size of array of pointers to workspace (batched case)
     size_t size_workArr;
-    rocsolver_sytrd_hetrd_getMemorySize<T, true>(n, batch_count, &size_scalars, &size_work,
+    rocsolver_sytrd_hetrd_getMemorySize<true, T>(n, batch_count, &size_scalars, &size_work,
                                                  &size_norms, &size_tmptau_W, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_sytrd_hetrd_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sytrd_hetrd_strided_batched.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_sytrd_hetrd.hpp"
 
-template <typename S, typename T, typename U>
+template <typename T, typename S, typename U>
 rocblas_status rocsolver_sytrd_hetrd_strided_batched_impl(rocblas_handle handle,
                                                           const rocblas_fill uplo,
                                                           const rocblas_int n,
@@ -67,9 +67,9 @@ rocblas_status rocsolver_sytrd_hetrd_strided_batched_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_sytrd_hetrd_template(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,
-                                          strideE, tau, strideP, batch_count, (T*)scalars, (T*)work,
-                                          (T*)norms, (T*)tmptau_W, (T**)workArr);
+    return rocsolver_sytrd_hetrd_template<T>(handle, uplo, n, A, shiftA, lda, strideA, D, strideD,
+                                             E, strideE, tau, strideP, batch_count, (T*)scalars,
+                                             (T*)work, (T*)norms, (T*)tmptau_W, (T**)workArr);
 }
 
 /*
@@ -94,7 +94,7 @@ rocblas_status rocsolver_ssytrd_strided_batched(rocblas_handle handle,
                                                 const rocblas_stride strideP,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_sytrd_hetrd_strided_batched_impl<float, float>(
+    return rocsolver_sytrd_hetrd_strided_batched_impl<float>(
         handle, uplo, n, A, lda, strideA, D, strideD, E, strideE, tau, strideP, batch_count);
 }
 
@@ -112,7 +112,7 @@ rocblas_status rocsolver_dsytrd_strided_batched(rocblas_handle handle,
                                                 const rocblas_stride strideP,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_sytrd_hetrd_strided_batched_impl<double, double>(
+    return rocsolver_sytrd_hetrd_strided_batched_impl<double>(
         handle, uplo, n, A, lda, strideA, D, strideD, E, strideE, tau, strideP, batch_count);
 }
 
@@ -130,7 +130,7 @@ rocblas_status rocsolver_chetrd_strided_batched(rocblas_handle handle,
                                                 const rocblas_stride strideP,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_sytrd_hetrd_strided_batched_impl<float, rocblas_float_complex>(
+    return rocsolver_sytrd_hetrd_strided_batched_impl<rocblas_float_complex>(
         handle, uplo, n, A, lda, strideA, D, strideD, E, strideE, tau, strideP, batch_count);
 }
 
@@ -148,7 +148,7 @@ rocblas_status rocsolver_zhetrd_strided_batched(rocblas_handle handle,
                                                 const rocblas_stride strideP,
                                                 const rocblas_int batch_count)
 {
-    return rocsolver_sytrd_hetrd_strided_batched_impl<double, rocblas_double_complex>(
+    return rocsolver_sytrd_hetrd_strided_batched_impl<rocblas_double_complex>(
         handle, uplo, n, A, lda, strideA, D, strideD, E, strideE, tau, strideP, batch_count);
 }
 

--- a/library/src/lapack/roclapack_sytrd_hetrd_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sytrd_hetrd_strided_batched.cpp
@@ -43,7 +43,7 @@ rocblas_status rocsolver_sytrd_hetrd_strided_batched_impl(rocblas_handle handle,
     size_t size_norms, size_work, size_tmptau_W;
     // size of array of pointers to workspace (batched case)
     size_t size_workArr;
-    rocsolver_sytrd_hetrd_getMemorySize<T, false>(n, batch_count, &size_scalars, &size_work,
+    rocsolver_sytrd_hetrd_getMemorySize<false, T>(n, batch_count, &size_scalars, &size_work,
                                                   &size_norms, &size_tmptau_W, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))


### PR DESCRIPTION
Establishes a consistent ordering for typename S and bool BATCHED template arguments across the library. In summary:

- typename S always follows typename T.
- Test functions and _impl functions that do not have an argument of type S will use `using S = decltype(std::real(T{}));` instead of a template argument.
- bool BATCHED always precedes typename T in `getMemorySize` functions.