### PR TITLE
Fix multi-level logging file output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 ### Fixed
 - Fixed missing synchronization in SYTRF with `rocblas_fill_lower` that could potentially
   result in incorrect pivot values.
+- Fixed multi-level logging output to file with the `ROCSOLVER_LOG_PATH`,
+  `ROCSOLVER_LOG_TRACE_PATH`, `ROCSOLVER_LOG_BENCH_PATH` and `ROCSOLVER_LOG_PROFILE_PATH`
+  environment variables.
 
 
 ## rocSOLVER 3.16.0 for ROCm 5.0.0

--- a/library/src/common/rocsolver_logger.cpp
+++ b/library/src/common/rocsolver_logger.cpp
@@ -229,8 +229,10 @@ try
     logger->trace_os = logger->open_log_stream("ROCSOLVER_LOG_TRACE_PATH");
     logger->bench_os = logger->open_log_stream("ROCSOLVER_LOG_BENCH_PATH");
     logger->profile_os = logger->open_log_stream("ROCSOLVER_LOG_PROFILE_PATH");
-
-    return rocblas_status_success;
+    if(logger->trace_os->good() && logger->bench_os->good() && logger->profile_os->good())
+        return rocblas_status_success;
+    else
+        return rocblas_status_internal_error;
 }
 catch(...)
 {

--- a/library/src/common/rocsolver_logger.cpp
+++ b/library/src/common/rocsolver_logger.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include <cerrno>
@@ -46,7 +46,7 @@ std::ostream* rocsolver_logger::open_log_stream(const char* environment_variable
     if((logfile = std::getenv(environment_variable)) != nullptr
        || (logfile = std::getenv("ROCSOLVER_LOG_PATH")) != nullptr)
     {
-        file_streams.emplace_front(logfile, std::ios::out | std::ios::app | std::ios::trunc);
+        file_streams.emplace_front(logfile);
         std::ostream& os = file_streams.front();
 
         // print version info only once per file


### PR DESCRIPTION
It is not valid to open a stream using both `std::ios::app` and `std::ios::trunc`. The flags are contradictory, and were added by mistake in 659b64c8e0fbfa5c360dc25d411f80003f47f84c. The default behaviour of `std::ofstream` is equivalent to `std::ios::out | std::ios::trunc`. This change reverts to using the same flags as when the feature was introduced in b193d895b9b43f797b9d66afa973cdb80ee135f6.

See SWDEV-319538. 