### PR TITLE
Add gfx1010 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed missing synchronization in SYTRF with `rocblas_fill_lower` that could potentially
+  result in incorrect pivot values.
+
 ### Known Issues
 ### Security
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
+# Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
 # ########################################################################
 
 cmake_minimum_required(VERSION 3.13)
@@ -125,7 +125,7 @@ rocm_check_target_ids(OPTIONAL_AMDGPU_TARGETS
 
 # Set this before finding hip so that hip::device has the required arch flags
 # added as usage requirements on its interface
-set(AMDGPU_TARGETS "gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx1030;${OPTIONAL_AMDGPU_TARGETS}"
+set(AMDGPU_TARGETS "gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx1010;gfx1030;${OPTIONAL_AMDGPU_TARGETS}"
   CACHE STRING "List of specific machine types for library to target")
 
 # Find HIP dependencies

--- a/library/src/lapack/roclapack_sytrf.hpp
+++ b/library/src/lapack/roclapack_sytrf.hpp
@@ -5,7 +5,7 @@
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
  *
- * Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
  * ***********************************************************************/
 
 #pragma once
@@ -118,6 +118,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(SYTRF_MAX_THDS)
             sytf2_device_lower<SYTRF_MAX_THDS>(tid, n - k, A + k + k * lda, lda, ipiv + k, &iinfo,
                                                sidx, sval);
             ktemp = n;
+            __syncthreads();
         }
 
         if(tid == 0 && iinfo != 0 && info[bid] == 0)


### PR DESCRIPTION
I picked up an RX 5700 XT to give gfx1010 a try. rocBLAS has supported it since ROCm 4.2, and I figured we might as well enable it in rocSOLVER if it works.

The full rocsolver-test suite passes after a small fix to `sytrf_kernel_lower`. The lack of a sync resulted in incorrect pivot indices returned for the sytrf family of functions when called with `rocblas_fill_lower`. In theory, this sync is needed on all architectures, but the bug doesn't seem to manifest except on gfx1010. Thanks to @tfalders for identifying the cause of this problem.