### PR TITLE
Address cppcheck warnings - 1/2

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -70,8 +70,8 @@ try
     argus.timing = 1;
 
     std::string function;
-    char precision;
-    rocblas_int device_id;
+    char precision = 's';
+    rocblas_int device_id = 0;
 
     // take arguments and set default values
     // clang-format off

--- a/clients/common/lapack_host_reference.cpp
+++ b/clients/common/lapack_host_reference.cpp
@@ -2460,7 +2460,6 @@ void cblas_labrd<float, float>(rocblas_int m,
                                float* Y,
                                rocblas_int ldy)
 {
-    int info;
     slabrd_(&m, &n, &nb, A, &lda, D, E, tauq, taup, X, &ldx, Y, &ldy);
 }
 
@@ -2479,7 +2478,6 @@ void cblas_labrd<double, double>(rocblas_int m,
                                  double* Y,
                                  rocblas_int ldy)
 {
-    int info;
     dlabrd_(&m, &n, &nb, A, &lda, D, E, tauq, taup, X, &ldx, Y, &ldy);
 }
 
@@ -2498,7 +2496,6 @@ void cblas_labrd<rocblas_float_complex, float>(rocblas_int m,
                                                rocblas_float_complex* Y,
                                                rocblas_int ldy)
 {
-    int info;
     clabrd_(&m, &n, &nb, A, &lda, D, E, tauq, taup, X, &ldx, Y, &ldy);
 }
 
@@ -2517,7 +2514,6 @@ void cblas_labrd<rocblas_double_complex, double>(rocblas_int m,
                                                  rocblas_double_complex* Y,
                                                  rocblas_int ldy)
 {
-    int info;
     zlabrd_(&m, &n, &nb, A, &lda, D, E, tauq, taup, X, &ldx, Y, &ldy);
 }
 

--- a/clients/rocblascommon/rocblas_random.hpp
+++ b/clients/rocblascommon/rocblas_random.hpp
@@ -57,41 +57,41 @@ class rocblas_nan_rng
 public:
     // Random integer
     template <typename T, std::enable_if_t<std::is_integral<T>{}, int> = 0>
-    explicit operator T()
+    explicit operator T() const
     {
         return std::uniform_int_distribution<T>{}(rocblas_rng);
     }
 
     // Random NaN double
-    explicit operator double()
+    explicit operator double() const
     {
         return random_nan_data<double, uint64_t, 52, 11>();
     }
 
     // Random NaN float
-    explicit operator float()
+    explicit operator float() const
     {
         return random_nan_data<float, uint32_t, 23, 8>();
     }
 
     // Random NaN half
-    explicit operator rocblas_half()
+    explicit operator rocblas_half() const
     {
         return random_nan_data<rocblas_half, uint16_t, 10, 5>();
     }
 
     // Random NaN bfloat16
-    explicit operator rocblas_bfloat16()
+    explicit operator rocblas_bfloat16() const
     {
         return random_nan_data<rocblas_bfloat16, uint16_t, 7, 8>();
     }
 
-    explicit operator rocblas_float_complex()
+    explicit operator rocblas_float_complex() const
     {
         return {float(*this), float(*this)};
     }
 
-    explicit operator rocblas_double_complex()
+    explicit operator rocblas_double_complex() const
     {
         return {double(*this), double(*this)};
     }

--- a/library/src/lapack/roclapack_gesvd.hpp
+++ b/library/src/lapack/roclapack_gesvd.hpp
@@ -180,13 +180,13 @@ void rocsolver_gesvd_getMemorySize(const rocblas_svect left_svect,
     const bool rightvO = (right_svect == rocblas_svect_overwrite);
     const bool rightvA = (right_svect == rocblas_svect_all);
     const bool rightvN = (right_svect == rocblas_svect_none);
-    const bool leadvS = row ? leftvS : rightvS;
+    //const bool leadvS = row ? leftvS : rightvS;
     const bool leadvO = row ? leftvO : rightvO;
     const bool leadvA = row ? leftvA : rightvA;
     const bool leadvN = row ? leftvN : rightvN;
-    const bool othervS = !row ? leftvS : rightvS;
+    //const bool othervS = !row ? leftvS : rightvS;
     const bool othervO = !row ? leftvO : rightvO;
-    const bool othervA = !row ? leftvA : rightvA;
+    //const bool othervA = !row ? leftvA : rightvA;
     const bool othervN = !row ? leftvN : rightvN;
     const bool thinSVD = (m >= THIN_SVD_SWITCH * n || n >= THIN_SVD_SWITCH * m);
     const bool fast_thinSVD = (thinSVD && fast_alg == rocblas_outofplace);

--- a/library/src/lapack/roclapack_getri.hpp
+++ b/library/src/lapack/roclapack_getri.hpp
@@ -25,11 +25,10 @@ __device__ void copy_and_zero(const rocblas_int m,
 {
     // Copies the lower triangular part of the matrix to the workspace and then
     // replaces it with zeroes
-    int i, j;
     for(int k = hipThreadIdx_y; k < m * n; k += hipBlockDim_y)
     {
-        i = k % m;
-        j = k / m;
+        int i = k % m;
+        int j = k / m;
         if(i > j)
         {
             w[i + j * ldw] = a[i + j * lda];
@@ -44,11 +43,10 @@ __device__ void zero_work(const rocblas_int m, const rocblas_int n, T* w, const 
 {
     // Zeroes the workspace so that calls to gemm and trsm do not alter the matrix
     // (used for singular matrices)
-    int i, j;
     for(int k = hipThreadIdx_y; k < m * n; k += hipBlockDim_y)
     {
-        i = k % m;
-        j = k / m;
+        int i = k % m;
+        int j = k / m;
         w[i + j * ldw] = 0;
     }
     __syncthreads();


### PR DESCRIPTION
Addresses SWDEV-306986. There was nothing strictly necessary, but a few of the warnings were useful.

- Remove unused variables in cblas_labrd
- Initialize benchmark arguments 
- Add const to rocblas_nan_rng member functions
- Reduce variable scope in getri
- Comment out unused variables in gesvd