### PR TITLE
Build option cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 ### Optimizations
 ### Changed
 - Raised reference LAPACK version used for rocSOLVER test and benchmark clients to v3.9.1
+- Minor CMake improvements for users building from source without install.sh:
+    - Removed fmt::fmt from rocsolver's public usage requirements
+    - Enabled small-size optimizations by default
 
 ### Removed
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ unset(ENV{ROCM_BUILD_ID})
 project(rocsolver LANGUAGES CXX)
 
 option(ROCSOLVER_EMBED_FMT "Hide libfmt symbols" OFF)
+option(OPTIMAL "Build specialized kernels for small matrix sizes" ON)
 
 # Add our CMake helper files to the lookup path
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/install.sh
+++ b/install.sh
@@ -327,8 +327,10 @@ build_docs=false
 optimal=true
 cleanup=false
 build_sanitizer=false
-architecture=
 build_codecoverage=false
+unset architecture
+unset rocblas_dir
+unset rocsolver_dir
 
 
 # #################################################
@@ -544,7 +546,7 @@ if [[ "${optimal}" == false ]]; then
   cmake_common_options="${cmake_common_options} -DOPTIMAL=OFF"
 fi
 
-if [[ -n "${architecture}" ]]; then
+if [[ -n "${architecture+x}" ]]; then
   cmake_common_options="${cmake_common_options} -DAMDGPU_TARGETS=${architecture}"
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -540,8 +540,8 @@ if [[ "${static_lib}" == true ]]; then
   cmake_common_options="${cmake_common_options} -DBUILD_SHARED_LIBS=OFF"
 fi
 
-if [[ "${optimal}" == true ]]; then
-  cmake_common_options="${cmake_common_options} -DOPTIMAL=ON"
+if [[ "${optimal}" == false ]]; then
+  cmake_common_options="${cmake_common_options} -DOPTIMAL=OFF"
 fi
 
 if [[ -n "${architecture}" ]]; then

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -160,7 +160,7 @@ target_link_libraries(rocsolver
 if(ROCSOLVER_EMBED_FMT)
   target_link_libraries(rocsolver PRIVATE fmt::fmt-header-only)
 else()
-  target_link_libraries(rocsolver PUBLIC fmt::fmt)
+  target_link_libraries(rocsolver PRIVATE fmt::fmt)
 endif()
 
 # In ROCm 4.0 and earlier, the default maximum threads per block is 256


### PR DESCRIPTION
These changes only affect users that build rocSOLVER from source
without using install.sh (such as Linux distro package maintainers).
The install.sh script avoids these cases.

- The default for OPTIMAL in install.sh is ON, but was OFF when
  calling cmake directly. We probably want these to match.
- fmt::fmt doesn't need to be PUBLIC. CMake propagates the linking
  dependency to library users even when set to PRIVATE. The PUBLIC
  specification would only be needed for propagating include
  directories (which is not needed). install.sh always specifies
  ROCSOLVER_EMBED_FMT=ON, which avoids this case.