### PR TITLE
Consistency check for syev and sygv

### DIFF
--- a/clients/include/testing_sygv_hegv.hpp
+++ b/clients/include/testing_sygv_hegv.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -46,7 +46,7 @@ void sygv_hegv_checkBadArgs(const rocblas_handle handle,
                                               uplo, n, dA, lda, stA, dB, ldb, stB, dD, stD, dE, stE,
                                               dInfo, bc),
                           rocblas_status_invalid_value);
-    EXPECT_ROCBLAS_STATUS(rocsolver_sygv_hegv(STRIDED, handle, itype, evect, rocblas_fill(-1), n, dA,
+    EXPECT_ROCBLAS_STATUS(rocsolver_sygv_hegv(STRIDED, handle, itype, evect, rocblas_fill_full, n, dA,
                                               lda, stA, dB, ldb, stB, dD, stD, dE, stE, dInfo, bc),
                           rocblas_status_invalid_value);
 
@@ -308,28 +308,24 @@ void sygv_hegv_getError(const rocblas_handle handle,
 
     double err;
 
-    if(evect == rocblas_evect_none)
+    for(rocblas_int b = 0; b < bc; ++b)
     {
-        // only eigenvalues needed; can compare with LAPACK
-
-        // error is ||hD - hDRes|| / ||hD||
-        // using frobenius norm
-        for(rocblas_int b = 0; b < bc; ++b)
+        if(evect == rocblas_evect_none)
         {
+            // only eigenvalues needed; can compare with LAPACK
+
+            // error is ||hD - hDRes|| / ||hD||
+            // using frobenius norm
             if(hInfoRes[b][0] == 0)
             {
                 err = norm_error('F', 1, n, 1, hD[b], hDRes[b]);
                 *max_err = err > *max_err ? err : *max_err;
             }
         }
-    }
-    else
-    {
-        // both eigenvalues and eigenvectors needed; need to implicitly test
-        // eigenvectors due to non-uniqueness of eigenvectors under scaling
-
-        for(rocblas_int b = 0; b < bc; ++b)
+        else
         {
+            // both eigenvalues and eigenvectors needed; need to implicitly test
+            // eigenvectors due to non-uniqueness of eigenvectors under scaling
             if(hInfoRes[b][0] == 0)
             {
                 T alpha = 1;
@@ -578,30 +574,34 @@ void testing_sygv_hegv(Arguments& argus)
         CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
+    // memory allocations (all cases)
+    // host
+    host_strided_batch_vector<S> hD(size_D, 1, stD, bc);
+    host_strided_batch_vector<S> hDRes(size_DRes, 1, stDRes, bc);
+    host_strided_batch_vector<rocblas_int> hInfo(1, 1, 1, bc);
+    host_strided_batch_vector<rocblas_int> hInfoRes(1, 1, 1, bc);
+    // device
+    device_strided_batch_vector<S> dD(size_D, 1, stD, bc);
+    device_strided_batch_vector<S> dE(size_E, 1, stE, bc);
+    device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, bc);
+    if(size_D)
+        CHECK_HIP_ERROR(dD.memcheck());
+    if(size_E)
+        CHECK_HIP_ERROR(dE.memcheck());
+    CHECK_HIP_ERROR(dInfo.memcheck());
+
     if(BATCHED)
     {
         // memory allocations
         host_batch_vector<T> hA(size_A, 1, bc);
         host_batch_vector<T> hARes(size_ARes, 1, bc);
         host_batch_vector<T> hB(size_B, 1, bc);
-        host_strided_batch_vector<S> hD(size_D, 1, stD, bc);
-        host_strided_batch_vector<S> hDRes(size_DRes, 1, stDRes, bc);
-        host_strided_batch_vector<rocblas_int> hInfo(1, 1, 1, bc);
-        host_strided_batch_vector<rocblas_int> hInfoRes(1, 1, 1, bc);
         device_batch_vector<T> dA(size_A, 1, bc);
         device_batch_vector<T> dB(size_B, 1, bc);
-        device_strided_batch_vector<S> dD(size_D, 1, stD, bc);
-        device_strided_batch_vector<S> dE(size_E, 1, stE, bc);
-        device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, bc);
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
         if(size_B)
             CHECK_HIP_ERROR(dB.memcheck());
-        if(size_D)
-            CHECK_HIP_ERROR(dD.memcheck());
-        if(size_E)
-            CHECK_HIP_ERROR(dE.memcheck());
-        CHECK_HIP_ERROR(dInfo.memcheck());
 
         // check quick return
         if(n == 0 || bc == 0)
@@ -637,24 +637,12 @@ void testing_sygv_hegv(Arguments& argus)
         host_strided_batch_vector<T> hA(size_A, 1, stA, bc);
         host_strided_batch_vector<T> hARes(size_ARes, 1, stARes, bc);
         host_strided_batch_vector<T> hB(size_B, 1, stB, bc);
-        host_strided_batch_vector<S> hD(size_D, 1, stD, bc);
-        host_strided_batch_vector<S> hDRes(size_DRes, 1, stDRes, bc);
-        host_strided_batch_vector<rocblas_int> hInfo(1, 1, 1, bc);
-        host_strided_batch_vector<rocblas_int> hInfoRes(1, 1, 1, bc);
         device_strided_batch_vector<T> dA(size_A, 1, stA, bc);
         device_strided_batch_vector<T> dB(size_B, 1, stB, bc);
-        device_strided_batch_vector<S> dD(size_D, 1, stD, bc);
-        device_strided_batch_vector<S> dE(size_E, 1, stE, bc);
-        device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, bc);
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
         if(size_B)
             CHECK_HIP_ERROR(dB.memcheck());
-        if(size_D)
-            CHECK_HIP_ERROR(dD.memcheck());
-        if(size_E)
-            CHECK_HIP_ERROR(dE.memcheck());
-        CHECK_HIP_ERROR(dInfo.memcheck());
 
         // check quick return
         if(n == 0 || bc == 0)

--- a/clients/include/testing_sygvd_hegvd.hpp
+++ b/clients/include/testing_sygvd_hegvd.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -46,8 +46,9 @@ void sygvd_hegvd_checkBadArgs(const rocblas_handle handle,
                                                 uplo, n, dA, lda, stA, dB, ldb, stB, dD, stD, dE,
                                                 stE, dInfo, bc),
                           rocblas_status_invalid_value);
-    EXPECT_ROCBLAS_STATUS(rocsolver_sygvd_hegvd(STRIDED, handle, itype, evect, rocblas_fill(-1), n, dA,
-                                                lda, stA, dB, ldb, stB, dD, stD, dE, stE, dInfo, bc),
+    EXPECT_ROCBLAS_STATUS(rocsolver_sygvd_hegvd(STRIDED, handle, itype, evect, rocblas_fill_full, n,
+                                                dA, lda, stA, dB, ldb, stB, dD, stD, dE, stE, dInfo,
+                                                bc),
                           rocblas_status_invalid_value);
 
     // sizes (only check batch_count if applicable)
@@ -323,28 +324,24 @@ void sygvd_hegvd_getError(const rocblas_handle handle,
 
     double err;
 
-    if(evect == rocblas_evect_none)
+    for(rocblas_int b = 0; b < bc; ++b)
     {
-        // only eigenvalues needed; can compare with LAPACK
-
-        // error is ||hD - hDRes|| / ||hD||
-        // using frobenius norm
-        for(rocblas_int b = 0; b < bc; ++b)
+        if(evect == rocblas_evect_none)
         {
+            // only eigenvalues needed; can compare with LAPACK
+
+            // error is ||hD - hDRes|| / ||hD||
+            // using frobenius norm
             if(hInfoRes[b][0] == 0)
             {
                 err = norm_error('F', 1, n, 1, hD[b], hDRes[b]);
                 *max_err = err > *max_err ? err : *max_err;
             }
         }
-    }
-    else
-    {
-        // both eigenvalues and eigenvectors needed; need to implicitly test
-        // eigenvectors due to non-uniqueness of eigenvectors under scaling
-
-        for(rocblas_int b = 0; b < bc; ++b)
+        else
         {
+            // both eigenvalues and eigenvectors needed; need to implicitly test
+            // eigenvectors due to non-uniqueness of eigenvectors under scaling
             if(hInfoRes[b][0] == 0)
             {
                 T alpha = 1;
@@ -605,30 +602,34 @@ void testing_sygvd_hegvd(Arguments& argus)
         CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
     }
 
+    // memory allocations (all cases)
+    // host
+    host_strided_batch_vector<S> hD(size_D, 1, stD, bc);
+    host_strided_batch_vector<S> hDRes(size_DRes, 1, stDRes, bc);
+    host_strided_batch_vector<rocblas_int> hInfo(1, 1, 1, bc);
+    host_strided_batch_vector<rocblas_int> hInfoRes(1, 1, 1, bc);
+    // device
+    device_strided_batch_vector<S> dD(size_D, 1, stD, bc);
+    device_strided_batch_vector<S> dE(size_E, 1, stE, bc);
+    device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, bc);
+    if(size_D)
+        CHECK_HIP_ERROR(dD.memcheck());
+    if(size_E)
+        CHECK_HIP_ERROR(dE.memcheck());
+    CHECK_HIP_ERROR(dInfo.memcheck());
+
     if(BATCHED)
     {
         // memory allocations
         host_batch_vector<T> hA(size_A, 1, bc);
         host_batch_vector<T> hARes(size_ARes, 1, bc);
         host_batch_vector<T> hB(size_B, 1, bc);
-        host_strided_batch_vector<S> hD(size_D, 1, stD, bc);
-        host_strided_batch_vector<S> hDRes(size_DRes, 1, stDRes, bc);
-        host_strided_batch_vector<rocblas_int> hInfo(1, 1, 1, bc);
-        host_strided_batch_vector<rocblas_int> hInfoRes(1, 1, 1, bc);
         device_batch_vector<T> dA(size_A, 1, bc);
         device_batch_vector<T> dB(size_B, 1, bc);
-        device_strided_batch_vector<S> dD(size_D, 1, stD, bc);
-        device_strided_batch_vector<S> dE(size_E, 1, stE, bc);
-        device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, bc);
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
         if(size_B)
             CHECK_HIP_ERROR(dB.memcheck());
-        if(size_D)
-            CHECK_HIP_ERROR(dD.memcheck());
-        if(size_E)
-            CHECK_HIP_ERROR(dE.memcheck());
-        CHECK_HIP_ERROR(dInfo.memcheck());
 
         // check quick return
         if(n == 0 || bc == 0)
@@ -664,24 +665,12 @@ void testing_sygvd_hegvd(Arguments& argus)
         host_strided_batch_vector<T> hA(size_A, 1, stA, bc);
         host_strided_batch_vector<T> hARes(size_ARes, 1, stARes, bc);
         host_strided_batch_vector<T> hB(size_B, 1, stB, bc);
-        host_strided_batch_vector<S> hD(size_D, 1, stD, bc);
-        host_strided_batch_vector<S> hDRes(size_DRes, 1, stDRes, bc);
-        host_strided_batch_vector<rocblas_int> hInfo(1, 1, 1, bc);
-        host_strided_batch_vector<rocblas_int> hInfoRes(1, 1, 1, bc);
         device_strided_batch_vector<T> dA(size_A, 1, stA, bc);
         device_strided_batch_vector<T> dB(size_B, 1, stB, bc);
-        device_strided_batch_vector<S> dD(size_D, 1, stD, bc);
-        device_strided_batch_vector<S> dE(size_E, 1, stE, bc);
-        device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, bc);
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
         if(size_B)
             CHECK_HIP_ERROR(dB.memcheck());
-        if(size_D)
-            CHECK_HIP_ERROR(dD.memcheck());
-        if(size_E)
-            CHECK_HIP_ERROR(dE.memcheck());
-        CHECK_HIP_ERROR(dInfo.memcheck());
 
         // check quick return
         if(n == 0 || bc == 0)

--- a/library/include/rocsolver-functions.h
+++ b/library/include/rocsolver-functions.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #ifndef _ROCLAPACK_FUNCTIONS_H
@@ -14884,57 +14884,57 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zheevd_strided_batched(rocblas_handle 
     \f]
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    itype     #rocblas_eform.\n
-              Specifies the form of the generalized eigenproblem.
+    itype       #rocblas_eform.\n
+                Specifies the form of the generalized eigenproblem.
     @param[in]
-    evect     #rocblas_evect.\n
-              Specifies whether the eigenvectors are to be computed.
-              If evect is rocblas_evect_original, then the eigenvectors are computed.
-              rocblas_evect_tridiagonal is not supported.
+    evect       #rocblas_evect.\n
+                Specifies whether the eigenvectors are to be computed.
+                If evect is rocblas_evect_original, then the eigenvectors are computed.
+                rocblas_evect_tridiagonal is not supported.
     @param[in]
-    uplo      rocblas_fill.\n
-              Specifies whether the upper or lower parts of the matrices
-              A and B are stored. If uplo indicates lower (or upper),
-              then the upper (or lower) parts of A and B are not used.
+    uplo        rocblas_fill.\n
+                Specifies whether the upper or lower parts of the matrices
+                A and B are stored. If uplo indicates lower (or upper),
+                then the upper (or lower) parts of A and B are not used.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The matrix dimensions.
+    n           rocblas_int. n >= 0.\n
+                The matrix dimensions.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the symmetric matrix A. On exit, if evect is original,
-              the normalized matrix Z of eigenvectors. If evect is none, then the upper or lower triangular
-              part of the matrix A (including the diagonal) is destroyed,
-              depending on the value of uplo.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the symmetric matrix A. On exit, if evect is original,
+                the normalized matrix Z of eigenvectors. If evect is none, then the upper or lower triangular
+                part of the matrix A (including the diagonal) is destroyed,
+                depending on the value of uplo.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              Specifies the leading dimension of A.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of A.
     @param[out]
-    B         pointer to type. Array on the GPU of dimension ldb*n.\n
-              On entry, the symmetric positive definite matrix B. On exit, the
-              triangular factor of B as returned by \ref rocsolver_spotrf "POTRF".
+    B           pointer to type. Array on the GPU of dimension ldb*n.\n
+                On entry, the symmetric positive definite matrix B. On exit, the
+                triangular factor of B as returned by \ref rocsolver_spotrf "POTRF".
     @param[in]
-    ldb       rocblas_int. ldb >= n.\n
-              Specifies the leading dimension of B.
+    ldb         rocblas_int. ldb >= n.\n
+                Specifies the leading dimension of B.
     @param[out]
-    D         pointer to type. Array on the GPU of dimension n.\n
-              On exit, the eigenvalues in increasing order.
+    D           pointer to type. Array on the GPU of dimension n.\n
+                On exit, the eigenvalues in increasing order.
     @param[out]
-    E         pointer to type. Array on the GPU of dimension n.\n
-              This array is used to work internally with the tridiagonal matrix T associated with
-              the reduced eigenvalue problem.
-              On exit, if 0 < info <= n, it contains the unconverged off-diagonal elements of T
-              (or properly speaking, a tridiagonal matrix equivalent to T). The diagonal elements
-              of this matrix are in D; those that converged correspond to a subset of the
-              eigenvalues (not necessarily ordered).
+    E           pointer to type. Array on the GPU of dimension n.\n
+                This array is used to work internally with the tridiagonal matrix T associated with
+                the reduced eigenvalue problem.
+                On exit, if 0 < info <= n, it contains the unconverged off-diagonal elements of T
+                (or properly speaking, a tridiagonal matrix equivalent to T). The diagonal elements
+                of this matrix are in D; those that converged correspond to a subset of the
+                eigenvalues (not necessarily ordered).
     @param[out]
-    info      pointer to a rocblas_int on the GPU.\n
-              If info = 0, successful exit.
-              If info = j <= n, j off-diagonal elements of an intermediate
-              tridiagonal form did not converge to zero.
-              If info = n + j, the leading minor of order j of B is not
-              positive definite.
+    info        pointer to a rocblas_int on the GPU.\n
+                If info = 0, successful exit.
+                If info = i <= n, i off-diagonal elements of an intermediate
+                tridiagonal form did not converge to zero.
+                If info = n + i, the leading minor of order i of B is not
+                positive definite.
 
     ********************************************************************/
 
@@ -14993,57 +14993,57 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_dsygv(rocblas_handle handle,
     \f]
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    itype     #rocblas_eform.\n
-              Specifies the form of the generalized eigenproblem.
+    itype       #rocblas_eform.\n
+                Specifies the form of the generalized eigenproblem.
     @param[in]
-    evect     #rocblas_evect.\n
-              Specifies whether the eigenvectors are to be computed.
-              If evect is rocblas_evect_original, then the eigenvectors are computed.
-              rocblas_evect_tridiagonal is not supported.
+    evect       #rocblas_evect.\n
+                Specifies whether the eigenvectors are to be computed.
+                If evect is rocblas_evect_original, then the eigenvectors are computed.
+                rocblas_evect_tridiagonal is not supported.
     @param[in]
-    uplo      rocblas_fill.\n
-              Specifies whether the upper or lower parts of the matrices
-              A and B are stored. If uplo indicates lower (or upper),
-              then the upper (or lower) parts of A and B are not used.
+    uplo        rocblas_fill.\n
+                Specifies whether the upper or lower parts of the matrices
+                A and B are stored. If uplo indicates lower (or upper),
+                then the upper (or lower) parts of A and B are not used.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The matrix dimensions.
+    n           rocblas_int. n >= 0.\n
+                The matrix dimensions.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the hermitian matrix A. On exit, if evect is original,
-              the normalized matrix Z of eigenvectors. If evect is none, then the upper or lower triangular
-              part of the matrix A (including the diagonal) is destroyed,
-              depending on the value of uplo.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the hermitian matrix A. On exit, if evect is original,
+                the normalized matrix Z of eigenvectors. If evect is none, then the upper or lower triangular
+                part of the matrix A (including the diagonal) is destroyed,
+                depending on the value of uplo.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              Specifies the leading dimension of A.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of A.
     @param[out]
-    B         pointer to type. Array on the GPU of dimension ldb*n.\n
-              On entry, the hermitian positive definite matrix B. On exit, the
-              triangular factor of B as returned by \ref rocsolver_spotrf "POTRF".
+    B           pointer to type. Array on the GPU of dimension ldb*n.\n
+                On entry, the hermitian positive definite matrix B. On exit, the
+                triangular factor of B as returned by \ref rocsolver_spotrf "POTRF".
     @param[in]
-    ldb       rocblas_int. ldb >= n.\n
-              Specifies the leading dimension of B.
+    ldb         rocblas_int. ldb >= n.\n
+                Specifies the leading dimension of B.
     @param[out]
-    D         pointer to real type. Array on the GPU of dimension n.\n
-              On exit, the eigenvalues in increasing order.
+    D           pointer to real type. Array on the GPU of dimension n.\n
+                On exit, the eigenvalues in increasing order.
     @param[out]
-    E         pointer to real type. Array on the GPU of dimension n.\n
-              This array is used to work internally with the tridiagonal matrix T associated with
-              the reduced eigenvalue problem.
-              On exit, if 0 < info <= n, it contains the unconverged off-diagonal elements of T
-              (or properly speaking, a tridiagonal matrix equivalent to T). The diagonal elements
-              of this matrix are in D; those that converged correspond to a subset of the
-              eigenvalues (not necessarily ordered).
+    E           pointer to real type. Array on the GPU of dimension n.\n
+                This array is used to work internally with the tridiagonal matrix T associated with
+                the reduced eigenvalue problem.
+                On exit, if 0 < info <= n, it contains the unconverged off-diagonal elements of T
+                (or properly speaking, a tridiagonal matrix equivalent to T). The diagonal elements
+                of this matrix are in D; those that converged correspond to a subset of the
+                eigenvalues (not necessarily ordered).
     @param[out]
-    info      pointer to a rocblas_int on the GPU.\n
-              If info = 0, successful exit.
-              If info = j <= n, j off-diagonal elements of an intermediate
-              tridiagonal form did not converge to zero.
-              If info = n + j, the leading minor of order j of B is not
-              positive definite.
+    info        pointer to a rocblas_int on the GPU.\n
+                If info = 0, successful exit.
+                If info = i <= n, i off-diagonal elements of an intermediate
+                tridiagonal form did not converge to zero.
+                If info = n + i, the leading minor of order i of B is not
+                positive definite.
 
     ********************************************************************/
 
@@ -15083,84 +15083,84 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zhegv(rocblas_handle handle,
 
     \f[
         \begin{array}{cl}
-        A_i X_i = \lambda B_i X_i & \: \text{1st form,}\\
-        A_i B_i X_i = \lambda X_i & \: \text{2nd form, or}\\
-        B_i A_i X_i = \lambda X_i & \: \text{3rd form,}
+        A_j X_j = \lambda B_j X_j & \: \text{1st form,}\\
+        A_j B_j X_j = \lambda X_j & \: \text{2nd form, or}\\
+        B_j A_j X_j = \lambda X_j & \: \text{3rd form,}
         \end{array}
     \f]
 
     depending on the value of itype. The eigenvectors are computed depending on the
     value of evect.
 
-    When computed, the matrix \f$Z_i\f$ of eigenvectors is normalized as follows:
+    When computed, the matrix \f$Z_j\f$ of eigenvectors is normalized as follows:
 
     \f[
         \begin{array}{cl}
-        Z_i^T B_i Z_i=I & \: \text{if 1st or 2nd form, or}\\
-        Z_i^T B_i^{-1} Z_i=I & \: \text{if 3rd form.}
+        Z_j^T B_j Z_j=I & \: \text{if 1st or 2nd form, or}\\
+        Z_j^T B_j^{-1} Z_j=I & \: \text{if 3rd form.}
         \end{array}
     \f]
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    itype     #rocblas_eform.\n
-              Specifies the form of the generalized eigenproblems.
+    itype       #rocblas_eform.\n
+                Specifies the form of the generalized eigenproblems.
     @param[in]
-    evect     #rocblas_evect.\n
-              Specifies whether the eigenvectors are to be computed.
-              If evect is rocblas_evect_original, then the eigenvectors are computed.
-              rocblas_evect_tridiagonal is not supported.
+    evect       #rocblas_evect.\n
+                Specifies whether the eigenvectors are to be computed.
+                If evect is rocblas_evect_original, then the eigenvectors are computed.
+                rocblas_evect_tridiagonal is not supported.
     @param[in]
-    uplo      rocblas_fill.\n
-              Specifies whether the upper or lower parts of the matrices
-              A_i and B_i are stored. If uplo indicates lower (or upper),
-              then the upper (or lower) parts of A_i and B_i are not used.
+    uplo        rocblas_fill.\n
+                Specifies whether the upper or lower parts of the matrices
+                A_j and B_j are stored. If uplo indicates lower (or upper),
+                then the upper (or lower) parts of A_j and B_j are not used.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The matrix dimensions.
+    n           rocblas_int. n >= 0.\n
+                The matrix dimensions.
     @param[inout]
-    A         array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
-              On entry, the symmetric matrices A_i. On exit, if evect is original,
-              the normalized matrix Z_i of eigenvectors. If evect is none, then the upper or lower triangular
-              part of the matrices A_i (including the diagonal) are destroyed,
-              depending on the value of uplo.
+    A           array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+                On entry, the symmetric matrices A_j. On exit, if evect is original,
+                the normalized matrix Z_j of eigenvectors. If evect is none, then the upper or lower triangular
+                part of the matrices A_j (including the diagonal) are destroyed,
+                depending on the value of uplo.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              Specifies the leading dimension of A_i.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of A_j.
     @param[out]
-    B         array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.\n
-              On entry, the symmetric positive definite matrices B_i. On exit, the
-              triangular factor of B_i as returned by \ref rocsolver_spotrf_batched "POTRF_BATCHED".
+    B           array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.\n
+                On entry, the symmetric positive definite matrices B_j. On exit, the
+                triangular factor of B_j as returned by \ref rocsolver_spotrf_batched "POTRF_BATCHED".
     @param[in]
-    ldb       rocblas_int. ldb >= n.\n
-              Specifies the leading dimension of B_i.
+    ldb         rocblas_int. ldb >= n.\n
+                Specifies the leading dimension of B_j.
     @param[out]
-    D         pointer to type. Array on the GPU (the size depends on the value of strideD).\n
-              On exit, the eigenvalues in increasing order.
+    D           pointer to type. Array on the GPU (the size depends on the value of strideD).\n
+                On exit, the eigenvalues in increasing order.
     @param[in]
-    strideD   rocblas_stride.\n
-              Stride from the start of one vector D_i to the next one D_(i+1).
-              There is no restriction for the value of strideD. Normal use is strideD >= n.
+    strideD     rocblas_stride.\n
+                Stride from the start of one vector D_j to the next one D_(j+1).
+                There is no restriction for the value of strideD. Normal use is strideD >= n.
     @param[out]
-    E         pointer to type. Array on the GPU (the size depends on the value of strideE).\n
-              This array is used to work internally with the tridiagonal matrix T_i associated with
-              the ith reduced eigenvalue problem.
-              On exit, if 0 < info[i] <= n, E_i contains the unconverged off-diagonal elements of T_i
-              (or properly speaking, a tridiagonal matrix equivalent to T_i). The diagonal elements
-              of this matrix are in D_i; those that converged correspond to a subset of the
-              eigenvalues (not necessarily ordered).
+    E           pointer to type. Array on the GPU (the size depends on the value of strideE).\n
+                This array is used to work internally with the tridiagonal matrix T_j associated with
+                the jth reduced eigenvalue problem.
+                On exit, if 0 < info[j] <= n, E_j contains the unconverged off-diagonal elements of T_j
+                (or properly speaking, a tridiagonal matrix equivalent to T_j). The diagonal elements
+                of this matrix are in D_j; those that converged correspond to a subset of the
+                eigenvalues (not necessarily ordered).
     @param[in]
-    strideE   rocblas_stride.\n
-              Stride from the start of one vector E_i to the next one E_(i+1).
-              There is no restriction for the value of strideE. Normal use is strideE >= n.
+    strideE     rocblas_stride.\n
+                Stride from the start of one vector E_j to the next one E_(j+1).
+                There is no restriction for the value of strideE. Normal use is strideE >= n.
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[i] = 0, successful exit of batch instance i.
-              If info[i] = j <= n, j off-diagonal elements of an intermediate
-              tridiagonal form did not converge to zero.
-              If info[i] = n + j, the leading minor of order j of B_i is not
-              positive definite.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful exit of batch instance j.
+                If info[j] = i <= n, i off-diagonal elements of an intermediate
+                tridiagonal form did not converge to zero.
+                If info[j] = n + i, the leading minor of order i of B_j is not
+                positive definite.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.
@@ -15209,84 +15209,84 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_dsygv_batched(rocblas_handle handle,
 
     \f[
         \begin{array}{cl}
-        A_i X_i = \lambda B_i X_i & \: \text{1st form,}\\
-        A_i B_i X_i = \lambda X_i & \: \text{2nd form, or}\\
-        B_i A_i X_i = \lambda X_i & \: \text{3rd form,}
+        A_j X_j = \lambda B_j X_j & \: \text{1st form,}\\
+        A_j B_j X_j = \lambda X_j & \: \text{2nd form, or}\\
+        B_j A_j X_j = \lambda X_j & \: \text{3rd form,}
         \end{array}
     \f]
 
     depending on the value of itype. The eigenvectors are computed depending on the
     value of evect.
 
-    When computed, the matrix \f$Z_i\f$ of eigenvectors is normalized as follows:
+    When computed, the matrix \f$Z_j\f$ of eigenvectors is normalized as follows:
 
     \f[
         \begin{array}{cl}
-        Z_i^H B_i Z_i=I & \: \text{if 1st or 2nd form, or}\\
-        Z_i^H B_i^{-1} Z_i=I & \: \text{if 3rd form.}
+        Z_j^H B_j Z_j=I & \: \text{if 1st or 2nd form, or}\\
+        Z_j^H B_j^{-1} Z_j=I & \: \text{if 3rd form.}
         \end{array}
     \f]
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    itype     #rocblas_eform.\n
-              Specifies the form of the generalized eigenproblems.
+    itype       #rocblas_eform.\n
+                Specifies the form of the generalized eigenproblems.
     @param[in]
-    evect     #rocblas_evect.\n
-              Specifies whether the eigenvectors are to be computed.
-              If evect is rocblas_evect_original, then the eigenvectors are computed.
-              rocblas_evect_tridiagonal is not supported.
+    evect       #rocblas_evect.\n
+                Specifies whether the eigenvectors are to be computed.
+                If evect is rocblas_evect_original, then the eigenvectors are computed.
+                rocblas_evect_tridiagonal is not supported.
     @param[in]
-    uplo      rocblas_fill.\n
-              Specifies whether the upper or lower parts of the matrices
-              A_i and B_i are stored. If uplo indicates lower (or upper),
-              then the upper (or lower) parts of A_i and B_i are not used.
+    uplo        rocblas_fill.\n
+                Specifies whether the upper or lower parts of the matrices
+                A_j and B_j are stored. If uplo indicates lower (or upper),
+                then the upper (or lower) parts of A_j and B_j are not used.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The matrix dimensions.
+    n           rocblas_int. n >= 0.\n
+                The matrix dimensions.
     @param[inout]
-    A         array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
-              On entry, the hermitian matrices A_i. On exit, if evect is original,
-              the normalized matrix Z_i of eigenvectors. If evect is none, then the upper or lower triangular
-              part of the matrices A_i (including the diagonal) are destroyed,
-              depending on the value of uplo.
+    A           array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+                On entry, the hermitian matrices A_j. On exit, if evect is original,
+                the normalized matrix Z_j of eigenvectors. If evect is none, then the upper or lower triangular
+                part of the matrices A_j (including the diagonal) are destroyed,
+                depending on the value of uplo.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              Specifies the leading dimension of A_i.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of A_j.
     @param[out]
-    B         array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.\n
-              On entry, the hermitian positive definite matrices B_i. On exit, the
-              triangular factor of B_i as returned by \ref rocsolver_spotrf_batched "POTRF_BATCHED".
+    B           array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.\n
+                On entry, the hermitian positive definite matrices B_j. On exit, the
+                triangular factor of B_j as returned by \ref rocsolver_spotrf_batched "POTRF_BATCHED".
     @param[in]
-    ldb       rocblas_int. ldb >= n.\n
-              Specifies the leading dimension of B_i.
+    ldb         rocblas_int. ldb >= n.\n
+                Specifies the leading dimension of B_j.
     @param[out]
-    D         pointer to real type. Array on the GPU (the size depends on the value of strideD).\n
-              On exit, the eigenvalues in increasing order.
+    D           pointer to real type. Array on the GPU (the size depends on the value of strideD).\n
+                On exit, the eigenvalues in increasing order.
     @param[in]
-    strideD   rocblas_stride.\n
-              Stride from the start of one vector D_i to the next one D_(i+1).
-              There is no restriction for the value of strideD. Normal use is strideD >= n.
+    strideD     rocblas_stride.\n
+                Stride from the start of one vector D_j to the next one D_(j+1).
+                There is no restriction for the value of strideD. Normal use is strideD >= n.
     @param[out]
-    E         pointer to real type. Array on the GPU (the size depends on the value of strideE).\n
-              This array is used to work internally with the tridiagonal matrix T_i associated with
-              the ith reduced eigenvalue problem.
-              On exit, if 0 < info[i] <= n, it contains the unconverged off-diagonal elements of T_i
-              (or properly speaking, a tridiagonal matrix equivalent to T_i). The diagonal elements
-              of this matrix are in D_i; those that converged correspond to a subset of the
-              eigenvalues (not necessarily ordered).
+    E           pointer to real type. Array on the GPU (the size depends on the value of strideE).\n
+                This array is used to work internally with the tridiagonal matrix T_j associated with
+                the jth reduced eigenvalue problem.
+                On exit, if 0 < info[j] <= n, it contains the unconverged off-diagonal elements of T_j
+                (or properly speaking, a tridiagonal matrix equivalent to T_j). The diagonal elements
+                of this matrix are in D_j; those that converged correspond to a subset of the
+                eigenvalues (not necessarily ordered).
     @param[in]
-    strideE   rocblas_stride.\n
-              Stride from the start of one vector E_i to the next one E_(i+1).
-              There is no restriction for the value of strideE. Normal use is strideE >= n.
+    strideE     rocblas_stride.\n
+                Stride from the start of one vector E_j to the next one E_(j+1).
+                There is no restriction for the value of strideE. Normal use is strideE >= n.
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[i] = 0, successful exit of batch i.
-              If info[i] = j <= n, j off-diagonal elements of an intermediate
-              tridiagonal form did not converge to zero.
-              If info[i] = n + j, the leading minor of order j of B_i is not
-              positive definite.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful exit of batch j.
+                If info[j] = i <= n, i off-diagonal elements of an intermediate
+                tridiagonal form did not converge to zero.
+                If info[j] = n + i, the leading minor of order i of B_j is not
+                positive definite.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.
@@ -15335,92 +15335,92 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zhegv_batched(rocblas_handle handle,
 
     \f[
         \begin{array}{cl}
-        A_i X_i = \lambda B_i X_i & \: \text{1st form,}\\
-        A_i B_i X_i = \lambda X_i & \: \text{2nd form, or}\\
-        B_i A_i X_i = \lambda X_i & \: \text{3rd form,}
+        A_j X_j = \lambda B_j X_j & \: \text{1st form,}\\
+        A_j B_j X_j = \lambda X_j & \: \text{2nd form, or}\\
+        B_j A_j X_j = \lambda X_j & \: \text{3rd form,}
         \end{array}
     \f]
 
     depending on the value of itype. The eigenvectors are computed depending on the
     value of evect.
 
-    When computed, the matrix \f$Z_i\f$ of eigenvectors is normalized as follows:
+    When computed, the matrix \f$Z_j\f$ of eigenvectors is normalized as follows:
 
     \f[
         \begin{array}{cl}
-        Z_i^T B_i Z_i=I & \: \text{if 1st or 2nd form, or}\\
-        Z_i^T B_i^{-1} Z_i=I & \: \text{if 3rd form.}
+        Z_j^T B_j Z_j=I & \: \text{if 1st or 2nd form, or}\\
+        Z_j^T B_j^{-1} Z_j=I & \: \text{if 3rd form.}
         \end{array}
     \f]
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    itype     #rocblas_eform.\n
-              Specifies the form of the generalized eigenproblems.
+    itype       #rocblas_eform.\n
+                Specifies the form of the generalized eigenproblems.
     @param[in]
-    evect     #rocblas_evect.\n
-              Specifies whether the eigenvectors are to be computed.
-              If evect is rocblas_evect_original, then the eigenvectors are computed.
-              rocblas_evect_tridiagonal is not supported.
+    evect       #rocblas_evect.\n
+                Specifies whether the eigenvectors are to be computed.
+                If evect is rocblas_evect_original, then the eigenvectors are computed.
+                rocblas_evect_tridiagonal is not supported.
     @param[in]
-    uplo      rocblas_fill.\n
-              Specifies whether the upper or lower parts of the matrices
-              A_i and B_i are stored. If uplo indicates lower (or upper),
-              then the upper (or lower) parts of A_i and B_i are not used.
+    uplo        rocblas_fill.\n
+                Specifies whether the upper or lower parts of the matrices
+                A_j and B_j are stored. If uplo indicates lower (or upper),
+                then the upper (or lower) parts of A_j and B_j are not used.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The matrix dimensions.
+    n           rocblas_int. n >= 0.\n
+                The matrix dimensions.
     @param[inout]
-    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
-              On entry, the symmetric matrices A_i. On exit, if evect is original,
-              the normalized matrix Z_i of eigenvectors. If evect is none, then the upper or lower triangular
-              part of the matrices A_i (including the diagonal) are destroyed,
-              depending on the value of uplo.
+    A           pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+                On entry, the symmetric matrices A_j. On exit, if evect is original,
+                the normalized matrix Z_j of eigenvectors. If evect is none, then the upper or lower triangular
+                part of the matrices A_j (including the diagonal) are destroyed,
+                depending on the value of uplo.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              Specifies the leading dimension of A_i.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of A_j.
     @param[in]
-    strideA   rocblas_stride.\n
-              Stride from the start of one matrix A_i to the next one A_(i+1).
-              There is no restriction for the value of strideA. Normal use is strideA >= lda*n.
+    strideA     rocblas_stride.\n
+                Stride from the start of one matrix A_j to the next one A_(j+1).
+                There is no restriction for the value of strideA. Normal use is strideA >= lda*n.
     @param[out]
-    B         pointer to type. Array on the GPU (the size depends on the value of strideB).\n
-              On entry, the symmetric positive definite matrices B_i. On exit, the
-              triangular factor of B_i as returned by \ref rocsolver_spotrf_strided_batched "POTRF_STRIDED_BATCHED".
+    B           pointer to type. Array on the GPU (the size depends on the value of strideB).\n
+                On entry, the symmetric positive definite matrices B_j. On exit, the
+                triangular factor of B_j as returned by \ref rocsolver_spotrf_strided_batched "POTRF_STRIDED_BATCHED".
     @param[in]
-    ldb       rocblas_int. ldb >= n.\n
-              Specifies the leading dimension of B_i.
+    ldb         rocblas_int. ldb >= n.\n
+                Specifies the leading dimension of B_j.
     @param[in]
-    strideB   rocblas_stride.\n
-              Stride from the start of one matrix B_i to the next one B_(i+1).
-              There is no restriction for the value of strideB. Normal use is strideB >= ldb*n.
+    strideB     rocblas_stride.\n
+                Stride from the start of one matrix B_j to the next one B_(j+1).
+                There is no restriction for the value of strideB. Normal use is strideB >= ldb*n.
     @param[out]
-    D         pointer to type. Array on the GPU (the size depends on the value of strideD).\n
-              On exit, the eigenvalues in increasing order.
+    D           pointer to type. Array on the GPU (the size depends on the value of strideD).\n
+                On exit, the eigenvalues in increasing order.
     @param[in]
-    strideD   rocblas_stride.\n
-              Stride from the start of one vector D_i to the next one D_(i+1).
-              There is no restriction for the value of strideD. Normal use is strideD >= n.
+    strideD     rocblas_stride.\n
+                Stride from the start of one vector D_j to the next one D_(j+1).
+                There is no restriction for the value of strideD. Normal use is strideD >= n.
     @param[out]
-    E         pointer to type. Array on the GPU (the size depends on the value of strideE).\n
-              This array is used to work internally with the tridiagonal matrix T_i associated with
-              the ith reduced eigenvalue problem.
-              On exit, if 0 < info[i] <= n, it contains the unconverged off-diagonal elements of T_i
-              (or properly speaking, a tridiagonal matrix equivalent to T_i). The diagonal elements
-              of this matrix are in D_i; those that converged correspond to a subset of the
-              eigenvalues (not necessarily ordered).
+    E           pointer to type. Array on the GPU (the size depends on the value of strideE).\n
+                This array is used to work internally with the tridiagonal matrix T_j associated with
+                the jth reduced eigenvalue problem.
+                On exit, if 0 < info[j] <= n, it contains the unconverged off-diagonal elements of T_j
+                (or properly speaking, a tridiagonal matrix equivalent to T_j). The diagonal elements
+                of this matrix are in D_j; those that converged correspond to a subset of the
+                eigenvalues (not necessarily ordered).
     @param[in]
-    strideE   rocblas_stride.\n
-              Stride from the start of one vector E_i to the next one E_(i+1).
-              There is no restriction for the value of strideE. Normal use is strideE >= n.
+    strideE     rocblas_stride.\n
+                Stride from the start of one vector E_j to the next one E_(j+1).
+                There is no restriction for the value of strideE. Normal use is strideE >= n.
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[i] = 0, successful exit of batch i.
-              If info[i] = j <= n, j off-diagonal elements of an intermediate
-              tridiagonal form did not converge to zero.
-              If info[i] = n + j, the leading minor of order j of B_i is not
-              positive definite.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful exit of batch j.
+                If info[j] = i <= n, i off-diagonal elements of an intermediate
+                tridiagonal form did not converge to zero.
+                If info[j] = n + i, the leading minor of order i of B_j is not
+                positive definite.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.
@@ -15473,92 +15473,92 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_dsygv_strided_batched(rocblas_handle h
 
     \f[
         \begin{array}{cl}
-        A_i X_i = \lambda B_i X_i & \: \text{1st form,}\\
-        A_i B_i X_i = \lambda X_i & \: \text{2nd form, or}\\
-        B_i A_i X_i = \lambda X_i & \: \text{3rd form,}
+        A_j X_j = \lambda B_j X_j & \: \text{1st form,}\\
+        A_j B_j X_j = \lambda X_j & \: \text{2nd form, or}\\
+        B_j A_j X_j = \lambda X_j & \: \text{3rd form,}
         \end{array}
     \f]
 
     depending on the value of itype. The eigenvectors are computed depending on the
     value of evect.
 
-    When computed, the matrix \f$Z_i\f$ of eigenvectors is normalized as follows:
+    When computed, the matrix \f$Z_j\f$ of eigenvectors is normalized as follows:
 
     \f[
         \begin{array}{cl}
-        Z_i^H B_i Z_i=I & \: \text{if 1st or 2nd form, or}\\
-        Z_i^H B_i^{-1} Z_i=I & \: \text{if 3rd form.}
+        Z_j^H B_j Z_j=I & \: \text{if 1st or 2nd form, or}\\
+        Z_j^H B_j^{-1} Z_j=I & \: \text{if 3rd form.}
         \end{array}
     \f]
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    itype     #rocblas_eform.\n
-              Specifies the form of the generalized eigenproblems.
+    itype       #rocblas_eform.\n
+                Specifies the form of the generalized eigenproblems.
     @param[in]
-    evect     #rocblas_evect.\n
-              Specifies whether the eigenvectors are to be computed.
-              If evect is rocblas_evect_original, then the eigenvectors are computed.
-              rocblas_evect_tridiagonal is not supported.
+    evect       #rocblas_evect.\n
+                Specifies whether the eigenvectors are to be computed.
+                If evect is rocblas_evect_original, then the eigenvectors are computed.
+                rocblas_evect_tridiagonal is not supported.
     @param[in]
-    uplo      rocblas_fill.\n
-              Specifies whether the upper or lower parts of the matrices
-              A_i and B_i are stored. If uplo indicates lower (or upper),
-              then the upper (or lower) parts of A_i and B_i are not used.
+    uplo        rocblas_fill.\n
+                Specifies whether the upper or lower parts of the matrices
+                A_j and B_j are stored. If uplo indicates lower (or upper),
+                then the upper (or lower) parts of A_j and B_j are not used.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The matrix dimensions.
+    n           rocblas_int. n >= 0.\n
+                The matrix dimensions.
     @param[inout]
-    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
-              On entry, the hermitian matrices A_i. On exit, if evect is original,
-              the normalized matrix Z_i of eigenvectors. If evect is none, then the upper or lower triangular
-              part of the matrices A_i (including the diagonal) are destroyed,
-              depending on the value of uplo.
+    A           pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+                On entry, the hermitian matrices A_j. On exit, if evect is original,
+                the normalized matrix Z_j of eigenvectors. If evect is none, then the upper or lower triangular
+                part of the matrices A_j (including the diagonal) are destroyed,
+                depending on the value of uplo.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              Specifies the leading dimension of A_i.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of A_j.
     @param[in]
-    strideA   rocblas_stride.\n
-              Stride from the start of one matrix A_i to the next one A_(i+1).
-              There is no restriction for the value of strideA. Normal use is strideA >= lda*n.
+    strideA     rocblas_stride.\n
+                Stride from the start of one matrix A_j to the next one A_(j+1).
+                There is no restriction for the value of strideA. Normal use is strideA >= lda*n.
     @param[out]
-    B         pointer to type. Array on the GPU (the size depends on the value of strideB).\n
-              On entry, the hermitian positive definite matrices B_i. On exit, the
-              triangular factor of B_i as returned by \ref rocsolver_spotrf_strided_batched "POTRF_STRIDED_BATCHED".
+    B           pointer to type. Array on the GPU (the size depends on the value of strideB).\n
+                On entry, the hermitian positive definite matrices B_j. On exit, the
+                triangular factor of B_j as returned by \ref rocsolver_spotrf_strided_batched "POTRF_STRIDED_BATCHED".
     @param[in]
-    ldb       rocblas_int. ldb >= n.\n
-              Specifies the leading dimension of B_i.
+    ldb         rocblas_int. ldb >= n.\n
+                Specifies the leading dimension of B_j.
     @param[in]
-    strideB   rocblas_stride.\n
-              Stride from the start of one matrix B_i to the next one B_(i+1).
-              There is no restriction for the value of strideB. Normal use is strideB >= ldb*n.
+    strideB     rocblas_stride.\n
+                Stride from the start of one matrix B_j to the next one B_(j+1).
+                There is no restriction for the value of strideB. Normal use is strideB >= ldb*n.
     @param[out]
-    D         pointer to real type. Array on the GPU (the size depends on the value of strideD).\n
-              On exit, the eigenvalues in increasing order.
+    D           pointer to real type. Array on the GPU (the size depends on the value of strideD).\n
+                On exit, the eigenvalues in increasing order.
     @param[in]
-    strideD   rocblas_stride.\n
-              Stride from the start of one vector D_i to the next one D_(i+1).
-              There is no restriction for the value of strideD. Normal use is strideD >= n.
+    strideD     rocblas_stride.\n
+                Stride from the start of one vector D_j to the next one D_(j+1).
+                There is no restriction for the value of strideD. Normal use is strideD >= n.
     @param[out]
-    E         pointer to real type. Array on the GPU (the size depends on the value of strideE).\n
-              This array is used to work internally with the tridiagonal matrix T_i associated with
-              the ith reduced eigenvalue problem.
-              On exit, if 0 < info[i] <= n, it contains the unconverged off-diagonal elements of T_i
-              (or properly speaking, a tridiagonal matrix equivalent to T_i). The diagonal elements
-              of this matrix are in D_i; those that converged correspond to a subset of the
-              eigenvalues (not necessarily ordered).
+    E           pointer to real type. Array on the GPU (the size depends on the value of strideE).\n
+                This array is used to work internally with the tridiagonal matrix T_j associated with
+                the jth reduced eigenvalue problem.
+                On exit, if 0 < info[j] <= n, it contains the unconverged off-diagonal elements of T_j
+                (or properly speaking, a tridiagonal matrix equivalent to T_j). The diagonal elements
+                of this matrix are in D_j; those that converged correspond to a subset of the
+                eigenvalues (not necessarily ordered).
     @param[in]
-    strideE   rocblas_stride.\n
-              Stride from the start of one vector E_i to the next one E_(i+1).
-              There is no restriction for the value of strideE. Normal use is strideE >= n.
+    strideE     rocblas_stride.\n
+                Stride from the start of one vector E_j to the next one E_(j+1).
+                There is no restriction for the value of strideE. Normal use is strideE >= n.
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[i] = 0, successful exit of batch i.
-              If info[i] = j <= n, j off-diagonal elements of an intermediate
-              tridiagonal form did not converge to zero.
-              If info[i] = n + j, the leading minor of order j of B_i is not
-              positive definite.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful exit of batch j.
+                If info[j] = i <= n, i off-diagonal elements of an intermediate
+                tridiagonal form did not converge to zero.
+                If info[j] = n + i, the leading minor of order i of B_j is not
+                positive definite.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.
@@ -15630,59 +15630,59 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zhegv_strided_batched(rocblas_handle h
     \f]
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    itype     #rocblas_eform.\n
-              Specifies the form of the generalized eigenproblem.
+    itype       #rocblas_eform.\n
+                Specifies the form of the generalized eigenproblem.
     @param[in]
-    evect     #rocblas_evect.\n
-              Specifies whether the eigenvectors are to be computed.
-              If evect is rocblas_evect_original, then the eigenvectors are computed.
-              rocblas_evect_tridiagonal is not supported.
+    evect       #rocblas_evect.\n
+                Specifies whether the eigenvectors are to be computed.
+                If evect is rocblas_evect_original, then the eigenvectors are computed.
+                rocblas_evect_tridiagonal is not supported.
     @param[in]
-    uplo      rocblas_fill.\n
-              Specifies whether the upper or lower parts of the matrices
-              A and B are stored. If uplo indicates lower (or upper),
-              then the upper (or lower) parts of A and B are not used.
+    uplo        rocblas_fill.\n
+                Specifies whether the upper or lower parts of the matrices
+                A and B are stored. If uplo indicates lower (or upper),
+                then the upper (or lower) parts of A and B are not used.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The matrix dimensions.
+    n           rocblas_int. n >= 0.\n
+                The matrix dimensions.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the symmetric matrix A. On exit, if evect is original,
-              the normalized matrix Z of eigenvectors. If evect is none, then the upper or lower triangular
-              part of the matrix A (including the diagonal) is destroyed,
-              depending on the value of uplo.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the symmetric matrix A. On exit, if evect is original,
+                the normalized matrix Z of eigenvectors. If evect is none, then the upper or lower triangular
+                part of the matrix A (including the diagonal) is destroyed,
+                depending on the value of uplo.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              Specifies the leading dimension of A.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of A.
     @param[out]
-    B         pointer to type. Array on the GPU of dimension ldb*n.\n
-              On entry, the symmetric positive definite matrix B. On exit, the
-              triangular factor of B as returned by \ref rocsolver_spotrf "POTRF".
+    B           pointer to type. Array on the GPU of dimension ldb*n.\n
+                On entry, the symmetric positive definite matrix B. On exit, the
+                triangular factor of B as returned by \ref rocsolver_spotrf "POTRF".
     @param[in]
-    ldb       rocblas_int. ldb >= n.\n
-              Specifies the leading dimension of B.
+    ldb         rocblas_int. ldb >= n.\n
+                Specifies the leading dimension of B.
     @param[out]
-    D         pointer to type. Array on the GPU of dimension n.\n
-              On exit, the eigenvalues in increasing order.
+    D           pointer to type. Array on the GPU of dimension n.\n
+                On exit, the eigenvalues in increasing order.
     @param[out]
-    E         pointer to type. Array on the GPU of dimension n.\n
-              This array is used to work internally with the tridiagonal matrix T associated with
-              the reduced eigenvalue problem.
-              On exit, if 0 < info <= n, it contains the unconverged off-diagonal elements of T
-              (or properly speaking, a tridiagonal matrix equivalent to T). The diagonal elements
-              of this matrix are in D; those that converged correspond to a subset of the
-              eigenvalues (not necessarily ordered).
+    E           pointer to type. Array on the GPU of dimension n.\n
+                This array is used to work internally with the tridiagonal matrix T associated with
+                the reduced eigenvalue problem.
+                On exit, if 0 < info <= n, it contains the unconverged off-diagonal elements of T
+                (or properly speaking, a tridiagonal matrix equivalent to T). The diagonal elements
+                of this matrix are in D; those that converged correspond to a subset of the
+                eigenvalues (not necessarily ordered).
     @param[out]
-    info      pointer to a rocblas_int on the GPU.\n
-              If info = 0, successful exit.
-              If info = j <= n and evect is rocblas_evect_none, j off-diagonal elements of an
-              intermediate tridiagonal form did not converge to zero.
-              If info = j <= n and evect is rocblas_evect_original, the algorithm failed to
-              compute an eigenvalue in the submatrix from [j/(n+1), j/(n+1)] to [j%(n+1), j%(n+1)].
-              If info = n + j, the leading minor of order j of B is not
-              positive definite.
+    info        pointer to a rocblas_int on the GPU.\n
+                If info = 0, successful exit.
+                If info = i <= n and evect is rocblas_evect_none, i off-diagonal elements of an
+                intermediate tridiagonal form did not converge to zero.
+                If info = i <= n and evect is rocblas_evect_original, the algorithm failed to
+                compute an eigenvalue in the submatrix from [i/(n+1), i/(n+1)] to [i%(n+1), i%(n+1)].
+                If info = n + i, the leading minor of order i of B is not
+                positive definite.
 
     ********************************************************************/
 
@@ -15741,59 +15741,59 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_dsygvd(rocblas_handle handle,
     \f]
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    itype     #rocblas_eform.\n
-              Specifies the form of the generalized eigenproblem.
+    itype       #rocblas_eform.\n
+                Specifies the form of the generalized eigenproblem.
     @param[in]
-    evect     #rocblas_evect.\n
-              Specifies whether the eigenvectors are to be computed.
-              If evect is rocblas_evect_original, then the eigenvectors are computed.
-              rocblas_evect_tridiagonal is not supported.
+    evect       #rocblas_evect.\n
+                Specifies whether the eigenvectors are to be computed.
+                If evect is rocblas_evect_original, then the eigenvectors are computed.
+                rocblas_evect_tridiagonal is not supported.
     @param[in]
-    uplo      rocblas_fill.\n
-              Specifies whether the upper or lower parts of the matrices
-              A and B are stored. If uplo indicates lower (or upper),
-              then the upper (or lower) parts of A and B are not used.
+    uplo        rocblas_fill.\n
+                Specifies whether the upper or lower parts of the matrices
+                A and B are stored. If uplo indicates lower (or upper),
+                then the upper (or lower) parts of A and B are not used.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The matrix dimensions.
+    n           rocblas_int. n >= 0.\n
+                The matrix dimensions.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the hermitian matrix A. On exit, if evect is original,
-              the normalized matrix Z of eigenvectors. If evect is none, then the upper or lower triangular
-              part of the matrix A (including the diagonal) is destroyed,
-              depending on the value of uplo.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the hermitian matrix A. On exit, if evect is original,
+                the normalized matrix Z of eigenvectors. If evect is none, then the upper or lower triangular
+                part of the matrix A (including the diagonal) is destroyed,
+                depending on the value of uplo.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              Specifies the leading dimension of A.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of A.
     @param[out]
-    B         pointer to type. Array on the GPU of dimension ldb*n.\n
-              On entry, the hermitian positive definite matrix B. On exit, the
-              triangular factor of B as returned by \ref rocsolver_spotrf "POTRF".
+    B           pointer to type. Array on the GPU of dimension ldb*n.\n
+                On entry, the hermitian positive definite matrix B. On exit, the
+                triangular factor of B as returned by \ref rocsolver_spotrf "POTRF".
     @param[in]
-    ldb       rocblas_int. ldb >= n.\n
-              Specifies the leading dimension of B.
+    ldb         rocblas_int. ldb >= n.\n
+                Specifies the leading dimension of B.
     @param[out]
-    D         pointer to real type. Array on the GPU of dimension n.\n
-              On exit, the eigenvalues in increasing order.
+    D           pointer to real type. Array on the GPU of dimension n.\n
+                On exit, the eigenvalues in increasing order.
     @param[out]
-    E         pointer to real type. Array on the GPU of dimension n.\n
-              This array is used to work internally with the tridiagonal matrix T associated with
-              the reduced eigenvalue problem.
-              On exit, if 0 < info <= n, it contains the unconverged off-diagonal elements of T
-              (or properly speaking, a tridiagonal matrix equivalent to T). The diagonal elements
-              of this matrix are in D; those that converged correspond to a subset of the
-              eigenvalues (not necessarily ordered).
+    E           pointer to real type. Array on the GPU of dimension n.\n
+                This array is used to work internally with the tridiagonal matrix T associated with
+                the reduced eigenvalue problem.
+                On exit, if 0 < info <= n, it contains the unconverged off-diagonal elements of T
+                (or properly speaking, a tridiagonal matrix equivalent to T). The diagonal elements
+                of this matrix are in D; those that converged correspond to a subset of the
+                eigenvalues (not necessarily ordered).
     @param[out]
-    info      pointer to a rocblas_int on the GPU.\n
-              If info = 0, successful exit.
-              If info = j <= n and evect is rocblas_evect_none, j off-diagonal elements of an
-              intermediate tridiagonal form did not converge to zero.
-              If info = j <= n and evect is rocblas_evect_original, the algorithm failed to
-              compute an eigenvalue in the submatrix from [j/(n+1), j/(n+1)] to [j%(n+1), j%(n+1)].
-              If info = n + j, the leading minor of order j of B is not
-              positive definite.
+    info        pointer to a rocblas_int on the GPU.\n
+                If info = 0, successful exit.
+                If info = i <= n and evect is rocblas_evect_none, i off-diagonal elements of an
+                intermediate tridiagonal form did not converge to zero.
+                If info = i <= n and evect is rocblas_evect_original, the algorithm failed to
+                compute an eigenvalue in the submatrix from [i/(n+1), i/(n+1)] to [i%(n+1), i%(n+1)].
+                If info = n + i, the leading minor of order i of B is not
+                positive definite.
 
     ********************************************************************/
 
@@ -15833,86 +15833,86 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zhegvd(rocblas_handle handle,
 
     \f[
         \begin{array}{cl}
-        A_i X_i = \lambda B_i X_i & \: \text{1st form,}\\
-        A_i B_i X_i = \lambda X_i & \: \text{2nd form, or}\\
-        B_i A_i X_i = \lambda X_i & \: \text{3rd form,}
+        A_j X_j = \lambda B_j X_j & \: \text{1st form,}\\
+        A_j B_j X_j = \lambda X_j & \: \text{2nd form, or}\\
+        B_j A_j X_j = \lambda X_j & \: \text{3rd form,}
         \end{array}
     \f]
 
     depending on the value of itype. The eigenvectors are computed using a divide-and-conquer algorithm, depending on the
     value of evect.
 
-    When computed, the matrix \f$Z_i\f$ of eigenvectors is normalized as follows:
+    When computed, the matrix \f$Z_j\f$ of eigenvectors is normalized as follows:
 
     \f[
         \begin{array}{cl}
-        Z_i^T B_i Z_i=I & \: \text{if 1st or 2nd form, or}\\
-        Z_i^T B_i^{-1} Z_i=I & \: \text{if 3rd form.}
+        Z_j^T B_j Z_j=I & \: \text{if 1st or 2nd form, or}\\
+        Z_j^T B_j^{-1} Z_j=I & \: \text{if 3rd form.}
         \end{array}
     \f]
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    itype     #rocblas_eform.\n
-              Specifies the form of the generalized eigenproblems.
+    itype       #rocblas_eform.\n
+                Specifies the form of the generalized eigenproblems.
     @param[in]
-    evect     #rocblas_evect.\n
-              Specifies whether the eigenvectors are to be computed.
-              If evect is rocblas_evect_original, then the eigenvectors are computed.
-              rocblas_evect_tridiagonal is not supported.
+    evect       #rocblas_evect.\n
+                Specifies whether the eigenvectors are to be computed.
+                If evect is rocblas_evect_original, then the eigenvectors are computed.
+                rocblas_evect_tridiagonal is not supported.
     @param[in]
-    uplo      rocblas_fill.\n
-              Specifies whether the upper or lower parts of the matrices
-              A_i and B_i are stored. If uplo indicates lower (or upper),
-              then the upper (or lower) parts of A_i and B_i are not used.
+    uplo        rocblas_fill.\n
+                Specifies whether the upper or lower parts of the matrices
+                A_j and B_j are stored. If uplo indicates lower (or upper),
+                then the upper (or lower) parts of A_j and B_j are not used.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The matrix dimensions.
+    n           rocblas_int. n >= 0.\n
+                The matrix dimensions.
     @param[inout]
-    A         array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
-              On entry, the symmetric matrices A_i. On exit, if evect is original,
-              the normalized matrix Z_i of eigenvectors. If evect is none, then the upper or lower triangular
-              part of the matrices A_i (including the diagonal) are destroyed,
-              depending on the value of uplo.
+    A           array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+                On entry, the symmetric matrices A_j. On exit, if evect is original,
+                the normalized matrix Z_j of eigenvectors. If evect is none, then the upper or lower triangular
+                part of the matrices A_j (including the diagonal) are destroyed,
+                depending on the value of uplo.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              Specifies the leading dimension of A_i.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of A_j.
     @param[out]
-    B         array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.\n
-              On entry, the symmetric positive definite matrices B_i. On exit, the
-              triangular factor of B_i as returned by \ref rocsolver_spotrf_batched "POTRF_BATCHED".
+    B           array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.\n
+                On entry, the symmetric positive definite matrices B_j. On exit, the
+                triangular factor of B_j as returned by \ref rocsolver_spotrf_batched "POTRF_BATCHED".
     @param[in]
-    ldb       rocblas_int. ldb >= n.\n
-              Specifies the leading dimension of B_i.
+    ldb         rocblas_int. ldb >= n.\n
+                Specifies the leading dimension of B_j.
     @param[out]
-    D         pointer to type. Array on the GPU (the size depends on the value of strideD).\n
-              On exit, the eigenvalues in increasing order.
+    D           pointer to type. Array on the GPU (the size depends on the value of strideD).\n
+                On exit, the eigenvalues in increasing order.
     @param[in]
-    strideD   rocblas_stride.\n
-              Stride from the start of one vector D_i to the next one D_(i+1).
-              There is no restriction for the value of strideD. Normal use is strideD >= n.
+    strideD     rocblas_stride.\n
+                Stride from the start of one vector D_j to the next one D_(j+1).
+                There is no restriction for the value of strideD. Normal use is strideD >= n.
     @param[out]
-    E         pointer to type. Array on the GPU (the size depends on the value of strideE).\n
-              This array is used to work internally with the tridiagonal matrix T_i associated with
-              the ith reduced eigenvalue problem.
-              On exit, if 0 < info[i] <= n, it contains the unconverged off-diagonal elements of T_i
-              (or properly speaking, a tridiagonal matrix equivalent to T_i). The diagonal elements
-              of this matrix are in D_i; those that converged correspond to a subset of the
-              eigenvalues (not necessarily ordered).
+    E           pointer to type. Array on the GPU (the size depends on the value of strideE).\n
+                This array is used to work internally with the tridiagonal matrix T_j associated with
+                the jth reduced eigenvalue problem.
+                On exit, if 0 < info[j] <= n, it contains the unconverged off-diagonal elements of T_j
+                (or properly speaking, a tridiagonal matrix equivalent to T_j). The diagonal elements
+                of this matrix are in D_j; those that converged correspond to a subset of the
+                eigenvalues (not necessarily ordered).
     @param[in]
-    strideE   rocblas_stride.\n
-              Stride from the start of one vector E_i to the next one E_(i+1).
-              There is no restriction for the value of strideE. Normal use is strideE >= n.
+    strideE     rocblas_stride.\n
+                Stride from the start of one vector E_j to the next one E_(j+1).
+                There is no restriction for the value of strideE. Normal use is strideE >= n.
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[i] = 0, successful exit of batch i.
-              If info[i] = j <= n and evect is rocblas_evect_none, j off-diagonal elements of an
-              intermediate tridiagonal form did not converge to zero.
-              If info[i] = j <= n and evect is rocblas_evect_original, the algorithm failed to
-              compute an eigenvalue in the submatrix from [j/(n+1), j/(n+1)] to [j%(n+1), j%(n+1)].
-              If info[i] = n + j, the leading minor of order j of B_i is not
-              positive definite.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful exit of batch j.
+                If info[j] = i <= n and evect is rocblas_evect_none, i off-diagonal elements of an
+                intermediate tridiagonal form did not converge to zero.
+                If info[j] = i <= n and evect is rocblas_evect_original, the algorithm failed to
+                compute an eigenvalue in the submatrix from [i/(n+1), i/(n+1)] to [i%(n+1), i%(n+1)].
+                If info[j] = n + i, the leading minor of order i of B_j is not
+                positive definite.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.
@@ -15961,86 +15961,86 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_dsygvd_batched(rocblas_handle handle,
 
     \f[
         \begin{array}{cl}
-        A_i X_i = \lambda B_i X_i & \: \text{1st form,}\\
-        A_i B_i X_i = \lambda X_i & \: \text{2nd form, or}\\
-        B_i A_i X_i = \lambda X_i & \: \text{3rd form,}
+        A_j X_j = \lambda B_j X_j & \: \text{1st form,}\\
+        A_j B_j X_j = \lambda X_j & \: \text{2nd form, or}\\
+        B_j A_j X_j = \lambda X_j & \: \text{3rd form,}
         \end{array}
     \f]
 
     depending on the value of itype. The eigenvectors are computed using a divide-and-conquer algorithm, depending on the
     value of evect.
 
-    When computed, the matrix \f$Z_i\f$ of eigenvectors is normalized as follows:
+    When computed, the matrix \f$Z_j\f$ of eigenvectors is normalized as follows:
 
     \f[
         \begin{array}{cl}
-        Z_i^H B_i Z_i=I & \: \text{if 1st or 2nd form, or}\\
-        Z_i^H B_i^{-1} Z_i=I & \: \text{if 3rd form.}
+        Z_j^H B_j Z_j=I & \: \text{if 1st or 2nd form, or}\\
+        Z_j^H B_j^{-1} Z_j=I & \: \text{if 3rd form.}
         \end{array}
     \f]
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    itype     #rocblas_eform.\n
-              Specifies the form of the generalized eigenproblems.
+    itype       #rocblas_eform.\n
+                Specifies the form of the generalized eigenproblems.
     @param[in]
-    evect     #rocblas_evect.\n
-              Specifies whether the eigenvectors are to be computed.
-              If evect is rocblas_evect_original, then the eigenvectors are computed.
-              rocblas_evect_tridiagonal is not supported.
+    evect       #rocblas_evect.\n
+                Specifies whether the eigenvectors are to be computed.
+                If evect is rocblas_evect_original, then the eigenvectors are computed.
+                rocblas_evect_tridiagonal is not supported.
     @param[in]
-    uplo      rocblas_fill.\n
-              Specifies whether the upper or lower parts of the matrices
-              A_i and B_i are stored. If uplo indicates lower (or upper),
-              then the upper (or lower) parts of A_i and B_i are not used.
+    uplo        rocblas_fill.\n
+                Specifies whether the upper or lower parts of the matrices
+                A_j and B_j are stored. If uplo indicates lower (or upper),
+                then the upper (or lower) parts of A_j and B_j are not used.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The matrix dimensions.
+    n           rocblas_int. n >= 0.\n
+                The matrix dimensions.
     @param[inout]
-    A         array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
-              On entry, the hermitian matrices A_i. On exit, if evect is original,
-              the normalized matrix Z_i of eigenvectors. If evect is none, then the upper or lower triangular
-              part of the matrices A_i (including the diagonal) are destroyed,
-              depending on the value of uplo.
+    A           array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+                On entry, the hermitian matrices A_j. On exit, if evect is original,
+                the normalized matrix Z_j of eigenvectors. If evect is none, then the upper or lower triangular
+                part of the matrices A_j (including the diagonal) are destroyed,
+                depending on the value of uplo.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              Specifies the leading dimension of A_i.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of A_j.
     @param[out]
-    B         array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.\n
-              On entry, the hermitian positive definite matrices B_i. On exit, the
-              triangular factor of B_i as returned by \ref rocsolver_spotrf_batched "POTRF_BATCHED".
+    B           array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.\n
+                On entry, the hermitian positive definite matrices B_j. On exit, the
+                triangular factor of B_j as returned by \ref rocsolver_spotrf_batched "POTRF_BATCHED".
     @param[in]
-    ldb       rocblas_int. ldb >= n.\n
-              Specifies the leading dimension of B_i.
+    ldb         rocblas_int. ldb >= n.\n
+                Specifies the leading dimension of B_j.
     @param[out]
-    D         pointer to real type. Array on the GPU (the size depends on the value of strideD).\n
-              On exit, the eigenvalues in increasing order.
+    D           pointer to real type. Array on the GPU (the size depends on the value of strideD).\n
+                On exit, the eigenvalues in increasing order.
     @param[in]
-    strideD   rocblas_stride.\n
-              Stride from the start of one vector D_i to the next one D_(i+1).
-              There is no restriction for the value of strideD. Normal use is strideD >= n.
+    strideD     rocblas_stride.\n
+                Stride from the start of one vector D_j to the next one D_(j+1).
+                There is no restriction for the value of strideD. Normal use is strideD >= n.
     @param[out]
-    E         pointer to real type. Array on the GPU (the size depends on the value of strideE).\n
-              This array is used to work internally with the tridiagonal matrix T_i associated with
-              the ith reduced eigenvalue problem.
-              On exit, if 0 < info[i] <= n, it contains the unconverged off-diagonal elements of T_i
-              (or properly speaking, a tridiagonal matrix equivalent to T_i). The diagonal elements
-              of this matrix are in D_i; those that converged correspond to a subset of the
-              eigenvalues (not necessarily ordered).
+    E           pointer to real type. Array on the GPU (the size depends on the value of strideE).\n
+                This array is used to work internally with the tridiagonal matrix T_j associated with
+                the jth reduced eigenvalue problem.
+                On exit, if 0 < info[j] <= n, it contains the unconverged off-diagonal elements of T_j
+                (or properly speaking, a tridiagonal matrix equivalent to T_j). The diagonal elements
+                of this matrix are in D_j; those that converged correspond to a subset of the
+                eigenvalues (not necessarily ordered).
     @param[in]
-    strideE   rocblas_stride.\n
-              Stride from the start of one vector E_i to the next one E_(i+1).
-              There is no restriction for the value of strideE. Normal use is strideE >= n.
+    strideE     rocblas_stride.\n
+                Stride from the start of one vector E_j to the next one E_(j+1).
+                There is no restriction for the value of strideE. Normal use is strideE >= n.
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[i] = 0, successful exit of batch i.
-              If info[i] = j <= n and evect is rocblas_evect_none, j off-diagonal elements of an
-              intermediate tridiagonal form did not converge to zero.
-              If info[i] = j <= n and evect is rocblas_evect_original, the algorithm failed to
-              compute an eigenvalue in the submatrix from [j/(n+1), j/(n+1)] to [j%(n+1), j%(n+1)].
-              If info[i] = n + j, the leading minor of order j of B_i is not
-              positive definite.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful exit of batch j.
+                If info[j] = i <= n and evect is rocblas_evect_none, i off-diagonal elements of an
+                intermediate tridiagonal form did not converge to zero.
+                If info[j] = i <= n and evect is rocblas_evect_original, the algorithm failed to
+                compute an eigenvalue in the submatrix from [i/(n+1), i/(n+1)] to [i%(n+1), i%(n+1)].
+                If info[j] = n + i, the leading minor of order i of B_j is not
+                positive definite.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.
@@ -16089,94 +16089,94 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zhegvd_batched(rocblas_handle handle,
 
     \f[
         \begin{array}{cl}
-        A_i X_i = \lambda B_i X_i & \: \text{1st form,}\\
-        A_i B_i X_i = \lambda X_i & \: \text{2nd form, or}\\
-        B_i A_i X_i = \lambda X_i & \: \text{3rd form,}
+        A_j X_j = \lambda B_j X_j & \: \text{1st form,}\\
+        A_j B_j X_j = \lambda X_j & \: \text{2nd form, or}\\
+        B_j A_j X_j = \lambda X_j & \: \text{3rd form,}
         \end{array}
     \f]
 
     depending on the value of itype. The eigenvectors are computed using a divide-and-conquer algorithm, depending on the
     value of evect.
 
-    When computed, the matrix \f$Z_i\f$ of eigenvectors is normalized as follows:
+    When computed, the matrix \f$Z_j\f$ of eigenvectors is normalized as follows:
 
     \f[
         \begin{array}{cl}
-        Z_i^T B_i Z_i=I & \: \text{if 1st or 2nd form, or}\\
-        Z_i^T B_i^{-1} Z_i=I & \: \text{if 3rd form.}
+        Z_j^T B_j Z_j=I & \: \text{if 1st or 2nd form, or}\\
+        Z_j^T B_j^{-1} Z_j=I & \: \text{if 3rd form.}
         \end{array}
     \f]
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    itype     #rocblas_eform.\n
-              Specifies the form of the generalized eigenproblems.
+    itype       #rocblas_eform.\n
+                Specifies the form of the generalized eigenproblems.
     @param[in]
-    evect     #rocblas_evect.\n
-              Specifies whether the eigenvectors are to be computed.
-              If evect is rocblas_evect_original, then the eigenvectors are computed.
-              rocblas_evect_tridiagonal is not supported.
+    evect       #rocblas_evect.\n
+                Specifies whether the eigenvectors are to be computed.
+                If evect is rocblas_evect_original, then the eigenvectors are computed.
+                rocblas_evect_tridiagonal is not supported.
     @param[in]
-    uplo      rocblas_fill.\n
-              Specifies whether the upper or lower parts of the matrices
-              A_i and B_i are stored. If uplo indicates lower (or upper),
-              then the upper (or lower) parts of A_i and B_i are not used.
+    uplo        rocblas_fill.\n
+                Specifies whether the upper or lower parts of the matrices
+                A_j and B_j are stored. If uplo indicates lower (or upper),
+                then the upper (or lower) parts of A_j and B_j are not used.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The matrix dimensions.
+    n           rocblas_int. n >= 0.\n
+                The matrix dimensions.
     @param[inout]
-    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
-              On entry, the symmetric matrices A_i. On exit, if evect is original,
-              the normalized matrix Z_i of eigenvectors. If evect is none, then the upper or lower triangular
-              part of the matrices A_i (including the diagonal) are destroyed,
-              depending on the value of uplo.
+    A           pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+                On entry, the symmetric matrices A_j. On exit, if evect is original,
+                the normalized matrix Z_j of eigenvectors. If evect is none, then the upper or lower triangular
+                part of the matrices A_j (including the diagonal) are destroyed,
+                depending on the value of uplo.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              Specifies the leading dimension of A_i.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of A_j.
     @param[in]
-    strideA   rocblas_stride.\n
-              Stride from the start of one matrix A_i to the next one A_(i+1).
-              There is no restriction for the value of strideA. Normal use is strideA >= lda*n.
+    strideA     rocblas_stride.\n
+                Stride from the start of one matrix A_j to the next one A_(j+1).
+                There is no restriction for the value of strideA. Normal use is strideA >= lda*n.
     @param[out]
-    B         pointer to type. Array on the GPU (the size depends on the value of strideB).\n
-              On entry, the symmetric positive definite matrices B_i. On exit, the
-              triangular factor of B_i as returned by \ref rocsolver_spotrf_strided_batched "POTRF_STRIDED_BATCHED".
+    B           pointer to type. Array on the GPU (the size depends on the value of strideB).\n
+                On entry, the symmetric positive definite matrices B_j. On exit, the
+                triangular factor of B_j as returned by \ref rocsolver_spotrf_strided_batched "POTRF_STRIDED_BATCHED".
     @param[in]
-    ldb       rocblas_int. ldb >= n.\n
-              Specifies the leading dimension of B_i.
+    ldb         rocblas_int. ldb >= n.\n
+                Specifies the leading dimension of B_j.
     @param[in]
-    strideB   rocblas_stride.\n
-              Stride from the start of one matrix B_i to the next one B_(i+1).
-              There is no restriction for the value of strideB. Normal use is strideB >= ldb*n.
+    strideB     rocblas_stride.\n
+                Stride from the start of one matrix B_j to the next one B_(j+1).
+                There is no restriction for the value of strideB. Normal use is strideB >= ldb*n.
     @param[out]
-    D         pointer to type. Array on the GPU (the size depends on the value of strideD).\n
-              On exit, the eigenvalues in increasing order.
+    D           pointer to type. Array on the GPU (the size depends on the value of strideD).\n
+                On exit, the eigenvalues in increasing order.
     @param[in]
-    strideD   rocblas_stride.\n
-              Stride from the start of one vector D_i to the next one D_(i+1).
-              There is no restriction for the value of strideD. Normal use is strideD >= n.
+    strideD     rocblas_stride.\n
+                Stride from the start of one vector D_j to the next one D_(j+1).
+                There is no restriction for the value of strideD. Normal use is strideD >= n.
     @param[out]
-    E         pointer to type. Array on the GPU (the size depends on the value of strideE).\n
-              This array is used to work internally with the tridiagonal matrix T_i associated with
-              the ith reduced eigenvalue problem.
-              On exit, if 0 < info[i] <= n, it contains the unconverged off-diagonal elements of T_i
-              (or properly speaking, a tridiagonal matrix equivalent to T_i). The diagonal elements
-              of this matrix are in D_i; those that converged correspond to a subset of the
-              eigenvalues (not necessarily ordered).
+    E           pointer to type. Array on the GPU (the size depends on the value of strideE).\n
+                This array is used to work internally with the tridiagonal matrix T_j associated with
+                the jth reduced eigenvalue problem.
+                On exit, if 0 < info[j] <= n, it contains the unconverged off-diagonal elements of T_j
+                (or properly speaking, a tridiagonal matrix equivalent to T_j). The diagonal elements
+                of this matrix are in D_j; those that converged correspond to a subset of the
+                eigenvalues (not necessarily ordered).
     @param[in]
-    strideE   rocblas_stride.\n
-              Stride from the start of one vector E_i to the next one E_(i+1).
-              There is no restriction for the value of strideE. Normal use is strideE >= n.
+    strideE     rocblas_stride.\n
+                Stride from the start of one vector E_j to the next one E_(j+1).
+                There is no restriction for the value of strideE. Normal use is strideE >= n.
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[i] = 0, successful exit of batch i.
-              If info[i] = j <= n and evect is rocblas_evect_none, j off-diagonal elements of an
-              intermediate tridiagonal form did not converge to zero.
-              If info[i] = j <= n and evect is rocblas_evect_original, the algorithm failed to
-              compute an eigenvalue in the submatrix from [j/(n+1), j/(n+1)] to [j%(n+1), j%(n+1)].
-              If info[i] = n + j, the leading minor of order j of B_i is not
-              positive definite.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful exit of batch j.
+                If info[j] = i <= n and evect is rocblas_evect_none, i off-diagonal elements of an
+                intermediate tridiagonal form did not converge to zero.
+                If info[j] = i <= n and evect is rocblas_evect_original, the algorithm failed to
+                compute an eigenvalue in the submatrix from [i/(n+1), i/(n+1)] to [i%(n+1), i%(n+1)].
+                If info[j] = n + i, the leading minor of order i of B_j is not
+                positive definite.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.
@@ -16229,94 +16229,94 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_dsygvd_strided_batched(rocblas_handle 
 
     \f[
         \begin{array}{cl}
-        A_i X_i = \lambda B_i X_i & \: \text{1st form,}\\
-        A_i B_i X_i = \lambda X_i & \: \text{2nd form, or}\\
-        B_i A_i X_i = \lambda X_i & \: \text{3rd form,}
+        A_j X_j = \lambda B_j X_j & \: \text{1st form,}\\
+        A_j B_j X_j = \lambda X_j & \: \text{2nd form, or}\\
+        B_j A_j X_j = \lambda X_j & \: \text{3rd form,}
         \end{array}
     \f]
 
     depending on the value of itype. The eigenvectors are computed using a divide-and-conquer algorithm, depending on the
     value of evect.
 
-    When computed, the matrix \f$Z_i\f$ of eigenvectors is normalized as follows:
+    When computed, the matrix \f$Z_j\f$ of eigenvectors is normalized as follows:
 
     \f[
         \begin{array}{cl}
-        Z_i^H B_i Z_i=I & \: \text{if 1st or 2nd form, or}\\
-        Z_i^H B_i^{-1} Z_i=I & \: \text{if 3rd form.}
+        Z_j^H B_j Z_j=I & \: \text{if 1st or 2nd form, or}\\
+        Z_j^H B_j^{-1} Z_j=I & \: \text{if 3rd form.}
         \end{array}
     \f]
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    itype     #rocblas_eform.\n
-              Specifies the form of the generalized eigenproblems.
+    itype       #rocblas_eform.\n
+                Specifies the form of the generalized eigenproblems.
     @param[in]
-    evect     #rocblas_evect.\n
-              Specifies whether the eigenvectors are to be computed.
-              If evect is rocblas_evect_original, then the eigenvectors are computed.
-              rocblas_evect_tridiagonal is not supported.
+    evect       #rocblas_evect.\n
+                Specifies whether the eigenvectors are to be computed.
+                If evect is rocblas_evect_original, then the eigenvectors are computed.
+                rocblas_evect_tridiagonal is not supported.
     @param[in]
-    uplo      rocblas_fill.\n
-              Specifies whether the upper or lower parts of the matrices
-              A_i and B_i are stored. If uplo indicates lower (or upper),
-              then the upper (or lower) parts of A_i and B_i are not used.
+    uplo        rocblas_fill.\n
+                Specifies whether the upper or lower parts of the matrices
+                A_j and B_j are stored. If uplo indicates lower (or upper),
+                then the upper (or lower) parts of A_j and B_j are not used.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The matrix dimensions.
+    n           rocblas_int. n >= 0.\n
+                The matrix dimensions.
     @param[inout]
-    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
-              On entry, the hermitian matrices A_i. On exit, if evect is original,
-              the normalized matrix Z_i of eigenvectors. If evect is none, then the upper or lower triangular
-              part of the matrices A_i (including the diagonal) are destroyed,
-              depending on the value of uplo.
+    A           pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+                On entry, the hermitian matrices A_j. On exit, if evect is original,
+                the normalized matrix Z_j of eigenvectors. If evect is none, then the upper or lower triangular
+                part of the matrices A_j (including the diagonal) are destroyed,
+                depending on the value of uplo.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              Specifies the leading dimension of A_i.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of A_j.
     @param[in]
-    strideA   rocblas_stride.\n
-              Stride from the start of one matrix A_i to the next one A_(i+1).
-              There is no restriction for the value of strideA. Normal use is strideA >= lda*n.
+    strideA     rocblas_stride.\n
+                Stride from the start of one matrix A_j to the next one A_(j+1).
+                There is no restriction for the value of strideA. Normal use is strideA >= lda*n.
     @param[out]
-    B         pointer to type. Array on the GPU (the size depends on the value of strideB).\n
-              On entry, the hermitian positive definite matrices B_i. On exit, the
-              triangular factor of B_i as returned by \ref rocsolver_spotrf_strided_batched "POTRF_STRIDED_BATCHED".
+    B           pointer to type. Array on the GPU (the size depends on the value of strideB).\n
+                On entry, the hermitian positive definite matrices B_j. On exit, the
+                triangular factor of B_j as returned by \ref rocsolver_spotrf_strided_batched "POTRF_STRIDED_BATCHED".
     @param[in]
-    ldb       rocblas_int. ldb >= n.\n
-              Specifies the leading dimension of B_i.
+    ldb         rocblas_int. ldb >= n.\n
+                Specifies the leading dimension of B_j.
     @param[in]
-    strideB   rocblas_stride.\n
-              Stride from the start of one matrix B_i to the next one B_(i+1).
-              There is no restriction for the value of strideB. Normal use is strideB >= ldb*n.
+    strideB     rocblas_stride.\n
+                Stride from the start of one matrix B_j to the next one B_(j+1).
+                There is no restriction for the value of strideB. Normal use is strideB >= ldb*n.
     @param[out]
-    D         pointer to real type. Array on the GPU (the size depends on the value of strideD).\n
-              On exit, the eigenvalues in increasing order.
+    D           pointer to real type. Array on the GPU (the size depends on the value of strideD).\n
+                On exit, the eigenvalues in increasing order.
     @param[in]
-    strideD   rocblas_stride.\n
-              Stride from the start of one vector D_i to the next one D_(i+1).
-              There is no restriction for the value of strideD. Normal use is strideD >= n.
+    strideD     rocblas_stride.\n
+                Stride from the start of one vector D_j to the next one D_(j+1).
+                There is no restriction for the value of strideD. Normal use is strideD >= n.
     @param[out]
-    E         pointer to real type. Array on the GPU (the size depends on the value of strideE).\n
-              This array is used to work internally with the tridiagonal matrix T_i associated with
-              the ith reduced eigenvalue problem.
-              On exit, if 0 < info[i] <= n, it contains the unconverged off-diagonal elements of T_i
-              (or properly speaking, a tridiagonal matrix equivalent to T_i). The diagonal elements
-              of this matrix are in D_i; those that converged correspond to a subset of the
-              eigenvalues (not necessarily ordered).
+    E           pointer to real type. Array on the GPU (the size depends on the value of strideE).\n
+                This array is used to work internally with the tridiagonal matrix T_j associated with
+                the jth reduced eigenvalue problem.
+                On exit, if 0 < info[j] <= n, it contains the unconverged off-diagonal elements of T_j
+                (or properly speaking, a tridiagonal matrix equivalent to T_j). The diagonal elements
+                of this matrix are in D_j; those that converged correspond to a subset of the
+                eigenvalues (not necessarily ordered).
     @param[in]
-    strideE   rocblas_stride.\n
-              Stride from the start of one vector E_i to the next one E_(i+1).
-              There is no restriction for the value of strideE. Normal use is strideE >= n.
+    strideE     rocblas_stride.\n
+                Stride from the start of one vector E_j to the next one E_(j+1).
+                There is no restriction for the value of strideE. Normal use is strideE >= n.
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[i] = 0, successful exit of batch i.
-              If info[i] = j <= n and evect is rocblas_evect_none, j off-diagonal elements of an
-              intermediate tridiagonal form did not converge to zero.
-              If info[i] = j <= n and evect is rocblas_evect_original, the algorithm failed to
-              compute an eigenvalue in the submatrix from [j/(n+1), j/(n+1)] to [j%(n+1), j%(n+1)].
-              If info[i] = n + j, the leading minor of order j of B_i is not
-              positive definite.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful exit of batch j.
+                If info[j] = i <= n and evect is rocblas_evect_none, i off-diagonal elements of an
+                intermediate tridiagonal form did not converge to zero.
+                If info[j] = i <= n and evect is rocblas_evect_original, the algorithm failed to
+                compute an eigenvalue in the submatrix from [i/(n+1), i/(n+1)] to [i%(n+1), i%(n+1)].
+                If info[j] = n + i, the leading minor of order i of B_j is not
+                positive definite.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.

--- a/library/src/lapack/roclapack_syev_heev.hpp
+++ b/library/src/lapack/roclapack_syev_heev.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
  * ***********************************************************************/
 
 #pragma once
@@ -57,41 +57,6 @@ ROCSOLVER_KERNEL void scalar_case(const rocblas_evect evect,
         if(evect == rocblas_evect_original)
             A[0] = T(1);
     }
-}
-
-/** Argument checking **/
-template <typename T, typename S>
-rocblas_status rocsolver_syev_heev_argCheck(rocblas_handle handle,
-                                            const rocblas_evect evect,
-                                            const rocblas_fill uplo,
-                                            const rocblas_int n,
-                                            T A,
-                                            const rocblas_int lda,
-                                            S* D,
-                                            S* E,
-                                            rocblas_int* info,
-                                            const rocblas_int batch_count = 1)
-{
-    // order is important for unit tests:
-
-    // 1. invalid/non-supported values
-    if((evect != rocblas_evect_original && evect != rocblas_evect_none)
-       || (uplo != rocblas_fill_lower && uplo != rocblas_fill_upper))
-        return rocblas_status_invalid_value;
-
-    // 2. invalid size
-    if(n < 0 || lda < n || batch_count < 0)
-        return rocblas_status_invalid_size;
-
-    // skip pointer check if querying memory size
-    if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_status_continue;
-
-    // 3. invalid pointers
-    if((n && !A) || (n && !E) || (n && !D) || (batch_count && !info))
-        return rocblas_status_invalid_pointer;
-
-    return rocblas_status_continue;
 }
 
 /** Helper to calculate workspace sizes **/
@@ -150,6 +115,41 @@ void rocsolver_syev_heev_getMemorySize(const rocblas_evect evect,
 
     // size of array for temporary householder scalars
     *size_tau = sizeof(T) * n * batch_count;
+}
+
+/** Argument checking **/
+template <typename T, typename S>
+rocblas_status rocsolver_syev_heev_argCheck(rocblas_handle handle,
+                                            const rocblas_evect evect,
+                                            const rocblas_fill uplo,
+                                            const rocblas_int n,
+                                            T A,
+                                            const rocblas_int lda,
+                                            S* D,
+                                            S* E,
+                                            rocblas_int* info,
+                                            const rocblas_int batch_count = 1)
+{
+    // order is important for unit tests:
+
+    // 1. invalid/non-supported values
+    if((evect != rocblas_evect_original && evect != rocblas_evect_none)
+       || (uplo != rocblas_fill_lower && uplo != rocblas_fill_upper))
+        return rocblas_status_invalid_value;
+
+    // 2. invalid size
+    if(n < 0 || lda < n || batch_count < 0)
+        return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
+
+    // 3. invalid pointers
+    if((n && !A) || (n && !E) || (n && !D) || (batch_count && !info))
+        return rocblas_status_invalid_pointer;
+
+    return rocblas_status_continue;
 }
 
 template <bool BATCHED, bool STRIDED, typename T, typename S, typename W>

--- a/library/src/lapack/roclapack_syevd_heevd.hpp
+++ b/library/src/lapack/roclapack_syevd_heevd.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
  * ***********************************************************************/
 
 #pragma once
@@ -173,9 +173,10 @@ rocblas_status rocsolver_syevd_heevd_template(rocblas_handle handle,
             (T*)work3, workArr);
 
         // copy matrix product into A
-        const rocblas_int copyblocks = (n - 1) / 32 + 1;
-        ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(copyblocks, copyblocks, batch_count), dim3(32, 32),
-                                0, stream, n, n, tmptau_W, 0, ldw, strideW, A, shiftA, lda, strideA);
+        const rocblas_int copyblocks = (n - 1) / BS2 + 1;
+        ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(copyblocks, copyblocks, batch_count),
+                                dim3(BS2, BS2), 0, stream, n, n, tmptau_W, 0, ldw, strideW, A,
+                                shiftA, lda, strideA);
     }
 
     return rocblas_status_success;

--- a/library/src/lapack/roclapack_sygv_hegv.hpp
+++ b/library/src/lapack/roclapack_sygv_hegv.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
  * ***********************************************************************/
 
 #pragma once
@@ -229,7 +229,7 @@ rocblas_status rocsolver_sygv_hegv_template(rocblas_handle handle,
     ROCSOLVER_LAUNCH_KERNEL(sygv_update_info, gridReset, threads, 0, stream, info, iinfo, n,
                             batch_count);
 
-    /** (TODO: Similarly, if only neig < n eigenvalues converged, TRSMM or TRMM below should not
+    /** (TODO: Similarly, if only neig < n eigenvalues converged, TRSM or TRMM below should not
         work with the entire matrix. Need to find a way to do this efficiently; for now we ignore
         iinfo and set neig = n) **/
 


### PR DESCRIPTION
Introduces a bunch of minor changes to make syev/syevd and sygv/sygvd more consistent with each other.

The most important part of this change (as it's user-facing) is the update to the documentation so that `j` is consistently used as the batch index and `i` is consistently used as the info index. This is a change I would like to make across the other functions in the library as well, since it's currently a hodgepodge of which letter is used for which index, but that's for a later date.