### PR TITLE
Fix missing header in rocsolver.h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 ### Deprecated
 ### Removed
 ### Fixed
+- Added missing stdint.h include to rocsolver.h
+
 ### Known Issues
 ### Security
 

--- a/library/include/rocsolver-extra-types.h
+++ b/library/include/rocsolver-extra-types.h
@@ -5,6 +5,8 @@
 #ifndef ROCSOLVER_EXTRAS_H_
 #define ROCSOLVER_EXTRAS_H_
 
+#include <stdint.h>
+
 /*! \brief Used to specify the logging layer mode using a bitwise combination
  *of rocblas_layer_mode values.
  ********************************************************************************/


### PR DESCRIPTION
rocsolver-extra-types.h uses uint32_t, which requires stdint.h. The problem can be reproduced with a test program:

```
#include <rocsolver.h>
int main()
{
}
```