### PR TITLE
Remove loop unrolls from large loops

### DIFF
--- a/library/src/specialized/roclapack_getf2_specialized_kernels.hpp
+++ b/library/src/specialized/roclapack_getf2_specialized_kernels.hpp
@@ -96,7 +96,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(GETF2_MAX_THDS)
         else if(myinfo == 0)
             myinfo = j + 1;
 
-        // swap rows (lazy swaping)
+        // swap rows (lazy swapping)
         if(myrow == pivot_index)
         {
             myrow = j;

--- a/library/src/specialized/roclapack_getf2_specialized_kernels.hpp
+++ b/library/src/specialized/roclapack_getf2_specialized_kernels.hpp
@@ -4,7 +4,7 @@
  * Factorization and inversion of a million matrices using GPUs: Challenges
  * and countermeasures. Procedia Computer Science, 108, 606-615.
  *
- * Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
  * ***********************************************************************/
 
 #pragma once
@@ -71,8 +71,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(GETF2_MAX_THDS)
     for(int j = 0; j < DIM; ++j)
         rA[j] = A[myrow + j * lda];
 
-        // for each pivot (main loop)
-#pragma unroll DIM
+    // for each pivot (main loop)
     for(int k = 0; k < DIM; ++k)
     {
         // share current column
@@ -176,8 +175,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(GETF2_MAX_THDS)
     for(int j = 0; j < DIM; ++j)
         rA[j] = A[myrow + j * lda];
 
-        // for each pivot (main loop)
-#pragma unroll DIM
+    // for each pivot (main loop)
     for(int k = 0; k < DIM; ++k)
     {
         // share pivot row and check singularity

--- a/library/src/specialized/roclapack_getri_specialized_kernels.hpp
+++ b/library/src/specialized/roclapack_getri_specialized_kernels.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
  * ***********************************************************************/
 
 #pragma once
@@ -81,7 +81,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(TRTRI_MAX_COLS)
         diag[i] = -rA[i];
 
         // compute element i of each column j
-#pragma unroll
         for(rocblas_int j = 1; j < DIM; j++)
         {
             // share current column and diagonal
@@ -104,8 +103,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(TRTRI_MAX_COLS)
     if(info[b] != 0)
         return;
 
-        //--- GETRI ---
-#pragma unroll
+    //--- GETRI ---
     for(rocblas_int j = DIM - 2; j >= 0; j--)
     {
         // extract lower triangular column (copy_and_zero)

--- a/library/src/specialized/roclapack_trtri_specialized_kernels.hpp
+++ b/library/src/specialized/roclapack_trtri_specialized_kernels.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
  * ***********************************************************************/
 
 #pragma once
@@ -61,7 +61,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(TRTRI_MAX_COLS)
     // compute element i of each column j
     if(uplo == rocblas_fill_upper)
     {
-#pragma unroll
         for(rocblas_int j = 1; j < DIM; j++)
         {
             // share current column and diagonal
@@ -81,7 +80,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(TRTRI_MAX_COLS)
     }
     else
     {
-#pragma unroll
         for(rocblas_int j = DIM - 2; j >= 0; j--)
         {
             // share current column and diagonal


### PR DESCRIPTION
As promised, I've been looking again at removing some loop unrolls from our small-size kernels. I was more thorough with my tests this time (I'll send an email with the results), and there does not appear to be any significant slowdown caused by removing the unrolls. Changes to getf2's kernel since my last attempt seem to have fixed the slowdown issue we saw previously (my changes in this PR, other than removing the unrolls, are really just cosmetic and can be removed if desired).

With these changes in place, the .so file from my debug build went from ~1680 MB to ~985 MB.