### PR TITLE
Remove logic for installing LICENSE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 ### Added
 ### Optimized
 ### Changed
+- Moved license directory from `share/doc/rocSOLVER` to `share/doc/rocsolver`.
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
+# Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
 # ########################################################################
 
 # package_targets is used as a list of install target
@@ -281,11 +281,6 @@ endif()
 
 ############################################################
 # Installation
-
-# Force installation of LICENSE.md
-install(FILES "../../LICENSE.md"
-	DESTINATION "share/doc/rocSOLVER"
-)
 
 rocm_install_targets(
   TARGETS ${package_targets}


### PR DESCRIPTION
The license installation is handled by rocm-cmake as of https://github.com/RadeonOpenCompute/rocm-cmake/pull/63.