### PR TITLE
Added getri_npvt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 
 ## [(Unreleased) rocSOLVER]
 ### Added
+- General matrix inversion without pivoting:
+    - GETRI\_NPVT (with batched and strided\_batched versions)
+    - GETRI\_NPVT\_OUTOFPLACE (with batched and strided\_batched versions)
 - Added `rocsolver_get_version_string_size` to help with version string queries
 
 ### Optimized

--- a/clients/gtest/getri_gtest.cpp
+++ b/clients/gtest/getri_gtest.cpp
@@ -4,6 +4,8 @@
  * ************************************************************************ */
 
 #include "testing_getri.hpp"
+#include "testing_getri_npvt.hpp"
+#include "testing_getri_npvt_outofplace.hpp"
 #include "testing_getri_outofplace.hpp"
 
 using ::testing::Combine;
@@ -79,6 +81,30 @@ protected:
     }
 };
 
+class GETRI_NPVT : public ::TestWithParam<getri_tuple>
+{
+protected:
+    GETRI_NPVT() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+
+    template <bool BATCHED, bool STRIDED, typename T>
+    void run_tests()
+    {
+        Arguments arg = getri_setup_arguments(GetParam(), false);
+
+        if(arg.peek<rocblas_int>("n") == 0)
+            testing_getri_npvt_bad_arg<BATCHED, STRIDED, T>();
+
+        arg.batch_count = (BATCHED || STRIDED ? 3 : 1);
+        if(arg.singular == 1)
+            testing_getri_npvt<BATCHED, STRIDED, T>(arg);
+
+        arg.singular = 0;
+        testing_getri_npvt<BATCHED, STRIDED, T>(arg);
+    }
+};
+
 class GETRI_OUTOFPLACE : public ::TestWithParam<getri_tuple>
 {
 protected:
@@ -100,6 +126,30 @@ protected:
 
         arg.singular = 0;
         testing_getri_outofplace<BATCHED, STRIDED, T>(arg);
+    }
+};
+
+class GETRI_NPVT_OUTOFPLACE : public ::TestWithParam<getri_tuple>
+{
+protected:
+    GETRI_NPVT_OUTOFPLACE() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+
+    template <bool BATCHED, bool STRIDED, typename T>
+    void run_tests()
+    {
+        Arguments arg = getri_setup_arguments(GetParam(), true);
+
+        if(arg.peek<rocblas_int>("n") == 0)
+            testing_getri_npvt_outofplace_bad_arg<BATCHED, STRIDED, T>();
+
+        arg.batch_count = (BATCHED || STRIDED ? 3 : 1);
+        if(arg.singular == 1)
+            testing_getri_npvt_outofplace<BATCHED, STRIDED, T>(arg);
+
+        arg.singular = 0;
+        testing_getri_npvt_outofplace<BATCHED, STRIDED, T>(arg);
     }
 };
 
@@ -125,6 +175,26 @@ TEST_P(GETRI, __double_complex)
     run_tests<false, false, rocblas_double_complex>();
 }
 
+TEST_P(GETRI_NPVT, __float)
+{
+    run_tests<false, false, float>();
+}
+
+TEST_P(GETRI_NPVT, __double)
+{
+    run_tests<false, false, double>();
+}
+
+TEST_P(GETRI_NPVT, __float_complex)
+{
+    run_tests<false, false, rocblas_float_complex>();
+}
+
+TEST_P(GETRI_NPVT, __double_complex)
+{
+    run_tests<false, false, rocblas_double_complex>();
+}
+
 TEST_P(GETRI_OUTOFPLACE, __float)
 {
     run_tests<false, false, float>();
@@ -141,6 +211,26 @@ TEST_P(GETRI_OUTOFPLACE, __float_complex)
 }
 
 TEST_P(GETRI_OUTOFPLACE, __double_complex)
+{
+    run_tests<false, false, rocblas_double_complex>();
+}
+
+TEST_P(GETRI_NPVT_OUTOFPLACE, __float)
+{
+    run_tests<false, false, float>();
+}
+
+TEST_P(GETRI_NPVT_OUTOFPLACE, __double)
+{
+    run_tests<false, false, double>();
+}
+
+TEST_P(GETRI_NPVT_OUTOFPLACE, __float_complex)
+{
+    run_tests<false, false, rocblas_float_complex>();
+}
+
+TEST_P(GETRI_NPVT_OUTOFPLACE, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
@@ -167,6 +257,26 @@ TEST_P(GETRI, batched__double_complex)
     run_tests<true, true, rocblas_double_complex>();
 }
 
+TEST_P(GETRI_NPVT, batched__float)
+{
+    run_tests<true, true, float>();
+}
+
+TEST_P(GETRI_NPVT, batched__double)
+{
+    run_tests<true, true, double>();
+}
+
+TEST_P(GETRI_NPVT, batched__float_complex)
+{
+    run_tests<true, true, rocblas_float_complex>();
+}
+
+TEST_P(GETRI_NPVT, batched__double_complex)
+{
+    run_tests<true, true, rocblas_double_complex>();
+}
+
 TEST_P(GETRI_OUTOFPLACE, batched__float)
 {
     run_tests<true, true, float>();
@@ -183,6 +293,26 @@ TEST_P(GETRI_OUTOFPLACE, batched__float_complex)
 }
 
 TEST_P(GETRI_OUTOFPLACE, batched__double_complex)
+{
+    run_tests<true, true, rocblas_double_complex>();
+}
+
+TEST_P(GETRI_NPVT_OUTOFPLACE, batched__float)
+{
+    run_tests<true, true, float>();
+}
+
+TEST_P(GETRI_NPVT_OUTOFPLACE, batched__double)
+{
+    run_tests<true, true, double>();
+}
+
+TEST_P(GETRI_NPVT_OUTOFPLACE, batched__float_complex)
+{
+    run_tests<true, true, rocblas_float_complex>();
+}
+
+TEST_P(GETRI_NPVT_OUTOFPLACE, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
@@ -209,6 +339,26 @@ TEST_P(GETRI, strided_batched__double_complex)
     run_tests<false, true, rocblas_double_complex>();
 }
 
+TEST_P(GETRI_NPVT, strided_batched__float)
+{
+    run_tests<false, true, float>();
+}
+
+TEST_P(GETRI_NPVT, strided_batched__double)
+{
+    run_tests<false, true, double>();
+}
+
+TEST_P(GETRI_NPVT, strided_batched__float_complex)
+{
+    run_tests<false, true, rocblas_float_complex>();
+}
+
+TEST_P(GETRI_NPVT, strided_batched__double_complex)
+{
+    run_tests<false, true, rocblas_double_complex>();
+}
+
 TEST_P(GETRI_OUTOFPLACE, strided_batched__float)
 {
     run_tests<false, true, float>();
@@ -229,10 +379,38 @@ TEST_P(GETRI_OUTOFPLACE, strided_batched__double_complex)
     run_tests<false, true, rocblas_double_complex>();
 }
 
+TEST_P(GETRI_NPVT_OUTOFPLACE, strided_batched__float)
+{
+    run_tests<false, true, float>();
+}
+
+TEST_P(GETRI_NPVT_OUTOFPLACE, strided_batched__double)
+{
+    run_tests<false, true, double>();
+}
+
+TEST_P(GETRI_NPVT_OUTOFPLACE, strided_batched__float_complex)
+{
+    run_tests<false, true, rocblas_float_complex>();
+}
+
+TEST_P(GETRI_NPVT_OUTOFPLACE, strided_batched__double_complex)
+{
+    run_tests<false, true, rocblas_double_complex>();
+}
+
 INSTANTIATE_TEST_SUITE_P(daily_lapack, GETRI, ValuesIn(large_matrix_size_range));
 
 INSTANTIATE_TEST_SUITE_P(checkin_lapack, GETRI, ValuesIn(matrix_size_range));
 
+INSTANTIATE_TEST_SUITE_P(daily_lapack, GETRI_NPVT, ValuesIn(large_matrix_size_range));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack, GETRI_NPVT, ValuesIn(matrix_size_range));
+
 INSTANTIATE_TEST_SUITE_P(daily_lapack, GETRI_OUTOFPLACE, ValuesIn(large_matrix_size_range));
 
 INSTANTIATE_TEST_SUITE_P(checkin_lapack, GETRI_OUTOFPLACE, ValuesIn(matrix_size_range));
+
+INSTANTIATE_TEST_SUITE_P(daily_lapack, GETRI_NPVT_OUTOFPLACE, ValuesIn(large_matrix_size_range));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack, GETRI_NPVT_OUTOFPLACE, ValuesIn(matrix_size_range));

--- a/clients/include/rocsolver.hpp
+++ b/clients/include/rocsolver.hpp
@@ -3050,6 +3050,138 @@ inline rocblas_status rocsolver_getri_outofplace(bool STRIDED,
 }
 /********************************************************/
 
+/******************** GETRI_NPVT_OUTOFPLACE ********************/
+// normal and strided_batched
+inline rocblas_status rocsolver_getri_npvt_outofplace(bool STRIDED,
+                                                      rocblas_handle handle,
+                                                      rocblas_int n,
+                                                      float* A,
+                                                      rocblas_int lda,
+                                                      rocblas_stride stA,
+                                                      float* C,
+                                                      rocblas_int ldc,
+                                                      rocblas_stride stC,
+                                                      rocblas_int* info,
+                                                      rocblas_int bc)
+{
+    return STRIDED ? rocsolver_sgetri_npvt_outofplace_strided_batched(handle, n, A, lda, stA, C,
+                                                                      ldc, stC, info, bc)
+                   : rocsolver_sgetri_npvt_outofplace(handle, n, A, lda, C, ldc, info);
+}
+
+inline rocblas_status rocsolver_getri_npvt_outofplace(bool STRIDED,
+                                                      rocblas_handle handle,
+                                                      rocblas_int n,
+                                                      double* A,
+                                                      rocblas_int lda,
+                                                      rocblas_stride stA,
+                                                      double* C,
+                                                      rocblas_int ldc,
+                                                      rocblas_stride stC,
+                                                      rocblas_int* info,
+                                                      rocblas_int bc)
+{
+    return STRIDED ? rocsolver_dgetri_npvt_outofplace_strided_batched(handle, n, A, lda, stA, C,
+                                                                      ldc, stC, info, bc)
+                   : rocsolver_dgetri_npvt_outofplace(handle, n, A, lda, C, ldc, info);
+}
+
+inline rocblas_status rocsolver_getri_npvt_outofplace(bool STRIDED,
+                                                      rocblas_handle handle,
+                                                      rocblas_int n,
+                                                      rocblas_float_complex* A,
+                                                      rocblas_int lda,
+                                                      rocblas_stride stA,
+                                                      rocblas_float_complex* C,
+                                                      rocblas_int ldc,
+                                                      rocblas_stride stC,
+                                                      rocblas_int* info,
+                                                      rocblas_int bc)
+{
+    return STRIDED ? rocsolver_cgetri_npvt_outofplace_strided_batched(handle, n, A, lda, stA, C,
+                                                                      ldc, stC, info, bc)
+                   : rocsolver_cgetri_npvt_outofplace(handle, n, A, lda, C, ldc, info);
+}
+
+inline rocblas_status rocsolver_getri_npvt_outofplace(bool STRIDED,
+                                                      rocblas_handle handle,
+                                                      rocblas_int n,
+                                                      rocblas_double_complex* A,
+                                                      rocblas_int lda,
+                                                      rocblas_stride stA,
+                                                      rocblas_double_complex* C,
+                                                      rocblas_int ldc,
+                                                      rocblas_stride stC,
+                                                      rocblas_int* info,
+                                                      rocblas_int bc)
+{
+    return STRIDED ? rocsolver_zgetri_npvt_outofplace_strided_batched(handle, n, A, lda, stA, C,
+                                                                      ldc, stC, info, bc)
+                   : rocsolver_zgetri_npvt_outofplace(handle, n, A, lda, C, ldc, info);
+}
+
+// batched
+inline rocblas_status rocsolver_getri_npvt_outofplace(bool STRIDED,
+                                                      rocblas_handle handle,
+                                                      rocblas_int n,
+                                                      float* const A[],
+                                                      rocblas_int lda,
+                                                      rocblas_stride stA,
+                                                      float* const C[],
+                                                      rocblas_int ldc,
+                                                      rocblas_stride stC,
+                                                      rocblas_int* info,
+                                                      rocblas_int bc)
+{
+    return rocsolver_sgetri_npvt_outofplace_batched(handle, n, A, lda, C, ldc, info, bc);
+}
+
+inline rocblas_status rocsolver_getri_npvt_outofplace(bool STRIDED,
+                                                      rocblas_handle handle,
+                                                      rocblas_int n,
+                                                      double* const A[],
+                                                      rocblas_int lda,
+                                                      rocblas_stride stA,
+                                                      double* const C[],
+                                                      rocblas_int ldc,
+                                                      rocblas_stride stC,
+                                                      rocblas_int* info,
+                                                      rocblas_int bc)
+{
+    return rocsolver_dgetri_npvt_outofplace_batched(handle, n, A, lda, C, ldc, info, bc);
+}
+
+inline rocblas_status rocsolver_getri_npvt_outofplace(bool STRIDED,
+                                                      rocblas_handle handle,
+                                                      rocblas_int n,
+                                                      rocblas_float_complex* const A[],
+                                                      rocblas_int lda,
+                                                      rocblas_stride stA,
+                                                      rocblas_float_complex* const C[],
+                                                      rocblas_int ldc,
+                                                      rocblas_stride stC,
+                                                      rocblas_int* info,
+                                                      rocblas_int bc)
+{
+    return rocsolver_cgetri_npvt_outofplace_batched(handle, n, A, lda, C, ldc, info, bc);
+}
+
+inline rocblas_status rocsolver_getri_npvt_outofplace(bool STRIDED,
+                                                      rocblas_handle handle,
+                                                      rocblas_int n,
+                                                      rocblas_double_complex* const A[],
+                                                      rocblas_int lda,
+                                                      rocblas_stride stA,
+                                                      rocblas_double_complex* const C[],
+                                                      rocblas_int ldc,
+                                                      rocblas_stride stC,
+                                                      rocblas_int* info,
+                                                      rocblas_int bc)
+{
+    return rocsolver_zgetri_npvt_outofplace_batched(handle, n, A, lda, C, ldc, info, bc);
+}
+/********************************************************/
+
 /******************** GETRI ********************/
 // normal and strided_batched
 inline rocblas_status rocsolver_getri(bool STRIDED,
@@ -3167,6 +3299,110 @@ inline rocblas_status rocsolver_getri(bool STRIDED,
                                       rocblas_int bc)
 {
     return rocsolver_zgetri_batched(handle, n, A, lda, ipiv, stP, info, bc);
+}
+/********************************************************/
+
+/******************** GETRI_NPVT ********************/
+// normal and strided_batched
+inline rocblas_status rocsolver_getri_npvt(bool STRIDED,
+                                           rocblas_handle handle,
+                                           rocblas_int n,
+                                           float* A,
+                                           rocblas_int lda,
+                                           rocblas_stride stA,
+                                           rocblas_int* info,
+                                           rocblas_int bc)
+{
+    return STRIDED ? rocsolver_sgetri_npvt_strided_batched(handle, n, A, lda, stA, info, bc)
+                   : rocsolver_sgetri_npvt(handle, n, A, lda, info);
+}
+
+inline rocblas_status rocsolver_getri_npvt(bool STRIDED,
+                                           rocblas_handle handle,
+                                           rocblas_int n,
+                                           double* A,
+                                           rocblas_int lda,
+                                           rocblas_stride stA,
+                                           rocblas_int* info,
+                                           rocblas_int bc)
+{
+    return STRIDED ? rocsolver_dgetri_npvt_strided_batched(handle, n, A, lda, stA, info, bc)
+                   : rocsolver_dgetri_npvt(handle, n, A, lda, info);
+}
+
+inline rocblas_status rocsolver_getri_npvt(bool STRIDED,
+                                           rocblas_handle handle,
+                                           rocblas_int n,
+                                           rocblas_float_complex* A,
+                                           rocblas_int lda,
+                                           rocblas_stride stA,
+                                           rocblas_int* info,
+                                           rocblas_int bc)
+{
+    return STRIDED ? rocsolver_cgetri_npvt_strided_batched(handle, n, A, lda, stA, info, bc)
+                   : rocsolver_cgetri_npvt(handle, n, A, lda, info);
+}
+
+inline rocblas_status rocsolver_getri_npvt(bool STRIDED,
+                                           rocblas_handle handle,
+                                           rocblas_int n,
+                                           rocblas_double_complex* A,
+                                           rocblas_int lda,
+                                           rocblas_stride stA,
+                                           rocblas_int* info,
+                                           rocblas_int bc)
+{
+    return STRIDED ? rocsolver_zgetri_npvt_strided_batched(handle, n, A, lda, stA, info, bc)
+                   : rocsolver_zgetri_npvt(handle, n, A, lda, info);
+}
+
+// batched
+inline rocblas_status rocsolver_getri_npvt(bool STRIDED,
+                                           rocblas_handle handle,
+                                           rocblas_int n,
+                                           float* const A[],
+                                           rocblas_int lda,
+                                           rocblas_stride stA,
+                                           rocblas_int* info,
+                                           rocblas_int bc)
+{
+    return rocsolver_sgetri_npvt_batched(handle, n, A, lda, info, bc);
+}
+
+inline rocblas_status rocsolver_getri_npvt(bool STRIDED,
+                                           rocblas_handle handle,
+                                           rocblas_int n,
+                                           double* const A[],
+                                           rocblas_int lda,
+                                           rocblas_stride stA,
+                                           rocblas_int* info,
+                                           rocblas_int bc)
+{
+    return rocsolver_dgetri_npvt_batched(handle, n, A, lda, info, bc);
+}
+
+inline rocblas_status rocsolver_getri_npvt(bool STRIDED,
+                                           rocblas_handle handle,
+                                           rocblas_int n,
+                                           rocblas_float_complex* const A[],
+                                           rocblas_int lda,
+                                           rocblas_stride stA,
+                                           rocblas_int* info,
+                                           rocblas_int bc)
+{
+    return rocsolver_cgetri_npvt_batched(handle, n, A, lda, info, bc);
+}
+
+inline rocblas_status rocsolver_getri_npvt(bool STRIDED,
+                                           rocblas_handle handle,
+                                           rocblas_int n,
+                                           rocblas_double_complex* const A[],
+                                           rocblas_int lda,
+                                           rocblas_stride stA,
+                                           rocblas_int* info,
+                                           rocblas_int bc)
+{
+    return rocsolver_zgetri_npvt_batched(handle, n, A, lda, info, bc);
 }
 /********************************************************/
 

--- a/clients/include/rocsolver_dispatcher.hpp
+++ b/clients/include/rocsolver_dispatcher.hpp
@@ -21,6 +21,8 @@
 #include "testing_getf2_getrf.hpp"
 #include "testing_getf2_getrf_npvt.hpp"
 #include "testing_getri.hpp"
+#include "testing_getri_npvt.hpp"
+#include "testing_getri_npvt_outofplace.hpp"
 #include "testing_getri_outofplace.hpp"
 #include "testing_getrs.hpp"
 #include "testing_labrd.hpp"
@@ -159,18 +161,26 @@ class rocsolver_dispatcher
             {"gesvd", testing_gesvd<false, false, T>},
             {"gesvd_batched", testing_gesvd<true, true, T>},
             {"gesvd_strided_batched", testing_gesvd<false, true, T>},
-            // getri
-            {"getri", testing_getri<false, false, T>},
-            {"getri_batched", testing_getri<true, true, T>},
-            {"getri_strided_batched", testing_getri<false, true, T>},
             // trtri
             {"trtri", testing_trtri<false, false, T>},
             {"trtri_batched", testing_trtri<true, true, T>},
             {"trtri_strided_batched", testing_trtri<false, true, T>},
+            // getri
+            {"getri", testing_getri<false, false, T>},
+            {"getri_batched", testing_getri<true, true, T>},
+            {"getri_strided_batched", testing_getri<false, true, T>},
+            // getri_npvt
+            {"getri_npvt", testing_getri_npvt<false, false, T>},
+            {"getri_npvt_batched", testing_getri_npvt<true, true, T>},
+            {"getri_npvt_strided_batched", testing_getri_npvt<false, true, T>},
             // getri_outofplace
             {"getri_outofplace", testing_getri_outofplace<false, false, T>},
             {"getri_outofplace_batched", testing_getri_outofplace<true, true, T>},
             {"getri_outofplace_strided_batched", testing_getri_outofplace<false, true, T>},
+            // getri_npvt_outofplace
+            {"getri_npvt_outofplace", testing_getri_npvt_outofplace<false, false, T>},
+            {"getri_npvt_outofplace_batched", testing_getri_npvt_outofplace<true, true, T>},
+            {"getri_npvt_outofplace_strided_batched", testing_getri_npvt_outofplace<false, true, T>},
             // gels
             {"gels", testing_gels<false, false, T>},
             {"gels_batched", testing_gels<true, true, T>},

--- a/clients/include/testing_getri_npvt.hpp
+++ b/clients/include/testing_getri_npvt.hpp
@@ -1,0 +1,464 @@
+/* ************************************************************************
+ * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#pragma once
+
+#include "clientcommon.hpp"
+#include "lapack_host_reference.hpp"
+#include "norm.hpp"
+#include "rocsolver.hpp"
+#include "rocsolver_arguments.hpp"
+#include "rocsolver_test.hpp"
+
+template <bool STRIDED, typename T, typename U>
+void getri_npvt_checkBadArgs(const rocblas_handle handle,
+                             const rocblas_int n,
+                             T dA,
+                             const rocblas_int lda,
+                             const rocblas_stride stA,
+                             U dInfo,
+                             const rocblas_int bc)
+{
+    // handle
+    EXPECT_ROCBLAS_STATUS(rocsolver_getri_npvt(STRIDED, nullptr, n, dA, lda, stA, dInfo, bc),
+                          rocblas_status_invalid_handle);
+
+    // values
+    // N/A
+
+    // sizes (only check batch_count if applicable)
+    if(STRIDED)
+        EXPECT_ROCBLAS_STATUS(rocsolver_getri_npvt(STRIDED, handle, n, dA, lda, stA, dInfo, -1),
+                              rocblas_status_invalid_size);
+
+    // pointers
+    EXPECT_ROCBLAS_STATUS(rocsolver_getri_npvt(STRIDED, handle, n, (T) nullptr, lda, stA, dInfo, bc),
+                          rocblas_status_invalid_pointer);
+    EXPECT_ROCBLAS_STATUS(rocsolver_getri_npvt(STRIDED, handle, n, dA, lda, stA, (U) nullptr, bc),
+                          rocblas_status_invalid_pointer);
+
+    // quick return with invalid pointers
+    EXPECT_ROCBLAS_STATUS(rocsolver_getri_npvt(STRIDED, handle, 0, (T) nullptr, lda, stA, dInfo, bc),
+                          rocblas_status_success);
+
+    // quick return with zero batch_count if applicable
+    if(STRIDED)
+        EXPECT_ROCBLAS_STATUS(rocsolver_getri_npvt(STRIDED, handle, n, dA, lda, stA, (U) nullptr, 0),
+                              rocblas_status_success);
+}
+
+template <bool BATCHED, bool STRIDED, typename T>
+void testing_getri_npvt_bad_arg()
+{
+    // safe arguments
+    rocblas_local_handle handle;
+    rocblas_int n = 1;
+    rocblas_int lda = 1;
+    rocblas_stride stA = 1;
+    rocblas_int bc = 1;
+
+    if(BATCHED)
+    {
+        // memory allocations
+        device_batch_vector<T> dA(1, 1, 1);
+        device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, 1);
+        CHECK_HIP_ERROR(dA.memcheck());
+        CHECK_HIP_ERROR(dInfo.memcheck());
+
+        // check bad arguments
+        getri_npvt_checkBadArgs<STRIDED>(handle, n, dA.data(), lda, stA, dInfo.data(), bc);
+    }
+    else
+    {
+        // memory allocations
+        device_strided_batch_vector<T> dA(1, 1, 1, 1);
+        device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, 1);
+        CHECK_HIP_ERROR(dA.memcheck());
+        CHECK_HIP_ERROR(dInfo.memcheck());
+
+        // check bad arguments
+        getri_npvt_checkBadArgs<STRIDED>(handle, n, dA.data(), lda, stA, dInfo.data(), bc);
+    }
+}
+
+template <bool CPU, bool GPU, typename T, typename Td, typename Th, typename Uh>
+void getri_npvt_initData(const rocblas_handle handle,
+                         const rocblas_int n,
+                         Td& dA,
+                         const rocblas_int lda,
+                         const rocblas_int bc,
+                         Th& hA,
+                         Uh& hIpiv,
+                         Uh& hInfo,
+                         const bool singular)
+{
+    if(CPU)
+    {
+        T tmp;
+        rocblas_init<T>(hA, true);
+
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // scale A to avoid singularities
+            // leaving matrix as diagonal dominant so that pivoting is not required
+            for(rocblas_int i = 0; i < n; i++)
+            {
+                for(rocblas_int j = 0; j < n; j++)
+                {
+                    if(i == j)
+                        hA[b][i + j * lda] += 400;
+                    else
+                        hA[b][i + j * lda] -= 4;
+                }
+            }
+
+            // do the LU decomposition of matrix A w/ the reference LAPACK routine
+            cblas_getrf<T>(n, n, hA[b], lda, hIpiv[b], hInfo[b]);
+
+            if(singular && (b == bc / 4 || b == bc / 2 || b == bc - 1))
+            {
+                // add some singularities
+                // always the same elements for debugging purposes
+                // the algorithm must detect the first zero pivot in those
+                // matrices in the batch that are singular
+                rocblas_int i = n / 4 + b;
+                i -= (i / n) * n;
+                hA[b][i + i * lda] = 0;
+                i = n / 2 + b;
+                i -= (i / n) * n;
+                hA[b][i + i * lda] = 0;
+                i = n - 1 + b;
+                i -= (i / n) * n;
+                hA[b][i + i * lda] = 0;
+            }
+        }
+    }
+
+    // now copy data to the GPU
+    if(GPU)
+    {
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+    }
+}
+
+template <bool STRIDED, typename T, typename Td, typename Ud, typename Th, typename Uh>
+void getri_npvt_getError(const rocblas_handle handle,
+                         const rocblas_int n,
+                         Td& dA,
+                         const rocblas_int lda,
+                         const rocblas_stride stA,
+                         Ud& dInfo,
+                         const rocblas_int bc,
+                         Th& hA,
+                         Th& hARes,
+                         Uh& hIpiv,
+                         Uh& hInfo,
+                         Uh& hInfoRes,
+                         double* max_err,
+                         const bool singular)
+{
+    rocblas_int sizeW = n;
+    std::vector<T> hW(sizeW);
+
+    // input data initialization
+    getri_npvt_initData<true, true, T>(handle, n, dA, lda, bc, hA, hIpiv, hInfo, singular);
+
+    // execute computations
+    // GPU lapack
+    CHECK_ROCBLAS_ERROR(
+        rocsolver_getri_npvt(STRIDED, handle, n, dA.data(), lda, stA, dInfo.data(), bc));
+
+    CHECK_HIP_ERROR(hARes.transfer_from(dA));
+    CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
+
+    // CPU lapack
+    for(rocblas_int b = 0; b < bc; ++b)
+    {
+        cblas_getri<T>(n, hA[b], lda, hIpiv[b], hW.data(), sizeW, hInfo[b]);
+    }
+
+    // check info for singularities
+    double err = 0;
+    *max_err = 0;
+    for(rocblas_int b = 0; b < bc; ++b)
+    {
+        if(hInfo[b][0] != hInfoRes[b][0])
+            err++;
+    }
+    *max_err += err;
+
+    // error is ||hA - hARes|| / ||hA||
+    // (THIS DOES NOT ACCOUNT FOR NUMERICAL REPRODUCIBILITY ISSUES.
+    // IT MIGHT BE REVISITED IN THE FUTURE)
+    // using frobenius norm
+    for(rocblas_int b = 0; b < bc; ++b)
+    {
+        if(hInfoRes[b][0] == 0)
+        {
+            err = norm_error('F', n, n, lda, hA[b], hARes[b]);
+            *max_err = err > *max_err ? err : *max_err;
+        }
+    }
+}
+
+template <bool STRIDED, typename T, typename Td, typename Ud, typename Th, typename Uh>
+void getri_npvt_getPerfData(const rocblas_handle handle,
+                            const rocblas_int n,
+                            Td& dA,
+                            const rocblas_int lda,
+                            const rocblas_stride stA,
+                            Ud& dInfo,
+                            const rocblas_int bc,
+                            Th& hA,
+                            Uh& hIpiv,
+                            Uh& hInfo,
+                            double* gpu_time_used,
+                            double* cpu_time_used,
+                            const rocblas_int hot_calls,
+                            const int profile,
+                            const bool perf,
+                            const bool singular)
+{
+    rocblas_int sizeW = n;
+    std::vector<T> hW(sizeW);
+
+    if(!perf)
+    {
+        getri_npvt_initData<true, false, T>(handle, n, dA, lda, bc, hA, hIpiv, hInfo, singular);
+
+        // cpu-lapack performance (only if not in perf mode)
+        *cpu_time_used = get_time_us_no_sync();
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            cblas_getri<T>(n, hA[b], lda, hIpiv[b], hW.data(), sizeW, hInfo[b]);
+        }
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
+    }
+
+    getri_npvt_initData<true, false, T>(handle, n, dA, lda, bc, hA, hIpiv, hInfo, singular);
+
+    // cold calls
+    for(int iter = 0; iter < 2; iter++)
+    {
+        getri_npvt_initData<false, true, T>(handle, n, dA, lda, bc, hA, hIpiv, hInfo, singular);
+
+        CHECK_ROCBLAS_ERROR(
+            rocsolver_getri_npvt(STRIDED, handle, n, dA.data(), lda, stA, dInfo.data(), bc));
+    }
+
+    // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
+    double start;
+
+    if(profile > 0)
+    {
+        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        rocsolver_log_set_max_levels(profile);
+    }
+
+    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    {
+        getri_npvt_initData<false, true, T>(handle, n, dA, lda, bc, hA, hIpiv, hInfo, singular);
+
+        start = get_time_us_sync(stream);
+        rocsolver_getri_npvt(STRIDED, handle, n, dA.data(), lda, stA, dInfo.data(), bc);
+        *gpu_time_used += get_time_us_sync(stream) - start;
+    }
+    *gpu_time_used /= hot_calls;
+}
+
+template <bool BATCHED, bool STRIDED, typename T>
+void testing_getri_npvt(Arguments& argus)
+{
+    // get arguments
+    rocblas_local_handle handle;
+    rocblas_int n = argus.get<rocblas_int>("n");
+    rocblas_int lda = argus.get<rocblas_int>("lda", n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stP = argus.get<rocblas_stride>("strideP", n);
+
+    rocblas_int bc = argus.batch_count;
+    rocblas_int hot_calls = argus.iters;
+
+    rocblas_stride stARes = (argus.unit_check || argus.norm_check) ? stA : 0;
+
+    // check non-supported values
+    // N/A
+
+    // determine sizes
+    size_t size_A = size_t(lda) * n;
+    size_t size_P = size_t(n);
+    double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
+
+    size_t size_ARes = (argus.unit_check || argus.norm_check) ? size_A : 0;
+
+    // check invalid sizes
+    bool invalid_size = (n < 0 || lda < n || bc < 0);
+    if(invalid_size)
+    {
+        if(BATCHED)
+            EXPECT_ROCBLAS_STATUS(rocsolver_getri_npvt(STRIDED, handle, n, (T* const*)nullptr, lda,
+                                                       stA, (rocblas_int*)nullptr, bc),
+                                  rocblas_status_invalid_size);
+        else
+            EXPECT_ROCBLAS_STATUS(rocsolver_getri_npvt(STRIDED, handle, n, (T*)nullptr, lda, stA,
+                                                       (rocblas_int*)nullptr, bc),
+                                  rocblas_status_invalid_size);
+
+        if(argus.timing)
+            rocsolver_bench_inform(inform_invalid_size);
+
+        return;
+    }
+
+    // memory size query is necessary
+    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        if(BATCHED)
+            CHECK_ALLOC_QUERY(rocsolver_getri_npvt(STRIDED, handle, n, (T* const*)nullptr, lda, stA,
+                                                   (rocblas_int*)nullptr, bc));
+        else
+            CHECK_ALLOC_QUERY(rocsolver_getri_npvt(STRIDED, handle, n, (T*)nullptr, lda, stA,
+                                                   (rocblas_int*)nullptr, bc));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+        if(argus.mem_query)
+        {
+            rocsolver_bench_inform(inform_mem_query, size);
+            return;
+        }
+
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
+    if(BATCHED)
+    {
+        // memory allocations
+        host_batch_vector<T> hA(size_A, 1, bc);
+        host_batch_vector<T> hARes(size_ARes, 1, bc);
+        host_strided_batch_vector<rocblas_int> hIpiv(size_P, 1, stP, bc);
+        host_strided_batch_vector<rocblas_int> hInfo(1, 1, 1, bc);
+        host_strided_batch_vector<rocblas_int> hInfoRes(1, 1, 1, bc);
+        device_batch_vector<T> dA(size_A, 1, bc);
+        device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, bc);
+        if(size_A)
+            CHECK_HIP_ERROR(dA.memcheck());
+        CHECK_HIP_ERROR(dInfo.memcheck());
+
+        // check quick return
+        if(n == 0 || bc == 0)
+        {
+            EXPECT_ROCBLAS_STATUS(
+                rocsolver_getri_npvt(STRIDED, handle, n, dA.data(), lda, stA, dInfo.data(), bc),
+                rocblas_status_success);
+            if(argus.timing)
+                rocsolver_bench_inform(inform_quick_return);
+
+            return;
+        }
+
+        // check computations
+        if(argus.unit_check || argus.norm_check)
+            getri_npvt_getError<STRIDED, T>(handle, n, dA, lda, stA, dInfo, bc, hA, hARes, hIpiv,
+                                            hInfo, hInfoRes, &max_error, argus.singular);
+
+        // collect performance data
+        if(argus.timing)
+            getri_npvt_getPerfData<STRIDED, T>(handle, n, dA, lda, stA, dInfo, bc, hA, hIpiv, hInfo,
+                                               &gpu_time_used, &cpu_time_used, hot_calls,
+                                               argus.profile, argus.perf, argus.singular);
+    }
+
+    else
+    {
+        // memory allocations
+        host_strided_batch_vector<T> hA(size_A, 1, stA, bc);
+        host_strided_batch_vector<T> hARes(size_ARes, 1, stARes, bc);
+        host_strided_batch_vector<rocblas_int> hIpiv(size_P, 1, stP, bc);
+        host_strided_batch_vector<rocblas_int> hInfo(1, 1, 1, bc);
+        host_strided_batch_vector<rocblas_int> hInfoRes(1, 1, 1, bc);
+        device_strided_batch_vector<T> dA(size_A, 1, stA, bc);
+        device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, bc);
+        if(size_A)
+            CHECK_HIP_ERROR(dA.memcheck());
+        CHECK_HIP_ERROR(dInfo.memcheck());
+
+        // check quick return
+        if(n == 0 || bc == 0)
+        {
+            EXPECT_ROCBLAS_STATUS(
+                rocsolver_getri_npvt(STRIDED, handle, n, dA.data(), lda, stA, dInfo.data(), bc),
+                rocblas_status_success);
+            if(argus.timing)
+                rocsolver_bench_inform(inform_quick_return);
+
+            return;
+        }
+
+        // check computations
+        if(argus.unit_check || argus.norm_check)
+            getri_npvt_getError<STRIDED, T>(handle, n, dA, lda, stA, dInfo, bc, hA, hARes, hIpiv,
+                                            hInfo, hInfoRes, &max_error, argus.singular);
+
+        // collect performance data
+        if(argus.timing)
+            getri_npvt_getPerfData<STRIDED, T>(handle, n, dA, lda, stA, dInfo, bc, hA, hIpiv, hInfo,
+                                               &gpu_time_used, &cpu_time_used, hot_calls,
+                                               argus.profile, argus.perf, argus.singular);
+    }
+
+    // validate results for rocsolver-test
+    // using n * machine_precision as tolerance
+    if(argus.unit_check)
+        ROCSOLVER_TEST_CHECK(T, max_error, n);
+
+    // output results for rocsolver-bench
+    if(argus.timing)
+    {
+        if(!argus.perf)
+        {
+            rocsolver_bench_header("Arguments:");
+            if(BATCHED)
+            {
+                rocsolver_bench_output("n", "lda", "batch_c");
+                rocsolver_bench_output(n, lda, bc);
+            }
+            else if(STRIDED)
+            {
+                rocsolver_bench_output("n", "lda", "strideA", "batch_c");
+                rocsolver_bench_output(n, lda, stA, bc);
+            }
+            else
+            {
+                rocsolver_bench_output("n", "lda");
+                rocsolver_bench_output(n, lda);
+            }
+            rocsolver_bench_header("Results:");
+            if(argus.norm_check)
+            {
+                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
+            }
+            else
+            {
+                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output(cpu_time_used, gpu_time_used);
+            }
+            rocsolver_bench_endl();
+        }
+        else
+        {
+            if(argus.norm_check)
+                rocsolver_bench_output(gpu_time_used, max_error);
+            else
+                rocsolver_bench_output(gpu_time_used);
+        }
+    }
+
+    // ensure all arguments were consumed
+    argus.validate_consumed();
+}

--- a/clients/include/testing_getri_npvt_outofplace.hpp
+++ b/clients/include/testing_getri_npvt_outofplace.hpp
@@ -1,0 +1,511 @@
+/* ************************************************************************
+ * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#pragma once
+
+#include "clientcommon.hpp"
+#include "lapack_host_reference.hpp"
+#include "norm.hpp"
+#include "rocsolver.hpp"
+#include "rocsolver_arguments.hpp"
+#include "rocsolver_test.hpp"
+
+template <bool STRIDED, typename T, typename U>
+void getri_npvt_outofplace_checkBadArgs(const rocblas_handle handle,
+                                        const rocblas_int n,
+                                        T dA,
+                                        const rocblas_int lda,
+                                        const rocblas_stride stA,
+                                        T dC,
+                                        const rocblas_int ldc,
+                                        const rocblas_stride stC,
+                                        U dInfo,
+                                        const rocblas_int bc)
+{
+    // handle
+    EXPECT_ROCBLAS_STATUS(
+        rocsolver_getri_npvt_outofplace(STRIDED, nullptr, n, dA, lda, stA, dC, ldc, stC, dInfo, bc),
+        rocblas_status_invalid_handle);
+
+    // values
+    // N/A
+
+    // sizes (only check batch_count if applicable)
+    if(STRIDED)
+        EXPECT_ROCBLAS_STATUS(rocsolver_getri_npvt_outofplace(STRIDED, handle, n, dA, lda, stA, dC,
+                                                              ldc, stC, dInfo, -1),
+                              rocblas_status_invalid_size);
+
+    // pointers
+    EXPECT_ROCBLAS_STATUS(rocsolver_getri_npvt_outofplace(STRIDED, handle, n, (T) nullptr, lda, stA,
+                                                          dC, ldc, stC, dInfo, bc),
+                          rocblas_status_invalid_pointer);
+    EXPECT_ROCBLAS_STATUS(rocsolver_getri_npvt_outofplace(STRIDED, handle, n, dA, lda, stA,
+                                                          (T) nullptr, ldc, stC, dInfo, bc),
+                          rocblas_status_invalid_pointer);
+    EXPECT_ROCBLAS_STATUS(rocsolver_getri_npvt_outofplace(STRIDED, handle, n, dA, lda, stA, dC, ldc,
+                                                          stC, (U) nullptr, bc),
+                          rocblas_status_invalid_pointer);
+
+    // quick return with invalid pointers
+    EXPECT_ROCBLAS_STATUS(rocsolver_getri_npvt_outofplace(STRIDED, handle, 0, (T) nullptr, lda, stA,
+                                                          (T) nullptr, ldc, stC, dInfo, bc),
+                          rocblas_status_success);
+
+    // quick return with zero batch_count if applicable
+    if(STRIDED)
+        EXPECT_ROCBLAS_STATUS(rocsolver_getri_npvt_outofplace(STRIDED, handle, n, dA, lda, stA, dC,
+                                                              ldc, stC, (U) nullptr, 0),
+                              rocblas_status_success);
+}
+
+template <bool BATCHED, bool STRIDED, typename T>
+void testing_getri_npvt_outofplace_bad_arg()
+{
+    // safe arguments
+    rocblas_local_handle handle;
+    rocblas_int n = 1;
+    rocblas_int lda = 1;
+    rocblas_int ldc = 1;
+    rocblas_stride stA = 1;
+    rocblas_stride stC = 1;
+    rocblas_int bc = 1;
+
+    if(BATCHED)
+    {
+        // memory allocations
+        device_batch_vector<T> dA(1, 1, 1);
+        device_batch_vector<T> dC(1, 1, 1);
+        device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, 1);
+        CHECK_HIP_ERROR(dA.memcheck());
+        CHECK_HIP_ERROR(dC.memcheck());
+        CHECK_HIP_ERROR(dInfo.memcheck());
+
+        // check bad arguments
+        getri_npvt_outofplace_checkBadArgs<STRIDED>(handle, n, dA.data(), lda, stA, dC.data(), ldc,
+                                                    stC, dInfo.data(), bc);
+    }
+    else
+    {
+        // memory allocations
+        device_strided_batch_vector<T> dA(1, 1, 1, 1);
+        device_strided_batch_vector<T> dC(1, 1, 1, 1);
+        device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, 1);
+        CHECK_HIP_ERROR(dA.memcheck());
+        CHECK_HIP_ERROR(dC.memcheck());
+        CHECK_HIP_ERROR(dInfo.memcheck());
+
+        // check bad arguments
+        getri_npvt_outofplace_checkBadArgs<STRIDED>(handle, n, dA.data(), lda, stA, dC.data(), ldc,
+                                                    stC, dInfo.data(), bc);
+    }
+}
+
+template <bool CPU, bool GPU, typename T, typename Td, typename Th, typename Uh>
+void getri_npvt_outofplace_initData(const rocblas_handle handle,
+                                    const rocblas_int n,
+                                    Td& dA,
+                                    const rocblas_int lda,
+                                    const rocblas_int bc,
+                                    Th& hA,
+                                    Uh& hIpiv,
+                                    Uh& hInfo,
+                                    const bool singular)
+{
+    if(CPU)
+    {
+        T tmp;
+        rocblas_init<T>(hA, true);
+
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // scale A to avoid singularities
+            // leaving matrix as diagonal dominant so that pivoting is not required
+            for(rocblas_int i = 0; i < n; i++)
+            {
+                for(rocblas_int j = 0; j < n; j++)
+                {
+                    if(i == j)
+                        hA[b][i + j * lda] += 400;
+                    else
+                        hA[b][i + j * lda] -= 4;
+                }
+            }
+
+            // do the LU decomposition of matrix A w/ the reference LAPACK routine
+            cblas_getrf<T>(n, n, hA[b], lda, hIpiv[b], hInfo[b]);
+
+            if(singular && (b == bc / 4 || b == bc / 2 || b == bc - 1))
+            {
+                // add some singularities
+                // always the same elements for debugging purposes
+                // the algorithm must detect the first zero pivot in those
+                // matrices in the batch that are singular
+                rocblas_int i = n / 4 + b;
+                i -= (i / n) * n;
+                hA[b][i + i * lda] = 0;
+                i = n / 2 + b;
+                i -= (i / n) * n;
+                hA[b][i + i * lda] = 0;
+                i = n - 1 + b;
+                i -= (i / n) * n;
+                hA[b][i + i * lda] = 0;
+            }
+        }
+    }
+
+    // now copy data to the GPU
+    if(GPU)
+    {
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+    }
+}
+
+template <bool STRIDED, typename T, typename Td, typename Ud, typename Th, typename Uh>
+void getri_npvt_outofplace_getError(const rocblas_handle handle,
+                                    const rocblas_int n,
+                                    Td& dA,
+                                    const rocblas_int lda,
+                                    const rocblas_stride stA,
+                                    Td& dC,
+                                    const rocblas_int ldc,
+                                    const rocblas_stride stC,
+                                    Ud& dInfo,
+                                    const rocblas_int bc,
+                                    Th& hA,
+                                    Th& hARes,
+                                    Uh& hIpiv,
+                                    Uh& hInfo,
+                                    Uh& hInfoRes,
+                                    double* max_err,
+                                    const bool singular)
+{
+    rocblas_int sizeW = n;
+    std::vector<T> hW(sizeW);
+
+    // input data initialization
+    getri_npvt_outofplace_initData<true, true, T>(handle, n, dA, lda, bc, hA, hIpiv, hInfo, singular);
+
+    // execute computations
+    // GPU lapack
+    CHECK_ROCBLAS_ERROR(rocsolver_getri_npvt_outofplace(STRIDED, handle, n, dA.data(), lda, stA,
+                                                        dC.data(), ldc, stC, dInfo.data(), bc));
+    CHECK_HIP_ERROR(hARes.transfer_from(dC));
+    CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
+
+    // CPU lapack
+    for(rocblas_int b = 0; b < bc; ++b)
+    {
+        cblas_getri<T>(n, hA[b], lda, hIpiv[b], hW.data(), sizeW, hInfo[b]);
+    }
+
+    // check info for singularities
+    double err = 0;
+    *max_err = 0;
+    for(rocblas_int b = 0; b < bc; ++b)
+    {
+        if(hInfo[b][0] != hInfoRes[b][0])
+            err++;
+    }
+    *max_err += err;
+
+    // error is ||hA - hARes|| / ||hA||
+    // (THIS DOES NOT ACCOUNT FOR NUMERICAL REPRODUCIBILITY ISSUES.
+    // IT MIGHT BE REVISITED IN THE FUTURE)
+    // using frobenius norm
+    for(rocblas_int b = 0; b < bc; ++b)
+    {
+        if(hInfoRes[b][0] == 0)
+        {
+            err = norm_error('F', n, n, lda, hA[b], hARes[b], ldc);
+            *max_err = err > *max_err ? err : *max_err;
+        }
+    }
+}
+
+template <bool STRIDED, typename T, typename Td, typename Ud, typename Th, typename Uh>
+void getri_npvt_outofplace_getPerfData(const rocblas_handle handle,
+                                       const rocblas_int n,
+                                       Td& dA,
+                                       const rocblas_int lda,
+                                       const rocblas_stride stA,
+                                       Td& dC,
+                                       const rocblas_int ldc,
+                                       const rocblas_stride stC,
+                                       Ud& dInfo,
+                                       const rocblas_int bc,
+                                       Th& hA,
+                                       Uh& hIpiv,
+                                       Uh& hInfo,
+                                       double* gpu_time_used,
+                                       double* cpu_time_used,
+                                       const rocblas_int hot_calls,
+                                       const int profile,
+                                       const bool perf,
+                                       const bool singular)
+{
+    rocblas_int sizeW = n;
+    std::vector<T> hW(sizeW);
+
+    if(!perf)
+    {
+        getri_npvt_outofplace_initData<true, false, T>(handle, n, dA, lda, bc, hA, hIpiv, hInfo,
+                                                       singular);
+
+        // cpu-lapack performance (only if not in perf mode)
+        *cpu_time_used = get_time_us_no_sync();
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            cblas_getri<T>(n, hA[b], lda, hIpiv[b], hW.data(), sizeW, hInfo[b]);
+        }
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
+    }
+
+    getri_npvt_outofplace_initData<true, false, T>(handle, n, dA, lda, bc, hA, hIpiv, hInfo,
+                                                   singular);
+
+    // cold calls
+    for(int iter = 0; iter < 2; iter++)
+    {
+        getri_npvt_outofplace_initData<false, true, T>(handle, n, dA, lda, bc, hA, hIpiv, hInfo,
+                                                       singular);
+
+        CHECK_ROCBLAS_ERROR(rocsolver_getri_npvt_outofplace(STRIDED, handle, n, dA.data(), lda, stA,
+                                                            dC.data(), ldc, stC, dInfo.data(), bc));
+    }
+
+    // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
+    double start;
+
+    if(profile > 0)
+    {
+        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        rocsolver_log_set_max_levels(profile);
+    }
+
+    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    {
+        getri_npvt_outofplace_initData<false, true, T>(handle, n, dA, lda, bc, hA, hIpiv, hInfo,
+                                                       singular);
+
+        start = get_time_us_sync(stream);
+        rocsolver_getri_npvt_outofplace(STRIDED, handle, n, dA.data(), lda, stA, dC.data(), ldc,
+                                        stC, dInfo.data(), bc);
+        *gpu_time_used += get_time_us_sync(stream) - start;
+    }
+    *gpu_time_used /= hot_calls;
+}
+
+template <bool BATCHED, bool STRIDED, typename T>
+void testing_getri_npvt_outofplace(Arguments& argus)
+{
+    // get arguments
+    rocblas_local_handle handle;
+    rocblas_int n = argus.get<rocblas_int>("n");
+    rocblas_int lda = argus.get<rocblas_int>("lda", n);
+    rocblas_int ldc = argus.get<rocblas_int>("ldc", n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stC = argus.get<rocblas_stride>("strideC", ldc * n);
+    rocblas_stride stP = argus.get<rocblas_stride>("strideP", n);
+
+    rocblas_int bc = argus.batch_count;
+    rocblas_int hot_calls = argus.iters;
+
+    rocblas_stride stARes = (argus.unit_check || argus.norm_check) ? stC : 0;
+
+    // check non-supported values
+    // N/A
+
+    // determine sizes
+    size_t size_A = size_t(lda) * n;
+    size_t size_C = size_t(ldc) * n;
+    size_t size_P = size_t(n);
+    double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
+
+    size_t size_ARes = (argus.unit_check || argus.norm_check) ? size_C : 0;
+
+    // check invalid sizes
+    bool invalid_size = (n < 0 || lda < n || ldc < n || bc < 0);
+    if(invalid_size)
+    {
+        if(BATCHED)
+            EXPECT_ROCBLAS_STATUS(rocsolver_getri_npvt_outofplace(
+                                      STRIDED, handle, n, (T* const*)nullptr, lda, stA,
+                                      (T* const*)nullptr, ldc, stC, (rocblas_int*)nullptr, bc),
+                                  rocblas_status_invalid_size);
+        else
+            EXPECT_ROCBLAS_STATUS(rocsolver_getri_npvt_outofplace(STRIDED, handle, n, (T*)nullptr,
+                                                                  lda, stA, (T*)nullptr, ldc, stC,
+                                                                  (rocblas_int*)nullptr, bc),
+                                  rocblas_status_invalid_size);
+
+        if(argus.timing)
+            rocsolver_bench_inform(inform_invalid_size);
+
+        return;
+    }
+
+    // memory size query is necessary
+    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        if(BATCHED)
+            CHECK_ALLOC_QUERY(rocsolver_getri_npvt_outofplace(STRIDED, handle, n, (T* const*)nullptr,
+                                                              lda, stA, (T* const*)nullptr, ldc,
+                                                              stC, (rocblas_int*)nullptr, bc));
+        else
+            CHECK_ALLOC_QUERY(rocsolver_getri_npvt_outofplace(STRIDED, handle, n, (T*)nullptr, lda,
+                                                              stA, (T*)nullptr, ldc, stC,
+                                                              (rocblas_int*)nullptr, bc));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+        if(argus.mem_query)
+        {
+            rocsolver_bench_inform(inform_mem_query, size);
+            return;
+        }
+
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
+    if(BATCHED)
+    {
+        // memory allocations
+        host_batch_vector<T> hA(size_A, 1, bc);
+        host_batch_vector<T> hARes(size_ARes, 1, bc);
+        host_strided_batch_vector<rocblas_int> hIpiv(size_P, 1, stP, bc);
+        host_strided_batch_vector<rocblas_int> hInfo(1, 1, 1, bc);
+        host_strided_batch_vector<rocblas_int> hInfoRes(1, 1, 1, bc);
+        device_batch_vector<T> dC(size_C, 1, bc);
+        device_batch_vector<T> dA(size_A, 1, bc);
+        device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, bc);
+        if(size_C)
+            CHECK_HIP_ERROR(dC.memcheck());
+        if(size_A)
+            CHECK_HIP_ERROR(dA.memcheck());
+        CHECK_HIP_ERROR(dInfo.memcheck());
+
+        // check quick return
+        if(n == 0 || bc == 0)
+        {
+            EXPECT_ROCBLAS_STATUS(rocsolver_getri_npvt_outofplace(STRIDED, handle, n, dA.data(),
+                                                                  lda, stA, dC.data(), ldc, stC,
+                                                                  dInfo.data(), bc),
+                                  rocblas_status_success);
+            if(argus.timing)
+                rocsolver_bench_inform(inform_quick_return);
+
+            return;
+        }
+
+        // check computations
+        if(argus.unit_check || argus.norm_check)
+            getri_npvt_outofplace_getError<STRIDED, T>(handle, n, dA, lda, stA, dC, ldc, stC, dInfo,
+                                                       bc, hA, hARes, hIpiv, hInfo, hInfoRes,
+                                                       &max_error, argus.singular);
+
+        // collect performance data
+        if(argus.timing)
+            getri_npvt_outofplace_getPerfData<STRIDED, T>(
+                handle, n, dA, lda, stA, dC, ldc, stC, dInfo, bc, hA, hIpiv, hInfo, &gpu_time_used,
+                &cpu_time_used, hot_calls, argus.profile, argus.perf, argus.singular);
+    }
+
+    else
+    {
+        // memory allocations
+        host_strided_batch_vector<T> hA(size_A, 1, stA, bc);
+        host_strided_batch_vector<T> hARes(size_ARes, 1, stARes, bc);
+        host_strided_batch_vector<rocblas_int> hIpiv(size_P, 1, stP, bc);
+        host_strided_batch_vector<rocblas_int> hInfo(1, 1, 1, bc);
+        host_strided_batch_vector<rocblas_int> hInfoRes(1, 1, 1, bc);
+        device_strided_batch_vector<T> dC(size_C, 1, stC, bc);
+        device_strided_batch_vector<T> dA(size_A, 1, stA, bc);
+        device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, bc);
+        if(size_C)
+            CHECK_HIP_ERROR(dC.memcheck());
+        if(size_A)
+            CHECK_HIP_ERROR(dA.memcheck());
+        CHECK_HIP_ERROR(dInfo.memcheck());
+
+        // check quick return
+        if(n == 0 || bc == 0)
+        {
+            EXPECT_ROCBLAS_STATUS(rocsolver_getri_npvt_outofplace(STRIDED, handle, n, dA.data(),
+                                                                  lda, stA, dC.data(), ldc, stC,
+                                                                  dInfo.data(), bc),
+                                  rocblas_status_success);
+            if(argus.timing)
+                rocsolver_bench_inform(inform_quick_return);
+
+            return;
+        }
+
+        // check computations
+        if(argus.unit_check || argus.norm_check)
+            getri_npvt_outofplace_getError<STRIDED, T>(handle, n, dA, lda, stA, dC, ldc, stC, dInfo,
+                                                       bc, hA, hARes, hIpiv, hInfo, hInfoRes,
+                                                       &max_error, argus.singular);
+
+        // collect performance data
+        if(argus.timing)
+            getri_npvt_outofplace_getPerfData<STRIDED, T>(
+                handle, n, dA, lda, stA, dC, ldc, stC, dInfo, bc, hA, hIpiv, hInfo, &gpu_time_used,
+                &cpu_time_used, hot_calls, argus.profile, argus.perf, argus.singular);
+    }
+
+    // validate results for rocsolver-test
+    // using n * machine_precision as tolerance
+    if(argus.unit_check)
+        ROCSOLVER_TEST_CHECK(T, max_error, n);
+
+    // output results for rocsolver-bench
+    if(argus.timing)
+    {
+        if(!argus.perf)
+        {
+            rocsolver_bench_header("Arguments:");
+            if(BATCHED)
+            {
+                rocsolver_bench_output("n", "lda", "ldc", "batch_c");
+                rocsolver_bench_output(n, lda, ldc, bc);
+            }
+            else if(STRIDED)
+            {
+                rocsolver_bench_output("n", "lda", "strideA", "ldc", "strideC", "batch_c");
+                rocsolver_bench_output(n, lda, stA, ldc, stC, bc);
+            }
+            else
+            {
+                rocsolver_bench_output("n", "lda", "ldc");
+                rocsolver_bench_output(n, lda, ldc);
+            }
+            rocsolver_bench_header("Results:");
+            if(argus.norm_check)
+            {
+                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
+            }
+            else
+            {
+                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output(cpu_time_used, gpu_time_used);
+            }
+            rocsolver_bench_endl();
+        }
+        else
+        {
+            if(argus.norm_check)
+                rocsolver_bench_output(gpu_time_used, max_error);
+            else
+                rocsolver_bench_output(gpu_time_used);
+        }
+    }
+
+    // ensure all arguments were consumed
+    argus.validate_consumed();
+}

--- a/docs/source/api_lapacklike.rst
+++ b/docs/source/api_lapacklike.rst
@@ -106,6 +106,38 @@ Linear-systems solvers
    :local:
    :backlinks: top
 
+.. _getri_npvt:
+
+rocsolver_<type>getri_npvt()
+-----------------------------------------------------
+.. doxygenfunction:: rocsolver_zgetri_npvt
+   :outline:
+.. doxygenfunction:: rocsolver_cgetri_npvt
+   :outline:
+.. doxygenfunction:: rocsolver_dgetri_npvt
+   :outline:
+.. doxygenfunction:: rocsolver_sgetri_npvt
+
+rocsolver_<type>getri_npvt_batched()
+-----------------------------------------------------
+.. doxygenfunction:: rocsolver_zgetri_npvt_batched
+   :outline:
+.. doxygenfunction:: rocsolver_cgetri_npvt_batched
+   :outline:
+.. doxygenfunction:: rocsolver_dgetri_npvt_batched
+   :outline:
+.. doxygenfunction:: rocsolver_sgetri_npvt_batched
+
+rocsolver_<type>getri_npvt_strided_batched()
+-----------------------------------------------------
+.. doxygenfunction:: rocsolver_zgetri_npvt_strided_batched
+   :outline:
+.. doxygenfunction:: rocsolver_cgetri_npvt_strided_batched
+   :outline:
+.. doxygenfunction:: rocsolver_dgetri_npvt_strided_batched
+   :outline:
+.. doxygenfunction:: rocsolver_sgetri_npvt_strided_batched
+
 .. _getri_outofplace:
 
 rocsolver_<type>getri_outofplace()
@@ -137,4 +169,36 @@ rocsolver_<type>getri_outofplace_strided_batched()
 .. doxygenfunction:: rocsolver_dgetri_outofplace_strided_batched
    :outline:
 .. doxygenfunction:: rocsolver_sgetri_outofplace_strided_batched
+
+.. _getri_npvt_outofplace:
+
+rocsolver_<type>getri_npvt_outofplace()
+-----------------------------------------------------
+.. doxygenfunction:: rocsolver_zgetri_npvt_outofplace
+   :outline:
+.. doxygenfunction:: rocsolver_cgetri_npvt_outofplace
+   :outline:
+.. doxygenfunction:: rocsolver_dgetri_npvt_outofplace
+   :outline:
+.. doxygenfunction:: rocsolver_sgetri_npvt_outofplace
+
+rocsolver_<type>getri_npvt_outofplace_batched()
+-----------------------------------------------------
+.. doxygenfunction:: rocsolver_zgetri_npvt_outofplace_batched
+   :outline:
+.. doxygenfunction:: rocsolver_cgetri_npvt_outofplace_batched
+   :outline:
+.. doxygenfunction:: rocsolver_dgetri_npvt_outofplace_batched
+   :outline:
+.. doxygenfunction:: rocsolver_sgetri_npvt_outofplace_batched
+
+rocsolver_<type>getri_npvt_outofplace_strided_batched()
+-----------------------------------------------------
+.. doxygenfunction:: rocsolver_zgetri_npvt_outofplace_strided_batched
+   :outline:
+.. doxygenfunction:: rocsolver_cgetri_npvt_outofplace_strided_batched
+   :outline:
+.. doxygenfunction:: rocsolver_dgetri_npvt_outofplace_strided_batched
+   :outline:
+.. doxygenfunction:: rocsolver_sgetri_npvt_outofplace_strided_batched
 

--- a/docs/source/userguide_intro.rst
+++ b/docs/source/userguide_intro.rst
@@ -183,6 +183,8 @@ LAPACK-like functions
 .. csv-table:: Linear-systems solvers
     :header: "Function", "single", "double", "single complex", "double complex"
 
+    :ref:`rocsolver_getri_npvt <getri_npvt>`, x, x, x, x
     :ref:`rocsolver_getri_outofplace <getri_outofplace>`, x, x, x, x
+    :ref:`rocsolver_getri_npvt_outofplace <getri_npvt_outofplace>`, x, x, x, x
 
 

--- a/library/include/rocsolver-functions.h
+++ b/library/include/rocsolver-functions.h
@@ -8860,6 +8860,204 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgetri_strided_batched(rocblas_handle 
 //! @}
 
 /*! @{
+    \brief GETRI_NPVT inverts a general n-by-n matrix A using the LU factorization
+    computed by \ref rocsolver_sgetrf_npvt "GETRF_NPVT".
+
+    \details
+    The inverse is computed by solving the linear system
+
+    \f[
+        A^{-1}L = U^{-1}
+    \f]
+
+    where L is the lower triangular factor of A with unit diagonal elements, and U is the
+    upper triangular factor.
+
+    @param[in]
+    handle    rocblas_handle.
+    @param[in]
+    n         rocblas_int. n >= 0.\n
+              The number of rows and columns of the matrix A.
+    @param[inout]
+    A         pointer to type. Array on the GPU of dimension lda*n.\n
+              On entry, the factors L and U of the factorization A = L*U returned by \ref rocsolver_sgetrf_npvt "GETRF_NPVT".
+              On exit, the inverse of A if info = 0; otherwise undefined.
+    @param[in]
+    lda       rocblas_int. lda >= n.\n
+              Specifies the leading dimension of A.
+    @param[out]
+    info      pointer to a rocblas_int on the GPU.\n
+              If info = 0, successful exit.
+              If info = i > 0, U is singular. U[i,i] is the first zero pivot.
+
+    ********************************************************************/
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_sgetri_npvt(rocblas_handle handle,
+                                                      const rocblas_int n,
+                                                      float* A,
+                                                      const rocblas_int lda,
+                                                      rocblas_int* info);
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_dgetri_npvt(rocblas_handle handle,
+                                                      const rocblas_int n,
+                                                      double* A,
+                                                      const rocblas_int lda,
+                                                      rocblas_int* info);
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_cgetri_npvt(rocblas_handle handle,
+                                                      const rocblas_int n,
+                                                      rocblas_float_complex* A,
+                                                      const rocblas_int lda,
+                                                      rocblas_int* info);
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_zgetri_npvt(rocblas_handle handle,
+                                                      const rocblas_int n,
+                                                      rocblas_double_complex* A,
+                                                      const rocblas_int lda,
+                                                      rocblas_int* info);
+//! @}
+
+/*! @{
+    \brief GETRI_NPVT_BATCHED inverts a batch of general n-by-n matrices using
+    the LU factorization computed by \ref rocsolver_sgetrf_npvt_batched "GETRF_NPVT_BATCHED".
+
+    \details
+    The inverse of matrix \f$A_j\f$ in the batch is computed by solving the linear system
+
+    \f[
+        A_j^{-1} L_j = U_j^{-1}
+    \f]
+
+    where \f$L_j\f$ is the lower triangular factor of \f$A_j\f$ with unit diagonal elements, and \f$U_j\f$ is the
+    upper triangular factor.
+
+    @param[in]
+    handle    rocblas_handle.
+    @param[in]
+    n         rocblas_int. n >= 0.\n
+              The number of rows and columns of all matrices A_j in the batch.
+    @param[inout]
+    A         array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+              On entry, the factors L_j and U_j of the factorization A = L_j*U_j returned by
+              \ref rocsolver_sgetrf_npvt_batched "GETRF_NPVT_BATCHED".
+              On exit, the inverses of A_j if info[j] = 0; otherwise undefined.
+    @param[in]
+    lda       rocblas_int. lda >= n.\n
+              Specifies the leading dimension of matrices A_j.
+    @param[out]
+    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+              If info[j] = 0, successful exit for inversion of A_j.
+              If info[j] = i > 0, U_j is singular. U_j[i,i] is the first zero pivot.
+    @param[in]
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
+
+    ********************************************************************/
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_sgetri_npvt_batched(rocblas_handle handle,
+                                                              const rocblas_int n,
+                                                              float* const A[],
+                                                              const rocblas_int lda,
+                                                              rocblas_int* info,
+                                                              const rocblas_int batch_count);
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_dgetri_npvt_batched(rocblas_handle handle,
+                                                              const rocblas_int n,
+                                                              double* const A[],
+                                                              const rocblas_int lda,
+                                                              rocblas_int* info,
+                                                              const rocblas_int batch_count);
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_cgetri_npvt_batched(rocblas_handle handle,
+                                                              const rocblas_int n,
+                                                              rocblas_float_complex* const A[],
+                                                              const rocblas_int lda,
+                                                              rocblas_int* info,
+                                                              const rocblas_int batch_count);
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_zgetri_npvt_batched(rocblas_handle handle,
+                                                              const rocblas_int n,
+                                                              rocblas_double_complex* const A[],
+                                                              const rocblas_int lda,
+                                                              rocblas_int* info,
+                                                              const rocblas_int batch_count);
+//! @}
+
+/*! @{
+    \brief GETRI_NPVT_STRIDED_BATCHED inverts a batch of general n-by-n matrices
+    using the LU factorization computed by \ref rocsolver_sgetrf_npvt_strided_batched "GETRF_NPVT_STRIDED_BATCHED".
+
+    \details
+    The inverse of matrix \f$A_j\f$ in the batch is computed by solving the linear system
+
+    \f[
+        A_j^{-1} L_j = U_j^{-1}
+    \f]
+
+    where \f$L_j\f$ is the lower triangular factor of \f$A_j\f$ with unit diagonal elements, and \f$U_j\f$ is the
+    upper triangular factor.
+
+    @param[in]
+    handle    rocblas_handle.
+    @param[in]
+    n         rocblas_int. n >= 0.\n
+              The number of rows and columns of all matrices A_j in the batch.
+    @param[inout]
+    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+              On entry, the factors L_j and U_j of the factorization A_j = L_j*U_j returned by
+              \ref rocsolver_sgetrf_npvt_strided_batched "GETRF_NPVT_STRIDED_BATCHED".
+              On exit, the inverses of A_j if info[j] = 0; otherwise undefined.
+    @param[in]
+    lda       rocblas_int. lda >= n.\n
+              Specifies the leading dimension of matrices A_j.
+    @param[in]
+    strideA   rocblas_stride.\n
+              Stride from the start of one matrix A_j to the next one A_(j+1).
+              There is no restriction for the value of strideA. Normal use case is strideA >= lda*n
+    @param[out]
+    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+              If info[j] = 0, successful exit for inversion of A_j.
+              If info[j] = i > 0, U_j is singular. U_j[i,i] is the first zero pivot.
+    @param[in]
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
+
+    ********************************************************************/
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_sgetri_npvt_strided_batched(rocblas_handle handle,
+                                                                      const rocblas_int n,
+                                                                      float* A,
+                                                                      const rocblas_int lda,
+                                                                      const rocblas_stride strideA,
+                                                                      rocblas_int* info,
+                                                                      const rocblas_int batch_count);
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_dgetri_npvt_strided_batched(rocblas_handle handle,
+                                                                      const rocblas_int n,
+                                                                      double* A,
+                                                                      const rocblas_int lda,
+                                                                      const rocblas_stride strideA,
+                                                                      rocblas_int* info,
+                                                                      const rocblas_int batch_count);
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_cgetri_npvt_strided_batched(rocblas_handle handle,
+                                                                      const rocblas_int n,
+                                                                      rocblas_float_complex* A,
+                                                                      const rocblas_int lda,
+                                                                      const rocblas_stride strideA,
+                                                                      rocblas_int* info,
+                                                                      const rocblas_int batch_count);
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_zgetri_npvt_strided_batched(rocblas_handle handle,
+                                                                      const rocblas_int n,
+                                                                      rocblas_double_complex* A,
+                                                                      const rocblas_int lda,
+                                                                      const rocblas_stride strideA,
+                                                                      rocblas_int* info,
+                                                                      const rocblas_int batch_count);
+//! @}
+
+/*! @{
     \brief GELS solves an overdetermined (or underdetermined) linear system defined by an m-by-n
     matrix A, and a corresponding matrix B, using the QR factorization computed by \ref rocsolver_sgeqrf "GEQRF" (or the LQ
     factorization computed by \ref rocsolver_sgelqf "GELQF").
@@ -16303,6 +16501,252 @@ ROCSOLVER_EXPORT rocblas_status
                                                 const rocblas_stride strideC,
                                                 rocblas_int* info,
                                                 const rocblas_int batch_count);
+//! @}
+
+/*! @{
+    \brief GETRI_NPVT_OUTOFPLACE computes the inverse \f$C = A^{-1}\f$ of a general n-by-n matrix A without partial pivoting.
+
+    \details
+    The inverse is computed by solving the linear system
+
+    \f[
+        AC = I
+    \f]
+
+    where I is the identity matrix, and A is factorized as \f$A = LU\f$ as given by \ref rocsolver_sgetrf_npvt "GETRF_NPVT".
+
+    @param[in]
+    handle    rocblas_handle.
+    @param[in]
+    n         rocblas_int. n >= 0.\n
+              The number of rows and columns of the matrix A.
+    @param[in]
+    A         pointer to type. Array on the GPU of dimension lda*n.\n
+              The factors L and U of the factorization A = L*U returned by \ref rocsolver_sgetrf_npvt "GETRF_NPVT".
+    @param[in]
+    lda       rocblas_int. lda >= n.\n
+              Specifies the leading dimension of A.
+    @param[out]
+    C         pointer to type. Array on the GPU of dimension ldc*n.\n
+              If info = 0, the inverse of A. Otherwise, undefined.
+    @param[in]
+    ldc       rocblas_int. ldc >= n.\n
+              Specifies the leading dimension of C.
+    @param[out]
+    info      pointer to a rocblas_int on the GPU.\n
+              If info = 0, successful exit.
+              If info = i > 0, U is singular. U[i,i] is the first zero pivot.
+
+    ********************************************************************/
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_sgetri_npvt_outofplace(rocblas_handle handle,
+                                                                 const rocblas_int n,
+                                                                 float* A,
+                                                                 const rocblas_int lda,
+                                                                 float* C,
+                                                                 const rocblas_int ldc,
+                                                                 rocblas_int* info);
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_dgetri_npvt_outofplace(rocblas_handle handle,
+                                                                 const rocblas_int n,
+                                                                 double* A,
+                                                                 const rocblas_int lda,
+                                                                 double* C,
+                                                                 const rocblas_int ldc,
+                                                                 rocblas_int* info);
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_cgetri_npvt_outofplace(rocblas_handle handle,
+                                                                 const rocblas_int n,
+                                                                 rocblas_float_complex* A,
+                                                                 const rocblas_int lda,
+                                                                 rocblas_float_complex* C,
+                                                                 const rocblas_int ldc,
+                                                                 rocblas_int* info);
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_zgetri_npvt_outofplace(rocblas_handle handle,
+                                                                 const rocblas_int n,
+                                                                 rocblas_double_complex* A,
+                                                                 const rocblas_int lda,
+                                                                 rocblas_double_complex* C,
+                                                                 const rocblas_int ldc,
+                                                                 rocblas_int* info);
+//! @}
+
+/*! @{
+    \brief GETRI_NPVT_OUTOFPLACE_BATCHED computes the inverse \f$C_j = A_j^{-1}\f$ of a batch of general n-by-n matrices \f$A_j\f$
+    without partial pivoting.
+
+    \details
+    The inverse is computed by solving the linear system
+
+    \f[
+        A_j C_j = I
+    \f]
+
+    where I is the identity matrix, and \f$A_j\f$ is factorized as \f$A_j = L_j  U_j\f$ as given by \ref rocsolver_sgetrf_npvt_batched "GETRF_NPVT_BATCHED".
+
+    @param[in]
+    handle    rocblas_handle.
+    @param[in]
+    n         rocblas_int. n >= 0.\n
+              The number of rows and columns of all matrices A_j in the batch.
+    @param[in]
+    A         array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+              The factors L_j and U_j of the factorization A_j = L_j*U_j returned by \ref rocsolver_sgetrf_npvt_batched "GETRF_NPVT_BATCHED".
+    @param[in]
+    lda       rocblas_int. lda >= n.\n
+              Specifies the leading dimension of matrices A_j.
+    @param[out]
+    C         array of pointers to type. Each pointer points to an array on the GPU of dimension ldc*n.\n
+              If info[j] = 0, the inverse of matrices A_j. Otherwise, undefined.
+    @param[in]
+    ldc       rocblas_int. ldc >= n.\n
+              Specifies the leading dimension of C_j.
+    @param[out]
+    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+              If info[j] = 0, successful exit for inversion of A_j.
+              If info[j] = i > 0, U_j is singular. U_j[i,i] is the first zero pivot.
+    @param[in]
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
+
+    ********************************************************************/
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_sgetri_npvt_outofplace_batched(rocblas_handle handle,
+                                                                         const rocblas_int n,
+                                                                         float* const A[],
+                                                                         const rocblas_int lda,
+                                                                         float* const C[],
+                                                                         const rocblas_int ldc,
+                                                                         rocblas_int* info,
+                                                                         const rocblas_int batch_count);
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_dgetri_npvt_outofplace_batched(rocblas_handle handle,
+                                                                         const rocblas_int n,
+                                                                         double* const A[],
+                                                                         const rocblas_int lda,
+                                                                         double* const C[],
+                                                                         const rocblas_int ldc,
+                                                                         rocblas_int* info,
+                                                                         const rocblas_int batch_count);
+
+ROCSOLVER_EXPORT rocblas_status
+    rocsolver_cgetri_npvt_outofplace_batched(rocblas_handle handle,
+                                             const rocblas_int n,
+                                             rocblas_float_complex* const A[],
+                                             const rocblas_int lda,
+                                             rocblas_float_complex* const C[],
+                                             const rocblas_int ldc,
+                                             rocblas_int* info,
+                                             const rocblas_int batch_count);
+
+ROCSOLVER_EXPORT rocblas_status
+    rocsolver_zgetri_npvt_outofplace_batched(rocblas_handle handle,
+                                             const rocblas_int n,
+                                             rocblas_double_complex* const A[],
+                                             const rocblas_int lda,
+                                             rocblas_double_complex* const C[],
+                                             const rocblas_int ldc,
+                                             rocblas_int* info,
+                                             const rocblas_int batch_count);
+//! @}
+
+/*! @{
+    \brief GETRI_NPVT_OUTOFPLACE_STRIDED_BATCHED computes the inverse \f$C_j = A_j^{-1}\f$ of a batch of general n-by-n matrices \f$A_j\f$
+    without partial pivoting.
+
+    \details
+    The inverse is computed by solving the linear system
+
+    \f[
+        A_j C_j = I
+    \f]
+
+    where I is the identity matrix, and \f$A_j\f$ is factorized as \f$A_j = L_j  U_j\f$ as given by \ref rocsolver_sgetrf_npvt_strided_batched "GETRF_NPVT_STRIDED_BATCHED".
+
+    @param[in]
+    handle    rocblas_handle.
+    @param[in]
+    n         rocblas_int. n >= 0.\n
+              The number of rows and columns of all matrices A_j in the batch.
+    @param[in]
+    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+              The factors L_j and U_j of the factorization A_j = L_j*U_j returned by
+              \ref rocsolver_sgetrf_npvt_strided_batched "GETRF_NPVT_STRIDED_BATCHED".
+    @param[in]
+    lda       rocblas_int. lda >= n.\n
+              Specifies the leading dimension of matrices A_j.
+    @param[in]
+    strideA   rocblas_stride.\n
+              Stride from the start of one matrix A_j to the next one A_(j+1).
+              There is no restriction for the value of strideA. Normal use case is strideA >= lda*n
+    @param[out]
+    C         pointer to type. Array on the GPU (the size depends on the value of strideC).\n
+              If info[j] = 0, the inverse of matrices A_j. Otherwise, undefined.
+    @param[in]
+    ldc       rocblas_int. ldc >= n.\n
+              Specifies the leading dimension of C_j.
+    @param[in]
+    strideC   rocblas_stride.\n
+              Stride from the start of one matrix C_j to the next one C_(j+1).
+              There is no restriction for the value of strideC. Normal use case is strideC >= ldc*n
+    @param[out]
+    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+              If info[j] = 0, successful exit for inversion of A_j.
+              If info[j] = i > 0, U_j is singular. U_j[i,i] is the first zero pivot.
+    @param[in]
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
+
+    ********************************************************************/
+
+ROCSOLVER_EXPORT rocblas_status
+    rocsolver_sgetri_npvt_outofplace_strided_batched(rocblas_handle handle,
+                                                     const rocblas_int n,
+                                                     float* A,
+                                                     const rocblas_int lda,
+                                                     const rocblas_stride strideA,
+                                                     float* C,
+                                                     const rocblas_int ldc,
+                                                     const rocblas_stride strideC,
+                                                     rocblas_int* info,
+                                                     const rocblas_int batch_count);
+
+ROCSOLVER_EXPORT rocblas_status
+    rocsolver_dgetri_npvt_outofplace_strided_batched(rocblas_handle handle,
+                                                     const rocblas_int n,
+                                                     double* A,
+                                                     const rocblas_int lda,
+                                                     const rocblas_stride strideA,
+                                                     double* C,
+                                                     const rocblas_int ldc,
+                                                     const rocblas_stride strideC,
+                                                     rocblas_int* info,
+                                                     const rocblas_int batch_count);
+
+ROCSOLVER_EXPORT rocblas_status
+    rocsolver_cgetri_npvt_outofplace_strided_batched(rocblas_handle handle,
+                                                     const rocblas_int n,
+                                                     rocblas_float_complex* A,
+                                                     const rocblas_int lda,
+                                                     const rocblas_stride strideA,
+                                                     rocblas_float_complex* C,
+                                                     const rocblas_int ldc,
+                                                     const rocblas_stride strideC,
+                                                     rocblas_int* info,
+                                                     const rocblas_int batch_count);
+
+ROCSOLVER_EXPORT rocblas_status
+    rocsolver_zgetri_npvt_outofplace_strided_batched(rocblas_handle handle,
+                                                     const rocblas_int n,
+                                                     rocblas_double_complex* A,
+                                                     const rocblas_int lda,
+                                                     const rocblas_stride strideA,
+                                                     rocblas_double_complex* C,
+                                                     const rocblas_int ldc,
+                                                     const rocblas_stride strideC,
+                                                     rocblas_int* info,
+                                                     const rocblas_int batch_count);
 //! @}
 
 /*! @{

--- a/library/src/lapack/roclapack_getri.cpp
+++ b/library/src/lapack/roclapack_getri.cpp
@@ -10,7 +10,8 @@ rocblas_status rocsolver_getri_impl(rocblas_handle handle,
                                     U A,
                                     const rocblas_int lda,
                                     rocblas_int* ipiv,
-                                    rocblas_int* info)
+                                    rocblas_int* info,
+                                    const bool pivot)
 {
     ROCSOLVER_ENTER_TOP("getri", "-n", n, "--lda", lda);
 
@@ -18,7 +19,7 @@ rocblas_status rocsolver_getri_impl(rocblas_handle handle,
         return rocblas_status_invalid_handle;
 
     // argument checking
-    rocblas_status st = rocsolver_getri_argCheck(handle, n, lda, A, ipiv, info);
+    rocblas_status st = rocsolver_getri_argCheck(handle, n, lda, A, ipiv, info, pivot);
     if(st != rocblas_status_continue)
         return st;
 
@@ -85,7 +86,7 @@ rocblas_status rocsolver_sgetri(rocblas_handle handle,
                                 rocblas_int* ipiv,
                                 rocblas_int* info)
 {
-    return rocsolver_getri_impl<float>(handle, n, A, lda, ipiv, info);
+    return rocsolver_getri_impl<float>(handle, n, A, lda, ipiv, info, true);
 }
 
 rocblas_status rocsolver_dgetri(rocblas_handle handle,
@@ -95,7 +96,7 @@ rocblas_status rocsolver_dgetri(rocblas_handle handle,
                                 rocblas_int* ipiv,
                                 rocblas_int* info)
 {
-    return rocsolver_getri_impl<double>(handle, n, A, lda, ipiv, info);
+    return rocsolver_getri_impl<double>(handle, n, A, lda, ipiv, info, true);
 }
 
 rocblas_status rocsolver_cgetri(rocblas_handle handle,
@@ -105,7 +106,7 @@ rocblas_status rocsolver_cgetri(rocblas_handle handle,
                                 rocblas_int* ipiv,
                                 rocblas_int* info)
 {
-    return rocsolver_getri_impl<rocblas_float_complex>(handle, n, A, lda, ipiv, info);
+    return rocsolver_getri_impl<rocblas_float_complex>(handle, n, A, lda, ipiv, info, true);
 }
 
 rocblas_status rocsolver_zgetri(rocblas_handle handle,
@@ -115,7 +116,7 @@ rocblas_status rocsolver_zgetri(rocblas_handle handle,
                                 rocblas_int* ipiv,
                                 rocblas_int* info)
 {
-    return rocsolver_getri_impl<rocblas_double_complex>(handle, n, A, lda, ipiv, info);
+    return rocsolver_getri_impl<rocblas_double_complex>(handle, n, A, lda, ipiv, info, true);
 }
 
 } // extern C

--- a/library/src/lapack/roclapack_getri.cpp
+++ b/library/src/lapack/roclapack_getri.cpp
@@ -119,4 +119,44 @@ rocblas_status rocsolver_zgetri(rocblas_handle handle,
     return rocsolver_getri_impl<rocblas_double_complex>(handle, n, A, lda, ipiv, info, true);
 }
 
+rocblas_status rocsolver_sgetri_npvt(rocblas_handle handle,
+                                     const rocblas_int n,
+                                     float* A,
+                                     const rocblas_int lda,
+                                     rocblas_int* info)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_impl<float>(handle, n, A, lda, ipiv, info, false);
+}
+
+rocblas_status rocsolver_dgetri_npvt(rocblas_handle handle,
+                                     const rocblas_int n,
+                                     double* A,
+                                     const rocblas_int lda,
+                                     rocblas_int* info)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_impl<double>(handle, n, A, lda, ipiv, info, false);
+}
+
+rocblas_status rocsolver_cgetri_npvt(rocblas_handle handle,
+                                     const rocblas_int n,
+                                     rocblas_float_complex* A,
+                                     const rocblas_int lda,
+                                     rocblas_int* info)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_impl<rocblas_float_complex>(handle, n, A, lda, ipiv, info, false);
+}
+
+rocblas_status rocsolver_zgetri_npvt(rocblas_handle handle,
+                                     const rocblas_int n,
+                                     rocblas_double_complex* A,
+                                     const rocblas_int lda,
+                                     rocblas_int* info)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_impl<rocblas_double_complex>(handle, n, A, lda, ipiv, info, false);
+}
+
 } // extern C

--- a/library/src/lapack/roclapack_getri.cpp
+++ b/library/src/lapack/roclapack_getri.cpp
@@ -13,7 +13,8 @@ rocblas_status rocsolver_getri_impl(rocblas_handle handle,
                                     rocblas_int* info,
                                     const bool pivot)
 {
-    ROCSOLVER_ENTER_TOP("getri", "-n", n, "--lda", lda);
+    const char* name = (pivot ? "getri" : "getri_npvt");
+    ROCSOLVER_ENTER_TOP(name, "-n", n, "--lda", lda);
 
     if(!handle)
         return rocblas_status_invalid_handle;

--- a/library/src/lapack/roclapack_getri.hpp
+++ b/library/src/lapack/roclapack_getri.hpp
@@ -336,6 +336,7 @@ rocblas_status rocsolver_getri_template(rocblas_handle handle,
     rocblas_int threads = min(((n - 1) / 64 + 1) * 64, BLOCKSIZE);
     rocblas_int ldw = n;
     rocblas_stride strideW = n * n;
+    const bool pivot = (ipiv != nullptr);
 
     // get block size
     rocblas_int blk = getri_get_blksize<ISBATCHED>(n);
@@ -374,7 +375,7 @@ rocblas_status rocsolver_getri_template(rocblas_handle handle,
     }
 
     // apply pivoting (column interchanges)
-    if(ipiv != nullptr)
+    if(pivot)
         hipLaunchKernelGGL(getri_kernel_large2<T>, dim3(batch_count, 1, 1), dim3(1, threads, 1), 0,
                            stream, n, A, shiftA, lda, strideA, ipiv, shiftP, strideP, info);
 

--- a/library/src/lapack/roclapack_getri_batched.cpp
+++ b/library/src/lapack/roclapack_getri_batched.cpp
@@ -15,8 +15,9 @@ rocblas_status rocsolver_getri_batched_impl(rocblas_handle handle,
                                             const bool pivot,
                                             const rocblas_int batch_count)
 {
-    ROCSOLVER_ENTER_TOP("getri_batched", "-n", n, "--lda", lda, "--strideP", strideP,
-                        "--batch_count", batch_count);
+    const char* name = (pivot ? "getri_batched" : "getri_npvt_batched");
+    ROCSOLVER_ENTER_TOP(name, "-n", n, "--lda", lda, "--strideP", strideP, "--batch_count",
+                        batch_count);
 
     if(!handle)
         return rocblas_status_invalid_handle;

--- a/library/src/lapack/roclapack_getri_batched.cpp
+++ b/library/src/lapack/roclapack_getri_batched.cpp
@@ -12,6 +12,7 @@ rocblas_status rocsolver_getri_batched_impl(rocblas_handle handle,
                                             rocblas_int* ipiv,
                                             const rocblas_stride strideP,
                                             rocblas_int* info,
+                                            const bool pivot,
                                             const rocblas_int batch_count)
 {
     ROCSOLVER_ENTER_TOP("getri_batched", "-n", n, "--lda", lda, "--strideP", strideP,
@@ -21,7 +22,7 @@ rocblas_status rocsolver_getri_batched_impl(rocblas_handle handle,
         return rocblas_status_invalid_handle;
 
     // argument checking
-    rocblas_status st = rocsolver_getri_argCheck(handle, n, lda, A, ipiv, info, batch_count);
+    rocblas_status st = rocsolver_getri_argCheck(handle, n, lda, A, ipiv, info, pivot, batch_count);
     if(st != rocblas_status_continue)
         return st;
 
@@ -88,7 +89,8 @@ rocblas_status rocsolver_sgetri_batched(rocblas_handle handle,
                                         rocblas_int* info,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_getri_batched_impl<float>(handle, n, A, lda, ipiv, strideP, info, batch_count);
+    return rocsolver_getri_batched_impl<float>(handle, n, A, lda, ipiv, strideP, info, true,
+                                               batch_count);
 }
 
 rocblas_status rocsolver_dgetri_batched(rocblas_handle handle,
@@ -100,7 +102,8 @@ rocblas_status rocsolver_dgetri_batched(rocblas_handle handle,
                                         rocblas_int* info,
                                         const rocblas_int batch_count)
 {
-    return rocsolver_getri_batched_impl<double>(handle, n, A, lda, ipiv, strideP, info, batch_count);
+    return rocsolver_getri_batched_impl<double>(handle, n, A, lda, ipiv, strideP, info, true,
+                                                batch_count);
 }
 
 rocblas_status rocsolver_cgetri_batched(rocblas_handle handle,
@@ -113,7 +116,7 @@ rocblas_status rocsolver_cgetri_batched(rocblas_handle handle,
                                         const rocblas_int batch_count)
 {
     return rocsolver_getri_batched_impl<rocblas_float_complex>(handle, n, A, lda, ipiv, strideP,
-                                                               info, batch_count);
+                                                               info, true, batch_count);
 }
 
 rocblas_status rocsolver_zgetri_batched(rocblas_handle handle,
@@ -126,7 +129,7 @@ rocblas_status rocsolver_zgetri_batched(rocblas_handle handle,
                                         const rocblas_int batch_count)
 {
     return rocsolver_getri_batched_impl<rocblas_double_complex>(handle, n, A, lda, ipiv, strideP,
-                                                                info, batch_count);
+                                                                info, true, batch_count);
 }
 
 } // extern C

--- a/library/src/lapack/roclapack_getri_batched.cpp
+++ b/library/src/lapack/roclapack_getri_batched.cpp
@@ -132,4 +132,50 @@ rocblas_status rocsolver_zgetri_batched(rocblas_handle handle,
                                                                 info, true, batch_count);
 }
 
+rocblas_status rocsolver_sgetri_npvt_batched(rocblas_handle handle,
+                                             const rocblas_int n,
+                                             float* const A[],
+                                             const rocblas_int lda,
+                                             rocblas_int* info,
+                                             const rocblas_int batch_count)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_batched_impl<float>(handle, n, A, lda, ipiv, 0, info, false, batch_count);
+}
+
+rocblas_status rocsolver_dgetri_npvt_batched(rocblas_handle handle,
+                                             const rocblas_int n,
+                                             double* const A[],
+                                             const rocblas_int lda,
+                                             rocblas_int* info,
+                                             const rocblas_int batch_count)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_batched_impl<double>(handle, n, A, lda, ipiv, 0, info, false, batch_count);
+}
+
+rocblas_status rocsolver_cgetri_npvt_batched(rocblas_handle handle,
+                                             const rocblas_int n,
+                                             rocblas_float_complex* const A[],
+                                             const rocblas_int lda,
+                                             rocblas_int* info,
+                                             const rocblas_int batch_count)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_batched_impl<rocblas_float_complex>(handle, n, A, lda, ipiv, 0, info,
+                                                               false, batch_count);
+}
+
+rocblas_status rocsolver_zgetri_npvt_batched(rocblas_handle handle,
+                                             const rocblas_int n,
+                                             rocblas_double_complex* const A[],
+                                             const rocblas_int lda,
+                                             rocblas_int* info,
+                                             const rocblas_int batch_count)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_batched_impl<rocblas_double_complex>(handle, n, A, lda, ipiv, 0, info,
+                                                                false, batch_count);
+}
+
 } // extern C

--- a/library/src/lapack/roclapack_getri_optimized.cpp
+++ b/library/src/lapack/roclapack_getri_optimized.cpp
@@ -30,7 +30,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(WAVESIZE) getri_kernel_small(U AA,
 
     // batch instance
     T* A = load_ptr_batch<T>(AA, b, shiftA, strideA);
-    rocblas_int* ipiv = load_ptr_batch<rocblas_int>(ipivA, b, shiftP, strideP);
+    rocblas_int* ipiv;
+    if(ipivA != nullptr)
+        ipiv = load_ptr_batch<rocblas_int>(ipivA, b, shiftP, strideP);
 
     // shared memory (for communication between threads in group)
     __shared__ T common[DIM];
@@ -116,15 +118,18 @@ ROCSOLVER_KERNEL void __launch_bounds__(WAVESIZE) getri_kernel_small(U AA,
     }
 
     // apply pivots (getri_pivot)
-#pragma unroll
-    for(rocblas_int j = DIM - 2; j >= 0; j--)
+    if(ipivA != nullptr)
     {
-        jp = ipiv[j] - 1;
-        if(jp != j)
+#pragma unroll
+        for(rocblas_int j = DIM - 2; j >= 0; j--)
         {
-            temp = rA[j];
-            rA[j] = rA[jp];
-            rA[jp] = temp;
+            jp = ipiv[j] - 1;
+            if(jp != j)
+            {
+                temp = rA[j];
+                rA[j] = rA[jp];
+                rA[jp] = temp;
+            }
         }
     }
 

--- a/library/src/lapack/roclapack_getri_outofplace.cpp
+++ b/library/src/lapack/roclapack_getri_outofplace.cpp
@@ -15,7 +15,8 @@ rocblas_status rocsolver_getri_outofplace_impl(rocblas_handle handle,
                                                rocblas_int* info,
                                                const bool pivot)
 {
-    ROCSOLVER_ENTER_TOP("getri_outofplace", "-n", n, "--lda", lda, "--ldc", ldc);
+    const char* name = (pivot ? "getri_outofplace" : "getri_npvt_outofplace");
+    ROCSOLVER_ENTER_TOP(name, "-n", n, "--lda", lda, "--ldc", ldc);
 
     if(!handle)
         return rocblas_status_invalid_handle;

--- a/library/src/lapack/roclapack_getri_outofplace.cpp
+++ b/library/src/lapack/roclapack_getri_outofplace.cpp
@@ -12,7 +12,8 @@ rocblas_status rocsolver_getri_outofplace_impl(rocblas_handle handle,
                                                rocblas_int* ipiv,
                                                U C,
                                                const rocblas_int ldc,
-                                               rocblas_int* info)
+                                               rocblas_int* info,
+                                               const bool pivot)
 {
     ROCSOLVER_ENTER_TOP("getri_outofplace", "-n", n, "--lda", lda, "--ldc", ldc);
 
@@ -20,7 +21,8 @@ rocblas_status rocsolver_getri_outofplace_impl(rocblas_handle handle,
         return rocblas_status_invalid_handle;
 
     // argument checking
-    rocblas_status st = rocsolver_getri_outofplace_argCheck(handle, n, lda, ldc, A, C, ipiv, info);
+    rocblas_status st
+        = rocsolver_getri_outofplace_argCheck(handle, n, lda, ldc, A, C, ipiv, info, pivot);
     if(st != rocblas_status_continue)
         return st;
 
@@ -83,7 +85,7 @@ rocblas_status rocsolver_sgetri_outofplace(rocblas_handle handle,
                                            const rocblas_int ldc,
                                            rocblas_int* info)
 {
-    return rocsolver_getri_outofplace_impl<float>(handle, n, A, lda, ipiv, C, ldc, info);
+    return rocsolver_getri_outofplace_impl<float>(handle, n, A, lda, ipiv, C, ldc, info, true);
 }
 
 rocblas_status rocsolver_dgetri_outofplace(rocblas_handle handle,
@@ -95,7 +97,7 @@ rocblas_status rocsolver_dgetri_outofplace(rocblas_handle handle,
                                            const rocblas_int ldc,
                                            rocblas_int* info)
 {
-    return rocsolver_getri_outofplace_impl<double>(handle, n, A, lda, ipiv, C, ldc, info);
+    return rocsolver_getri_outofplace_impl<double>(handle, n, A, lda, ipiv, C, ldc, info, true);
 }
 
 rocblas_status rocsolver_cgetri_outofplace(rocblas_handle handle,
@@ -108,7 +110,7 @@ rocblas_status rocsolver_cgetri_outofplace(rocblas_handle handle,
                                            rocblas_int* info)
 {
     return rocsolver_getri_outofplace_impl<rocblas_float_complex>(handle, n, A, lda, ipiv, C, ldc,
-                                                                  info);
+                                                                  info, true);
 }
 
 rocblas_status rocsolver_zgetri_outofplace(rocblas_handle handle,
@@ -121,7 +123,7 @@ rocblas_status rocsolver_zgetri_outofplace(rocblas_handle handle,
                                            rocblas_int* info)
 {
     return rocsolver_getri_outofplace_impl<rocblas_double_complex>(handle, n, A, lda, ipiv, C, ldc,
-                                                                   info);
+                                                                   info, true);
 }
 
 } // extern C

--- a/library/src/lapack/roclapack_getri_outofplace.cpp
+++ b/library/src/lapack/roclapack_getri_outofplace.cpp
@@ -126,4 +126,54 @@ rocblas_status rocsolver_zgetri_outofplace(rocblas_handle handle,
                                                                    info, true);
 }
 
+rocblas_status rocsolver_sgetri_npvt_outofplace(rocblas_handle handle,
+                                                const rocblas_int n,
+                                                float* A,
+                                                const rocblas_int lda,
+                                                float* C,
+                                                const rocblas_int ldc,
+                                                rocblas_int* info)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_outofplace_impl<float>(handle, n, A, lda, ipiv, C, ldc, info, false);
+}
+
+rocblas_status rocsolver_dgetri_npvt_outofplace(rocblas_handle handle,
+                                                const rocblas_int n,
+                                                double* A,
+                                                const rocblas_int lda,
+                                                double* C,
+                                                const rocblas_int ldc,
+                                                rocblas_int* info)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_outofplace_impl<double>(handle, n, A, lda, ipiv, C, ldc, info, false);
+}
+
+rocblas_status rocsolver_cgetri_npvt_outofplace(rocblas_handle handle,
+                                                const rocblas_int n,
+                                                rocblas_float_complex* A,
+                                                const rocblas_int lda,
+                                                rocblas_float_complex* C,
+                                                const rocblas_int ldc,
+                                                rocblas_int* info)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_outofplace_impl<rocblas_float_complex>(handle, n, A, lda, ipiv, C, ldc,
+                                                                  info, false);
+}
+
+rocblas_status rocsolver_zgetri_npvt_outofplace(rocblas_handle handle,
+                                                const rocblas_int n,
+                                                rocblas_double_complex* A,
+                                                const rocblas_int lda,
+                                                rocblas_double_complex* C,
+                                                const rocblas_int ldc,
+                                                rocblas_int* info)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_outofplace_impl<rocblas_double_complex>(handle, n, A, lda, ipiv, C, ldc,
+                                                                   info, false);
+}
+
 } // extern C

--- a/library/src/lapack/roclapack_getri_outofplace.hpp
+++ b/library/src/lapack/roclapack_getri_outofplace.hpp
@@ -41,6 +41,7 @@ rocblas_status rocsolver_getri_outofplace_argCheck(rocblas_handle handle,
                                                    T C,
                                                    rocblas_int* ipiv,
                                                    rocblas_int* info,
+                                                   const bool pivot,
                                                    const rocblas_int batch_count = 1)
 {
     // order is important for unit tests:
@@ -57,7 +58,7 @@ rocblas_status rocsolver_getri_outofplace_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((n && !A) || (n && !C) || (n && !ipiv) || (batch_count && !info))
+    if((n && !A) || (n && !C) || (n && pivot && !ipiv) || (batch_count && !info))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/lapack/roclapack_getri_outofplace_batched.cpp
+++ b/library/src/lapack/roclapack_getri_outofplace_batched.cpp
@@ -14,6 +14,7 @@ rocblas_status rocsolver_getri_outofplace_batched_impl(rocblas_handle handle,
                                                        U C,
                                                        const rocblas_int ldc,
                                                        rocblas_int* info,
+                                                       const bool pivot,
                                                        const rocblas_int batch_count)
 {
     ROCSOLVER_ENTER_TOP("getri_outofplace_batched", "-n", n, "--lda", lda, "--strideP", strideP,
@@ -23,8 +24,8 @@ rocblas_status rocsolver_getri_outofplace_batched_impl(rocblas_handle handle,
         return rocblas_status_invalid_handle;
 
     // argument checking
-    rocblas_status st
-        = rocsolver_getri_outofplace_argCheck(handle, n, lda, ldc, A, C, ipiv, info, batch_count);
+    rocblas_status st = rocsolver_getri_outofplace_argCheck(handle, n, lda, ldc, A, C, ipiv, info,
+                                                            pivot, batch_count);
     if(st != rocblas_status_continue)
         return st;
 
@@ -88,7 +89,7 @@ rocblas_status rocsolver_sgetri_outofplace_batched(rocblas_handle handle,
                                                    const rocblas_int batch_count)
 {
     return rocsolver_getri_outofplace_batched_impl<float>(handle, n, A, lda, ipiv, strideP, C, ldc,
-                                                          info, batch_count);
+                                                          info, true, batch_count);
 }
 
 rocblas_status rocsolver_dgetri_outofplace_batched(rocblas_handle handle,
@@ -103,7 +104,7 @@ rocblas_status rocsolver_dgetri_outofplace_batched(rocblas_handle handle,
                                                    const rocblas_int batch_count)
 {
     return rocsolver_getri_outofplace_batched_impl<double>(handle, n, A, lda, ipiv, strideP, C, ldc,
-                                                           info, batch_count);
+                                                           info, true, batch_count);
 }
 
 rocblas_status rocsolver_cgetri_outofplace_batched(rocblas_handle handle,
@@ -118,7 +119,7 @@ rocblas_status rocsolver_cgetri_outofplace_batched(rocblas_handle handle,
                                                    const rocblas_int batch_count)
 {
     return rocsolver_getri_outofplace_batched_impl<rocblas_float_complex>(
-        handle, n, A, lda, ipiv, strideP, C, ldc, info, batch_count);
+        handle, n, A, lda, ipiv, strideP, C, ldc, info, true, batch_count);
 }
 
 rocblas_status rocsolver_zgetri_outofplace_batched(rocblas_handle handle,
@@ -133,7 +134,7 @@ rocblas_status rocsolver_zgetri_outofplace_batched(rocblas_handle handle,
                                                    const rocblas_int batch_count)
 {
     return rocsolver_getri_outofplace_batched_impl<rocblas_double_complex>(
-        handle, n, A, lda, ipiv, strideP, C, ldc, info, batch_count);
+        handle, n, A, lda, ipiv, strideP, C, ldc, info, true, batch_count);
 }
 
 } // extern C

--- a/library/src/lapack/roclapack_getri_outofplace_batched.cpp
+++ b/library/src/lapack/roclapack_getri_outofplace_batched.cpp
@@ -17,8 +17,9 @@ rocblas_status rocsolver_getri_outofplace_batched_impl(rocblas_handle handle,
                                                        const bool pivot,
                                                        const rocblas_int batch_count)
 {
-    ROCSOLVER_ENTER_TOP("getri_outofplace_batched", "-n", n, "--lda", lda, "--strideP", strideP,
-                        "--ldc", ldc, "--batch_count", batch_count);
+    const char* name = (pivot ? "getri_outofplace_batched" : "getri_npvt_outofplace_batched");
+    ROCSOLVER_ENTER_TOP(name, "-n", n, "--lda", lda, "--strideP", strideP, "--ldc", ldc,
+                        "--batch_count", batch_count);
 
     if(!handle)
         return rocblas_status_invalid_handle;

--- a/library/src/lapack/roclapack_getri_outofplace_batched.cpp
+++ b/library/src/lapack/roclapack_getri_outofplace_batched.cpp
@@ -137,4 +137,60 @@ rocblas_status rocsolver_zgetri_outofplace_batched(rocblas_handle handle,
         handle, n, A, lda, ipiv, strideP, C, ldc, info, true, batch_count);
 }
 
+rocblas_status rocsolver_sgetri_npvt_outofplace_batched(rocblas_handle handle,
+                                                        const rocblas_int n,
+                                                        float* const A[],
+                                                        const rocblas_int lda,
+                                                        float* const C[],
+                                                        const rocblas_int ldc,
+                                                        rocblas_int* info,
+                                                        const rocblas_int batch_count)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_outofplace_batched_impl<float>(handle, n, A, lda, ipiv, 0, C, ldc, info,
+                                                          false, batch_count);
+}
+
+rocblas_status rocsolver_dgetri_npvt_outofplace_batched(rocblas_handle handle,
+                                                        const rocblas_int n,
+                                                        double* const A[],
+                                                        const rocblas_int lda,
+                                                        double* const C[],
+                                                        const rocblas_int ldc,
+                                                        rocblas_int* info,
+                                                        const rocblas_int batch_count)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_outofplace_batched_impl<double>(handle, n, A, lda, ipiv, 0, C, ldc, info,
+                                                           false, batch_count);
+}
+
+rocblas_status rocsolver_cgetri_npvt_outofplace_batched(rocblas_handle handle,
+                                                        const rocblas_int n,
+                                                        rocblas_float_complex* const A[],
+                                                        const rocblas_int lda,
+                                                        rocblas_float_complex* const C[],
+                                                        const rocblas_int ldc,
+                                                        rocblas_int* info,
+                                                        const rocblas_int batch_count)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_outofplace_batched_impl<rocblas_float_complex>(
+        handle, n, A, lda, ipiv, 0, C, ldc, info, false, batch_count);
+}
+
+rocblas_status rocsolver_zgetri_npvt_outofplace_batched(rocblas_handle handle,
+                                                        const rocblas_int n,
+                                                        rocblas_double_complex* const A[],
+                                                        const rocblas_int lda,
+                                                        rocblas_double_complex* const C[],
+                                                        const rocblas_int ldc,
+                                                        rocblas_int* info,
+                                                        const rocblas_int batch_count)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_outofplace_batched_impl<rocblas_double_complex>(
+        handle, n, A, lda, ipiv, 0, C, ldc, info, false, batch_count);
+}
+
 } // extern C

--- a/library/src/lapack/roclapack_getri_outofplace_strided_batched.cpp
+++ b/library/src/lapack/roclapack_getri_outofplace_strided_batched.cpp
@@ -19,9 +19,10 @@ rocblas_status rocsolver_getri_outofplace_strided_batched_impl(rocblas_handle ha
                                                                const bool pivot,
                                                                const rocblas_int batch_count)
 {
-    ROCSOLVER_ENTER_TOP("getri_outofplace_strided_batched", "-n", n, "--lda", lda, "--strideA",
-                        strideA, "--strideP", strideP, "--ldc", ldc, "--strideC", strideC,
-                        "--batch_count", batch_count);
+    const char* name
+        = (pivot ? "getri_outofplace_strided_batched" : "getri_npvt_outofplace_strided_batched");
+    ROCSOLVER_ENTER_TOP(name, "-n", n, "--lda", lda, "--strideA", strideA, "--strideP", strideP,
+                        "--ldc", ldc, "--strideC", strideC, "--batch_count", batch_count);
 
     if(!handle)
         return rocblas_status_invalid_handle;

--- a/library/src/lapack/roclapack_getri_outofplace_strided_batched.cpp
+++ b/library/src/lapack/roclapack_getri_outofplace_strided_batched.cpp
@@ -144,4 +144,68 @@ rocblas_status rocsolver_zgetri_outofplace_strided_batched(rocblas_handle handle
         handle, n, A, lda, strideA, ipiv, strideP, C, ldc, strideC, info, true, batch_count);
 }
 
+rocblas_status rocsolver_sgetri_npvt_outofplace_strided_batched(rocblas_handle handle,
+                                                                const rocblas_int n,
+                                                                float* A,
+                                                                const rocblas_int lda,
+                                                                const rocblas_stride strideA,
+                                                                float* C,
+                                                                const rocblas_int ldc,
+                                                                const rocblas_stride strideC,
+                                                                rocblas_int* info,
+                                                                const rocblas_int batch_count)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_outofplace_strided_batched_impl<float>(
+        handle, n, A, lda, strideA, ipiv, 0, C, ldc, strideC, info, false, batch_count);
+}
+
+rocblas_status rocsolver_dgetri_npvt_outofplace_strided_batched(rocblas_handle handle,
+                                                                const rocblas_int n,
+                                                                double* A,
+                                                                const rocblas_int lda,
+                                                                const rocblas_stride strideA,
+                                                                double* C,
+                                                                const rocblas_int ldc,
+                                                                const rocblas_stride strideC,
+                                                                rocblas_int* info,
+                                                                const rocblas_int batch_count)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_outofplace_strided_batched_impl<double>(
+        handle, n, A, lda, strideA, ipiv, 0, C, ldc, strideC, info, false, batch_count);
+}
+
+rocblas_status rocsolver_cgetri_npvt_outofplace_strided_batched(rocblas_handle handle,
+                                                                const rocblas_int n,
+                                                                rocblas_float_complex* A,
+                                                                const rocblas_int lda,
+                                                                const rocblas_stride strideA,
+                                                                rocblas_float_complex* C,
+                                                                const rocblas_int ldc,
+                                                                const rocblas_stride strideC,
+                                                                rocblas_int* info,
+                                                                const rocblas_int batch_count)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_outofplace_strided_batched_impl<rocblas_float_complex>(
+        handle, n, A, lda, strideA, ipiv, 0, C, ldc, strideC, info, false, batch_count);
+}
+
+rocblas_status rocsolver_zgetri_npvt_outofplace_strided_batched(rocblas_handle handle,
+                                                                const rocblas_int n,
+                                                                rocblas_double_complex* A,
+                                                                const rocblas_int lda,
+                                                                const rocblas_stride strideA,
+                                                                rocblas_double_complex* C,
+                                                                const rocblas_int ldc,
+                                                                const rocblas_stride strideC,
+                                                                rocblas_int* info,
+                                                                const rocblas_int batch_count)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_outofplace_strided_batched_impl<rocblas_double_complex>(
+        handle, n, A, lda, strideA, ipiv, 0, C, ldc, strideC, info, false, batch_count);
+}
+
 } // extern C

--- a/library/src/lapack/roclapack_getri_outofplace_strided_batched.cpp
+++ b/library/src/lapack/roclapack_getri_outofplace_strided_batched.cpp
@@ -16,6 +16,7 @@ rocblas_status rocsolver_getri_outofplace_strided_batched_impl(rocblas_handle ha
                                                                const rocblas_int ldc,
                                                                const rocblas_int strideC,
                                                                rocblas_int* info,
+                                                               const bool pivot,
                                                                const rocblas_int batch_count)
 {
     ROCSOLVER_ENTER_TOP("getri_outofplace_strided_batched", "-n", n, "--lda", lda, "--strideA",
@@ -26,8 +27,8 @@ rocblas_status rocsolver_getri_outofplace_strided_batched_impl(rocblas_handle ha
         return rocblas_status_invalid_handle;
 
     // argument checking
-    rocblas_status st
-        = rocsolver_getri_outofplace_argCheck(handle, n, lda, ldc, A, C, ipiv, info, batch_count);
+    rocblas_status st = rocsolver_getri_outofplace_argCheck(handle, n, lda, ldc, A, C, ipiv, info,
+                                                            pivot, batch_count);
     if(st != rocblas_status_continue)
         return st;
 
@@ -89,7 +90,7 @@ rocblas_status rocsolver_sgetri_outofplace_strided_batched(rocblas_handle handle
                                                            const rocblas_int batch_count)
 {
     return rocsolver_getri_outofplace_strided_batched_impl<float>(
-        handle, n, A, lda, strideA, ipiv, strideP, C, ldc, strideC, info, batch_count);
+        handle, n, A, lda, strideA, ipiv, strideP, C, ldc, strideC, info, true, batch_count);
 }
 
 rocblas_status rocsolver_dgetri_outofplace_strided_batched(rocblas_handle handle,
@@ -106,7 +107,7 @@ rocblas_status rocsolver_dgetri_outofplace_strided_batched(rocblas_handle handle
                                                            const rocblas_int batch_count)
 {
     return rocsolver_getri_outofplace_strided_batched_impl<double>(
-        handle, n, A, lda, strideA, ipiv, strideP, C, ldc, strideC, info, batch_count);
+        handle, n, A, lda, strideA, ipiv, strideP, C, ldc, strideC, info, true, batch_count);
 }
 
 rocblas_status rocsolver_cgetri_outofplace_strided_batched(rocblas_handle handle,
@@ -123,7 +124,7 @@ rocblas_status rocsolver_cgetri_outofplace_strided_batched(rocblas_handle handle
                                                            const rocblas_int batch_count)
 {
     return rocsolver_getri_outofplace_strided_batched_impl<rocblas_float_complex>(
-        handle, n, A, lda, strideA, ipiv, strideP, C, ldc, strideC, info, batch_count);
+        handle, n, A, lda, strideA, ipiv, strideP, C, ldc, strideC, info, true, batch_count);
 }
 
 rocblas_status rocsolver_zgetri_outofplace_strided_batched(rocblas_handle handle,
@@ -140,7 +141,7 @@ rocblas_status rocsolver_zgetri_outofplace_strided_batched(rocblas_handle handle
                                                            const rocblas_int batch_count)
 {
     return rocsolver_getri_outofplace_strided_batched_impl<rocblas_double_complex>(
-        handle, n, A, lda, strideA, ipiv, strideP, C, ldc, strideC, info, batch_count);
+        handle, n, A, lda, strideA, ipiv, strideP, C, ldc, strideC, info, true, batch_count);
 }
 
 } // extern C

--- a/library/src/lapack/roclapack_getri_strided_batched.cpp
+++ b/library/src/lapack/roclapack_getri_strided_batched.cpp
@@ -13,6 +13,7 @@ rocblas_status rocsolver_getri_strided_batched_impl(rocblas_handle handle,
                                                     rocblas_int* ipiv,
                                                     const rocblas_stride strideP,
                                                     rocblas_int* info,
+                                                    const bool pivot,
                                                     const rocblas_int batch_count)
 {
     ROCSOLVER_ENTER_TOP("getri_strided_batched", "-n", n, "--lda", lda, "--strideA", strideA,
@@ -22,7 +23,7 @@ rocblas_status rocsolver_getri_strided_batched_impl(rocblas_handle handle,
         return rocblas_status_invalid_handle;
 
     // argument checking
-    rocblas_status st = rocsolver_getri_argCheck(handle, n, lda, A, ipiv, info, batch_count);
+    rocblas_status st = rocsolver_getri_argCheck(handle, n, lda, A, ipiv, info, pivot, batch_count);
     if(st != rocblas_status_continue)
         return st;
 
@@ -88,7 +89,7 @@ rocblas_status rocsolver_sgetri_strided_batched(rocblas_handle handle,
                                                 const rocblas_int batch_count)
 {
     return rocsolver_getri_strided_batched_impl<float>(handle, n, A, lda, strideA, ipiv, strideP,
-                                                       info, batch_count);
+                                                       info, true, batch_count);
 }
 
 rocblas_status rocsolver_dgetri_strided_batched(rocblas_handle handle,
@@ -102,7 +103,7 @@ rocblas_status rocsolver_dgetri_strided_batched(rocblas_handle handle,
                                                 const rocblas_int batch_count)
 {
     return rocsolver_getri_strided_batched_impl<double>(handle, n, A, lda, strideA, ipiv, strideP,
-                                                        info, batch_count);
+                                                        info, true, batch_count);
 }
 
 rocblas_status rocsolver_cgetri_strided_batched(rocblas_handle handle,
@@ -116,7 +117,7 @@ rocblas_status rocsolver_cgetri_strided_batched(rocblas_handle handle,
                                                 const rocblas_int batch_count)
 {
     return rocsolver_getri_strided_batched_impl<rocblas_float_complex>(
-        handle, n, A, lda, strideA, ipiv, strideP, info, batch_count);
+        handle, n, A, lda, strideA, ipiv, strideP, info, true, batch_count);
 }
 
 rocblas_status rocsolver_zgetri_strided_batched(rocblas_handle handle,
@@ -130,7 +131,7 @@ rocblas_status rocsolver_zgetri_strided_batched(rocblas_handle handle,
                                                 const rocblas_int batch_count)
 {
     return rocsolver_getri_strided_batched_impl<rocblas_double_complex>(
-        handle, n, A, lda, strideA, ipiv, strideP, info, batch_count);
+        handle, n, A, lda, strideA, ipiv, strideP, info, true, batch_count);
 }
 
 } // extern C

--- a/library/src/lapack/roclapack_getri_strided_batched.cpp
+++ b/library/src/lapack/roclapack_getri_strided_batched.cpp
@@ -134,4 +134,56 @@ rocblas_status rocsolver_zgetri_strided_batched(rocblas_handle handle,
         handle, n, A, lda, strideA, ipiv, strideP, info, true, batch_count);
 }
 
+rocblas_status rocsolver_sgetri_npvt_strided_batched(rocblas_handle handle,
+                                                     const rocblas_int n,
+                                                     float* A,
+                                                     const rocblas_int lda,
+                                                     const rocblas_stride strideA,
+                                                     rocblas_int* info,
+                                                     const rocblas_int batch_count)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_strided_batched_impl<float>(handle, n, A, lda, strideA, ipiv, 0, info,
+                                                       false, batch_count);
+}
+
+rocblas_status rocsolver_dgetri_npvt_strided_batched(rocblas_handle handle,
+                                                     const rocblas_int n,
+                                                     double* A,
+                                                     const rocblas_int lda,
+                                                     const rocblas_stride strideA,
+                                                     rocblas_int* info,
+                                                     const rocblas_int batch_count)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_strided_batched_impl<double>(handle, n, A, lda, strideA, ipiv, 0, info,
+                                                        false, batch_count);
+}
+
+rocblas_status rocsolver_cgetri_npvt_strided_batched(rocblas_handle handle,
+                                                     const rocblas_int n,
+                                                     rocblas_float_complex* A,
+                                                     const rocblas_int lda,
+                                                     const rocblas_stride strideA,
+                                                     rocblas_int* info,
+                                                     const rocblas_int batch_count)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_strided_batched_impl<rocblas_float_complex>(
+        handle, n, A, lda, strideA, ipiv, 0, info, false, batch_count);
+}
+
+rocblas_status rocsolver_zgetri_npvt_strided_batched(rocblas_handle handle,
+                                                     const rocblas_int n,
+                                                     rocblas_double_complex* A,
+                                                     const rocblas_int lda,
+                                                     const rocblas_stride strideA,
+                                                     rocblas_int* info,
+                                                     const rocblas_int batch_count)
+{
+    rocblas_int* ipiv = nullptr;
+    return rocsolver_getri_strided_batched_impl<rocblas_double_complex>(
+        handle, n, A, lda, strideA, ipiv, 0, info, false, batch_count);
+}
+
 } // extern C

--- a/library/src/lapack/roclapack_getri_strided_batched.cpp
+++ b/library/src/lapack/roclapack_getri_strided_batched.cpp
@@ -16,8 +16,9 @@ rocblas_status rocsolver_getri_strided_batched_impl(rocblas_handle handle,
                                                     const bool pivot,
                                                     const rocblas_int batch_count)
 {
-    ROCSOLVER_ENTER_TOP("getri_strided_batched", "-n", n, "--lda", lda, "--strideA", strideA,
-                        "--strideP", strideP, "--batch_count", batch_count);
+    const char* name = (pivot ? "getri_strided_batched" : "getri_npvt_strided_batched");
+    ROCSOLVER_ENTER_TOP(name, "-n", n, "--lda", lda, "--strideA", strideA, "--strideP", strideP,
+                        "--batch_count", batch_count);
 
     if(!handle)
         return rocblas_status_invalid_handle;

--- a/library/src/lapack/roclapack_getrs.hpp
+++ b/library/src/lapack/roclapack_getrs.hpp
@@ -115,11 +115,12 @@ rocblas_status rocsolver_getrs_template(rocblas_handle handle,
 
     // constants to use when calling rocblas functions
     T one = 1; // constant 1 in host
+    const bool pivot = (ipiv != nullptr);
 
     if(trans == rocblas_operation_none)
     {
         // first apply row interchanges to the right hand sides
-        if(ipiv != nullptr)
+        if(pivot)
             rocsolver_laswp_template<T>(handle, nrhs, B, shiftB, ldb, strideB, 1, n, ipiv, 0,
                                         strideP, 1, batch_count);
 
@@ -150,7 +151,7 @@ rocblas_status rocsolver_getrs_template(rocblas_handle handle,
                                      work3, work4);
 
         // then apply row interchanges to the solution vectors
-        if(ipiv != nullptr)
+        if(pivot)
             rocsolver_laswp_template<T>(handle, nrhs, B, shiftB, ldb, strideB, 1, n, ipiv, 0,
                                         strideP, -1, batch_count);
     }

--- a/library/src/lapack/roclapack_getrs.hpp
+++ b/library/src/lapack/roclapack_getrs.hpp
@@ -114,8 +114,9 @@ rocblas_status rocsolver_getrs_template(rocblas_handle handle,
     if(trans == rocblas_operation_none)
     {
         // first apply row interchanges to the right hand sides
-        rocsolver_laswp_template<T>(handle, nrhs, B, shiftB, ldb, strideB, 1, n, ipiv, 0, strideP,
-                                    1, batch_count);
+        if(ipiv != nullptr)
+            rocsolver_laswp_template<T>(handle, nrhs, B, shiftB, ldb, strideB, 1, n, ipiv, 0,
+                                        strideP, 1, batch_count);
 
         // solve L*X = B, overwriting B with X
         rocblasCall_trsm<BATCHED, T>(handle, rocblas_side_left, rocblas_fill_lower, trans,
@@ -144,8 +145,9 @@ rocblas_status rocsolver_getrs_template(rocblas_handle handle,
                                      work3, work4);
 
         // then apply row interchanges to the solution vectors
-        rocsolver_laswp_template<T>(handle, nrhs, B, shiftB, ldb, strideB, 1, n, ipiv, 0, strideP,
-                                    -1, batch_count);
+        if(ipiv != nullptr)
+            rocsolver_laswp_template<T>(handle, nrhs, B, shiftB, ldb, strideB, 1, n, ipiv, 0,
+                                        strideP, -1, batch_count);
     }
 
     rocblas_set_pointer_mode(handle, old_mode);


### PR DESCRIPTION
Partially addresses SWDEV-297252.

This PR adds getri_npvt and getri_npvt_outofplace routines to the public API, in preparation for calling getri_npvt_outofplace from hipBLAS.

I haven't tuned the optimized block sizes for the npvt routines, as I'm not sure how.