### PR TITLE
Add vcpkg manifest

### DIFF
--- a/bump_rocsolver_version.sh
+++ b/bump_rocsolver_version.sh
@@ -3,9 +3,9 @@
 # run this script in develop after merging develop/staging into master at the feature-complete date
 # Edit script to bump versions for new development cycle/release.
 
-OLD_ROCSOLVER_VERSION="3.17.0"  
-NEW_ROCSOLVER_VERSION="3.18.0"  
-sed -i "s/${OLD_ROCSOLVER_VERSION}/${NEW_ROCSOLVER_VERSION}/g" CMakeLists.txt
+OLD_ROCSOLVER_VERSION="3.17.0"
+NEW_ROCSOLVER_VERSION="3.18.0"
+sed -i "s/${OLD_ROCSOLVER_VERSION}/${NEW_ROCSOLVER_VERSION}/g" CMakeLists.txt vcpkg.json
 
 # for documentation
 OLD_ROCSOLVER_DOCS_VERSION="3.17"

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -19,8 +19,6 @@ if(NOT TARGET rocsolver)
 endif()
 
 if(BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
-  option(ROCSOLVER_USE_VCPKG_LAPACK "Use the LAPACK provided by vcpkg" OFF)
-
   add_library(clients-common INTERFACE)
   target_include_directories(clients-common INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -19,9 +19,7 @@ if(NOT TARGET rocsolver)
 endif()
 
 if(BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
-  # Linking lapack library requires fortran flags
-  find_package(cblas REQUIRED CONFIG)
-  target_include_directories(cblas SYSTEM INTERFACE ${CBLAS_INCLUDE_DIRS})
+  option(ROCSOLVER_USE_VCPKG_LAPACK "Use the LAPACK provided by vcpkg" OFF)
 
   add_library(clients-common INTERFACE)
   target_include_directories(clients-common INTERFACE
@@ -29,6 +27,18 @@ if(BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
     ${CMAKE_CURRENT_SOURCE_DIR}/include
   )
   target_link_libraries(clients-common INTERFACE fmt::fmt)
+  if(ROCSOLVER_USE_VCPKG_LAPACK)
+    find_package(lapack REQUIRED)
+    target_link_libraries(clients-common INTERFACE lapack)
+  else()
+    find_package(cblas REQUIRED CONFIG)
+    target_include_directories(cblas SYSTEM INTERFACE ${CBLAS_INCLUDE_DIRS})
+    target_link_libraries(clients-common INTERFACE
+      cblas
+      lapack
+      blas
+    )
+  endif()
   set(common_source_files
     common/lapack_host_reference.cpp
     rocblascommon/utility.cpp

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -27,18 +27,14 @@ if(BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
     ${CMAKE_CURRENT_SOURCE_DIR}/include
   )
   target_link_libraries(clients-common INTERFACE fmt::fmt)
-  if(ROCSOLVER_USE_VCPKG_LAPACK)
-    find_package(lapack REQUIRED)
-    target_link_libraries(clients-common INTERFACE lapack)
-  else()
-    find_package(cblas REQUIRED CONFIG)
-    target_include_directories(cblas SYSTEM INTERFACE ${CBLAS_INCLUDE_DIRS})
-    target_link_libraries(clients-common INTERFACE
-      cblas
-      lapack
-      blas
-    )
-  endif()
+  find_package(lapack REQUIRED CONFIG)
+  find_package(cblas REQUIRED CONFIG)
+  target_include_directories(cblas SYSTEM INTERFACE ${CBLAS_INCLUDE_DIRS})
+  target_link_libraries(clients-common INTERFACE
+    cblas
+    lapack
+    blas
+  )
   set(common_source_files
     common/lapack_host_reference.cpp
     rocblascommon/utility.cpp

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -28,6 +28,13 @@ if(BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
   find_package(lapack REQUIRED CONFIG)
   find_package(cblas REQUIRED CONFIG)
   target_include_directories(cblas SYSTEM INTERFACE ${CBLAS_INCLUDE_DIRS})
+  # Fixup targets for vcpkg lapack-reference 3.8.0#6 on x64-windows
+  if(NOT TARGET lapack)
+    add_library(lapack ALIAS LAPACK::LAPACK)
+  endif()
+  if(NOT TARGET blas)
+    add_library(blas ALIAS BLAS::BLAS)
+  endif()
   target_link_libraries(clients-common INTERFACE
     cblas
     lapack

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -7,9 +7,6 @@ add_executable(rocsolver-bench client.cpp)
 add_armor_flags(rocsolver-bench "${ARMOR_LEVEL}")
 
 target_link_libraries(rocsolver-bench PRIVATE
-  cblas
-  lapack
-  blas
   Threads::Threads
   hip::device
   rocsolver-common

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -115,9 +115,6 @@ if(WIN32)
 endif()
 
 target_link_libraries(rocsolver-test PRIVATE
-  cblas
-  lapack
-  blas
   GTest::GTest
   hip::device
   rocsolver-common

--- a/rmake.py
+++ b/rmake.py
@@ -112,6 +112,8 @@ def config_cmd():
             vcpkg_path =  pathlib.Path(os.getenv("VCPKG_PATH", "C:/github/vcpkg"))
             vcpkg_toolchain = vcpkg_path / 'scripts/buildsystems/vcpkg.cmake'
             cmake_options.append(f"-DCMAKE_TOOLCHAIN_FILE={vcpkg_toolchain.as_posix()} -DVCPKG_TARGET_TRIPLET=x64-windows")
+            if args.build_clients:
+                cmake_options.append("-DVCPKG_MANIFEST_FEATURES=tests")
         cmake_options.append("-DCMAKE_STATIC_LIBRARY_SUFFIX=.a")
         cmake_options.append("-DCMAKE_STATIC_LIBRARY_PREFIX=static_")
         cmake_options.append("-DCMAKE_SHARED_LIBRARY_SUFFIX=.dll")

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,10 +2,11 @@
   "registries": [
     {
       "kind": "git",
-      "baseline": "21cdaaa75fea30ef19a943d0c5fcc83cfad9525a",
+      "baseline": "c0ed6c5c2828f6dd1fbf2f554445308fce84ae89",
       "repository": "https://github.com/cgmb/rocm-vcpkg",
       "packages": [
         "cblas",
+        "lapack-reference",
         "rocm-cmake"
       ]
     }

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,8 +2,8 @@
   "registries": [
     {
       "kind": "git",
-      "baseline": "c0ed6c5c2828f6dd1fbf2f554445308fce84ae89",
-      "repository": "https://github.com/cgmb/rocm-vcpkg",
+      "baseline": "d9ab59cf053aafec41b990793c1e9a704d0efceb",
+      "repository": "git@github.com:ROCmSoftwarePlatform/rocm-vcpkg-registry.git",
       "packages": [
         "cblas",
         "lapack-reference",

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "registries": [
     {
       "kind": "git",
-      "baseline": "d665e72c1561a98a28036f1f7f985f9f16dd5458",
+      "baseline": "21cdaaa75fea30ef19a943d0c5fcc83cfad9525a",
       "repository": "https://github.com/cgmb/rocm-vcpkg",
       "packages": [
         "cblas",

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,12 @@
+{
+  "registries": [
+    {
+      "kind": "git",
+      "baseline": "f9d6e76bda1110cd8612881454c06dcedfc4ceb6",
+      "repository": "https://github.com/cgmb/rocm-vcpkg",
+      "packages": [
+        "cblas"
+      ]
+    }
+  ]
+}

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,10 +2,11 @@
   "registries": [
     {
       "kind": "git",
-      "baseline": "f9d6e76bda1110cd8612881454c06dcedfc4ceb6",
+      "baseline": "d665e72c1561a98a28036f1f7f985f9f16dd5458",
       "repository": "https://github.com/cgmb/rocm-vcpkg",
       "packages": [
-        "cblas"
+        "cblas",
+        "rocm-cmake"
       ]
     }
   ]

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,26 @@
+{
+  "name": "rocsolver",
+  "version": "3.17.0",
+  "description": "AMD GPU implementation of LAPACK",
+  "homepage": "https://github.com/ROCmSoftwarePlatform/rocSOLVER",
+  "documentation": "https://rocsolver.readthedocs.io",
+  "builtin-baseline": "193880f0a8d9738a62142dd49aab19069b1ff8d6",
+  "dependencies": [
+    "fmt"
+  ],
+  "features": {
+    "tests": {
+      "description": "The rocsolver-test client",
+      "dependencies": [
+        "gtest",
+        {
+          "name": "lapack-reference",
+          "default-features": false,
+          "features": [
+            "cblas"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "AMD GPU implementation of LAPACK",
   "homepage": "https://github.com/ROCmSoftwarePlatform/rocSOLVER",
   "documentation": "https://rocsolver.readthedocs.io",
-  "builtin-baseline": "5568f110b509a9fd90711978a7cb76bae75bb092",
+  "builtin-baseline": "603748b5dbed0bcd6aee02025c80260362e7d0df",
   "dependencies": [
     "fmt"
   ],
@@ -12,13 +12,11 @@
     "tests": {
       "description": "The rocsolver-test client",
       "dependencies": [
+        "cblas",
         "gtest",
         {
           "name": "lapack-reference",
-          "default-features": false,
-          "features": [
-            "cblas"
-          ]
+          "default-features": false
         }
       ]
     }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "AMD GPU implementation of LAPACK",
   "homepage": "https://github.com/ROCmSoftwarePlatform/rocSOLVER",
   "documentation": "https://rocsolver.readthedocs.io",
-  "builtin-baseline": "193880f0a8d9738a62142dd49aab19069b1ff8d6",
+  "builtin-baseline": "5568f110b509a9fd90711978a7cb76bae75bb092",
   "dependencies": [
     "fmt"
   ],

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,8 @@
   "documentation": "https://rocsolver.readthedocs.io",
   "builtin-baseline": "603748b5dbed0bcd6aee02025c80260362e7d0df",
   "dependencies": [
-    "fmt"
+    "fmt",
+    "rocm-cmake"
   ],
   "features": {
     "tests": {


### PR DESCRIPTION
This change adds a [vcpkg manifest](https://vcpkg.readthedocs.io/en/latest/users/manifests/). The vcpkg tool is an alternative way to install dependencies when building rocSOLVER, and the manifest specifies what packages that rocSOLVER depends on. The package versions are specified indirectly, through the "builtin-baseline".

The vcpkg.json file just seems like a good, standardized way of documenting what third-party dependencies we use. The fact that it can install them is more of a bonus. The LAPACK package is a bit weird, though. I needed to change our CMake to get it to work, so I put that behind an option.

To give it a try:
## Ubuntu
```bash
# install vcpkg
sudo apt install build-essential tar curl zip unzip git 
git clone https://github.com/microsoft/vcpkg.git
cd vcpkg
git checkout 603748b5dbed0bcd6aee02025c80260362e7d0df
./bootstrap-vcpkg.sh -disableMetrics

# note your vcpkg install directory
export VCPKG_ROOT="$(pwd)"

# build rocSOLVER
cd ~/rocSOLVER
./install.sh -cna gfx906:xnack- \
  --cmake-arg -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
  --cmake-arg -DVCPKG_MANIFEST_FEATURES=tests \
  --rocblas_dir=$HOME/rocBLAS/build/release/rocblas-install
```

## Windows
```bash
# install vcpkg
git clone https://github.com/microsoft/vcpkg.git
cd vcpkg
git checkout 603748b5dbed0bcd6aee02025c80260362e7d0df
.\bootstrap-vcpkg.bat -disableMetrics

# note your vcpkg install directory
set "VCPKG_PATH=%CD%"

# build rocSOLVER
cd C:\Workspace\rocSOLVER
python rmake.py -cna "gfx906:xnack-;gfx1030" ^
  --rocblas_dir=C:/hipSDK
```