### PR TITLE
Print version information in rocsolver-bench

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -408,6 +408,8 @@ try
         print_version_info();
 
         rocblas_int device_count = query_device_property();
+        if(device_count <= 0)
+            throw std::runtime_error("No devices found");
         if(device_count <= device_id)
             throw std::invalid_argument("Invalid Device ID");
     }
@@ -439,8 +441,7 @@ try
 
     return 0;
 }
-
-catch(const std::invalid_argument& exp)
+catch(const std::exception& exp)
 {
     fmt::print(stderr, "{}\n", exp.what());
     return -1;

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -33,6 +33,30 @@ Options:
 )HELP_STR";
 // clang-format on
 
+static std::string rocblas_version()
+{
+    size_t size;
+    rocblas_get_version_string_size(&size);
+    std::string str(size - 1, '\0');
+    rocblas_get_version_string(str.data(), size);
+    return str;
+}
+
+static std::string rocsolver_version()
+{
+    size_t size;
+    rocsolver_get_version_string_size(&size);
+    std::string str(size - 1, '\0');
+    rocsolver_get_version_string(str.data(), size);
+    return str;
+}
+
+static void print_version_info()
+{
+    fmt::print("rocSOLVER version {} (with rocBLAS {})\n", rocsolver_version(), rocblas_version());
+    std::fflush(stdout);
+}
+
 int main(int argc, char* argv[])
 try
 {
@@ -379,9 +403,10 @@ try
 
     argus.populate(vm);
 
-    // set device ID
     if(!argus.perf)
     {
+        print_version_info();
+
         rocblas_int device_count = query_device_property();
         if(device_count <= device_id)
             throw std::invalid_argument("Invalid Device ID");


### PR DESCRIPTION
This prints version information when rocsolver-bench is invoked. The version information is not printed when `--perf 1` is added, as that option has a specific output format.

I've also slightly changed the error messages when no devices are found.

Example output:
```
$ ROCR_VISIBLE_DEVICES='' build/release/clients/staging/rocsolver-bench -n 10
rocSOLVER version 3.16.0.2e3d8f64-dirty (with rocBLAS 2.42.0.c98b458c)
Query device error: cannot get device count
No devices found
```