### PR TITLE
Fix docs parameter formatting

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,6 @@ formats:
    - epub
 
 python:
-   version: "3"
+   version: "3.7"
    install:
    - requirements: docs/source/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,9 +6,7 @@ version: 2
 sphinx:
    configuration: docs/source/conf.py
 
-formats:
-   - pdf
-   - epub
+formats: all
 
 python:
    version: "3.7"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+sphinx:
+   configuration: docs/source/conf.py
+
+formats:
+   - pdf
+   - epub
+
+python:
+   version: "3"
+   install:
+   - requirements: docs/source/requirements.txt

--- a/docs/run_doc.sh
+++ b/docs/run_doc.sh
@@ -11,5 +11,5 @@ bash run_doxygen.sh
 # Build sphinx docs
 cd source
 make clean
-make html
-make latexpdf
+make SPHINXOPTS='-W --keep-going' html
+make SPHINXOPTS='-W --keep-going' latexpdf

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,3 +1,4 @@
+docutils==0.16
 sphinx==3.5.3
 sphinx_rtd_theme==0.4.3
 readthedocs_sphinx_ext==2.1.4

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,2 +1,4 @@
-
-breathe
+sphinx==3.5.3
+sphinx_rtd_theme==0.4.3
+readthedocs_sphinx_ext==2.1.4
+breathe==4.28.0


### PR DESCRIPTION
## Fix docs parameter formatting

I compared the original [ROCm 4.1.0 docs build](https://readthedocs.org/projects/rocsolver/builds/13407054/) and this [later build](https://readthedocs.org/projects/rocsolver/builds/13980290/) of the same tag. (You can find detailed logs by clicking 'View Raw'.) The main difference between the two seems to be the version of sphinx being used. The former is built with Sphinx 3 and the latter is built with Sphinx 4. We should follow the [ReadTheDocs recommendations for reproducible builds](https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html) and specify our Sphinx version explicitly.

After specifying our dependency versions to match the original build, the appearance returned to normal.
See generated docs for [this PR](https://rocsolver--318.org.readthedocs.build/en/318/api_lapackfunc.html#rocsolver-type-gesvd) vs. [master](https://rocsolver.readthedocs.io/en/latest/api_lapackfunc.html#rocsolver-type-gesvd).

Fixes SWDEV-292471.

## Add ReadTheDocs config file

The ReadTheDocs developers recommend using a configuration file. When [`.readthedocs.yaml`](https://docs.readthedocs.io/en/stable/config-file/v2.html) is present, the 'Advanced settings -> Default settings' section of the ReadTheDocs admin panel is ignored and the configuration file is used instead. The yaml config file has some benefits when compared to using the web-based settings panel:

- If you move `conf.py` or `requirements.txt`, you can update `.readthedocs.yaml` at the same time. That way, you retain the ability to easily rebuild old versions of the docs, because ReadTheDocs will automatically use the corresponding settings. (That would have been useful for rocSOLVER. You need to temporarily change the `conf.py` and `requirements.txt` paths in the ReadTheDocs web settings to build some older versions of the docs.)

- External contributors (who don't have access to our ReadTheDocs admin panel) can see how we have configured ReadTheDocs, which may help them in understanding our project structure with respect to documentation.

- There are some settings you can change via the yaml file that you cannot change via the web interface.

## Turn Sphinx warnings into errors

We turned Doxygen warnings into errors with #294, but some kinds of reference errors could still slip through. This PR turns Sphinx warnings into errors in order to catch problems like the one fixed by #304. This change only applies to local docs builds and the math-ci.
