### PR TITLE
Revert "Workaround for debug binary size on CI"

### DIFF
--- a/.jenkins/debug.groovy
+++ b/.jenkins/debug.groovy
@@ -21,7 +21,7 @@ def runCI =
     prj.defaults.ccache = true
 
     // customize for project
-    prj.paths.build_command = './install.sh -a "gfx900;gfx906:xnack-" -c'
+    prj.paths.build_command = './install.sh -c'
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)


### PR DESCRIPTION
Reverts ROCmSoftwarePlatform/rocSOLVER#265. That was a temporary workaround and it has outlived its usefulness.

Troy addressed the binary size problem in #289. The debug build is our early warning system for library size, so we should keep it at parity with the Release build.