### PR TITLE
Fix broken references in deprecation docs

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -2077,6 +2077,9 @@ INCLUDE_FILE_PATTERNS  =
 
 PREDEFINED             = __attribute__(x)= \
                          __inline= \
+                         __declspec(x)= \
+                         ROCSOLVER_DEPRECATED= \
+                         ROCSOLVER_DEPRECATED_X(x)= \
                          ROCSOLVER_EXPORT=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this


### PR DESCRIPTION
This change fixes Sphinx errors like:

> doxygentypedef: Cannot find typedef “rocsolver_int” in doxygen xml output for project “rocSOLVER” from directory: ../docBin/xml

that were introduced by #298. You can see the errors on [the 'latest' version of the docs](https://rocsolver.readthedocs.io/en/latest/api_deprecated.html#rocsolver-int).

Issue: SWDEV-298025 (HOTFIX)