### PR TITLE
Increase CI timeout for extended tests

### DIFF
--- a/.jenkins/extended.groovy
+++ b/.jenkins/extended.groovy
@@ -17,6 +17,7 @@ def runCI =
     def prj = new rocProject('rocSOLVER', 'Extended')
 
     prj.timeout.compile = 600
+    prj.timeout.test = 420
     prj.defaults.ccache = true
 
     // customize for project


### PR DESCRIPTION
Some CI nodes are faster than others, and we're seeing occasional
timeouts on the slower nodes while the tests are still going. We'll
bump the timeout higher as a temporary solution, until we can find
ways to speed up our test suite.