### PR TITLE
Add gfx1011 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ rocm_check_target_ids(OPTIONAL_AMDGPU_TARGETS
 
 # Set this before finding hip so that hip::device has the required arch flags
 # added as usage requirements on its interface
-set(AMDGPU_TARGETS "gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx1010;gfx1030;${OPTIONAL_AMDGPU_TARGETS}"
+set(AMDGPU_TARGETS "gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx1010;gfx1011;gfx1030;${OPTIONAL_AMDGPU_TARGETS}"
   CACHE STRING "List of specific machine types for library to target")
 
 # Find HIP dependencies


### PR DESCRIPTION
All rocsolver tests passed on an AMD Radeon Pro V520 GPU. Tested with the current master branches for rocSOLVER and rocBLAS. For posterity, that's rocSOLVER version 3.17.0.c095965 (with rocBLAS 2.43.0.b81635f5).

However, rocBLAS did not pass its test suite. It crashed attempting to access an inaccessible address in:

    trsm_strided_batched_ex.blas3_tensile/nightly_trsm_strided_batched_ex_manybatch_f32_r_LUCN_2014_1_1_2000_2048_1024_1024_64