### PR TITLE
Setup runtime and development packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ include(ROCMCreatePackage)
 include(ROCMInstallTargets)
 include(ROCMPackageConfigHelpers)
 include(ROCMInstallSymlinks)
-include(ROCMCheckTargetIds OPTIONAL) # rocm-4.4: Require ROCMCheckTargetIds
+include(ROCMCheckTargetIds)
 
 include(os-detection)
 get_os_id(OS_ID)
@@ -114,15 +114,13 @@ message(STATUS "Samples: ${BUILD_CLIENTS_SAMPLES}")
 # Force library install path to lib (CentOS 7 defaults to lib64)
 set(CMAKE_INSTALL_LIBDIR "lib" CACHE INTERNAL "Installation directory for libraries" FORCE)
 
-# rocm-4.4: Require rocm_check_target_ids
-if(COMMAND rocm_check_target_ids)
-  # Query for compiler support of GPU archs
-  rocm_check_target_ids(OPTIONAL_AMDGPU_TARGETS
-    TARGETS
-      gfx90a:xnack-
-      gfx90a:xnack+
-  )
-endif()
+# Query for compiler support of GPU archs
+rocm_check_target_ids(OPTIONAL_AMDGPU_TARGETS
+  TARGETS
+    gfx90a:xnack-
+    gfx90a:xnack+
+)
+
 # Set this before finding hip so that hip::device has the required arch flags
 # added as usage requirements on its interface
 set(AMDGPU_TARGETS "gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx1030;${OPTIONAL_AMDGPU_TARGETS}"

--- a/cmake/get-rocm-cmake.cmake
+++ b/cmake/get-rocm-cmake.cmake
@@ -8,7 +8,7 @@ if(NOT ROCM_PATH)
   set(ROCM_PATH /opt/rocm)
 endif()
 
-find_package(ROCM CONFIG QUIET PATHS ${ROCM_PATH})
+find_package(ROCM 0.6 CONFIG QUIET PATHS ${ROCM_PATH})
 if(NOT ROCM_FOUND)
   set(rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download")
   set(rocm_cmake_url "https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip")
@@ -30,6 +30,10 @@ if(NOT ROCM_FOUND)
 
   execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzvf "${rocm_cmake_archive}"
     WORKING_DIRECTORY ${PROJECT_EXTERN_DIR})
+  execute_process( COMMAND ${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=${PROJECT_EXTERN_DIR}/rocm-cmake .
+    WORKING_DIRECTORY ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag} )
+  execute_process( COMMAND ${CMAKE_COMMAND} --build rocm-cmake-${rocm_cmake_tag} --target install
+    WORKING_DIRECTORY ${PROJECT_EXTERN_DIR})
 
-  find_package(ROCM REQUIRED CONFIG PATHS "${rocm_cmake_path}")
+  find_package( ROCM 0.6 REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR}/rocm-cmake )
 endif()


### PR DESCRIPTION
As rocSOLVER already installs everything using the functions provided by rocm-cmake, all that is required to enable the development packages is getting the correct rocm-cmake version.

In order to ensure that CMake can get the version of rocm-cmake, it needs to be built and installed to a temporary directory.