### PR TITLE
Set optim_mem in getMemorySize functions

### DIFF
--- a/library/src/lapack/roclapack_gels.cpp
+++ b/library/src/lapack/roclapack_gels.cpp
@@ -37,19 +37,23 @@ rocblas_status rocsolver_gels_impl(rocblas_handle handle,
     const rocblas_stride strideB = 0;
     const rocblas_int batch_count = 1;
 
-    size_t size_scalars, size_work_x_temp, size_workArr_temp_arr, size_diag_trfac_invA,
-        size_trfact_workTrmm_invA_arr, size_ipiv;
+    // memory workspace sizes:
+    // size for constants in rocblas calls
+    size_t size_scalars;
+    // size of workspace (for calling GEQRF/GELQF, ORMQR/ORMLQ, and TRSM)
+    bool optim_mem;
+    size_t size_work_x_temp, size_workArr_temp_arr, size_diag_trfac_invA,
+        size_trfact_workTrmm_invA_arr;
+    // extra requirements for calling ORMQR/ORMLQ and to copy B
+    size_t size_ipiv;
     rocsolver_gels_getMemorySize<false, false, T>(
         m, n, nrhs, batch_count, &size_scalars, &size_work_x_temp, &size_workArr_temp_arr,
-        &size_diag_trfac_invA, &size_trfact_workTrmm_invA_arr, &size_ipiv);
+        &size_diag_trfac_invA, &size_trfact_workTrmm_invA_arr, &size_ipiv, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_x_temp,
                                                       size_workArr_temp_arr, size_diag_trfac_invA,
                                                       size_trfact_workTrmm_invA_arr, size_ipiv);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work, *workArr, *diag_trfac_invA, *trfact_workTrmm_invA, *ipiv;

--- a/library/src/lapack/roclapack_gels.hpp
+++ b/library/src/lapack/roclapack_gels.hpp
@@ -60,7 +60,7 @@ void rocsolver_gels_getMemorySize(const rocblas_int m,
         *size_diag_trfac_invA = 0;
         *size_trfact_workTrmm_invA_arr = 0;
         *size_ipiv_savedB = 0;
-        *optim_mem = false;
+        *optim_mem = true;
         return;
     }
 

--- a/library/src/lapack/roclapack_gels.hpp
+++ b/library/src/lapack/roclapack_gels.hpp
@@ -48,7 +48,8 @@ void rocsolver_gels_getMemorySize(const rocblas_int m,
                                   size_t* size_workArr_temp_arr,
                                   size_t* size_diag_trfac_invA,
                                   size_t* size_trfact_workTrmm_invA_arr,
-                                  size_t* size_ipiv_savedB)
+                                  size_t* size_ipiv_savedB,
+                                  bool* optim_mem)
 {
     // if quick return no workspace needed
     if(m == 0 || n == 0 || nrhs == 0 || batch_count == 0)
@@ -59,6 +60,7 @@ void rocsolver_gels_getMemorySize(const rocblas_int m,
         *size_diag_trfac_invA = 0;
         *size_trfact_workTrmm_invA_arr = 0;
         *size_ipiv_savedB = 0;
+        *optim_mem = false;
         return;
     }
 
@@ -100,6 +102,9 @@ void rocsolver_gels_getMemorySize(const rocblas_int m,
     *size_trfact_workTrmm_invA_arr = std::max({gexxf_trfact, ormxx_workTrmm, trsm_invA_arr});
     // size_ipiv = sizeof(T) * std::min(m, n) * batch_count, which is always less than size_savedB
     *size_ipiv_savedB = sizeof(T) * std::min(m, n) * nrhs * batch_count;
+
+    // always allocate all required memory for TRSM optimal performance
+    *optim_mem = true;
 }
 
 template <bool COMPLEX, typename T>

--- a/library/src/lapack/roclapack_gels_batched.cpp
+++ b/library/src/lapack/roclapack_gels_batched.cpp
@@ -37,19 +37,23 @@ rocblas_status rocsolver_gels_batched_impl(rocblas_handle handle,
     const rocblas_stride strideA = 0;
     const rocblas_stride strideB = 0;
 
-    size_t size_scalars, size_work_x_temp, size_workArr_temp_arr, size_diag_trfac_invA,
-        size_trfact_workTrmm_invA_arr, size_ipiv;
+    // memory workspace sizes:
+    // size for constants in rocblas calls
+    size_t size_scalars;
+    // size of workspace (for calling GEQRF/GELQF, ORMQR/ORMLQ, and TRSM)
+    bool optim_mem;
+    size_t size_work_x_temp, size_workArr_temp_arr, size_diag_trfac_invA,
+        size_trfact_workTrmm_invA_arr;
+    // extra requirements for calling ORMQR/ORMLQ and to copy B
+    size_t size_ipiv;
     rocsolver_gels_getMemorySize<true, false, T>(
         m, n, nrhs, batch_count, &size_scalars, &size_work_x_temp, &size_workArr_temp_arr,
-        &size_diag_trfac_invA, &size_trfact_workTrmm_invA_arr, &size_ipiv);
+        &size_diag_trfac_invA, &size_trfact_workTrmm_invA_arr, &size_ipiv, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_x_temp,
                                                       size_workArr_temp_arr, size_diag_trfac_invA,
                                                       size_trfact_workTrmm_invA_arr, size_ipiv);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work, *workArr, *diag_trfac_invA, *trfact_workTrmm_invA, *ipiv;

--- a/library/src/lapack/roclapack_gels_strided_batched.cpp
+++ b/library/src/lapack/roclapack_gels_strided_batched.cpp
@@ -36,19 +36,23 @@ rocblas_status rocsolver_gels_strided_batched_impl(rocblas_handle handle,
     const rocblas_int shiftA = 0;
     const rocblas_int shiftB = 0;
 
-    size_t size_scalars, size_work_x_temp, size_workArr_temp_arr, size_diag_trfac_invA,
-        size_trfact_workTrmm_invA_arr, size_ipiv;
+    // memory workspace sizes:
+    // size for constants in rocblas calls
+    size_t size_scalars;
+    // size of workspace (for calling GEQRF/GELQF, ORMQR/ORMLQ, and TRSM)
+    bool optim_mem;
+    size_t size_work_x_temp, size_workArr_temp_arr, size_diag_trfac_invA,
+        size_trfact_workTrmm_invA_arr;
+    // extra requirements for calling ORMQR/ORMLQ and to copy B
+    size_t size_ipiv;
     rocsolver_gels_getMemorySize<false, true, T>(
         m, n, nrhs, batch_count, &size_scalars, &size_work_x_temp, &size_workArr_temp_arr,
-        &size_diag_trfac_invA, &size_trfact_workTrmm_invA_arr, &size_ipiv);
+        &size_diag_trfac_invA, &size_trfact_workTrmm_invA_arr, &size_ipiv, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_x_temp,
                                                       size_workArr_temp_arr, size_diag_trfac_invA,
                                                       size_trfact_workTrmm_invA_arr, size_ipiv);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work_x_temp, *workArr_temp_arr, *diag_trfac_invA, *trfact_workTrmm_invA_arr,

--- a/library/src/lapack/roclapack_gesv.cpp
+++ b/library/src/lapack/roclapack_gesv.cpp
@@ -41,20 +41,18 @@ rocblas_status rocsolver_gesv_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspace (and for calling GETRF and GETRS)
+    bool optim_mem;
     size_t size_work, size_work1, size_work2, size_work3, size_work4;
     // extra requirements for calling GETRF
     size_t size_pivotval, size_pivotidx, size_iinfo;
     rocsolver_gesv_getMemorySize<false, false, T, S>(
         n, nrhs, batch_count, &size_scalars, &size_work, &size_work1, &size_work2, &size_work3,
-        &size_work4, &size_pivotval, &size_pivotidx, &size_iinfo);
+        &size_work4, &size_pivotval, &size_pivotidx, &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work, size_work1,
                                                       size_work2, size_work3, size_work4,
                                                       size_pivotval, size_pivotidx, size_iinfo);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work, *work1, *work2, *work3, *work4, *pivotval, *pivotidx, *iinfo;

--- a/library/src/lapack/roclapack_gesv.hpp
+++ b/library/src/lapack/roclapack_gesv.hpp
@@ -73,31 +73,29 @@ void rocsolver_gesv_getMemorySize(const rocblas_int n,
         *size_pivotval = 0;
         *size_pivotidx = 0;
         *size_iinfo = 0;
-        *optim_mem = false;
+        *optim_mem = true;
         return;
     }
 
-    bool unused;
+    bool opt1, opt2;
     size_t w1, w2, w3, w4;
 
     // workspace required for calling GETRF
     rocsolver_getrf_getMemorySize<BATCHED, STRIDED, true, T, S>(
         n, n, batch_count, size_scalars, size_work, size_work1, size_work2, size_work3, size_work4,
-        size_pivotval, size_pivotidx, size_iinfo, &unused);
+        size_pivotval, size_pivotidx, size_iinfo, &opt1);
 
     // workspace required for calling GETRS
-    rocsolver_getrs_getMemorySize<BATCHED, T>(n, nrhs, batch_count, &w1, &w2, &w3, &w4, &unused);
+    rocsolver_getrs_getMemorySize<BATCHED, T>(n, nrhs, batch_count, &w1, &w2, &w3, &w4, &opt2);
 
     *size_work1 = std::max(*size_work1, w1);
     *size_work2 = std::max(*size_work2, w2);
     *size_work3 = std::max(*size_work3, w3);
     *size_work4 = std::max(*size_work4, w4);
+    *optim_mem = opt1 && opt2;
 
     // extra space to copy B
     *size_work = std::max(*size_work, sizeof(T) * n * nrhs * batch_count);
-
-    // always allocate all required memory for TRSM optimal performance
-    *optim_mem = true;
 }
 
 template <bool BATCHED, bool STRIDED, typename T, typename S, typename U>

--- a/library/src/lapack/roclapack_gesv.hpp
+++ b/library/src/lapack/roclapack_gesv.hpp
@@ -58,7 +58,8 @@ void rocsolver_gesv_getMemorySize(const rocblas_int n,
                                   size_t* size_work4,
                                   size_t* size_pivotval,
                                   size_t* size_pivotidx,
-                                  size_t* size_iinfo)
+                                  size_t* size_iinfo,
+                                  bool* optim_mem)
 {
     // if quick return, no workspace is needed
     if(n == 0 || nrhs == 0 || batch_count == 0)
@@ -72,18 +73,20 @@ void rocsolver_gesv_getMemorySize(const rocblas_int n,
         *size_pivotval = 0;
         *size_pivotidx = 0;
         *size_iinfo = 0;
+        *optim_mem = false;
         return;
     }
 
+    bool unused;
     size_t w1, w2, w3, w4;
 
     // workspace required for calling GETRF
     rocsolver_getrf_getMemorySize<BATCHED, STRIDED, true, T, S>(
         n, n, batch_count, size_scalars, size_work, size_work1, size_work2, size_work3, size_work4,
-        size_pivotval, size_pivotidx, size_iinfo);
+        size_pivotval, size_pivotidx, size_iinfo, &unused);
 
     // workspace required for calling GETRS
-    rocsolver_getrs_getMemorySize<BATCHED, T>(n, nrhs, batch_count, &w1, &w2, &w3, &w4);
+    rocsolver_getrs_getMemorySize<BATCHED, T>(n, nrhs, batch_count, &w1, &w2, &w3, &w4, &unused);
 
     *size_work1 = std::max(*size_work1, w1);
     *size_work2 = std::max(*size_work2, w2);
@@ -92,6 +95,9 @@ void rocsolver_gesv_getMemorySize(const rocblas_int n,
 
     // extra space to copy B
     *size_work = std::max(*size_work, sizeof(T) * n * nrhs * batch_count);
+
+    // always allocate all required memory for TRSM optimal performance
+    *optim_mem = true;
 }
 
 template <bool BATCHED, bool STRIDED, typename T, typename S, typename U>

--- a/library/src/lapack/roclapack_gesv_batched.cpp
+++ b/library/src/lapack/roclapack_gesv_batched.cpp
@@ -43,20 +43,18 @@ rocblas_status rocsolver_gesv_batched_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspace (and for calling GETRF and GETRS)
+    bool optim_mem;
     size_t size_work, size_work1, size_work2, size_work3, size_work4;
     // extra requirements for calling GETRF
     size_t size_pivotval, size_pivotidx, size_iinfo;
     rocsolver_gesv_getMemorySize<true, false, T, S>(
         n, nrhs, batch_count, &size_scalars, &size_work, &size_work1, &size_work2, &size_work3,
-        &size_work4, &size_pivotval, &size_pivotidx, &size_iinfo);
+        &size_work4, &size_pivotval, &size_pivotidx, &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work, size_work1,
                                                       size_work2, size_work3, size_work4,
                                                       size_pivotval, size_pivotidx, size_iinfo);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work, *work1, *work2, *work3, *work4, *pivotval, *pivotidx, *iinfo;

--- a/library/src/lapack/roclapack_gesv_outofplace.cpp
+++ b/library/src/lapack/roclapack_gesv_outofplace.cpp
@@ -55,20 +55,18 @@ rocblas_status rocsolver_gesv_outofplace_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspace (and for calling GETRF and GETRS)
+    bool optim_mem;
     size_t size_work, size_work1, size_work2, size_work3, size_work4;
     // extra requirements for calling GETRF
     size_t size_pivotval, size_pivotidx, size_iinfo;
     rocsolver_gesv_outofplace_getMemorySize<false, false, T, S>(
         n, nrhs, batch_count, &size_scalars, &size_work, &size_work1, &size_work2, &size_work3,
-        &size_work4, &size_pivotval, &size_pivotidx, &size_iinfo);
+        &size_work4, &size_pivotval, &size_pivotidx, &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work, size_work1,
                                                       size_work2, size_work3, size_work4,
                                                       size_pivotval, size_pivotidx, size_iinfo);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work, *work1, *work2, *work3, *work4, *pivotval, *pivotidx, *iinfo;

--- a/library/src/lapack/roclapack_gesv_outofplace.hpp
+++ b/library/src/lapack/roclapack_gesv_outofplace.hpp
@@ -75,28 +75,26 @@ void rocsolver_gesv_outofplace_getMemorySize(const rocblas_int n,
         *size_pivotval = 0;
         *size_pivotidx = 0;
         *size_iinfo = 0;
-        *optim_mem = false;
+        *optim_mem = true;
         return;
     }
 
-    bool unused;
+    bool opt1, opt2;
     size_t w1, w2, w3, w4;
 
     // workspace required for calling GETRF
     rocsolver_getrf_getMemorySize<BATCHED, STRIDED, true, T, S>(
         n, n, batch_count, size_scalars, size_work, size_work1, size_work2, size_work3, size_work4,
-        size_pivotval, size_pivotidx, size_iinfo, &unused);
+        size_pivotval, size_pivotidx, size_iinfo, &opt1);
 
     // workspace required for calling GETRS
-    rocsolver_getrs_getMemorySize<BATCHED, T>(n, nrhs, batch_count, &w1, &w2, &w3, &w4, &unused);
+    rocsolver_getrs_getMemorySize<BATCHED, T>(n, nrhs, batch_count, &w1, &w2, &w3, &w4, &opt2);
 
     *size_work1 = std::max(*size_work1, w1);
     *size_work2 = std::max(*size_work2, w2);
     *size_work3 = std::max(*size_work3, w3);
     *size_work4 = std::max(*size_work4, w4);
-
-    // always allocate all required memory for TRSM optimal performance
-    *optim_mem = true;
+    *optim_mem = opt1 && opt2;
 }
 
 template <bool BATCHED, bool STRIDED, typename T, typename S, typename U>

--- a/library/src/lapack/roclapack_gesv_strided_batched.cpp
+++ b/library/src/lapack/roclapack_gesv_strided_batched.cpp
@@ -42,20 +42,18 @@ rocblas_status rocsolver_gesv_strided_batched_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspace (and for calling GETRF and GETRS)
+    bool optim_mem;
     size_t size_work, size_work1, size_work2, size_work3, size_work4;
     // extra requirements for calling GETRF
     size_t size_pivotval, size_pivotidx, size_iinfo;
     rocsolver_gesv_getMemorySize<false, true, T, S>(
         n, nrhs, batch_count, &size_scalars, &size_work, &size_work1, &size_work2, &size_work3,
-        &size_work4, &size_pivotval, &size_pivotidx, &size_iinfo);
+        &size_work4, &size_pivotval, &size_pivotidx, &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work, size_work1,
                                                       size_work2, size_work3, size_work4,
                                                       size_pivotval, size_pivotidx, size_iinfo);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work, *work1, *work2, *work3, *work4, *pivotval, *pivotidx, *iinfo;

--- a/library/src/lapack/roclapack_getrf.cpp
+++ b/library/src/lapack/roclapack_getrf.cpp
@@ -39,6 +39,7 @@ rocblas_status rocsolver_getrf_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspace (and for calling TRSM)
+    bool optim_mem;
     size_t size_work, size_work1, size_work2, size_work3, size_work4;
     // extra requirements for calling GETF2
     size_t size_pivotval, size_pivotidx;
@@ -46,15 +47,12 @@ rocblas_status rocsolver_getrf_impl(rocblas_handle handle,
     size_t size_iinfo;
     rocsolver_getrf_getMemorySize<false, false, PIVOT, T, S>(
         m, n, batch_count, &size_scalars, &size_work, &size_work1, &size_work2, &size_work3,
-        &size_work4, &size_pivotval, &size_pivotidx, &size_iinfo);
+        &size_work4, &size_pivotval, &size_pivotidx, &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work, size_work1,
                                                       size_work2, size_work3, size_work4,
                                                       size_pivotval, size_pivotidx, size_iinfo);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work, *work1, *work2, *work3, *work4, *pivotval, *pivotidx, *iinfo;

--- a/library/src/lapack/roclapack_getrf.hpp
+++ b/library/src/lapack/roclapack_getrf.hpp
@@ -94,7 +94,8 @@ void rocsolver_getrf_getMemorySize(const rocblas_int m,
                                    size_t* size_work4,
                                    size_t* size_pivotval,
                                    size_t* size_pivotidx,
-                                   size_t* size_iinfo)
+                                   size_t* size_iinfo,
+                                   bool* optim_mem)
 {
     static constexpr bool ISBATCHED = BATCHED || STRIDED;
 
@@ -110,6 +111,7 @@ void rocsolver_getrf_getMemorySize(const rocblas_int m,
         *size_pivotval = 0;
         *size_pivotidx = 0;
         *size_iinfo = 0;
+        *optim_mem = false;
         return;
     }
 
@@ -126,6 +128,7 @@ void rocsolver_getrf_getMemorySize(const rocblas_int m,
         *size_work3 = 0;
         *size_work4 = 0;
         *size_iinfo = 0;
+        *optim_mem = false;
     }
     else
     {
@@ -139,6 +142,9 @@ void rocsolver_getrf_getMemorySize(const rocblas_int m,
         // extra workspace (for calling TRSM)
         rocblasCall_trsm_mem<BATCHED, T>(rocblas_side_left, blk, n - blk, batch_count, size_work1,
                                          size_work2, size_work3, size_work4);
+
+        // always allocate all required memory for TRSM optimal performance
+        *optim_mem = true;
     }
 }
 

--- a/library/src/lapack/roclapack_getrf.hpp
+++ b/library/src/lapack/roclapack_getrf.hpp
@@ -111,7 +111,7 @@ void rocsolver_getrf_getMemorySize(const rocblas_int m,
         *size_pivotval = 0;
         *size_pivotidx = 0;
         *size_iinfo = 0;
-        *optim_mem = false;
+        *optim_mem = true;
         return;
     }
 
@@ -128,7 +128,7 @@ void rocsolver_getrf_getMemorySize(const rocblas_int m,
         *size_work3 = 0;
         *size_work4 = 0;
         *size_iinfo = 0;
-        *optim_mem = false;
+        *optim_mem = true;
     }
     else
     {

--- a/library/src/lapack/roclapack_getrf_batched.cpp
+++ b/library/src/lapack/roclapack_getrf_batched.cpp
@@ -41,6 +41,7 @@ rocblas_status rocsolver_getrf_batched_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspace (and for calling TRSM)
+    bool optim_mem;
     size_t size_work, size_work1, size_work2, size_work3, size_work4;
     // extra requirements for calling GETF2
     size_t size_pivotval, size_pivotidx;
@@ -48,15 +49,12 @@ rocblas_status rocsolver_getrf_batched_impl(rocblas_handle handle,
     size_t size_iinfo;
     rocsolver_getrf_getMemorySize<true, false, PIVOT, T, S>(
         m, n, batch_count, &size_scalars, &size_work, &size_work1, &size_work2, &size_work3,
-        &size_work4, &size_pivotval, &size_pivotidx, &size_iinfo);
+        &size_work4, &size_pivotval, &size_pivotidx, &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work, size_work1,
                                                       size_work2, size_work3, size_work4,
                                                       size_pivotval, size_pivotidx, size_iinfo);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work, *work1, *work2, *work3, *work4, *pivotval, *pivotidx, *iinfo;

--- a/library/src/lapack/roclapack_getrf_strided_batched.cpp
+++ b/library/src/lapack/roclapack_getrf_strided_batched.cpp
@@ -39,6 +39,7 @@ rocblas_status rocsolver_getrf_strided_batched_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspace (and for calling TRSM)
+    bool optim_mem;
     size_t size_work, size_work1, size_work2, size_work3, size_work4;
     // extra requirements for calling GETF2
     size_t size_pivotval, size_pivotidx;
@@ -46,15 +47,12 @@ rocblas_status rocsolver_getrf_strided_batched_impl(rocblas_handle handle,
     size_t size_iinfo;
     rocsolver_getrf_getMemorySize<false, true, PIVOT, T, S>(
         m, n, batch_count, &size_scalars, &size_work, &size_work1, &size_work2, &size_work3,
-        &size_work4, &size_pivotval, &size_pivotidx, &size_iinfo);
+        &size_work4, &size_pivotval, &size_pivotidx, &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work, size_work1,
                                                       size_work2, size_work3, size_work4,
                                                       size_pivotval, size_pivotidx, size_iinfo);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work, *work1, *work2, *work3, *work4, *pivotval, *pivotidx, *iinfo;

--- a/library/src/lapack/roclapack_getri.cpp
+++ b/library/src/lapack/roclapack_getri.cpp
@@ -33,6 +33,7 @@ rocblas_status rocsolver_getri_impl(rocblas_handle handle,
 
     // memory workspace sizes:
     // size of reusable workspace (for calling TRSM and TRTRI)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     // size of temporary array required for copies
     size_t size_tmpcopy;
@@ -40,14 +41,11 @@ rocblas_status rocsolver_getri_impl(rocblas_handle handle,
     size_t size_workArr;
     rocsolver_getri_getMemorySize<false, false, T>(n, batch_count, &size_work1, &size_work2,
                                                    &size_work3, &size_work4, &size_tmpcopy,
-                                                   &size_workArr);
+                                                   &size_workArr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
                                                       size_work4, size_tmpcopy, size_workArr);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *work1, *work2, *work3, *work4, *tmpcopy, *workArr;

--- a/library/src/lapack/roclapack_getri.hpp
+++ b/library/src/lapack/roclapack_getri.hpp
@@ -166,7 +166,7 @@ void rocsolver_getri_getMemorySize(const rocblas_int n,
         *size_work4 = 0;
         *size_tmpcopy = 0;
         *size_workArr = 0;
-        *optim_mem = false;
+        *optim_mem = true;
         return;
     }
 
@@ -182,18 +182,17 @@ void rocsolver_getri_getMemorySize(const rocblas_int n,
         *size_work4 = 0;
         *size_tmpcopy = 0;
         *size_workArr = 0;
-        *optim_mem = false;
+        *optim_mem = true;
         return;
     }
 #endif
 
-    bool unused_opt;
+    bool opt1, opt2;
     size_t unused, w1a = 0, w1b = 0, w2a = 0, w2b = 0, w3a = 0, w3b = 0, w4a = 0, w4b = 0, t1, t2;
 
     // requirements for calling TRTRI
     rocsolver_trtri_getMemorySize<BATCHED, STRIDED, T>(rocblas_diagonal_non_unit, n, batch_count,
-                                                       &w1b, &w2b, &w3b, &w4b, &t2, &unused,
-                                                       &unused_opt);
+                                                       &w1b, &w2b, &w3b, &w4b, &t2, &unused, &opt1);
 
     // size of array of pointers (batched cases)
     if(BATCHED)
@@ -233,7 +232,9 @@ void rocsolver_getri_getMemorySize(const rocblas_int n,
     *size_tmpcopy = max(t1, t2);
 
     // always allocate all required memory for TRSM optimal performance
-    *optim_mem = true;
+    opt2 = true;
+
+    *optim_mem = opt1 && opt2;
 }
 
 template <typename T>

--- a/library/src/lapack/roclapack_getri_batched.cpp
+++ b/library/src/lapack/roclapack_getri_batched.cpp
@@ -34,6 +34,7 @@ rocblas_status rocsolver_getri_batched_impl(rocblas_handle handle,
 
     // memory workspace sizes:
     // size of reusable workspace (for calling TRSM and TRTRI)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     // size of temporary array required for copies
     size_t size_tmpcopy;
@@ -41,14 +42,11 @@ rocblas_status rocsolver_getri_batched_impl(rocblas_handle handle,
     size_t size_workArr;
     rocsolver_getri_getMemorySize<true, false, T>(n, batch_count, &size_work1, &size_work2,
                                                   &size_work3, &size_work4, &size_tmpcopy,
-                                                  &size_workArr);
+                                                  &size_workArr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
                                                       size_work4, size_tmpcopy, size_workArr);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *work1, *work2, *work3, *work4, *tmpcopy, *workArr;

--- a/library/src/lapack/roclapack_getri_outofplace.cpp
+++ b/library/src/lapack/roclapack_getri_outofplace.cpp
@@ -36,18 +36,16 @@ rocblas_status rocsolver_getri_outofplace_impl(rocblas_handle handle,
     rocblas_int batch_count = 1;
 
     // memory workspace sizes:
-    // size of reusable workspace (for calling TRSM)
+    // size of reusable workspace (for calling GETRS)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
 
     rocsolver_getri_outofplace_getMemorySize<false, T>(n, batch_count, &size_work1, &size_work2,
-                                                       &size_work3, &size_work4);
+                                                       &size_work3, &size_work4, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
                                                       size_work4);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *work1, *work2, *work3, *work4;

--- a/library/src/lapack/roclapack_getri_outofplace.hpp
+++ b/library/src/lapack/roclapack_getri_outofplace.hpp
@@ -25,7 +25,7 @@ void rocsolver_getri_outofplace_getMemorySize(const rocblas_int n,
         *size_work2 = 0;
         *size_work3 = 0;
         *size_work4 = 0;
-        *optim_mem = false;
+        *optim_mem = true;
         return;
     }
 

--- a/library/src/lapack/roclapack_getri_outofplace.hpp
+++ b/library/src/lapack/roclapack_getri_outofplace.hpp
@@ -15,7 +15,8 @@ void rocsolver_getri_outofplace_getMemorySize(const rocblas_int n,
                                               size_t* size_work1,
                                               size_t* size_work2,
                                               size_t* size_work3,
-                                              size_t* size_work4)
+                                              size_t* size_work4,
+                                              bool* optim_mem)
 {
     // if quick return, no need of workspace
     if(n == 0 || batch_count == 0)
@@ -24,12 +25,13 @@ void rocsolver_getri_outofplace_getMemorySize(const rocblas_int n,
         *size_work2 = 0;
         *size_work3 = 0;
         *size_work4 = 0;
+        *optim_mem = false;
         return;
     }
 
     // requirements for calling GETRS
     rocsolver_getrs_getMemorySize<BATCHED, T>(n, n, batch_count, size_work1, size_work2, size_work3,
-                                              size_work4);
+                                              size_work4, optim_mem);
 }
 
 template <typename T>

--- a/library/src/lapack/roclapack_getri_outofplace_batched.cpp
+++ b/library/src/lapack/roclapack_getri_outofplace_batched.cpp
@@ -38,18 +38,16 @@ rocblas_status rocsolver_getri_outofplace_batched_impl(rocblas_handle handle,
     rocblas_stride strideC = 0;
 
     // memory workspace sizes:
-    // size of reusable workspace (for calling TRSM)
+    // size of reusable workspace (for calling GETRS)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
 
     rocsolver_getri_outofplace_getMemorySize<true, T>(n, batch_count, &size_work1, &size_work2,
-                                                      &size_work3, &size_work4);
+                                                      &size_work3, &size_work4, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
                                                       size_work4);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *work1, *work2, *work3, *work4;

--- a/library/src/lapack/roclapack_getri_outofplace_strided_batched.cpp
+++ b/library/src/lapack/roclapack_getri_outofplace_strided_batched.cpp
@@ -37,18 +37,16 @@ rocblas_status rocsolver_getri_outofplace_strided_batched_impl(rocblas_handle ha
     rocblas_int shiftC = 0;
 
     // memory workspace sizes:
-    // size of reusable workspace (for calling TRSM)
+    // size of reusable workspace (for calling GETRS)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
 
     rocsolver_getri_outofplace_getMemorySize<false, T>(n, batch_count, &size_work1, &size_work2,
-                                                       &size_work3, &size_work4);
+                                                       &size_work3, &size_work4, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
                                                       size_work4);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *work1, *work2, *work3, *work4;

--- a/library/src/lapack/roclapack_getri_strided_batched.cpp
+++ b/library/src/lapack/roclapack_getri_strided_batched.cpp
@@ -32,6 +32,7 @@ rocblas_status rocsolver_getri_strided_batched_impl(rocblas_handle handle,
 
     // memory workspace sizes:
     // size of reusable workspace (for calling TRSM and TRTRI)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     // size of temporary array required for copies
     size_t size_tmpcopy;
@@ -39,14 +40,11 @@ rocblas_status rocsolver_getri_strided_batched_impl(rocblas_handle handle,
     size_t size_workArr;
     rocsolver_getri_getMemorySize<false, true, T>(n, batch_count, &size_work1, &size_work2,
                                                   &size_work3, &size_work4, &size_tmpcopy,
-                                                  &size_workArr);
+                                                  &size_workArr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
                                                       size_work4, size_tmpcopy, size_workArr);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *work1, *work2, *work3, *work4, *tmpcopy, *workArr;

--- a/library/src/lapack/roclapack_getrs.cpp
+++ b/library/src/lapack/roclapack_getrs.cpp
@@ -38,16 +38,14 @@ rocblas_status rocsolver_getrs_impl(rocblas_handle handle,
 
     // memory workspace sizes:
     // size of workspace (for calling TRSM)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     rocsolver_getrs_getMemorySize<false, T>(n, nrhs, batch_count, &size_work1, &size_work2,
-                                            &size_work3, &size_work4);
+                                            &size_work3, &size_work4, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
                                                       size_work4);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *work1, *work2, *work3, *work4;

--- a/library/src/lapack/roclapack_getrs.hpp
+++ b/library/src/lapack/roclapack_getrs.hpp
@@ -54,7 +54,8 @@ void rocsolver_getrs_getMemorySize(const rocblas_int n,
                                    size_t* size_work1,
                                    size_t* size_work2,
                                    size_t* size_work3,
-                                   size_t* size_work4)
+                                   size_t* size_work4,
+                                   bool* optim_mem)
 {
     // if quick return, no workspace is needed
     if(n == 0 || nrhs == 0 || batch_count == 0)
@@ -63,12 +64,16 @@ void rocsolver_getrs_getMemorySize(const rocblas_int n,
         *size_work2 = 0;
         *size_work3 = 0;
         *size_work4 = 0;
+        *optim_mem = false;
         return;
     }
 
     // workspace required for calling TRSM
     rocblasCall_trsm_mem<BATCHED, T>(rocblas_side_left, n, nrhs, batch_count, size_work1,
                                      size_work2, size_work3, size_work4);
+
+    // always allocate all required memory for TRSM optimal performance
+    *optim_mem = true;
 }
 
 template <bool BATCHED, typename T, typename U>

--- a/library/src/lapack/roclapack_getrs.hpp
+++ b/library/src/lapack/roclapack_getrs.hpp
@@ -64,7 +64,7 @@ void rocsolver_getrs_getMemorySize(const rocblas_int n,
         *size_work2 = 0;
         *size_work3 = 0;
         *size_work4 = 0;
-        *optim_mem = false;
+        *optim_mem = true;
         return;
     }
 

--- a/library/src/lapack/roclapack_getrs_batched.cpp
+++ b/library/src/lapack/roclapack_getrs_batched.cpp
@@ -39,16 +39,14 @@ rocblas_status rocsolver_getrs_batched_impl(rocblas_handle handle,
 
     // memory workspace sizes:
     // size of workspace (for calling TRSM)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     rocsolver_getrs_getMemorySize<true, T>(n, nrhs, batch_count, &size_work1, &size_work2,
-                                           &size_work3, &size_work4);
+                                           &size_work3, &size_work4, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
                                                       size_work4);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *work1, *work2, *work3, *work4;

--- a/library/src/lapack/roclapack_getrs_strided_batched.cpp
+++ b/library/src/lapack/roclapack_getrs_strided_batched.cpp
@@ -38,16 +38,14 @@ rocblas_status rocsolver_getrs_strided_batched_impl(rocblas_handle handle,
 
     // memory workspace sizes:
     // size of workspace (for calling TRSM)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     rocsolver_getrs_getMemorySize<false, T>(n, nrhs, batch_count, &size_work1, &size_work2,
-                                            &size_work3, &size_work4);
+                                            &size_work3, &size_work4, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
                                                       size_work4);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *work1, *work2, *work3, *work4;

--- a/library/src/lapack/roclapack_posv.cpp
+++ b/library/src/lapack/roclapack_posv.cpp
@@ -39,21 +39,19 @@ rocblas_status rocsolver_posv_impl(rocblas_handle handle,
     // memory workspace sizes:
     // size for constants in rocblas calls
     size_t size_scalars;
-    // size of reusable workspace (and for calling TRSM)
+    // size of workspace (for calling POTRF and POTRS)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     // extra requirements for calling POTRF and to copy B
     size_t size_pivots_savedB, size_iinfo;
     rocsolver_posv_getMemorySize<false, T>(n, nrhs, uplo, batch_count, &size_scalars, &size_work1,
                                            &size_work2, &size_work3, &size_work4,
-                                           &size_pivots_savedB, &size_iinfo);
+                                           &size_pivots_savedB, &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
                                                       size_work3, size_work4, size_pivots_savedB,
                                                       size_iinfo);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work1, *work2, *work3, *work4, *pivots_savedB, *iinfo;

--- a/library/src/lapack/roclapack_posv.hpp
+++ b/library/src/lapack/roclapack_posv.hpp
@@ -71,31 +71,29 @@ void rocsolver_posv_getMemorySize(const rocblas_int n,
         *size_work4 = 0;
         *size_pivots_savedB = 0;
         *size_iinfo = 0;
-        *optim_mem = false;
+        *optim_mem = true;
         return;
     }
 
-    bool unused;
+    bool opt1, opt2;
     size_t w1, w2, w3, w4;
 
     // workspace required for potrf
     rocsolver_potrf_getMemorySize<BATCHED, T>(n, uplo, batch_count, size_scalars, size_work1,
                                               size_work2, size_work3, size_work4,
-                                              size_pivots_savedB, size_iinfo, &unused);
+                                              size_pivots_savedB, size_iinfo, &opt1);
 
     // workspace required for potrs
-    rocsolver_potrs_getMemorySize<BATCHED, T>(n, nrhs, batch_count, &w1, &w2, &w3, &w4, &unused);
+    rocsolver_potrs_getMemorySize<BATCHED, T>(n, nrhs, batch_count, &w1, &w2, &w3, &w4, &opt2);
 
     *size_work1 = std::max(*size_work1, w1);
     *size_work2 = std::max(*size_work2, w2);
     *size_work3 = std::max(*size_work3, w3);
     *size_work4 = std::max(*size_work4, w4);
+    *optim_mem = opt1 && opt2;
 
     // extra space to copy B
     *size_pivots_savedB = std::max(*size_pivots_savedB, sizeof(T) * n * nrhs * batch_count);
-
-    // always allocate all required memory for TRSM optimal performance
-    *optim_mem = true;
 }
 
 template <bool BATCHED, typename T, typename S, typename U>

--- a/library/src/lapack/roclapack_posv_batched.cpp
+++ b/library/src/lapack/roclapack_posv_batched.cpp
@@ -41,21 +41,19 @@ rocblas_status rocsolver_posv_batched_impl(rocblas_handle handle,
     // memory workspace sizes:
     // size for constants in rocblas calls
     size_t size_scalars;
-    // size of reusable workspace (and for calling TRSM)
+    // size of workspace (for calling POTRF and POTRS)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     // extra requirements for calling POTRF and to copy B
     size_t size_pivots_savedB, size_iinfo;
     rocsolver_posv_getMemorySize<true, T>(n, nrhs, uplo, batch_count, &size_scalars, &size_work1,
                                           &size_work2, &size_work3, &size_work4,
-                                          &size_pivots_savedB, &size_iinfo);
+                                          &size_pivots_savedB, &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
                                                       size_work3, size_work4, size_pivots_savedB,
                                                       size_iinfo);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work1, *work2, *work3, *work4, *pivots_savedB, *iinfo;

--- a/library/src/lapack/roclapack_posv_strided_batched.cpp
+++ b/library/src/lapack/roclapack_posv_strided_batched.cpp
@@ -40,21 +40,19 @@ rocblas_status rocsolver_posv_strided_batched_impl(rocblas_handle handle,
     // memory workspace sizes:
     // size for constants in rocblas calls
     size_t size_scalars;
-    // size of reusable workspace (and for calling TRSM)
+    // size of workspace (for calling POTRF and POTRS)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     // extra requirements for calling POTRF and to copy B
     size_t size_pivots_savedB, size_iinfo;
     rocsolver_posv_getMemorySize<false, T>(n, nrhs, uplo, batch_count, &size_scalars, &size_work1,
                                            &size_work2, &size_work3, &size_work4,
-                                           &size_pivots_savedB, &size_iinfo);
+                                           &size_pivots_savedB, &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
                                                       size_work3, size_work4, size_pivots_savedB,
                                                       size_iinfo);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work1, *work2, *work3, *work4, *pivots_savedB, *iinfo;

--- a/library/src/lapack/roclapack_potrf.cpp
+++ b/library/src/lapack/roclapack_potrf.cpp
@@ -35,6 +35,7 @@ rocblas_status rocsolver_potrf_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspace (and for calling TRSM)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     // extra requirements for calling POTF2
     size_t size_pivots;
@@ -42,15 +43,12 @@ rocblas_status rocsolver_potrf_impl(rocblas_handle handle,
     size_t size_iinfo;
     rocsolver_potrf_getMemorySize<false, T>(n, uplo, batch_count, &size_scalars, &size_work1,
                                             &size_work2, &size_work3, &size_work4, &size_pivots,
-                                            &size_iinfo);
+                                            &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
                                                       size_work3, size_work4, size_pivots,
                                                       size_iinfo);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work1, *work2, *work3, *work4, *pivots, *iinfo;

--- a/library/src/lapack/roclapack_potrf.hpp
+++ b/library/src/lapack/roclapack_potrf.hpp
@@ -46,7 +46,7 @@ void rocsolver_potrf_getMemorySize(const rocblas_int n,
         *size_work4 = 0;
         *size_pivots = 0;
         *size_iinfo = 0;
-        *optim_mem = false;
+        *optim_mem = true;
         return;
     }
 
@@ -58,7 +58,7 @@ void rocsolver_potrf_getMemorySize(const rocblas_int n,
         *size_work3 = 0;
         *size_work4 = 0;
         *size_iinfo = 0;
-        *optim_mem = false;
+        *optim_mem = true;
     }
     else
     {

--- a/library/src/lapack/roclapack_potrf.hpp
+++ b/library/src/lapack/roclapack_potrf.hpp
@@ -33,7 +33,8 @@ void rocsolver_potrf_getMemorySize(const rocblas_int n,
                                    size_t* size_work3,
                                    size_t* size_work4,
                                    size_t* size_pivots,
-                                   size_t* size_iinfo)
+                                   size_t* size_iinfo,
+                                   bool* optim_mem)
 {
     // if quick return no need of workspace
     if(n == 0 || batch_count == 0)
@@ -45,6 +46,7 @@ void rocsolver_potrf_getMemorySize(const rocblas_int n,
         *size_work4 = 0;
         *size_pivots = 0;
         *size_iinfo = 0;
+        *optim_mem = false;
         return;
     }
 
@@ -56,6 +58,7 @@ void rocsolver_potrf_getMemorySize(const rocblas_int n,
         *size_work3 = 0;
         *size_work4 = 0;
         *size_iinfo = 0;
+        *optim_mem = false;
     }
     else
     {
@@ -77,6 +80,9 @@ void rocsolver_potrf_getMemorySize(const rocblas_int n,
                                              size_work2, size_work3, size_work4);
 
         *size_work1 = max(s1, s2);
+
+        // always allocate all required memory for TRSM optimal performance
+        *optim_mem = true;
     }
 }
 

--- a/library/src/lapack/roclapack_potrf_batched.cpp
+++ b/library/src/lapack/roclapack_potrf_batched.cpp
@@ -36,6 +36,7 @@ rocblas_status rocsolver_potrf_batched_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspace (and for calling TRSM)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     // extra requirements for calling POTF2
     size_t size_pivots;
@@ -43,15 +44,12 @@ rocblas_status rocsolver_potrf_batched_impl(rocblas_handle handle,
     size_t size_iinfo;
     rocsolver_potrf_getMemorySize<true, T>(n, uplo, batch_count, &size_scalars, &size_work1,
                                            &size_work2, &size_work3, &size_work4, &size_pivots,
-                                           &size_iinfo);
+                                           &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
                                                       size_work3, size_work4, size_pivots,
                                                       size_iinfo);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work1, *work2, *work3, *work4, *pivots, *iinfo;

--- a/library/src/lapack/roclapack_potrf_strided_batched.cpp
+++ b/library/src/lapack/roclapack_potrf_strided_batched.cpp
@@ -34,6 +34,7 @@ rocblas_status rocsolver_potrf_strided_batched_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspace (and for calling TRSM)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     // extra requirements for calling POTF2
     size_t size_pivots;
@@ -41,15 +42,12 @@ rocblas_status rocsolver_potrf_strided_batched_impl(rocblas_handle handle,
     size_t size_iinfo;
     rocsolver_potrf_getMemorySize<false, T>(n, uplo, batch_count, &size_scalars, &size_work1,
                                             &size_work2, &size_work3, &size_work4, &size_pivots,
-                                            &size_iinfo);
+                                            &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
                                                       size_work3, size_work4, size_pivots,
                                                       size_iinfo);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work1, *work2, *work3, *work4, *pivots, *iinfo;

--- a/library/src/lapack/roclapack_potri.cpp
+++ b/library/src/lapack/roclapack_potri.cpp
@@ -30,20 +30,18 @@ rocblas_status rocsolver_potri_impl(rocblas_handle handle,
     rocblas_int batch_count = 1;
 
     // memory workspace sizes:
-    // extra requirements for calling TRTRI
+    // size of workspace (for calling TRTRI)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4, size_tmpcopy;
     // size of arrays of pointers (for batched cases)
     size_t size_workArr;
     rocsolver_potri_getMemorySize<false, false, T>(n, batch_count, &size_work1, &size_work2,
                                                    &size_work3, &size_work4, &size_tmpcopy,
-                                                   &size_workArr);
+                                                   &size_workArr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
                                                       size_work4, size_tmpcopy, size_workArr);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *work1, *work2, *work3, *work4, *tmpcopy, *workArr;

--- a/library/src/lapack/roclapack_potri.hpp
+++ b/library/src/lapack/roclapack_potri.hpp
@@ -21,7 +21,8 @@ void rocsolver_potri_getMemorySize(const rocblas_int n,
                                    size_t* size_work3,
                                    size_t* size_work4,
                                    size_t* size_tmpcopy,
-                                   size_t* size_workArr)
+                                   size_t* size_workArr,
+                                   bool* optim_mem)
 {
     // if quick return no need of workspace
     if(n == 0 || batch_count == 0)
@@ -32,13 +33,14 @@ void rocsolver_potri_getMemorySize(const rocblas_int n,
         *size_work4 = 0;
         *size_tmpcopy = 0;
         *size_workArr = 0;
+        *optim_mem = false;
         return;
     }
 
     // requirements for calling TRTRI
     rocsolver_trtri_getMemorySize<BATCHED, STRIDED, T>(rocblas_diagonal_non_unit, n, batch_count,
-                                                       size_work1, size_work2, size_work3,
-                                                       size_work4, size_tmpcopy, size_workArr);
+                                                       size_work1, size_work2, size_work3, size_work4,
+                                                       size_tmpcopy, size_workArr, optim_mem);
 
     // required space to copy A
     *size_tmpcopy = std::max(*size_tmpcopy, sizeof(T) * n * n * batch_count);

--- a/library/src/lapack/roclapack_potri.hpp
+++ b/library/src/lapack/roclapack_potri.hpp
@@ -33,7 +33,7 @@ void rocsolver_potri_getMemorySize(const rocblas_int n,
         *size_work4 = 0;
         *size_tmpcopy = 0;
         *size_workArr = 0;
-        *optim_mem = false;
+        *optim_mem = true;
         return;
     }
 

--- a/library/src/lapack/roclapack_potri_batched.cpp
+++ b/library/src/lapack/roclapack_potri_batched.cpp
@@ -31,20 +31,18 @@ rocblas_status rocsolver_potri_batched_impl(rocblas_handle handle,
     rocblas_stride strideA = 0;
 
     // memory workspace sizes:
-    // extra requirements for calling TRTRI
+    // size of workspace (for calling TRTRI)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4, size_tmpcopy;
     // size of arrays of pointers (for batched cases)
     size_t size_workArr;
     rocsolver_potri_getMemorySize<true, false, T>(n, batch_count, &size_work1, &size_work2,
                                                   &size_work3, &size_work4, &size_tmpcopy,
-                                                  &size_workArr);
+                                                  &size_workArr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
                                                       size_work4, size_tmpcopy, size_workArr);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *work1, *work2, *work3, *work4, *tmpcopy, *workArr;

--- a/library/src/lapack/roclapack_potri_strided_batched.cpp
+++ b/library/src/lapack/roclapack_potri_strided_batched.cpp
@@ -29,20 +29,18 @@ rocblas_status rocsolver_potri_strided_batched_impl(rocblas_handle handle,
     rocblas_int shiftA = 0;
 
     // memory workspace sizes:
-    // extra requirements for calling TRTRI
+    // size of workspace (for calling TRTRI)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4, size_tmpcopy;
     // size of arrays of pointers (for batched cases)
     size_t size_workArr;
     rocsolver_potri_getMemorySize<false, true, T>(n, batch_count, &size_work1, &size_work2,
                                                   &size_work3, &size_work4, &size_tmpcopy,
-                                                  &size_workArr);
+                                                  &size_workArr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
                                                       size_work4, size_tmpcopy, size_workArr);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *work1, *work2, *work3, *work4, *tmpcopy, *workArr;

--- a/library/src/lapack/roclapack_potrs.cpp
+++ b/library/src/lapack/roclapack_potrs.cpp
@@ -35,16 +35,14 @@ rocblas_status rocsolver_potrs_impl(rocblas_handle handle,
 
     // memory workspace sizes:
     // size of workspace (for calling TRSM)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     rocsolver_potrs_getMemorySize<false, T>(n, nrhs, batch_count, &size_work1, &size_work2,
-                                            &size_work3, &size_work4);
+                                            &size_work3, &size_work4, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
                                                       size_work4);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *work1, *work2, *work3, *work4;

--- a/library/src/lapack/roclapack_potrs.hpp
+++ b/library/src/lapack/roclapack_potrs.hpp
@@ -51,7 +51,8 @@ void rocsolver_potrs_getMemorySize(const rocblas_int n,
                                    size_t* size_work1,
                                    size_t* size_work2,
                                    size_t* size_work3,
-                                   size_t* size_work4)
+                                   size_t* size_work4,
+                                   bool* optim_mem)
 {
     // if quick return, no workspace is needed
     if(n == 0 || nrhs == 0 || batch_count == 0)
@@ -60,12 +61,16 @@ void rocsolver_potrs_getMemorySize(const rocblas_int n,
         *size_work2 = 0;
         *size_work3 = 0;
         *size_work4 = 0;
+        *optim_mem = false;
         return;
     }
 
     // workspace required for calling TRSM
     rocblasCall_trsm_mem<BATCHED, T>(rocblas_side_left, n, nrhs, batch_count, size_work1,
                                      size_work2, size_work3, size_work4);
+
+    // always allocate all required memory for TRSM optimal performance
+    *optim_mem = true;
 }
 
 template <bool BATCHED, typename T, typename U>

--- a/library/src/lapack/roclapack_potrs.hpp
+++ b/library/src/lapack/roclapack_potrs.hpp
@@ -61,7 +61,7 @@ void rocsolver_potrs_getMemorySize(const rocblas_int n,
         *size_work2 = 0;
         *size_work3 = 0;
         *size_work4 = 0;
-        *optim_mem = false;
+        *optim_mem = true;
         return;
     }
 

--- a/library/src/lapack/roclapack_potrs_batched.cpp
+++ b/library/src/lapack/roclapack_potrs_batched.cpp
@@ -36,16 +36,14 @@ rocblas_status rocsolver_potrs_batched_impl(rocblas_handle handle,
 
     // memory workspace sizes:
     // size of workspace (for calling TRSM)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     rocsolver_potrs_getMemorySize<true, T>(n, nrhs, batch_count, &size_work1, &size_work2,
-                                           &size_work3, &size_work4);
+                                           &size_work3, &size_work4, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
                                                       size_work4);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *work1, *work2, *work3, *work4;

--- a/library/src/lapack/roclapack_potrs_strided_batched.cpp
+++ b/library/src/lapack/roclapack_potrs_strided_batched.cpp
@@ -35,16 +35,14 @@ rocblas_status rocsolver_potrs_strided_batched_impl(rocblas_handle handle,
 
     // memory workspace sizes:
     // size of workspace (for calling TRSM)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     rocsolver_potrs_getMemorySize<false, T>(n, nrhs, batch_count, &size_work1, &size_work2,
-                                            &size_work3, &size_work4);
+                                            &size_work3, &size_work4, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
                                                       size_work4);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *work1, *work2, *work3, *work4;

--- a/library/src/lapack/roclapack_sygst_hegst.cpp
+++ b/library/src/lapack/roclapack_sygst_hegst.cpp
@@ -39,19 +39,17 @@ rocblas_status rocsolver_sygst_hegst_impl(rocblas_handle handle,
     // memory workspace sizes:
     // size for constants in rocblas calls
     size_t size_scalars;
-    // size of reusable workspace (and for calling TRSV or TRMV)
+    // size of reusable workspace (and for calling SYGS2/HEGS2 and TRSM)
+    bool optim_mem;
     size_t size_work_x_temp, size_workArr_temp_arr, size_store_wcs_invA, size_invA_arr;
     rocsolver_sygst_hegst_getMemorySize<false, T>(itype, n, batch_count, &size_scalars,
                                                   &size_work_x_temp, &size_workArr_temp_arr,
-                                                  &size_store_wcs_invA, &size_invA_arr);
+                                                  &size_store_wcs_invA, &size_invA_arr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_x_temp,
                                                       size_workArr_temp_arr, size_store_wcs_invA,
                                                       size_invA_arr);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work_x_temp, *workArr_temp_arr, *store_wcs_invA, *invA_arr;

--- a/library/src/lapack/roclapack_sygst_hegst.hpp
+++ b/library/src/lapack/roclapack_sygst_hegst.hpp
@@ -32,7 +32,7 @@ void rocsolver_sygst_hegst_getMemorySize(const rocblas_eform itype,
         *size_workArr_temp_arr = 0;
         *size_store_wcs_invA = 0;
         *size_invA_arr = 0;
-        *optim_mem = false;
+        *optim_mem = true;
         return;
     }
 
@@ -43,7 +43,7 @@ void rocsolver_sygst_hegst_getMemorySize(const rocblas_eform itype,
                                                         size_work_x_temp, size_store_wcs_invA,
                                                         size_workArr_temp_arr);
         *size_invA_arr = 0;
-        *optim_mem = false;
+        *optim_mem = true;
     }
     else
     {
@@ -73,7 +73,7 @@ void rocsolver_sygst_hegst_getMemorySize(const rocblas_eform itype,
             *optim_mem = true;
         }
         else
-            *optim_mem = false;
+            *optim_mem = true;
     }
 }
 

--- a/library/src/lapack/roclapack_sygst_hegst.hpp
+++ b/library/src/lapack/roclapack_sygst_hegst.hpp
@@ -21,7 +21,8 @@ void rocsolver_sygst_hegst_getMemorySize(const rocblas_eform itype,
                                          size_t* size_work_x_temp,
                                          size_t* size_workArr_temp_arr,
                                          size_t* size_store_wcs_invA,
-                                         size_t* size_invA_arr)
+                                         size_t* size_invA_arr,
+                                         bool* optim_mem)
 {
     // if quick return no need of workspace
     if(n == 0 || batch_count == 0)
@@ -31,6 +32,7 @@ void rocsolver_sygst_hegst_getMemorySize(const rocblas_eform itype,
         *size_workArr_temp_arr = 0;
         *size_store_wcs_invA = 0;
         *size_invA_arr = 0;
+        *optim_mem = false;
         return;
     }
 
@@ -41,6 +43,7 @@ void rocsolver_sygst_hegst_getMemorySize(const rocblas_eform itype,
                                                         size_work_x_temp, size_store_wcs_invA,
                                                         size_workArr_temp_arr);
         *size_invA_arr = 0;
+        *optim_mem = false;
     }
     else
     {
@@ -65,7 +68,12 @@ void rocsolver_sygst_hegst_getMemorySize(const rocblas_eform itype,
             *size_workArr_temp_arr = max(*size_workArr_temp_arr, max(temp2, temp6));
             *size_store_wcs_invA = max(*size_store_wcs_invA, max(temp3, temp7));
             *size_invA_arr = max(*size_invA_arr, max(temp4, temp8));
+
+            // always allocate all required memory for TRSM optimal performance
+            *optim_mem = true;
         }
+        else
+            *optim_mem = false;
     }
 }
 

--- a/library/src/lapack/roclapack_sygst_hegst_batched.cpp
+++ b/library/src/lapack/roclapack_sygst_hegst_batched.cpp
@@ -41,19 +41,17 @@ rocblas_status rocsolver_sygst_hegst_batched_impl(rocblas_handle handle,
     // memory workspace sizes:
     // size for constants in rocblas calls
     size_t size_scalars;
-    // size of reusable workspace (and for calling TRSV or TRMV)
+    // size of reusable workspace (and for calling SYGS2/HEGS2 and TRSM)
+    bool optim_mem;
     size_t size_work_x_temp, size_workArr_temp_arr, size_store_wcs_invA, size_invA_arr;
     rocsolver_sygst_hegst_getMemorySize<true, T>(itype, n, batch_count, &size_scalars,
                                                  &size_work_x_temp, &size_workArr_temp_arr,
-                                                 &size_store_wcs_invA, &size_invA_arr);
+                                                 &size_store_wcs_invA, &size_invA_arr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_x_temp,
                                                       size_workArr_temp_arr, size_store_wcs_invA,
                                                       size_invA_arr);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work_x_temp, *workArr_temp_arr, *store_invA, *invA_arr;

--- a/library/src/lapack/roclapack_sygst_hegst_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sygst_hegst_strided_batched.cpp
@@ -39,19 +39,17 @@ rocblas_status rocsolver_sygst_hegst_strided_batched_impl(rocblas_handle handle,
     // memory workspace sizes:
     // size for constants in rocblas calls
     size_t size_scalars;
-    // size of reusable workspace (and for calling TRSV or TRMV)
+    // size of reusable workspace (and for calling SYGS2/HEGS2 and TRSM)
+    bool optim_mem;
     size_t size_work_x_temp, size_workArr_temp_arr, size_store_wcs_invA, size_invA_arr;
     rocsolver_sygst_hegst_getMemorySize<false, T>(itype, n, batch_count, &size_scalars,
                                                   &size_work_x_temp, &size_workArr_temp_arr,
-                                                  &size_store_wcs_invA, &size_invA_arr);
+                                                  &size_store_wcs_invA, &size_invA_arr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_x_temp,
                                                       size_workArr_temp_arr, size_store_wcs_invA,
                                                       size_invA_arr);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work_x_temp, *workArr_temp_arr, *store_wcs_invA, *invA_arr;

--- a/library/src/lapack/roclapack_sygv_hegv.cpp
+++ b/library/src/lapack/roclapack_sygv_hegv.cpp
@@ -46,22 +46,20 @@ rocblas_status rocsolver_sygv_hegv_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspaces (and for calling TRSM, SYGST/HEGST, and SYEV/HEEV)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     // extra requirements for calling POTRF and SYEV/HEEV
     size_t size_pivots_workArr;
     // size of temporary info array
     size_t size_iinfo;
-    rocsolver_sygv_hegv_getMemorySize<false, T, S>(itype, evect, uplo, n, batch_count, &size_scalars,
-                                                   &size_work1, &size_work2, &size_work3,
-                                                   &size_work4, &size_pivots_workArr, &size_iinfo);
+    rocsolver_sygv_hegv_getMemorySize<false, T, S>(
+        itype, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
+        &size_work4, &size_pivots_workArr, &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
                                                       size_work3, size_work4, size_pivots_workArr,
                                                       size_iinfo);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work1, *work2, *work3, *work4, *pivots_workArr, *iinfo;

--- a/library/src/lapack/roclapack_sygv_hegv_batched.cpp
+++ b/library/src/lapack/roclapack_sygv_hegv_batched.cpp
@@ -47,22 +47,20 @@ rocblas_status rocsolver_sygv_hegv_batched_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspaces (and for calling TRSM, SYGST/HEGST, and SYEV/HEEV)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     // extra requirements for calling POTRF and SYEV/HEEV
     size_t size_pivots_workArr;
     // size of temporary info array
     size_t size_iinfo;
     rocsolver_sygv_hegv_getMemorySize<true, T, S>(itype, evect, uplo, n, batch_count, &size_scalars,
-                                                  &size_work1, &size_work2, &size_work3,
-                                                  &size_work4, &size_pivots_workArr, &size_iinfo);
+                                                  &size_work1, &size_work2, &size_work3, &size_work4,
+                                                  &size_pivots_workArr, &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
                                                       size_work3, size_work4, size_pivots_workArr,
                                                       size_iinfo);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work1, *work2, *work3, *work4, *pivots_workArr, *iinfo;

--- a/library/src/lapack/roclapack_sygv_hegv_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sygv_hegv_strided_batched.cpp
@@ -45,22 +45,20 @@ rocblas_status rocsolver_sygv_hegv_strided_batched_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspaces (and for calling TRSM, SYGST/HEGST, and SYEV/HEEV)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     // extra requirements for calling POTRF and SYEV/HEEV
     size_t size_pivots_workArr;
     // size of temporary info array
     size_t size_iinfo;
-    rocsolver_sygv_hegv_getMemorySize<false, T, S>(itype, evect, uplo, n, batch_count, &size_scalars,
-                                                   &size_work1, &size_work2, &size_work3,
-                                                   &size_work4, &size_pivots_workArr, &size_iinfo);
+    rocsolver_sygv_hegv_getMemorySize<false, T, S>(
+        itype, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
+        &size_work4, &size_pivots_workArr, &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
                                                       size_work3, size_work4, size_pivots_workArr,
                                                       size_iinfo);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work1, *work2, *work3, *work4, *pivots_workArr, *iinfo;

--- a/library/src/lapack/roclapack_sygvd_hegvd.cpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd.cpp
@@ -46,6 +46,7 @@ rocblas_status rocsolver_sygvd_hegvd_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspaces (and for calling TRSM, SYGST/HEGST, and SYEVD/HEEVD)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     // extra requirements for calling POTRF and SYEVD/HEEVD
     size_t size_tau;
@@ -54,15 +55,12 @@ rocblas_status rocsolver_sygvd_hegvd_impl(rocblas_handle handle,
     size_t size_iinfo;
     rocsolver_sygvd_hegvd_getMemorySize<false, T, S>(
         itype, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
-        &size_work4, &size_tau, &size_pivots_workArr, &size_iinfo);
+        &size_work4, &size_tau, &size_pivots_workArr, &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
                                                       size_work3, size_work4, size_tau,
                                                       size_pivots_workArr, size_iinfo);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work1, *work2, *work3, *work4, *tau, *pivots_workArr, *iinfo;

--- a/library/src/lapack/roclapack_sygvd_hegvd.hpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd.hpp
@@ -29,7 +29,8 @@ void rocsolver_sygvd_hegvd_getMemorySize(const rocblas_eform itype,
                                          size_t* size_work4,
                                          size_t* size_tau,
                                          size_t* size_pivots_workArr,
-                                         size_t* size_iinfo)
+                                         size_t* size_iinfo,
+                                         bool* optim_mem)
 {
     // if quick return no need of workspace
     if(n == 0 || batch_count == 0)
@@ -42,20 +43,22 @@ void rocsolver_sygvd_hegvd_getMemorySize(const rocblas_eform itype,
         *size_tau = 0;
         *size_pivots_workArr = 0;
         *size_iinfo = 0;
+        *optim_mem = false;
         return;
     }
 
+    bool unused_opt;
     size_t unused, temp1, temp2, temp3, temp4, temp5;
 
     // requirements for calling POTRF
     rocsolver_potrf_getMemorySize<BATCHED, T>(n, uplo, batch_count, size_scalars, size_work1,
                                               size_work2, size_work3, size_work4,
-                                              size_pivots_workArr, size_iinfo);
+                                              size_pivots_workArr, size_iinfo, &unused_opt);
     *size_iinfo = max(*size_iinfo, sizeof(rocblas_int) * batch_count);
 
     // requirements for calling SYGST/HEGST
     rocsolver_sygst_hegst_getMemorySize<BATCHED, T>(itype, n, batch_count, &unused, &temp1, &temp2,
-                                                    &temp3, &temp4);
+                                                    &temp3, &temp4, &unused_opt);
     *size_work1 = max(*size_work1, temp1);
     *size_work2 = max(*size_work2, temp2);
     *size_work3 = max(*size_work3, temp3);
@@ -83,6 +86,9 @@ void rocsolver_sygvd_hegvd_getMemorySize(const rocblas_eform itype,
             *size_work4 = max(*size_work4, temp4);
         }
     }
+
+    // always allocate all required memory for TRSM optimal performance
+    *optim_mem = true;
 }
 
 template <bool BATCHED, bool STRIDED, typename T, typename S, typename U, bool COMPLEX = is_complex<T>>

--- a/library/src/lapack/roclapack_sygvd_hegvd.hpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd.hpp
@@ -43,22 +43,22 @@ void rocsolver_sygvd_hegvd_getMemorySize(const rocblas_eform itype,
         *size_tau = 0;
         *size_pivots_workArr = 0;
         *size_iinfo = 0;
-        *optim_mem = false;
+        *optim_mem = true;
         return;
     }
 
-    bool unused_opt;
+    bool opt1, opt2, opt3 = true;
     size_t unused, temp1, temp2, temp3, temp4, temp5;
 
     // requirements for calling POTRF
     rocsolver_potrf_getMemorySize<BATCHED, T>(n, uplo, batch_count, size_scalars, size_work1,
                                               size_work2, size_work3, size_work4,
-                                              size_pivots_workArr, size_iinfo, &unused_opt);
+                                              size_pivots_workArr, size_iinfo, &opt1);
     *size_iinfo = max(*size_iinfo, sizeof(rocblas_int) * batch_count);
 
     // requirements for calling SYGST/HEGST
     rocsolver_sygst_hegst_getMemorySize<BATCHED, T>(itype, n, batch_count, &unused, &temp1, &temp2,
-                                                    &temp3, &temp4, &unused_opt);
+                                                    &temp3, &temp4, &opt2);
     *size_work1 = max(*size_work1, temp1);
     *size_work2 = max(*size_work2, temp2);
     *size_work3 = max(*size_work3, temp3);
@@ -84,11 +84,13 @@ void rocsolver_sygvd_hegvd_getMemorySize(const rocblas_eform itype,
             *size_work2 = max(*size_work2, temp2);
             *size_work3 = max(*size_work3, temp3);
             *size_work4 = max(*size_work4, temp4);
+
+            // always allocate all required memory for TRSM optimal performance
+            opt3 = true;
         }
     }
 
-    // always allocate all required memory for TRSM optimal performance
-    *optim_mem = true;
+    *optim_mem = opt1 && opt2 && opt3;
 }
 
 template <bool BATCHED, bool STRIDED, typename T, typename S, typename U, bool COMPLEX = is_complex<T>>

--- a/library/src/lapack/roclapack_sygvd_hegvd_batched.cpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd_batched.cpp
@@ -47,6 +47,7 @@ rocblas_status rocsolver_sygvd_hegvd_batched_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspaces (and for calling TRSM, SYGST/HEGST, and SYEVD/HEEVD)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     // extra requirements for calling POTRF and SYEVD/HEEVD
     size_t size_tau;
@@ -55,15 +56,12 @@ rocblas_status rocsolver_sygvd_hegvd_batched_impl(rocblas_handle handle,
     size_t size_iinfo;
     rocsolver_sygvd_hegvd_getMemorySize<true, T, S>(
         itype, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
-        &size_work4, &size_tau, &size_pivots_workArr, &size_iinfo);
+        &size_work4, &size_tau, &size_pivots_workArr, &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
                                                       size_work3, size_work4, size_tau,
                                                       size_pivots_workArr, size_iinfo);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work1, *work2, *work3, *work4, *tau, *pivots_workArr, *iinfo;

--- a/library/src/lapack/roclapack_sygvd_hegvd_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd_strided_batched.cpp
@@ -45,6 +45,7 @@ rocblas_status rocsolver_sygvd_hegvd_strided_batched_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspaces (and for calling TRSM, SYGST/HEGST, and SYEVD/HEEVD)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     // extra requirements for calling POTRF and SYEVD/HEEVD
     size_t size_tau;
@@ -53,15 +54,12 @@ rocblas_status rocsolver_sygvd_hegvd_strided_batched_impl(rocblas_handle handle,
     size_t size_iinfo;
     rocsolver_sygvd_hegvd_getMemorySize<false, T, S>(
         itype, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
-        &size_work4, &size_tau, &size_pivots_workArr, &size_iinfo);
+        &size_work4, &size_tau, &size_pivots_workArr, &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
                                                       size_work3, size_work4, size_tau,
                                                       size_pivots_workArr, size_iinfo);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *scalars, *work1, *work2, *work3, *work4, *tau, *pivots_workArr, *iinfo;

--- a/library/src/lapack/roclapack_trtri.cpp
+++ b/library/src/lapack/roclapack_trtri.cpp
@@ -32,6 +32,7 @@ rocblas_status rocsolver_trtri_impl(rocblas_handle handle,
 
     // memory workspace sizes:
     // size of reusable workspace (for calling TRSM)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     // size of temporary array required for copies
     size_t size_tmpcopy;
@@ -39,14 +40,11 @@ rocblas_status rocsolver_trtri_impl(rocblas_handle handle,
     size_t size_workArr;
     rocsolver_trtri_getMemorySize<false, false, T>(diag, n, batch_count, &size_work1, &size_work2,
                                                    &size_work3, &size_work4, &size_tmpcopy,
-                                                   &size_workArr);
+                                                   &size_workArr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
                                                       size_work4, size_tmpcopy, size_workArr);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *work1, *work2, *work3, *work4, *tmpcopy, *workArr;

--- a/library/src/lapack/roclapack_trtri.hpp
+++ b/library/src/lapack/roclapack_trtri.hpp
@@ -87,7 +87,7 @@ void rocsolver_trtri_getMemorySize(const rocblas_diagonal diag,
         *size_work4 = 0;
         *size_tmpcopy = 0;
         *size_workArr = 0;
-        *optim_mem = false;
+        *optim_mem = true;
         return;
     }
 
@@ -137,7 +137,7 @@ void rocsolver_trtri_getMemorySize(const rocblas_diagonal diag,
         rocblasCall_trtri_mem<BATCHED, T>(n, batch_count, size_work1, size_work2);
         *size_work3 = 0;
         *size_work4 = 0;
-        *optim_mem = false;
+        *optim_mem = true;
     }
     else if(blk == 1)
     {
@@ -145,7 +145,7 @@ void rocsolver_trtri_getMemorySize(const rocblas_diagonal diag,
         *size_work2 = 0;
         *size_work3 = w3a;
         *size_work4 = 0;
-        *optim_mem = false;
+        *optim_mem = true;
     }
     else
     {

--- a/library/src/lapack/roclapack_trtri.hpp
+++ b/library/src/lapack/roclapack_trtri.hpp
@@ -73,7 +73,8 @@ void rocsolver_trtri_getMemorySize(const rocblas_diagonal diag,
                                    size_t* size_work3,
                                    size_t* size_work4,
                                    size_t* size_tmpcopy,
-                                   size_t* size_workArr)
+                                   size_t* size_workArr,
+                                   bool* optim_mem)
 {
     static constexpr bool ISBATCHED = BATCHED || STRIDED;
 
@@ -86,6 +87,7 @@ void rocsolver_trtri_getMemorySize(const rocblas_diagonal diag,
         *size_work4 = 0;
         *size_tmpcopy = 0;
         *size_workArr = 0;
+        *optim_mem = false;
         return;
     }
 
@@ -135,6 +137,7 @@ void rocsolver_trtri_getMemorySize(const rocblas_diagonal diag,
         rocblasCall_trtri_mem<BATCHED, T>(n, batch_count, size_work1, size_work2);
         *size_work3 = 0;
         *size_work4 = 0;
+        *optim_mem = false;
     }
     else if(blk == 1)
     {
@@ -142,6 +145,7 @@ void rocsolver_trtri_getMemorySize(const rocblas_diagonal diag,
         *size_work2 = 0;
         *size_work3 = w3a;
         *size_work4 = 0;
+        *optim_mem = false;
     }
     else
     {
@@ -149,6 +153,9 @@ void rocsolver_trtri_getMemorySize(const rocblas_diagonal diag,
                                          &w3b, size_work4);
         *size_work1 = max(w1a, w1b);
         *size_work3 = max(w3a, w3b);
+
+        // always allocate all required memory for TRSM optimal performance
+        *optim_mem = true;
     }
 }
 

--- a/library/src/lapack/roclapack_trtri_batched.cpp
+++ b/library/src/lapack/roclapack_trtri_batched.cpp
@@ -33,6 +33,7 @@ rocblas_status rocsolver_trtri_batched_impl(rocblas_handle handle,
 
     // memory workspace sizes:
     // size of reusable workspace (for calling TRSM)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     // size of temporary array required for copies
     size_t size_tmpcopy;
@@ -40,14 +41,11 @@ rocblas_status rocsolver_trtri_batched_impl(rocblas_handle handle,
     size_t size_workArr;
     rocsolver_trtri_getMemorySize<true, false, T>(diag, n, batch_count, &size_work1, &size_work2,
                                                   &size_work3, &size_work4, &size_tmpcopy,
-                                                  &size_workArr);
+                                                  &size_workArr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
                                                       size_work4, size_tmpcopy, size_workArr);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *work1, *work2, *work3, *work4, *tmpcopy, *workArr;

--- a/library/src/lapack/roclapack_trtri_strided_batched.cpp
+++ b/library/src/lapack/roclapack_trtri_strided_batched.cpp
@@ -31,6 +31,7 @@ rocblas_status rocsolver_trtri_strided_batched_impl(rocblas_handle handle,
 
     // memory workspace sizes:
     // size of reusable workspace (for calling TRSM)
+    bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
     // size of temporary array required for copies
     size_t size_tmpcopy;
@@ -38,14 +39,11 @@ rocblas_status rocsolver_trtri_strided_batched_impl(rocblas_handle handle,
     size_t size_workArr;
     rocsolver_trtri_getMemorySize<false, true, T>(diag, n, batch_count, &size_work1, &size_work2,
                                                   &size_work3, &size_work4, &size_tmpcopy,
-                                                  &size_workArr);
+                                                  &size_workArr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
                                                       size_work4, size_tmpcopy, size_workArr);
-
-    // always allocate all required memory for TRSM optimal performance
-    bool optim_mem = true;
 
     // memory workspace allocation
     void *work1, *work2, *work3, *work4, *tmpcopy, *workArr;


### PR DESCRIPTION
Per the discussion on https://github.com/ROCmSoftwarePlatform/rocSOLVER/pull/291#discussion_r676286511, this PR moves the setting of optim_mem out of the cpp files and into the getMemorySize functions.