### PR TITLE
Drop gfx803 from default build architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ rocm_check_target_ids(OPTIONAL_AMDGPU_TARGETS
 
 # Set this before finding hip so that hip::device has the required arch flags
 # added as usage requirements on its interface
-set(AMDGPU_TARGETS "gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx1030;${OPTIONAL_AMDGPU_TARGETS}"
+set(AMDGPU_TARGETS "gfx900;gfx906:xnack-;gfx908:xnack-;gfx1030;${OPTIONAL_AMDGPU_TARGETS}"
   CACHE STRING "List of specific machine types for library to target")
 
 # Find HIP dependencies


### PR DESCRIPTION
rocBLAS has removed gfx803 from its default architectures. As rocSOLVER
depends on rocBLAS functionality in many of it's functions, our
supported architectures are a subset of those specified by rocBLAS.

gfx803 is not officially supported by HIP anymore, and dropping the
architecture will reduce the binary size and compile times.

Note that users can still build for gfx803 by explicitly choosing
the architecture via the CMake AMDGPU_TARGETS variable,
or ./install.sh -a gfx803. Community contributions that fix or
improve rocSOLVER on gfx803 remain welcome.