### PR TITLE
Consistency check for documentation (part 1)

### DIFF
--- a/library/include/rocsolver-functions.h
+++ b/library/include/rocsolver-functions.h
@@ -29,7 +29,6 @@ extern "C" {
     buf         A buffer that the version string will be written into.
     @param[in]
     len         The size of the given buffer in bytes.
-
  ******************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_get_version_string(char* buf, size_t len);
@@ -42,7 +41,6 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_get_version_string(char* buf, size_t l
     len         pointer to size_t.\n
                 The minimum length of buffer to pass to
                 \ref rocsolver_get_version_string.
-
  ******************************************************************************/
 ROCSOLVER_EXPORT rocblas_status rocsolver_get_version_string_size(size_t* len);
 
@@ -81,8 +79,8 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_log_end(void);
 
     \details
     @param[in]
-    layer_mode      rocblas_layer_mode_flags.\n
-                    Specifies the logging mode.
+    layer_mode  rocblas_layer_mode_flags.\n
+                Specifies the logging mode.
  ******************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_log_set_layer_mode(const rocblas_layer_mode_flags layer_mode);
@@ -92,9 +90,9 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_log_set_layer_mode(const rocblas_layer
 
     \details
     @param[in]
-    max_levels      rocblas_int. max_levels >= 1.\n
-                    Specifies the maximum depth at which nested function calls
-                    will appear in the trace and profile logs.
+    max_levels  rocblas_int. max_levels >= 1.\n
+                Specifies the maximum depth at which nested function calls
+                will appear in the trace and profile logs.
  ******************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_log_set_max_levels(const rocblas_int max_levels);
@@ -133,19 +131,19 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_log_flush_profile(void);
     It conjugates the n entries of a complex vector x with increment incx.
 
     @param[in]
-    handle          rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    n               rocblas_int. n >= 0.\n
-                    The dimension of vector x.
+    n           rocblas_int. n >= 0.\n
+                The dimension of vector x.
     @param[inout]
-    x               pointer to type. Array on the GPU of size at least n (size depends on the value of incx).\n
-                    On entry, the vector x.
-                    On exit, each entry is overwritten with its conjugate value.
+    x           pointer to type. Array on the GPU of size at least n (size depends on the value of incx).\n
+                On entry, the vector x.
+                On exit, each entry is overwritten with its conjugate value.
     @param[in]
-    incx            rocblas_int. incx != 0.\n
-                    The distance between two consecutive elements of x.
-                    If incx is negative, the elements of x are indexed in
-                    reverse order.
+    incx        rocblas_int. incx != 0.\n
+                The distance between two consecutive elements of x.
+                If incx is negative, the elements of x are indexed in
+                reverse order.
     *************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_clacgv(rocblas_handle handle,
@@ -167,34 +165,34 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zlacgv(rocblas_handle handle,
     will be interchanged with the r-th row of A, for \f$j = k_1,k_1+1,\dots,k_2\f$. Indices \f$k_1\f$ and \f$k_2\f$ are 1-based indices.
 
     @param[in]
-    handle          rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    n               rocblas_int. n >= 0.\n
-                    The number of columns of the matrix A.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of the matrix A.
     @param[inout]
-    A               pointer to type. Array on the GPU of dimension lda*n. \n
-                    On entry, the matrix to which the row
-                    interchanges will be applied. On exit, the resulting permuted matrix.
+    A           pointer to type. Array on the GPU of dimension lda*n. \n
+                On entry, the matrix to which the row
+                interchanges will be applied. On exit, the resulting permuted matrix.
     @param[in]
-    lda             rocblas_int. lda > 0.\n
-                    The leading dimension of the array A.
+    lda         rocblas_int. lda > 0.\n
+                The leading dimension of the array A.
     @param[in]
-    k1              rocblas_int. k1 > 0.\n
-                    The k_1 index. It is the first element of ipiv for which a row interchange will
-                    be done. This is a 1-based index.
+    k1          rocblas_int. k1 > 0.\n
+                The k_1 index. It is the first element of ipiv for which a row interchange will
+                be done. This is a 1-based index.
     @param[in]
-    k2              rocblas_int. k2 > k1 > 0.\n
-                    The k_2 index. k_2 - k_1 + 1 is the number of elements of ipiv for which a row
-                    interchange will be done. This is a 1-based index.
+    k2          rocblas_int. k2 > k1 > 0.\n
+                The k_2 index. k_2 - k_1 + 1 is the number of elements of ipiv for which a row
+                interchange will be done. This is a 1-based index.
     @param[in]
-    ipiv            pointer to rocblas_int. Array on the GPU of dimension at least k_1 + (k_2 - k_1)*abs(incx).\n
-                    The vector of pivot indices. Only the elements in positions
-                    k_1 through k_1 + (k_2 - k_1)*abs(incx) of this vector are accessed.
-                    Elements of ipiv are considered 1-based.
+    ipiv        pointer to rocblas_int. Array on the GPU of dimension at least k_1 + (k_2 - k_1)*abs(incx).\n
+                The vector of pivot indices. Only the elements in positions
+                k_1 through k_1 + (k_2 - k_1)*abs(incx) of this vector are accessed.
+                Elements of ipiv are considered 1-based.
     @param[in]
-    incx            rocblas_int. incx != 0.\n
-                    The distance between successive values of ipiv.  If incx
-                    is negative, the pivots are applied in reverse order.
+    incx        rocblas_int. incx != 0.\n
+                The distance between successive values of ipiv.  If incx
+                is negative, the pivots are applied in reverse order.
     **************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_slaswp(rocblas_handle handle,
@@ -278,25 +276,24 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zlaswp(rocblas_handle handle,
     (i.e. \f$H^H\neq H\f$ in general).
 
     @param[in]
-    handle          rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    n               rocblas_int. n >= 0.\n
-                    The order (size) of reflector H.
+    n           rocblas_int. n >= 0.\n
+                The order (size) of reflector H.
     @param[inout]
-    alpha           pointer to type. A scalar on the GPU.\n
-                    On entry, the scalar alpha.
-                    On exit, it is overwritten with beta.
+    alpha       pointer to type. A scalar on the GPU.\n
+                On entry, the scalar alpha.
+                On exit, it is overwritten with beta.
     @param[inout]
-    x               pointer to type. Array on the GPU of size at least n-1 (size depends on the value of incx).\n
-                    On entry, the vector x,
-                    On exit, it is overwritten with vector v.
+    x           pointer to type. Array on the GPU of size at least n-1 (size depends on the value of incx).\n
+                On entry, the vector x,
+                On exit, it is overwritten with vector v.
     @param[in]
-    incx            rocblas_int. incx > 0.\n
-                    The distance between two consecutive elements of x.
+    incx        rocblas_int. incx > 0.\n
+                The distance between two consecutive elements of x.
     @param[out]
-    tau             pointer to type. A scalar on the GPU.\n
-                    The Householder scalar tau.
-
+    tau         pointer to type. A scalar on the GPU.\n
+                The Householder scalar tau.
     *************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_slarfg(rocblas_handle handle,
@@ -358,36 +355,35 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zlarfg(rocblas_handle handle,
     where the i-th row of matrix V contains the Householder vector associated with \f$H_i\f$.
 
     @param[in]
-    handle              rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    direct              #rocblas_direct.\n
-                        Specifies the direction in which the Householder matrices are applied.
+    direct      #rocblas_direct.\n
+                Specifies the direction in which the Householder matrices are applied.
     @param[in]
-    storev              #rocblas_storev.\n
-                        Specifies how the Householder vectors are stored in matrix V.
+    storev      #rocblas_storev.\n
+                Specifies how the Householder vectors are stored in matrix V.
     @param[in]
-    n                   rocblas_int. n >= 0.\n
-                        The order (size) of the block reflector.
+    n           rocblas_int. n >= 0.\n
+                The order (size) of the block reflector.
     @param[in]
-    k                   rocblas_int. k >= 1.\n
-                        The number of Householder matrices forming H.
+    k           rocblas_int. k >= 1.\n
+                The number of Householder matrices forming H.
     @param[in]
-    V                   pointer to type. Array on the GPU of size ldv*k if column-wise, or ldv*n if row-wise.\n
-                        The matrix of Householder vectors.
+    V           pointer to type. Array on the GPU of size ldv*k if column-wise, or ldv*n if row-wise.\n
+                The matrix of Householder vectors.
     @param[in]
-    ldv                 rocblas_int. ldv >= n if column-wise, or ldv >= k if row-wise.\n
-                        Leading dimension of V.
+    ldv         rocblas_int. ldv >= n if column-wise, or ldv >= k if row-wise.\n
+                Leading dimension of V.
     @param[in]
-    tau                 pointer to type. Array of k scalars on the GPU.\n
-                        The vector of all the Householder scalars.
+    tau         pointer to type. Array of k scalars on the GPU.\n
+                The vector of all the Householder scalars.
     @param[out]
-    T                   pointer to type. Array on the GPU of dimension ldt*k.\n
-                        The triangular factor. T is upper triangular if direct indicates forward direction, otherwise it is
-                        lower triangular. The rest of the array is not used.
+    T           pointer to type. Array on the GPU of dimension ldt*k.\n
+                The triangular factor. T is upper triangular if direct indicates forward direction, otherwise it is
+                lower triangular. The rest of the array is not used.
     @param[in]
-    ldt                 rocblas_int. ldt >= k.\n
-                        The leading dimension of T.
-
+    ldt         rocblas_int. ldt >= k.\n
+                The leading dimension of T.
     **************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_slarft(rocblas_handle handle,
@@ -449,36 +445,34 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zlarft(rocblas_handle handle,
     where alpha is the Householder scalar and x is a Householder vector. H is never actually computed.
 
     @param[in]
-    handle          rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    side            rocblas_side.\n
-                    Determines whether H is applied from the left or the right.
+    side        rocblas_side.\n
+                Determines whether H is applied from the left or the right.
     @param[in]
-    m               rocblas_int. m >= 0.\n
-                    Number of rows of A.
+    m           rocblas_int. m >= 0.\n
+                Number of rows of A.
     @param[in]
-    n               rocblas_int. n >= 0.\n
-                    Number of columns of A.
+    n           rocblas_int. n >= 0.\n
+                Number of columns of A.
     @param[in]
-    x               pointer to type. Array on the GPU of
-                    size at least 1 + (m-1)*abs(incx) if left side, or
-                    at least 1 + (n-1)*abs(incx) if right side.\n
-                    The Householder vector x.
+    x           pointer to type. Array on the GPU of size at least 1 + (m-1)*abs(incx) if left side, or
+                at least 1 + (n-1)*abs(incx) if right side.\n
+                The Householder vector x.
     @param[in]
-    incx            rocblas_int. incx != 0.\n
-                    Distance between two consecutive elements of x.
-                    If incx < 0, the elements of x are indexed in reverse order.
+    incx        rocblas_int. incx != 0.\n
+                Distance between two consecutive elements of x.
+                If incx < 0, the elements of x are indexed in reverse order.
     @param[in]
-    alpha           pointer to type. A scalar on the GPU.\n
-                    The Householder scalar. If alpha = 0, then H = I (A will remain the same; x is never used)
+    alpha       pointer to type. A scalar on the GPU.\n
+                The Householder scalar. If alpha = 0, then H = I (A will remain the same; x is never used)
     @param[inout]
-    A               pointer to type. Array on the GPU of size lda*n.\n
-                    On entry, the matrix A. On exit, it is overwritten with
-                    H*A (or A*H).
+    A           pointer to type. Array on the GPU of size lda*n.\n
+                On entry, the matrix A. On exit, it is overwritten with
+                H*A (or A*H).
     @param[in]
-    lda             rocblas_int. lda >= m.\n
-                    Leading dimension of A.
-
+    lda         rocblas_int. lda >= m.\n
+                Leading dimension of A.
     *************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_slarf(rocblas_handle handle,
@@ -563,50 +557,49 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zlarf(rocblas_handle handle,
     T is the associated triangular factor as computed by \ref rocsolver_slarft "LARFT".
 
     @param[in]
-    handle              rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    side                rocblas_side.\n
-                        Specifies from which side to apply H.
+    side        rocblas_side.\n
+                Specifies from which side to apply H.
     @param[in]
-    trans               rocblas_operation.\n
-                        Specifies whether the block reflector or its transpose/conjugate transpose is to be applied.
+    trans       rocblas_operation.\n
+                Specifies whether the block reflector or its transpose/conjugate transpose is to be applied.
     @param[in]
-    direct              #rocblas_direct.\n
-                        Specifies the direction in which the Householder matrices are to be applied to generate H.
+    direct      #rocblas_direct.\n
+                Specifies the direction in which the Householder matrices are to be applied to generate H.
     @param[in]
-    storev              #rocblas_storev.\n
-                        Specifies how the Householder vectors are stored in matrix V.
+    storev      #rocblas_storev.\n
+                Specifies how the Householder vectors are stored in matrix V.
     @param[in]
-    m                   rocblas_int. m >= 0.\n
-                        Number of rows of matrix A.
+    m           rocblas_int. m >= 0.\n
+                Number of rows of matrix A.
     @param[in]
-    n                   rocblas_int. n >= 0.\n
-                        Number of columns of matrix A.
+    n           rocblas_int. n >= 0.\n
+                Number of columns of matrix A.
     @param[in]
-    k                   rocblas_int. k >= 1.\n
-                        The number of Householder matrices.
+    k           rocblas_int. k >= 1.\n
+                The number of Householder matrices.
     @param[in]
-    V                   pointer to type. Array on the GPU of size ldv*k if column-wise, ldv*n if row-wise and applying from the right,
-                        or ldv*m if row-wise and applying from the left.\n
-                        The matrix of Householder vectors.
+    V           pointer to type. Array on the GPU of size ldv*k if column-wise, ldv*n if row-wise and applying from the right,
+                or ldv*m if row-wise and applying from the left.\n
+                The matrix of Householder vectors.
     @param[in]
-    ldv                 rocblas_int. ldv >= k if row-wise, ldv >= m if column-wise and applying from the left, or ldv >= n if
-                        column-wise and applying from the right.\n
-                        Leading dimension of V.
+    ldv         rocblas_int. ldv >= k if row-wise, ldv >= m if column-wise and applying from the left, or ldv >= n if
+                column-wise and applying from the right.\n
+                Leading dimension of V.
     @param[in]
-    T                   pointer to type. Array on the GPU of dimension ldt*k.\n
-                        The triangular factor of the block reflector.
+    T           pointer to type. Array on the GPU of dimension ldt*k.\n
+                The triangular factor of the block reflector.
     @param[in]
-    ldt                 rocblas_int. ldt >= k.\n
-                        The leading dimension of T.
+    ldt         rocblas_int. ldt >= k.\n
+                The leading dimension of T.
     @param[inout]
-    A                   pointer to type. Array on the GPU of size lda*n.\n
-                        On entry, the matrix A. On exit, it is overwritten with
-                        H*A, A*H, H'*A, or A*H'.
+    A           pointer to type. Array on the GPU of size lda*n.\n
+                On entry, the matrix A. On exit, it is overwritten with
+                H*A, A*H, H'*A, or A*H'.
     @param[in]
-    lda                 rocblas_int. lda >= m.\n
-                        Leading dimension of A.
-
+    lda         rocblas_int. lda >= m.\n
+                Leading dimension of A.
     ****************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_slarfb(rocblas_handle handle,
@@ -715,55 +708,54 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zlarfb(rocblas_handle handle,
     where V and U are the m-by-k and n-by-k matrices formed with the vectors \f$v_i\f$ and \f$u_i\f$, respectively.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of the matrix A.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of the matrix A.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of the matrix A.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of the matrix A.
     @param[in]
-    k         rocblas_int. min(m,n) >= k >= 0.\n
-              The number of leading rows and columns of matrix A that will be reduced.
+    k           rocblas_int. min(m,n) >= k >= 0.\n
+                The number of leading rows and columns of matrix A that will be reduced.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrix to be reduced.
-              On exit, the first k elements on the diagonal and superdiagonal (if m >= n), or
-              subdiagonal (if m < n), contain the bidiagonal form B.
-              If m >= n, the elements below the diagonal of the first k columns are the possibly non-zero elements
-              of the Householder vectors associated with Q, while the elements above the
-              superdiagonal of the first k rows are the n - i - 1 possibly non-zero elements of the Householder vectors related to P.
-              If m < n, the elements below the subdiagonal of the first k columns are the m - i - 1 possibly non-zero
-              elements of the Householder vectors related to Q, while the elements above the
-              diagonal of the first k rows are the n - i possibly non-zero elements of the vectors associated with P.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrix to be reduced.
+                On exit, the first k elements on the diagonal and superdiagonal (if m >= n), or
+                subdiagonal (if m < n), contain the bidiagonal form B.
+                If m >= n, the elements below the diagonal of the first k columns are the possibly non-zero elements
+                of the Householder vectors associated with Q, while the elements above the
+                superdiagonal of the first k rows are the n - i - 1 possibly non-zero elements of the Householder vectors related to P.
+                If m < n, the elements below the subdiagonal of the first k columns are the m - i - 1 possibly non-zero
+                elements of the Householder vectors related to Q, while the elements above the
+                diagonal of the first k rows are the n - i possibly non-zero elements of the vectors associated with P.
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              specifies the leading dimension of A.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of A.
     @param[out]
-    D         pointer to real type. Array on the GPU of dimension k.\n
-              The diagonal elements of B.
+    D           pointer to real type. Array on the GPU of dimension k.\n
+                The diagonal elements of B.
     @param[out]
-    E         pointer to real type. Array on the GPU of dimension k.\n
-              The off-diagonal elements of B.
+    E           pointer to real type. Array on the GPU of dimension k.\n
+                The off-diagonal elements of B.
     @param[out]
-    tauq      pointer to type. Array on the GPU of dimension k.\n
-              The Householder scalars associated with matrix Q.
+    tauq        pointer to type. Array on the GPU of dimension k.\n
+                The Householder scalars associated with matrix Q.
     @param[out]
-    taup      pointer to type. Array on the GPU of dimension k.\n
-              The Householder scalars associated with matrix P.
+    taup        pointer to type. Array on the GPU of dimension k.\n
+                The Householder scalars associated with matrix P.
     @param[out]
-    X         pointer to type. Array on the GPU of dimension ldx*k.\n
-              The m-by-k matrix needed to update the unreduced part of A.
+    X           pointer to type. Array on the GPU of dimension ldx*k.\n
+                The m-by-k matrix needed to update the unreduced part of A.
     @param[in]
-    ldx       rocblas_int. ldx >= m.\n
-              The leading dimension of X.
+    ldx         rocblas_int. ldx >= m.\n
+                The leading dimension of X.
     @param[out]
-    Y         pointer to type. Array on the GPU of dimension ldy*k.\n
-              The n-by-k matrix needed to update the unreduced part of A.
+    Y           pointer to type. Array on the GPU of dimension ldy*k.\n
+                The n-by-k matrix needed to update the unreduced part of A.
     @param[in]
-    ldy       rocblas_int. ldy >= n.\n
-              The leading dimension of Y.
-
+    ldy         rocblas_int. ldy >= n.\n
+                The leading dimension of Y.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_slabrd(rocblas_handle handle,
@@ -869,43 +861,43 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zlabrd(rocblas_handle handle,
     where V is the n-by-k matrix formed by the vectors \f$v_i\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    uplo      rocblas_fill.\n
-              Specifies whether the upper or lower part of the matrix A is stored.
-              If uplo indicates lower (or upper), then the upper (or lower)
-              part of A is not used.
+    uplo        rocblas_fill.\n
+                Specifies whether the upper or lower part of the matrix A is stored.
+                If uplo indicates lower (or upper), then the upper (or lower)
+                part of A is not used.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of rows and columns of the matrix A.
+    n           rocblas_int. n >= 0.\n
+                The number of rows and columns of the matrix A.
     @param[in]
-    k         rocblas_int. 0 <= k <= n.\n
-              The number of rows and columns of the matrix A to be reduced.
+    k           rocblas_int. 0 <= k <= n.\n
+                The number of rows and columns of the matrix A to be reduced.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the n-by-n matrix to be reduced.
-              On exit, if uplo is lower, the first k columns have been reduced to tridiagonal form
-              (given in the diagonal elements of A and the array E), the elements below the diagonal
-              contain the possibly non-zero entries of the Householder vectors associated with Q, stored as columns.
-              If uplo is upper, the last k columns have been reduced to tridiagonal form
-              (given in the diagonal elements of A and the array E), the elements above the diagonal
-              contain the possibly non-zero entries of the Householder vectors associated with Q, stored as columns.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the n-by-n matrix to be reduced.
+                On exit, if uplo is lower, the first k columns have been reduced to tridiagonal form
+                (given in the diagonal elements of A and the array E), the elements below the diagonal
+                contain the possibly non-zero entries of the Householder vectors associated with Q, stored as columns.
+                If uplo is upper, the last k columns have been reduced to tridiagonal form
+                (given in the diagonal elements of A and the array E), the elements above the diagonal
+                contain the possibly non-zero entries of the Householder vectors associated with Q, stored as columns.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              The leading dimension of A.
+    lda         rocblas_int. lda >= n.\n
+                The leading dimension of A.
     @param[out]
-    E         pointer to real type. Array on the GPU of dimension n-1.\n
-              If upper (lower), the last (first) k elements of E are the off-diagonal elements of the
-              computed tridiagonal block.
+    E           pointer to real type. Array on the GPU of dimension n-1.\n
+                If upper (lower), the last (first) k elements of E are the off-diagonal elements of the
+                computed tridiagonal block.
     @param[out]
-    tau       pointer to type. Array on the GPU of dimension n-1.\n
-              If upper (lower), the last (first) k elements of tau are the Householder scalars related to Q.
+    tau         pointer to type. Array on the GPU of dimension n-1.\n
+                If upper (lower), the last (first) k elements of tau are the Householder scalars related to Q.
     @param[out]
-    W         pointer to type. Array on the GPU of dimension ldw*k.\n
-              The n-by-k matrix needed to update the unreduced part of A.
+    W           pointer to type. Array on the GPU of dimension ldw*k.\n
+                The n-by-k matrix needed to update the unreduced part of A.
     @param[in]
-    ldw       rocblas_int. ldw >= n.\n
-              The leading dimension of W.
+    ldw         rocblas_int. ldw >= n.\n
+                The leading dimension of W.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_slatrd(rocblas_handle handle,
@@ -992,48 +984,48 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zlatrd(rocblas_handle handle,
     is either \f$nb\f$ or \f$nb-1\f$, and is returned in the argument \f$kb\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    uplo      rocblas_fill.\n
-              Specifies whether the upper or lower part of the matrix A is stored.
-              If uplo indicates lower (or upper), then the upper (or lower)
-              part of A is not used.
+    uplo        rocblas_fill.\n
+                Specifies whether the upper or lower part of the matrix A is stored.
+                If uplo indicates lower (or upper), then the upper (or lower)
+                part of A is not used.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of rows and columns of the matrix A.
+    n           rocblas_int. n >= 0.\n
+                The number of rows and columns of the matrix A.
     @param[in]
-    nb        rocblas_int. 2 <= nb <= n.\n
-              The number of columns of A to be factored.
+    nb          rocblas_int. 2 <= nb <= n.\n
+                The number of columns of A to be factored.
     @param[out]
-    kb        pointer to a rocblas_int on the GPU.\n
-              The number of columns of A that were actually factored (either nb or
-              nb-1).
+    kb          pointer to a rocblas_int on the GPU.\n
+                The number of columns of A that were actually factored (either nb or
+                nb-1).
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the symmetric matrix A to be factored.
-              On exit, the partially factored matrix.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the symmetric matrix A to be factored.
+                On exit, the partially factored matrix.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              Specifies the leading dimension of A.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of A.
     @param[out]
-    ipiv      pointer to rocblas_int. Array on the GPU of dimension n.\n
-              The vector of pivot indices. Elements of ipiv are 1-based indices.
-              If uplo is upper, then only the last kb elements of ipiv will be
-              set. For n - kb < k <= n, if ipiv[k] > 0 then rows and columns k
-              and ipiv[k] were interchanged and D[k,k] is a 1-by-1 diagonal block.
-              If, instead, ipiv[k] = ipiv[k-1] < 0, then rows and columns k-1
-              and -ipiv[k] were interchanged and D[k-1,k-1] to D[k,k] is a 2-by-2
-              diagonal block.
-              If uplo is lower, then only the first kb elements of ipiv will be
-              set. For 1 <= k <= kb, if ipiv[k] > 0 then rows and columns k
-              and ipiv[k] were interchanged and D[k,k] is a 1-by-1 diagonal block.
-              If, instead, ipiv[k] = ipiv[k+1] < 0, then rows and columns k+1
-              and -ipiv[k] were interchanged and D[k,k] to D[k+1,k+1] is a 2-by-2
-              diagonal block.
+    ipiv        pointer to rocblas_int. Array on the GPU of dimension n.\n
+                The vector of pivot indices. Elements of ipiv are 1-based indices.
+                If uplo is upper, then only the last kb elements of ipiv will be
+                set. For n - kb < k <= n, if ipiv[k] > 0 then rows and columns k
+                and ipiv[k] were interchanged and D[k,k] is a 1-by-1 diagonal block.
+                If, instead, ipiv[k] = ipiv[k-1] < 0, then rows and columns k-1
+                and -ipiv[k] were interchanged and D[k-1,k-1] to D[k,k] is a 2-by-2
+                diagonal block.
+                If uplo is lower, then only the first kb elements of ipiv will be
+                set. For 1 <= k <= kb, if ipiv[k] > 0 then rows and columns k
+                and ipiv[k] were interchanged and D[k,k] is a 1-by-1 diagonal block.
+                If, instead, ipiv[k] = ipiv[k+1] < 0, then rows and columns k+1
+                and -ipiv[k] were interchanged and D[k,k] to D[k+1,k+1] is a 2-by-2
+                diagonal block.
     @param[out]
-    info      pointer to a rocblas_int on the GPU.\n
-              If info = 0, successful exit.
-              If info[i] = j > 0, D is singular. D[j,j] is the first diagonal zero.
+    info        pointer to a rocblas_int on the GPU.\n
+                If info = 0, successful exit.
+                If info = i > 0, D is singular. D[i,i] is the first diagonal zero.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_slasyf(rocblas_handle handle,
@@ -2057,39 +2049,39 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zungtr(rocblas_handle handle,
     calculated from the Householder vectors and scalars returned by the QR factorization \ref rocsolver_sgeqrf "GEQRF".
 
     @param[in]
-    handle              rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    side                rocblas_side.\n
-                        Specifies from which side to apply Q.
+    side        rocblas_side.\n
+                Specifies from which side to apply Q.
     @param[in]
-    trans               rocblas_operation.\n
-                        Specifies whether the matrix Q or its transpose is to be applied.
+    trans       rocblas_operation.\n
+                Specifies whether the matrix Q or its transpose is to be applied.
     @param[in]
-    m                   rocblas_int. m >= 0.\n
-                        Number of rows of matrix C.
+    m           rocblas_int. m >= 0.\n
+                Number of rows of matrix C.
     @param[in]
-    n                   rocblas_int. n >= 0.\n
-                        Number of columns of matrix C.
+    n           rocblas_int. n >= 0.\n
+                Number of columns of matrix C.
     @param[in]
-    k                   rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
-                        The number of Householder reflectors that form Q.
+    k           rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
+                The number of Householder reflectors that form Q.
     @param[in]
-    A                   pointer to type. Array on the GPU of size lda*k.\n
-                        The Householder vectors as returned by \ref rocsolver_sgeqrf "GEQRF"
-                        in the first k columns of its argument A.
+    A           pointer to type. Array on the GPU of size lda*k.\n
+                The Householder vectors as returned by \ref rocsolver_sgeqrf "GEQRF"
+                in the first k columns of its argument A.
     @param[in]
-    lda                 rocblas_int. lda >= m if side is left, or lda >= n if side is right. \n
-                        Leading dimension of A.
+    lda         rocblas_int. lda >= m if side is left, or lda >= n if side is right. \n
+                Leading dimension of A.
     @param[in]
-    ipiv                pointer to type. Array on the GPU of dimension at least k.\n
-                        The Householder scalars as returned by \ref rocsolver_sgeqrf "GEQRF".
+    ipiv        pointer to type. Array on the GPU of dimension at least k.\n
+                The Householder scalars as returned by \ref rocsolver_sgeqrf "GEQRF".
     @param[inout]
-    C                   pointer to type. Array on the GPU of size ldc*n.\n
-                        On entry, the matrix C. On exit, it is overwritten with
-                        Q*C, C*Q, Q'*C, or C*Q'.
+    C           pointer to type. Array on the GPU of size ldc*n.\n
+                On entry, the matrix C. On exit, it is overwritten with
+                Q*C, C*Q, Q'*C, or C*Q'.
     @param[in]
-    ldc                 rocblas_int. ldc >= m.\n
-                        Leading dimension of C.
+    ldc         rocblas_int. ldc >= m.\n
+                Leading dimension of C.
     ****************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sorm2r(rocblas_handle handle,
@@ -2146,39 +2138,39 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_dorm2r(rocblas_handle handle,
     calculated from the Householder vectors and scalars returned by the QR factorization \ref rocsolver_sgeqrf "GEQRF".
 
     @param[in]
-    handle              rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    side                rocblas_side.\n
-                        Specifies from which side to apply Q.
+    side        rocblas_side.\n
+                Specifies from which side to apply Q.
     @param[in]
-    trans               rocblas_operation.\n
-                        Specifies whether the matrix Q or its conjugate transpose is to be applied.
+    trans       rocblas_operation.\n
+                Specifies whether the matrix Q or its conjugate transpose is to be applied.
     @param[in]
-    m                   rocblas_int. m >= 0.\n
-                        Number of rows of matrix C.
+    m           rocblas_int. m >= 0.\n
+                Number of rows of matrix C.
     @param[in]
-    n                   rocblas_int. n >= 0.\n
-                        Number of columns of matrix C.
+    n           rocblas_int. n >= 0.\n
+                Number of columns of matrix C.
     @param[in]
-    k                   rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
-                        The number of Householder reflectors that form Q.
+    k           rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
+                The number of Householder reflectors that form Q.
     @param[in]
-    A                   pointer to type. Array on the GPU of size lda*k.\n
-                        The Householder vectors as returned by \ref rocsolver_sgeqrf "GEQRF"
-                        in the first k columns of its argument A.
+    A           pointer to type. Array on the GPU of size lda*k.\n
+                The Householder vectors as returned by \ref rocsolver_sgeqrf "GEQRF"
+                in the first k columns of its argument A.
     @param[in]
-    lda                 rocblas_int. lda >= m if side is left, or lda >= n if side is right. \n
-                        Leading dimension of A.
+    lda         rocblas_int. lda >= m if side is left, or lda >= n if side is right. \n
+                Leading dimension of A.
     @param[in]
-    ipiv                pointer to type. Array on the GPU of dimension at least k.\n
-                        The Householder scalars as returned by \ref rocsolver_sgeqrf "GEQRF".
+    ipiv        pointer to type. Array on the GPU of dimension at least k.\n
+                The Householder scalars as returned by \ref rocsolver_sgeqrf "GEQRF".
     @param[inout]
-    C                   pointer to type. Array on the GPU of size ldc*n.\n
-                        On entry, the matrix C. On exit, it is overwritten with
-                        Q*C, C*Q, Q'*C, or C*Q'.
+    C           pointer to type. Array on the GPU of size ldc*n.\n
+                On entry, the matrix C. On exit, it is overwritten with
+                Q*C, C*Q, Q'*C, or C*Q'.
     @param[in]
-    ldc                 rocblas_int. ldc >= m.\n
-                        Leading dimension of C.
+    ldc         rocblas_int. ldc >= m.\n
+                Leading dimension of C.
 
     ****************************************************************************/
 
@@ -2236,39 +2228,39 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zunm2r(rocblas_handle handle,
     calculated from the Householder vectors and scalars returned by the QR factorization \ref rocsolver_sgeqrf "GEQRF".
 
     @param[in]
-    handle              rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    side                rocblas_side.\n
-                        Specifies from which side to apply Q.
+    side        rocblas_side.\n
+                Specifies from which side to apply Q.
     @param[in]
-    trans               rocblas_operation.\n
-                        Specifies whether the matrix Q or its transpose is to be applied.
+    trans       rocblas_operation.\n
+                Specifies whether the matrix Q or its transpose is to be applied.
     @param[in]
-    m                   rocblas_int. m >= 0.\n
-                        Number of rows of matrix C.
+    m           rocblas_int. m >= 0.\n
+                Number of rows of matrix C.
     @param[in]
-    n                   rocblas_int. n >= 0.\n
-                        Number of columns of matrix C.
+    n           rocblas_int. n >= 0.\n
+                Number of columns of matrix C.
     @param[in]
-    k                   rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
-                        The number of Householder reflectors that form Q.
+    k           rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
+                The number of Householder reflectors that form Q.
     @param[in]
-    A                   pointer to type. Array on the GPU of size lda*k.\n
-                        The Householder vectors as returned by \ref rocsolver_sgeqrf "GEQRF"
-                        in the first k columns of its argument A.
+    A           pointer to type. Array on the GPU of size lda*k.\n
+                The Householder vectors as returned by \ref rocsolver_sgeqrf "GEQRF"
+                in the first k columns of its argument A.
     @param[in]
-    lda                 rocblas_int. lda >= m if side is left, or lda >= n if side is right. \n
-                        Leading dimension of A.
+    lda         rocblas_int. lda >= m if side is left, or lda >= n if side is right. \n
+                Leading dimension of A.
     @param[in]
-    ipiv                pointer to type. Array on the GPU of dimension at least k.\n
-                        The Householder scalars as returned by \ref rocsolver_sgeqrf "GEQRF".
+    ipiv        pointer to type. Array on the GPU of dimension at least k.\n
+                The Householder scalars as returned by \ref rocsolver_sgeqrf "GEQRF".
     @param[inout]
-    C                   pointer to type. Array on the GPU of size ldc*n.\n
-                        On entry, the matrix C. On exit, it is overwritten with
-                        Q*C, C*Q, Q'*C, or C*Q'.
+    C           pointer to type. Array on the GPU of size ldc*n.\n
+                On entry, the matrix C. On exit, it is overwritten with
+                Q*C, C*Q, Q'*C, or C*Q'.
     @param[in]
-    ldc                 rocblas_int. ldc >= m.\n
-                        Leading dimension of C.
+    ldc         rocblas_int. ldc >= m.\n
+                Leading dimension of C.
     ****************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sormqr(rocblas_handle handle,
@@ -2325,39 +2317,39 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_dormqr(rocblas_handle handle,
     calculated from the Householder vectors and scalars returned by the QR factorization \ref rocsolver_sgeqrf "GEQRF".
 
     @param[in]
-    handle              rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    side                rocblas_side.\n
-                        Specifies from which side to apply Q.
+    side        rocblas_side.\n
+                Specifies from which side to apply Q.
     @param[in]
-    trans               rocblas_operation.\n
-                        Specifies whether the matrix Q or its conjugate transpose is to be applied.
+    trans       rocblas_operation.\n
+                Specifies whether the matrix Q or its conjugate transpose is to be applied.
     @param[in]
-    m                   rocblas_int. m >= 0.\n
-                        Number of rows of matrix C.
+    m           rocblas_int. m >= 0.\n
+                Number of rows of matrix C.
     @param[in]
-    n                   rocblas_int. n >= 0.\n
-                        Number of columns of matrix C.
+    n           rocblas_int. n >= 0.\n
+                Number of columns of matrix C.
     @param[in]
-    k                   rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
-                        The number of Householder reflectors that form Q.
+    k           rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
+                The number of Householder reflectors that form Q.
     @param[in]
-    A                   pointer to type. Array on the GPU of size lda*k.\n
-                        The Householder vectors as returned by \ref rocsolver_sgeqrf "GEQRF"
-                        in the first k columns of its argument A.
+    A           pointer to type. Array on the GPU of size lda*k.\n
+                The Householder vectors as returned by \ref rocsolver_sgeqrf "GEQRF"
+                in the first k columns of its argument A.
     @param[in]
-    lda                 rocblas_int. lda >= m if side is left, or lda >= n if side is right. \n
-                        Leading dimension of A.
+    lda         rocblas_int. lda >= m if side is left, or lda >= n if side is right. \n
+                Leading dimension of A.
     @param[in]
-    ipiv                pointer to type. Array on the GPU of dimension at least k.\n
-                        The Householder scalars as returned by \ref rocsolver_sgeqrf "GEQRF".
+    ipiv        pointer to type. Array on the GPU of dimension at least k.\n
+                The Householder scalars as returned by \ref rocsolver_sgeqrf "GEQRF".
     @param[inout]
-    C                   pointer to type. Array on the GPU of size ldc*n.\n
-                        On entry, the matrix C. On exit, it is overwritten with
-                        Q*C, C*Q, Q'*C, or C*Q'.
+    C           pointer to type. Array on the GPU of size ldc*n.\n
+                On entry, the matrix C. On exit, it is overwritten with
+                Q*C, C*Q, Q'*C, or C*Q'.
     @param[in]
-    ldc                 rocblas_int. ldc >= m.\n
-                        Leading dimension of C.
+    ldc         rocblas_int. ldc >= m.\n
+                Leading dimension of C.
     ****************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_cunmqr(rocblas_handle handle,
@@ -2414,39 +2406,39 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zunmqr(rocblas_handle handle,
     calculated from the Householder vectors and scalars returned by the LQ factorization \ref rocsolver_sgelqf "GELQF".
 
     @param[in]
-    handle              rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    side                rocblas_side.\n
-                        Specifies from which side to apply Q.
+    side        rocblas_side.\n
+                Specifies from which side to apply Q.
     @param[in]
-    trans               rocblas_operation.\n
-                        Specifies whether the matrix Q or its transpose is to be applied.
+    trans       rocblas_operation.\n
+                Specifies whether the matrix Q or its transpose is to be applied.
     @param[in]
-    m                   rocblas_int. m >= 0.\n
-                        Number of rows of matrix C.
+    m           rocblas_int. m >= 0.\n
+                Number of rows of matrix C.
     @param[in]
-    n                   rocblas_int. n >= 0.\n
-                        Number of columns of matrix C.
+    n           rocblas_int. n >= 0.\n
+                Number of columns of matrix C.
     @param[in]
-    k                   rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
-                        The number of Householder reflectors that form Q.
+    k           rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
+                The number of Householder reflectors that form Q.
     @param[in]
-    A                   pointer to type. Array on the GPU of size lda*m if side is left, or lda*n if side is right.\n
-                        The Householder vectors as returned by \ref rocsolver_sgelqf "GELQF"
-                        in the first k rows of its argument A.
+    A           pointer to type. Array on the GPU of size lda*m if side is left, or lda*n if side is right.\n
+                The Householder vectors as returned by \ref rocsolver_sgelqf "GELQF"
+                in the first k rows of its argument A.
     @param[in]
-    lda                 rocblas_int. lda >= k. \n
-                        Leading dimension of A.
+    lda         rocblas_int. lda >= k. \n
+                Leading dimension of A.
     @param[in]
-    ipiv                pointer to type. Array on the GPU of dimension at least k.\n
-                        The Householder scalars as returned by \ref rocsolver_sgelqf "GELQF".
+    ipiv        pointer to type. Array on the GPU of dimension at least k.\n
+                The Householder scalars as returned by \ref rocsolver_sgelqf "GELQF".
     @param[inout]
-    C                   pointer to type. Array on the GPU of size ldc*n.\n
-                        On entry, the matrix C. On exit, it is overwritten with
-                        Q*C, C*Q, Q'*C, or C*Q'.
+    C           pointer to type. Array on the GPU of size ldc*n.\n
+                On entry, the matrix C. On exit, it is overwritten with
+                Q*C, C*Q, Q'*C, or C*Q'.
     @param[in]
-    ldc                 rocblas_int. ldc >= m.\n
-                        Leading dimension of C.
+    ldc         rocblas_int. ldc >= m.\n
+                Leading dimension of C.
 
     ****************************************************************************/
 
@@ -2504,39 +2496,39 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_dorml2(rocblas_handle handle,
     calculated from the Householder vectors and scalars returned by the LQ factorization \ref rocsolver_sgelqf "GELQF".
 
     @param[in]
-    handle              rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    side                rocblas_side.\n
-                        Specifies from which side to apply Q.
+    side        rocblas_side.\n
+                Specifies from which side to apply Q.
     @param[in]
-    trans               rocblas_operation.\n
-                        Specifies whether the matrix Q or its conjugate transpose is to be applied.
+    trans       rocblas_operation.\n
+                Specifies whether the matrix Q or its conjugate transpose is to be applied.
     @param[in]
-    m                   rocblas_int. m >= 0.\n
-                        Number of rows of matrix C.
+    m           rocblas_int. m >= 0.\n
+                Number of rows of matrix C.
     @param[in]
-    n                   rocblas_int. n >= 0.\n
-                        Number of columns of matrix C.
+    n           rocblas_int. n >= 0.\n
+                Number of columns of matrix C.
     @param[in]
-    k                   rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
-                        The number of Householder reflectors that form Q.
+    k           rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
+                The number of Householder reflectors that form Q.
     @param[in]
-    A                   pointer to type. Array on the GPU of size lda*m if side is left, or lda*n if side is right.\n
-                        The Householder vectors as returned by \ref rocsolver_sgelqf "GELQF"
-                        in the first k rows of its argument A.
+    A           pointer to type. Array on the GPU of size lda*m if side is left, or lda*n if side is right.\n
+                The Householder vectors as returned by \ref rocsolver_sgelqf "GELQF"
+                in the first k rows of its argument A.
     @param[in]
-    lda                 rocblas_int. lda >= k. \n
-                        Leading dimension of A.
+    lda         rocblas_int. lda >= k. \n
+                Leading dimension of A.
     @param[in]
-    ipiv                pointer to type. Array on the GPU of dimension at least k.\n
-                        The Householder scalars as returned by \ref rocsolver_sgelqf "GELQF".
+    ipiv        pointer to type. Array on the GPU of dimension at least k.\n
+                The Householder scalars as returned by \ref rocsolver_sgelqf "GELQF".
     @param[inout]
-    C                   pointer to type. Array on the GPU of size ldc*n.\n
-                        On entry, the matrix C. On exit, it is overwritten with
-                        Q*C, C*Q, Q'*C, or C*Q'.
+    C           pointer to type. Array on the GPU of size ldc*n.\n
+                On entry, the matrix C. On exit, it is overwritten with
+                Q*C, C*Q, Q'*C, or C*Q'.
     @param[in]
-    ldc                 rocblas_int. ldc >= m.\n
-                        Leading dimension of C.
+    ldc         rocblas_int. ldc >= m.\n
+                Leading dimension of C.
     ****************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_cunml2(rocblas_handle handle,
@@ -2593,39 +2585,39 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zunml2(rocblas_handle handle,
     calculated from the Householder vectors and scalars returned by the LQ factorization \ref rocsolver_sgelqf "GELQF".
 
     @param[in]
-    handle              rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    side                rocblas_side.\n
-                        Specifies from which side to apply Q.
+    side        rocblas_side.\n
+                Specifies from which side to apply Q.
     @param[in]
-    trans               rocblas_operation.\n
-                        Specifies whether the matrix Q or its transpose is to be applied.
+    trans       rocblas_operation.\n
+                Specifies whether the matrix Q or its transpose is to be applied.
     @param[in]
-    m                   rocblas_int. m >= 0.\n
-                        Number of rows of matrix C.
+    m           rocblas_int. m >= 0.\n
+                Number of rows of matrix C.
     @param[in]
-    n                   rocblas_int. n >= 0.\n
-                        Number of columns of matrix C.
+    n           rocblas_int. n >= 0.\n
+                Number of columns of matrix C.
     @param[in]
-    k                   rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
-                        The number of Householder reflectors that form Q.
+    k           rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
+                The number of Householder reflectors that form Q.
     @param[in]
-    A                   pointer to type. Array on the GPU of size lda*m if side is left, or lda*n if side is right.\n
-                        The Householder vectors as returned by \ref rocsolver_sgelqf "GELQF"
-                        in the first k rows of its argument A.
+    A           pointer to type. Array on the GPU of size lda*m if side is left, or lda*n if side is right.\n
+                The Householder vectors as returned by \ref rocsolver_sgelqf "GELQF"
+                in the first k rows of its argument A.
     @param[in]
-    lda                 rocblas_int. lda >= k. \n
-                        Leading dimension of A.
+    lda         rocblas_int. lda >= k. \n
+                Leading dimension of A.
     @param[in]
-    ipiv                pointer to type. Array on the GPU of dimension at least k.\n
-                        The Householder scalars as returned by \ref rocsolver_sgelqf "GELQF".
+    ipiv        pointer to type. Array on the GPU of dimension at least k.\n
+                The Householder scalars as returned by \ref rocsolver_sgelqf "GELQF".
     @param[inout]
-    C                   pointer to type. Array on the GPU of size ldc*n.\n
-                        On entry, the matrix C. On exit, it is overwritten with
-                        Q*C, C*Q, Q'*C, or C*Q'.
+    C           pointer to type. Array on the GPU of size ldc*n.\n
+                On entry, the matrix C. On exit, it is overwritten with
+                Q*C, C*Q, Q'*C, or C*Q'.
     @param[in]
-    ldc                 rocblas_int. ldc >= m.\n
-                        Leading dimension of C.
+    ldc         rocblas_int. ldc >= m.\n
+                Leading dimension of C.
     ****************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sormlq(rocblas_handle handle,
@@ -2682,39 +2674,39 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_dormlq(rocblas_handle handle,
     calculated from the Householder vectors and scalars returned by the LQ factorization \ref rocsolver_sgelqf "GELQF".
 
     @param[in]
-    handle              rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    side                rocblas_side.\n
-                        Specifies from which side to apply Q.
+    side        rocblas_side.\n
+                Specifies from which side to apply Q.
     @param[in]
-    trans               rocblas_operation.\n
-                        Specifies whether the matrix Q or its conjugate transpose is to be applied.
+    trans       rocblas_operation.\n
+                Specifies whether the matrix Q or its conjugate transpose is to be applied.
     @param[in]
-    m                   rocblas_int. m >= 0.\n
-                        Number of rows of matrix C.
+    m           rocblas_int. m >= 0.\n
+                Number of rows of matrix C.
     @param[in]
-    n                   rocblas_int. n >= 0.\n
-                        Number of columns of matrix C.
+    n           rocblas_int. n >= 0.\n
+                Number of columns of matrix C.
     @param[in]
-    k                   rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
-                        The number of Householder reflectors that form Q.
+    k           rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
+                The number of Householder reflectors that form Q.
     @param[in]
-    A                   pointer to type. Array on the GPU of size lda*m if side is left, or lda*n if side is right.\n
-                        The Householder vectors as returned by \ref rocsolver_sgelqf "GELQF"
-                        in the first k rows of its argument A.
+    A           pointer to type. Array on the GPU of size lda*m if side is left, or lda*n if side is right.\n
+                The Householder vectors as returned by \ref rocsolver_sgelqf "GELQF"
+                in the first k rows of its argument A.
     @param[in]
-    lda                 rocblas_int. lda >= k. \n
-                        Leading dimension of A.
+    lda         rocblas_int. lda >= k. \n
+                Leading dimension of A.
     @param[in]
-    ipiv                pointer to type. Array on the GPU of dimension at least k.\n
-                        The Householder scalars as returned by \ref rocsolver_sgelqf "GELQF".
+    ipiv        pointer to type. Array on the GPU of dimension at least k.\n
+                The Householder scalars as returned by \ref rocsolver_sgelqf "GELQF".
     @param[inout]
-    C                   pointer to type. Array on the GPU of size ldc*n.\n
-                        On entry, the matrix C. On exit, it is overwritten with
-                        Q*C, C*Q, Q'*C, or C*Q'.
+    C           pointer to type. Array on the GPU of size ldc*n.\n
+                On entry, the matrix C. On exit, it is overwritten with
+                Q*C, C*Q, Q'*C, or C*Q'.
     @param[in]
-    ldc                 rocblas_int. ldc >= m.\n
-                        Leading dimension of C.
+    ldc         rocblas_int. ldc >= m.\n
+                Leading dimension of C.
     ****************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_cunmlq(rocblas_handle handle,
@@ -2772,41 +2764,41 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zunmlq(rocblas_handle handle,
     returned by the QL factorization \ref rocsolver_sgeqlf "GEQLF".
 
     @param[in]
-    handle              rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    side                rocblas_side.\n
-                        Specifies from which side to apply Q.
+    side        rocblas_side.\n
+                Specifies from which side to apply Q.
     @param[in]
-    trans               rocblas_operation.\n
-                        Specifies whether the matrix Q or its transpose is to be
-                        applied.
+    trans       rocblas_operation.\n
+                Specifies whether the matrix Q or its transpose is to be
+                applied.
     @param[in]
-    m                   rocblas_int. m >= 0.\n
-                        Number of rows of matrix C.
+    m           rocblas_int. m >= 0.\n
+                Number of rows of matrix C.
     @param[in]
-    n                   rocblas_int. n >= 0.\n
-                        Number of columns of matrix C.
+    n           rocblas_int. n >= 0.\n
+                Number of columns of matrix C.
     @param[in]
-    k                   rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
-                        The number of Householder reflectors that form Q.
+    k           rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
+                The number of Householder reflectors that form Q.
     @param[in]
-    A                   pointer to type. Array on the GPU of size lda*k.\n
-                        The Householder vectors as returned by \ref rocsolver_sgeqlf "GEQLF" in the last k columns of its
-                        argument A.
+    A           pointer to type. Array on the GPU of size lda*k.\n
+                The Householder vectors as returned by \ref rocsolver_sgeqlf "GEQLF" in the last k columns of its
+                argument A.
     @param[in]
-    lda                 rocblas_int. lda >= m if side is left, lda >= n if side is right.\n
-                        Leading dimension of A.
+    lda         rocblas_int. lda >= m if side is left, lda >= n if side is right.\n
+                Leading dimension of A.
     @param[in]
-    ipiv                pointer to type. Array on the GPU of dimension at least k.\n
-                        The Householder scalars as returned by
-                        \ref rocsolver_sgeqlf "GEQLF".
+    ipiv        pointer to type. Array on the GPU of dimension at least k.\n
+                The Householder scalars as returned by
+                \ref rocsolver_sgeqlf "GEQLF".
     @param[inout]
-    C                   pointer to type. Array on the GPU of size ldc*n.\n
-                        On entry, the matrix C. On exit, it is overwritten with
-                        Q*C, C*Q, Q'*C, or C*Q'.
+    C           pointer to type. Array on the GPU of size ldc*n.\n
+                On entry, the matrix C. On exit, it is overwritten with
+                Q*C, C*Q, Q'*C, or C*Q'.
     @param[in]
-    ldc                 rocblas_int. ldc >= m.\n
-                        Leading dimension of C.
+    ldc         rocblas_int. ldc >= m.\n
+                Leading dimension of C.
     ****************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sorm2l(rocblas_handle handle,
@@ -2864,41 +2856,41 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_dorm2l(rocblas_handle handle,
     returned by the QL factorization \ref rocsolver_sgeqlf "GEQLF".
 
     @param[in]
-    handle              rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    side                rocblas_side.\n
-                        Specifies from which side to apply Q.
+    side        rocblas_side.\n
+                Specifies from which side to apply Q.
     @param[in]
-    trans               rocblas_operation.\n
-                        Specifies whether the matrix Q or its conjugate
-                        transpose is to be applied.
+    trans       rocblas_operation.\n
+                Specifies whether the matrix Q or its conjugate
+                transpose is to be applied.
     @param[in]
-    m                   rocblas_int. m >= 0.\n
-                        Number of rows of matrix C.
+    m           rocblas_int. m >= 0.\n
+                Number of rows of matrix C.
     @param[in]
-    n                   rocblas_int. n >= 0.\n
-                        Number of columns of matrix C.
+    n           rocblas_int. n >= 0.\n
+                Number of columns of matrix C.
     @param[in]
-    k                   rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
-                        The number of Householder reflectors that form Q.
+    k           rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
+                The number of Householder reflectors that form Q.
     @param[in]
-    A                   pointer to type. Array on the GPU of size lda*k.\n
-                        The Householder vectors as returned by \ref rocsolver_sgeqlf "GEQLF" in the last k columns of its
-                        argument A.
+    A           pointer to type. Array on the GPU of size lda*k.\n
+                The Householder vectors as returned by \ref rocsolver_sgeqlf "GEQLF" in the last k columns of its
+                argument A.
     @param[in]
-    lda                 rocblas_int. lda >= m if side is left, lda >= n if side is right.\n
-                        Leading dimension of A.
+    lda         rocblas_int. lda >= m if side is left, lda >= n if side is right.\n
+                Leading dimension of A.
     @param[in]
-    ipiv                pointer to type. Array on the GPU of dimension at least k.\n
-                        The Householder scalars as returned by
-                        \ref rocsolver_sgeqlf "GEQLF".
+    ipiv        pointer to type. Array on the GPU of dimension at least k.\n
+                The Householder scalars as returned by
+                \ref rocsolver_sgeqlf "GEQLF".
     @param[inout]
-    C                   pointer to type. Array on the GPU of size ldc*n.\n
-                        On entry, the matrix C. On exit, it is overwritten with
-                        Q*C, C*Q, Q'*C, or C*Q'.
+    C           pointer to type. Array on the GPU of size ldc*n.\n
+                On entry, the matrix C. On exit, it is overwritten with
+                Q*C, C*Q, Q'*C, or C*Q'.
     @param[in]
-    ldc                 rocblas_int. ldc >= m.\n
-                        Leading dimension of C.
+    ldc         rocblas_int. ldc >= m.\n
+                Leading dimension of C.
     ****************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_cunm2l(rocblas_handle handle,
@@ -2956,41 +2948,41 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zunm2l(rocblas_handle handle,
     returned by the QL factorization \ref rocsolver_sgeqlf "GEQLF".
 
     @param[in]
-    handle              rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    side                rocblas_side.\n
-                        Specifies from which side to apply Q.
+    side        rocblas_side.\n
+                Specifies from which side to apply Q.
     @param[in]
-    trans               rocblas_operation.\n
-                        Specifies whether the matrix Q or its transpose is to be
-                        applied.
+    trans       rocblas_operation.\n
+                Specifies whether the matrix Q or its transpose is to be
+                applied.
     @param[in]
-    m                   rocblas_int. m >= 0.\n
-                        Number of rows of matrix C.
+    m           rocblas_int. m >= 0.\n
+                Number of rows of matrix C.
     @param[in]
-    n                   rocblas_int. n >= 0.\n
-                        Number of columns of matrix C.
+    n           rocblas_int. n >= 0.\n
+                Number of columns of matrix C.
     @param[in]
-    k                   rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
-                        The number of Householder reflectors that form Q.
+    k           rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
+                The number of Householder reflectors that form Q.
     @param[in]
-    A                   pointer to type. Array on the GPU of size lda*k.\n
-                        The Householder vectors as returned by \ref rocsolver_sgeqlf "GEQLF" in the last k columns of its
-                        argument A.
+    A           pointer to type. Array on the GPU of size lda*k.\n
+                The Householder vectors as returned by \ref rocsolver_sgeqlf "GEQLF" in the last k columns of its
+                argument A.
     @param[in]
-    lda                 rocblas_int. lda >= m if side is left, lda >= n if side is right.\n
-                        Leading dimension of A.
+    lda         rocblas_int. lda >= m if side is left, lda >= n if side is right.\n
+                Leading dimension of A.
     @param[in]
-    ipiv                pointer to type. Array on the GPU of dimension at least k.\n
-                        The Householder scalars as returned by
-                        \ref rocsolver_sgeqlf "GEQLF".
+    ipiv        pointer to type. Array on the GPU of dimension at least k.\n
+                The Householder scalars as returned by
+                \ref rocsolver_sgeqlf "GEQLF".
     @param[inout]
-    C                   pointer to type. Array on the GPU of size ldc*n.\n
-                        On entry, the matrix C. On exit, it is overwritten with
-                        Q*C, C*Q, Q'*C, or C*Q'.
+    C           pointer to type. Array on the GPU of size ldc*n.\n
+                On entry, the matrix C. On exit, it is overwritten with
+                Q*C, C*Q, Q'*C, or C*Q'.
     @param[in]
-    ldc                 rocblas_int. ldc >= m.\n
-                        Leading dimension of C.
+    ldc         rocblas_int. ldc >= m.\n
+                Leading dimension of C.
     ****************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sormql(rocblas_handle handle,
@@ -3048,41 +3040,41 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_dormql(rocblas_handle handle,
     returned by the QL factorization \ref rocsolver_sgeqlf "GEQLF".
 
     @param[in]
-    handle              rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    side                rocblas_side.\n
-                        Specifies from which side to apply Q.
+    side        rocblas_side.\n
+                Specifies from which side to apply Q.
     @param[in]
-    trans               rocblas_operation.\n
-                        Specifies whether the matrix Q or its conjugate
-                        transpose is to be applied.
+    trans       rocblas_operation.\n
+                Specifies whether the matrix Q or its conjugate
+                transpose is to be applied.
     @param[in]
-    m                   rocblas_int. m >= 0.\n
-                        Number of rows of matrix C.
+    m           rocblas_int. m >= 0.\n
+                Number of rows of matrix C.
     @param[in]
-    n                   rocblas_int. n >= 0.\n
-                        Number of columns of matrix C.
+    n           rocblas_int. n >= 0.\n
+                Number of columns of matrix C.
     @param[in]
-    k                   rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
-                        The number of Householder reflectors that form Q.
+    k           rocblas_int. k >= 0; k <= m if side is left, k <= n if side is right.\n
+                The number of Householder reflectors that form Q.
     @param[in]
-    A                   pointer to type. Array on the GPU of size lda*k.\n
-                        The Householder vectors as returned by \ref rocsolver_sgeqlf "GEQLF" in the last k columns of its
-                        argument A.
+    A           pointer to type. Array on the GPU of size lda*k.\n
+                The Householder vectors as returned by \ref rocsolver_sgeqlf "GEQLF" in the last k columns of its
+                argument A.
     @param[in]
-    lda                 rocblas_int. lda >= m if side is left, lda >= n if side is right.\n
-                        Leading dimension of A.
+    lda         rocblas_int. lda >= m if side is left, lda >= n if side is right.\n
+                Leading dimension of A.
     @param[in]
-    ipiv                pointer to type. Array on the GPU of dimension at least k.\n
-                        The Householder scalars as returned by
-                        \ref rocsolver_sgeqlf "GEQLF".
+    ipiv        pointer to type. Array on the GPU of dimension at least k.\n
+                The Householder scalars as returned by
+                \ref rocsolver_sgeqlf "GEQLF".
     @param[inout]
-    C                   pointer to type. Array on the GPU of size ldc*n.\n
-                        On entry, the matrix C. On exit, it is overwritten with
-                        Q*C, C*Q, Q'*C, or C*Q'.
+    C           pointer to type. Array on the GPU of size ldc*n.\n
+                On entry, the matrix C. On exit, it is overwritten with
+                Q*C, C*Q, Q'*C, or C*Q'.
     @param[in]
-    ldc                 rocblas_int. ldc >= m.\n
-                        Leading dimension of C.
+    ldc         rocblas_int. ldc >= m.\n
+                Leading dimension of C.
     ****************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_cunmql(rocblas_handle handle,
@@ -3159,42 +3151,42 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zunmql(rocblas_handle handle,
     Householder vectors and scalars as returned by \ref rocsolver_sgebrd "GEBRD" in its arguments A and tauq or taup.
 
     @param[in]
-    handle              rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    storev              #rocblas_storev.\n
-                        Specifies whether to work column-wise or row-wise.
+    storev      #rocblas_storev.\n
+                Specifies whether to work column-wise or row-wise.
     @param[in]
-    side                rocblas_side.\n
-                        Specifies from which side to apply Q.
+    side        rocblas_side.\n
+                Specifies from which side to apply Q.
     @param[in]
-    trans               rocblas_operation.\n
-                        Specifies whether the matrix Q or its transpose is to be applied.
+    trans       rocblas_operation.\n
+                Specifies whether the matrix Q or its transpose is to be applied.
     @param[in]
-    m                   rocblas_int. m >= 0.\n
-                        Number of rows of matrix C.
+    m           rocblas_int. m >= 0.\n
+                Number of rows of matrix C.
     @param[in]
-    n                   rocblas_int. n >= 0.\n
-                        Number of columns of matrix C.
+    n           rocblas_int. n >= 0.\n
+                Number of columns of matrix C.
     @param[in]
-    k                   rocblas_int. k >= 0.\n
-                        The number of columns (if storev is column-wise) or rows (if row-wise) of the
-                        original matrix reduced by \ref rocsolver_sgebrd "GEBRD".
+    k           rocblas_int. k >= 0.\n
+                The number of columns (if storev is column-wise) or rows (if row-wise) of the
+                original matrix reduced by \ref rocsolver_sgebrd "GEBRD".
     @param[in]
-    A                   pointer to type. Array on the GPU of size lda*min(q,k) if column-wise, or lda*q if row-wise.\n
-                        The Householder vectors as returned by \ref rocsolver_sgebrd "GEBRD".
+    A           pointer to type. Array on the GPU of size lda*min(q,k) if column-wise, or lda*q if row-wise.\n
+                The Householder vectors as returned by \ref rocsolver_sgebrd "GEBRD".
     @param[in]
-    lda                 rocblas_int. lda >= q if column-wise, or lda >= min(q,k) if row-wise. \n
-                        Leading dimension of A.
+    lda         rocblas_int. lda >= q if column-wise, or lda >= min(q,k) if row-wise. \n
+                Leading dimension of A.
     @param[in]
-    ipiv                pointer to type. Array on the GPU of dimension at least min(q,k).\n
-                        The Householder scalars as returned by \ref rocsolver_sgebrd "GEBRD".
+    ipiv        pointer to type. Array on the GPU of dimension at least min(q,k).\n
+                The Householder scalars as returned by \ref rocsolver_sgebrd "GEBRD".
     @param[inout]
-    C                   pointer to type. Array on the GPU of size ldc*n.\n
-                        On entry, the matrix C. On exit, it is overwritten with
-                        Q*C, C*Q, Q'*C, or C*Q'.
+    C           pointer to type. Array on the GPU of size ldc*n.\n
+                On entry, the matrix C. On exit, it is overwritten with
+                Q*C, C*Q, Q'*C, or C*Q'.
     @param[in]
-    ldc                 rocblas_int. ldc >= m.\n
-                        Leading dimension of C.
+    ldc         rocblas_int. ldc >= m.\n
+                Leading dimension of C.
     ****************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sormbr(rocblas_handle handle,
@@ -3273,42 +3265,42 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_dormbr(rocblas_handle handle,
     Householder vectors and scalars as returned by \ref rocsolver_sgebrd "GEBRD" in its arguments A and tauq or taup.
 
     @param[in]
-    handle              rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    storev              #rocblas_storev.\n
-                        Specifies whether to work column-wise or row-wise.
+    storev      #rocblas_storev.\n
+                Specifies whether to work column-wise or row-wise.
     @param[in]
-    side                rocblas_side.\n
-                        Specifies from which side to apply Q.
+    side        rocblas_side.\n
+                Specifies from which side to apply Q.
     @param[in]
-    trans               rocblas_operation.\n
-                        Specifies whether the matrix Q or its conjugate transpose is to be applied.
+    trans       rocblas_operation.\n
+                Specifies whether the matrix Q or its conjugate transpose is to be applied.
     @param[in]
-    m                   rocblas_int. m >= 0.\n
-                        Number of rows of matrix C.
+    m           rocblas_int. m >= 0.\n
+                Number of rows of matrix C.
     @param[in]
-    n                   rocblas_int. n >= 0.\n
-                        Number of columns of matrix C.
+    n           rocblas_int. n >= 0.\n
+                Number of columns of matrix C.
     @param[in]
-    k                   rocblas_int. k >= 0.\n
-                        The number of columns (if storev is column-wise) or rows (if row-wise) of the
-                        original matrix reduced by \ref rocsolver_sgebrd "GEBRD".
+    k           rocblas_int. k >= 0.\n
+                The number of columns (if storev is column-wise) or rows (if row-wise) of the
+                original matrix reduced by \ref rocsolver_sgebrd "GEBRD".
     @param[in]
-    A                   pointer to type. Array on the GPU of size lda*min(q,k) if column-wise, or lda*q if row-wise.\n
-                        The Householder vectors as returned by \ref rocsolver_sgebrd "GEBRD".
+    A           pointer to type. Array on the GPU of size lda*min(q,k) if column-wise, or lda*q if row-wise.\n
+                The Householder vectors as returned by \ref rocsolver_sgebrd "GEBRD".
     @param[in]
-    lda                 rocblas_int. lda >= q if column-wise, or lda >= min(q,k) if row-wise. \n
-                        Leading dimension of A.
+    lda         rocblas_int. lda >= q if column-wise, or lda >= min(q,k) if row-wise. \n
+                Leading dimension of A.
     @param[in]
-    ipiv                pointer to type. Array on the GPU of dimension at least min(q,k).\n
-                        The Householder scalars as returned by \ref rocsolver_sgebrd "GEBRD".
+    ipiv        pointer to type. Array on the GPU of dimension at least min(q,k).\n
+                The Householder scalars as returned by \ref rocsolver_sgebrd "GEBRD".
     @param[inout]
-    C                   pointer to type. Array on the GPU of size ldc*n.\n
-                        On entry, the matrix C. On exit, it is overwritten with
-                        Q*C, C*Q, Q'*C, or C*Q'.
+    C           pointer to type. Array on the GPU of size ldc*n.\n
+                On entry, the matrix C. On exit, it is overwritten with
+                Q*C, C*Q, Q'*C, or C*Q'.
     @param[in]
-    ldc                 rocblas_int. ldc >= m.\n
-                        Leading dimension of C.
+    ldc         rocblas_int. ldc >= m.\n
+                Leading dimension of C.
     ****************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_cunmbr(rocblas_handle handle,
@@ -3375,43 +3367,43 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zunmbr(rocblas_handle handle,
     \ref rocsolver_ssytrd "SYTRD" in its arguments A and tau.
 
     @param[in]
-    handle              rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    side                rocblas_side.\n
-                        Specifies from which side to apply Q.
+    side        rocblas_side.\n
+                Specifies from which side to apply Q.
     @param[in]
-    uplo                rocblas_fill.\n
-                        Specifies whether the \ref rocsolver_ssytrd "SYTRD" factorization was upper or
-                        lower triangular. If uplo indicates lower (or upper), then the upper (or
-                        lower) part of A is not used.
+    uplo        rocblas_fill.\n
+                Specifies whether the \ref rocsolver_ssytrd "SYTRD" factorization was upper or
+                lower triangular. If uplo indicates lower (or upper), then the upper (or
+                lower) part of A is not used.
     @param[in]
-    trans               rocblas_operation.\n
-                        Specifies whether the matrix Q or its transpose is to be
-                        applied.
+    trans       rocblas_operation.\n
+                Specifies whether the matrix Q or its transpose is to be
+                applied.
     @param[in]
-    m                   rocblas_int. m >= 0.\n
-                        Number of rows of matrix C.
+    m           rocblas_int. m >= 0.\n
+                Number of rows of matrix C.
     @param[in]
-    n                   rocblas_int. n >= 0.\n
-                        Number of columns of matrix C.
+    n           rocblas_int. n >= 0.\n
+                Number of columns of matrix C.
     @param[in]
-    A                   pointer to type. Array on the GPU of size lda*q.\n
-                        On entry, the Householder vectors as
-                        returned by \ref rocsolver_ssytrd "SYTRD".
+    A           pointer to type. Array on the GPU of size lda*q.\n
+                On entry, the Householder vectors as
+                returned by \ref rocsolver_ssytrd "SYTRD".
     @param[in]
-    lda                 rocblas_int. lda >= q.\n
-                        Leading dimension of A.
+    lda         rocblas_int. lda >= q.\n
+                Leading dimension of A.
     @param[in]
-    ipiv                pointer to type. Array on the GPU of dimension at least q-1.\n
-                        The Householder scalars as returned by
-                        \ref rocsolver_ssytrd "SYTRD".
+    ipiv        pointer to type. Array on the GPU of dimension at least q-1.\n
+                The Householder scalars as returned by
+                \ref rocsolver_ssytrd "SYTRD".
     @param[inout]
-    C                   pointer to type. Array on the GPU of size ldc*n.\n
-                        On entry, the matrix C. On exit, it is overwritten with
-                        Q*C, C*Q, Q'*C, or C*Q'.
+    C           pointer to type. Array on the GPU of size ldc*n.\n
+                On entry, the matrix C. On exit, it is overwritten with
+                Q*C, C*Q, Q'*C, or C*Q'.
     @param[in]
-    ldc                 rocblas_int. ldc >= m.\n
-                        Leading dimension of C.
+    ldc         rocblas_int. ldc >= m.\n
+                Leading dimension of C.
     ****************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sormtr(rocblas_handle handle,
@@ -3476,43 +3468,43 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_dormtr(rocblas_handle handle,
     \ref rocsolver_chetrd "HETRD" in its arguments A and tau.
 
     @param[in]
-    handle              rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    side                rocblas_side.\n
-                        Specifies from which side to apply Q.
+    side        rocblas_side.\n
+                Specifies from which side to apply Q.
     @param[in]
-    uplo                rocblas_fill.\n
-                        Specifies whether the \ref rocsolver_chetrd "HETRD" factorization was upper or
-                        lower triangular. If uplo indicates lower (or upper), then the upper (or
-                        lower) part of A is not used.
+    uplo        rocblas_fill.\n
+                Specifies whether the \ref rocsolver_chetrd "HETRD" factorization was upper or
+                lower triangular. If uplo indicates lower (or upper), then the upper (or
+                lower) part of A is not used.
     @param[in]
-    trans               rocblas_operation.\n
-                        Specifies whether the matrix Q or its conjugate
-                        transpose is to be applied.
+    trans       rocblas_operation.\n
+                Specifies whether the matrix Q or its conjugate
+                transpose is to be applied.
     @param[in]
-    m                   rocblas_int. m >= 0.\n
-                        Number of rows of matrix C.
+    m           rocblas_int. m >= 0.\n
+                Number of rows of matrix C.
     @param[in]
-    n                   rocblas_int. n >= 0.\n
-                        Number of columns of matrix C.
+    n           rocblas_int. n >= 0.\n
+                Number of columns of matrix C.
     @param[in]
-    A                   pointer to type. Array on the GPU of size lda*q.\n
-                        On entry, the Householder vectors as
-                        returned by \ref rocsolver_chetrd "HETRD".
+    A           pointer to type. Array on the GPU of size lda*q.\n
+                On entry, the Householder vectors as
+                returned by \ref rocsolver_chetrd "HETRD".
     @param[in]
-    lda                 rocblas_int. lda >= q.\n
-                        Leading dimension of A.
+    lda         rocblas_int. lda >= q.\n
+                Leading dimension of A.
     @param[in]
-    ipiv                pointer to type. Array on the GPU of dimension at least q-1.\n
-                        The Householder scalars as returned by
-                        \ref rocsolver_chetrd "HETRD".
+    ipiv        pointer to type. Array on the GPU of dimension at least q-1.\n
+                The Householder scalars as returned by
+                \ref rocsolver_chetrd "HETRD".
     @param[inout]
-    C                   pointer to type. Array on the GPU of size ldc*n.\n
-                        On entry, the matrix C. On exit, it is overwritten with
-                        Q*C, C*Q, Q'*C, or C*Q'.
+    C           pointer to type. Array on the GPU of size ldc*n.\n
+                On entry, the matrix C. On exit, it is overwritten with
+                Q*C, C*Q, Q'*C, or C*Q'.
     @param[in]
-    ldc                 rocblas_int. ldc >= m.\n
-                        Leading dimension of C.
+    ldc         rocblas_int. ldc >= m.\n
+                Leading dimension of C.
     ****************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_cunmtr(rocblas_handle handle,
@@ -3692,30 +3684,29 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zbdsqr(rocblas_handle handle,
     diagonal elements D and the array of symmetric off-diagonal elements E.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of rows and columns of the tridiagonal matrix.
+    n           rocblas_int. n >= 0.\n
+                The number of rows and columns of the tridiagonal matrix.
     @param[inout]
-    D         pointer to real type. Array on the GPU of dimension n.\n
-              On entry, the diagonal elements of the tridiagonal matrix.
-              On exit, if info = 0, the eigenvalues in increasing order.
-              If info > 0, the diagonal elements of a tridiagonal matrix
-              that is similar to the original matrix (i.e. has the same
-              eigenvalues).
+    D           pointer to real type. Array on the GPU of dimension n.\n
+                On entry, the diagonal elements of the tridiagonal matrix.
+                On exit, if info = 0, the eigenvalues in increasing order.
+                If info > 0, the diagonal elements of a tridiagonal matrix
+                that is similar to the original matrix (i.e. has the same
+                eigenvalues).
     @param[inout]
-    E         pointer to real type. Array on the GPU of dimension n-1.\n
-              On entry, the off-diagonal elements of the tridiagonal matrix.
-              On exit, if info = 0, this array converges to zero.
-              If info > 0, the off-diagonal elements of a tridiagonal matrix
-              that is similar to the original matrix (i.e. has the same
-              eigenvalues).
+    E           pointer to real type. Array on the GPU of dimension n-1.\n
+                On entry, the off-diagonal elements of the tridiagonal matrix.
+                On exit, if info = 0, this array converges to zero.
+                If info > 0, the off-diagonal elements of a tridiagonal matrix
+                that is similar to the original matrix (i.e. has the same
+                eigenvalues).
     @param[out]
-    info      pointer to a rocblas_int on the GPU.\n
-              If info = 0, successful exit.
-              If info = i > 0, STERF did not converge. i elements of E did not
-              converge to zero.
-
+    info        pointer to a rocblas_int on the GPU.\n
+                If info = 0, successful exit.
+                If info = i > 0, STERF did not converge. i elements of E did not
+                converge to zero.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_ssterf(rocblas_handle handle,
@@ -3746,46 +3737,45 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_dsterf(rocblas_handle handle,
     be computed, depending on the value of evect.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    evect     #rocblas_evect.\n
-              Specifies how the eigenvectors are computed.
+    evect       #rocblas_evect.\n
+                Specifies how the eigenvectors are computed.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of rows and columns of the tridiagonal matrix.
+    n           rocblas_int. n >= 0.\n
+                The number of rows and columns of the tridiagonal matrix.
     @param[inout]
-    D         pointer to real type. Array on the GPU of dimension n.\n
-              On entry, the diagonal elements of the tridiagonal matrix.
-              On exit, if info = 0, the eigenvalues in increasing order.
-              If info > 0, the diagonal elements of a tridiagonal matrix
-              that is similar to the original matrix (i.e. has the same
-              eigenvalues).
+    D           pointer to real type. Array on the GPU of dimension n.\n
+                On entry, the diagonal elements of the tridiagonal matrix.
+                On exit, if info = 0, the eigenvalues in increasing order.
+                If info > 0, the diagonal elements of a tridiagonal matrix
+                that is similar to the original matrix (i.e. has the same
+                eigenvalues).
     @param[inout]
-    E         pointer to real type. Array on the GPU of dimension n-1.\n
-              On entry, the off-diagonal elements of the tridiagonal matrix.
-              On exit, if info = 0, this array converges to zero.
-              If info > 0, the off-diagonal elements of a tridiagonal matrix
-              that is similar to the original matrix (i.e. has the same
-              eigenvalues).
+    E           pointer to real type. Array on the GPU of dimension n-1.\n
+                On entry, the off-diagonal elements of the tridiagonal matrix.
+                On exit, if info = 0, this array converges to zero.
+                If info > 0, the off-diagonal elements of a tridiagonal matrix
+                that is similar to the original matrix (i.e. has the same
+                eigenvalues).
     @param[inout]
-    C         pointer to type. Array on the GPU of dimension ldc*n.\n
-              On entry, if evect is original, the orthogonal/unitary matrix
-              used for the reduction to tridiagonal form as returned by, e.g.,
-              \ref rocsolver_sorgtr "ORGTR" or \ref rocsolver_cungtr "UNGTR".
-              On exit, it is overwritten with the eigenvectors of the original
-              symmetric/Hermitian matrix (if evect is original), or the
-              eigenvectors of the tridiagonal matrix (if evect is tridiagonal).
-              (Not referenced if evect is none).
+    C           pointer to type. Array on the GPU of dimension ldc*n.\n
+                On entry, if evect is original, the orthogonal/unitary matrix
+                used for the reduction to tridiagonal form as returned by, e.g.,
+                \ref rocsolver_sorgtr "ORGTR" or \ref rocsolver_cungtr "UNGTR".
+                On exit, it is overwritten with the eigenvectors of the original
+                symmetric/Hermitian matrix (if evect is original), or the
+                eigenvectors of the tridiagonal matrix (if evect is tridiagonal).
+                (Not referenced if evect is none).
     @param[in]
-    ldc       rocblas_int. ldc >= n if evect is original or tridiagonal.\n
-              Specifies the leading dimension of C.
-              (Not referenced if evect is none).
+    ldc         rocblas_int. ldc >= n if evect is original or tridiagonal.\n
+                Specifies the leading dimension of C.
+                (Not referenced if evect is none).
     @param[out]
-    info      pointer to a rocblas_int on the GPU.\n
-              If info = 0, successful exit.
-              If info = i > 0, STEQR did not converge. i elements of E did not
-              converge to zero.
-
+    info        pointer to a rocblas_int on the GPU.\n
+                If info = 0, successful exit.
+                If info = i > 0, STEQR did not converge. i elements of E did not
+                converge to zero.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_ssteqr(rocblas_handle handle,
@@ -3840,38 +3830,38 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zsteqr(rocblas_handle handle,
     be computed, depending on the value of evect.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    evect     #rocblas_evect.\n
-              Specifies how the eigenvectors are computed.
+    evect       #rocblas_evect.\n
+                Specifies how the eigenvectors are computed.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of rows and columns of the tridiagonal matrix.
+    n           rocblas_int. n >= 0.\n
+                The number of rows and columns of the tridiagonal matrix.
     @param[inout]
-    D         pointer to real type. Array on the GPU of dimension n.\n
-              On entry, the diagonal elements of the tridiagonal matrix.
-              On exit, if info = 0, the eigenvalues in increasing order.
+    D           pointer to real type. Array on the GPU of dimension n.\n
+                On entry, the diagonal elements of the tridiagonal matrix.
+                On exit, if info = 0, the eigenvalues in increasing order.
     @param[inout]
-    E         pointer to real type. Array on the GPU of dimension n-1.\n
-              On entry, the off-diagonal elements of the tridiagonal matrix.
-              On exit, if info = 0, the values of this array are destroyed.
+    E           pointer to real type. Array on the GPU of dimension n-1.\n
+                On entry, the off-diagonal elements of the tridiagonal matrix.
+                On exit, if info = 0, the values of this array are destroyed.
     @param[inout]
-    C         pointer to type. Array on the GPU of dimension ldc*n.\n
-              On entry, if evect is original, the orthogonal/unitary matrix
-              used for the reduction to tridiagonal form as returned by, e.g.,
-              \ref rocsolver_sorgtr "ORGTR" or \ref rocsolver_cungtr "UNGTR".
-              On exit, if info = 0, it is overwritten with the eigenvectors of the original
-              symmetric/Hermitian matrix (if evect is original), or the
-              eigenvectors of the tridiagonal matrix (if evect is tridiagonal).
-              (Not referenced if evect is none).
+    C           pointer to type. Array on the GPU of dimension ldc*n.\n
+                On entry, if evect is original, the orthogonal/unitary matrix
+                used for the reduction to tridiagonal form as returned by, e.g.,
+                \ref rocsolver_sorgtr "ORGTR" or \ref rocsolver_cungtr "UNGTR".
+                On exit, if info = 0, it is overwritten with the eigenvectors of the original
+                symmetric/Hermitian matrix (if evect is original), or the
+                eigenvectors of the tridiagonal matrix (if evect is tridiagonal).
+                (Not referenced if evect is none).
     @param[in]
-    ldc       rocblas_int. ldc >= n if evect is original or tridiagonal.\n
-              Specifies the leading dimension of C. (Not referenced if evect is none).
+    ldc         rocblas_int. ldc >= n if evect is original or tridiagonal.\n
+                Specifies the leading dimension of C. (Not referenced if evect is none).
     @param[out]
-    info      pointer to a rocblas_int on the GPU.\n
-              If info = 0, successful exit.
-              If info = i > 0, STEDC failed to compute an eigenvalue on the sub-matrix formed by
-              the rows and columns info/(n+1) through mod(info,n+1).
+    info        pointer to a rocblas_int on the GPU.\n
+                If info = 0, successful exit.
+                If info = i > 0, STEDC failed to compute an eigenvalue on the sub-matrix formed by
+                the rows and columns info/(n+1) through mod(info,n+1).
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sstedc(rocblas_handle handle,

--- a/library/include/rocsolver-functions.h
+++ b/library/include/rocsolver-functions.h
@@ -7278,40 +7278,39 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgelqf_strided_batched(rocblas_handle 
     while the first i-1 elements of the Householder vector \f$u_i\f$ are zero, and \f$u_i[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of the matrix A.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of the matrix A.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of the matrix A.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of the matrix A.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrix to be factored.
-              On exit, the elements on the diagonal and superdiagonal (if m >= n), or
-              subdiagonal (if m < n) contain the bidiagonal form B.
-              If m >= n, the elements below the diagonal are the last m - i elements
-              of Householder vector v_i, and the elements above the
-              superdiagonal are the last n - i - 1 elements of Householder vector u_i.
-              If m < n, the elements below the subdiagonal are the last m - i - 1
-              elements of Householder vector v_i, and the elements above the
-              diagonal are the last n - i elements of Householder vector u_i.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrix to be factored.
+                On exit, the elements on the diagonal and superdiagonal (if m >= n), or
+                subdiagonal (if m < n) contain the bidiagonal form B.
+                If m >= n, the elements below the diagonal are the last m - i elements
+                of Householder vector v_i, and the elements above the
+                superdiagonal are the last n - i - 1 elements of Householder vector u_i.
+                If m < n, the elements below the subdiagonal are the last m - i - 1
+                elements of Householder vector v_i, and the elements above the
+                diagonal are the last n - i elements of Householder vector u_i.
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              specifies the leading dimension of A.
+    lda         rocblas_int. lda >= m.\n
+                specifies the leading dimension of A.
     @param[out]
-    D         pointer to real type. Array on the GPU of dimension min(m,n).\n
-              The diagonal elements of B.
+    D           pointer to real type. Array on the GPU of dimension min(m,n).\n
+                The diagonal elements of B.
     @param[out]
-    E         pointer to real type. Array on the GPU of dimension min(m,n)-1.\n
-              The off-diagonal elements of B.
+    E           pointer to real type. Array on the GPU of dimension min(m,n)-1.\n
+                The off-diagonal elements of B.
     @param[out]
-    tauq      pointer to type. Array on the GPU of dimension min(m,n).\n
-              The Householder scalars associated with matrix Q.
+    tauq        pointer to type. Array on the GPU of dimension min(m,n).\n
+                The Householder scalars associated with matrix Q.
     @param[out]
-    taup      pointer to type. Array on the GPU of dimension min(m,n).\n
-              The Householder scalars associated with matrix P.
-
+    taup        pointer to type. Array on the GPU of dimension min(m,n).\n
+                The Householder scalars associated with matrix P.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgebd2(rocblas_handle handle,
@@ -7393,61 +7392,60 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgebd2(rocblas_handle handle,
     while the first i-1 elements of the Householder vector \f$u_{j_i}\f$ are zero, and \f$u_{j_i}[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all the matrices A_j in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all the matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all the matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all the matrices A_j in the batch.
     @param[inout]
-    A         Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrices A_j to be factored.
-              On exit, the elements on the diagonal and superdiagonal (if m >= n), or
-              subdiagonal (if m < n) contain the bidiagonal form B_j.
-              If m >= n, the elements below the diagonal are the last m - i elements
-              of Householder vector v_(j_i), and the elements above the
-              superdiagonal are the last n - i - 1 elements of Householder vector u_(j_i).
-              If m < n, the elements below the subdiagonal are the last m - i - 1
-              elements of Householder vector v_(j_i), and the elements above the
-              diagonal are the last n - i elements of Householder vector u_(j_i).
+    A           Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the elements on the diagonal and superdiagonal (if m >= n), or
+                subdiagonal (if m < n) contain the bidiagonal form B_j.
+                If m >= n, the elements below the diagonal are the last m - i elements
+                of Householder vector v_(j_i), and the elements above the
+                superdiagonal are the last n - i - 1 elements of Householder vector u_(j_i).
+                If m < n, the elements below the subdiagonal are the last m - i - 1
+                elements of Householder vector v_(j_i), and the elements above the
+                diagonal are the last n - i elements of Householder vector u_(j_i).
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[out]
-    D         pointer to real type. Array on the GPU (the size depends on the value of strideD).\n
-              The diagonal elements of B_j.
+    D           pointer to real type. Array on the GPU (the size depends on the value of strideD).\n
+                The diagonal elements of B_j.
     @param[in]
-    strideD   rocblas_stride.\n
-              Stride from the start of one vector D_j to the next one D_(j+1).
-              There is no restriction for the value of strideD. Normal use case is strideD >= min(m,n).
+    strideD     rocblas_stride.\n
+                Stride from the start of one vector D_j to the next one D_(j+1).
+                There is no restriction for the value of strideD. Normal use case is strideD >= min(m,n).
     @param[out]
-    E         pointer to real type. Array on the GPU (the size depends on the value of strideE).\n
-              The off-diagonal elements of B_j.
+    E           pointer to real type. Array on the GPU (the size depends on the value of strideE).\n
+                The off-diagonal elements of B_j.
     @param[in]
-    strideE   rocblas_stride.\n
-              Stride from the start of one vector E_j to the next one E_(j+1).
-              There is no restriction for the value of strideE. Normal use case is strideE >= min(m,n)-1.
+    strideE     rocblas_stride.\n
+                Stride from the start of one vector E_j to the next one E_(j+1).
+                There is no restriction for the value of strideE. Normal use case is strideE >= min(m,n)-1.
     @param[out]
-    tauq      pointer to type. Array on the GPU (the size depends on the value of strideQ).\n
-              Contains the vectors tauq_j of Householder scalars associated with matrices Q_j.
+    tauq        pointer to type. Array on the GPU (the size depends on the value of strideQ).\n
+                Contains the vectors tauq_j of Householder scalars associated with matrices Q_j.
     @param[in]
-    strideQ   rocblas_stride.\n
-              Stride from the start of one vector tauq_j to the next one tauq_(j+1).
-              There is no restriction for the value
-              of strideQ. Normal use is strideQ >= min(m,n).
+    strideQ     rocblas_stride.\n
+                Stride from the start of one vector tauq_j to the next one tauq_(j+1).
+                There is no restriction for the value
+                of strideQ. Normal use is strideQ >= min(m,n).
     @param[out]
-    taup      pointer to type. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors taup_j of Householder scalars associated with matrices P_j.
+    taup        pointer to type. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors taup_j of Householder scalars associated with matrices P_j.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector taup_j to the next one taup_(j+1).
-              There is no restriction for the value
-              of strideP. Normal use is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector taup_j to the next one taup_(j+1).
+                There is no restriction for the value
+                of strideP. Normal use is strideP >= min(m,n).
     @param[in]
-    batch_count  rocblas_int. batch_count >= 0.\n
-                 Number of matrices in the batch.
-
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgebd2_batched(rocblas_handle handle,
@@ -7549,65 +7547,64 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgebd2_batched(rocblas_handle handle,
     while the first i-1 elements of the Householder vector \f$u_{j_i}\f$ are zero, and \f$u_{j_i}[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all the matrices A_j in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all the matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all the matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all the matrices A_j in the batch.
     @param[inout]
-    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
-              On entry, the m-by-n matrices A_j to be factored.
-              On exit, the elements on the diagonal and superdiagonal (if m >= n), or
-              subdiagonal (if m < n) contain the bidiagonal form B_j.
-              If m >= n, the elements below the diagonal are the last m - i elements
-              of Householder vector v_(j_i), and the elements above the
-              superdiagonal are the last n - i - 1 elements of Householder vector u_(j_i).
-              If m < n, the elements below the subdiagonal are the last m - i - 1
-              elements of Householder vector v_(j_i), and the elements above the
-              diagonal are the last n - i elements of Householder vector u_(j_i).
+    A           pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the elements on the diagonal and superdiagonal (if m >= n), or
+                subdiagonal (if m < n) contain the bidiagonal form B_j.
+                If m >= n, the elements below the diagonal are the last m - i elements
+                of Householder vector v_(j_i), and the elements above the
+                superdiagonal are the last n - i - 1 elements of Householder vector u_(j_i).
+                If m < n, the elements below the subdiagonal are the last m - i - 1
+                elements of Householder vector v_(j_i), and the elements above the
+                diagonal are the last n - i elements of Householder vector u_(j_i).
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[in]
-    strideA   rocblas_stride.\n
-              Stride from the start of one matrix A_j to the next one A_(j+1).
-              There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
+    strideA     rocblas_stride.\n
+                Stride from the start of one matrix A_j to the next one A_(j+1).
+                There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
     @param[out]
-    D         pointer to real type. Array on the GPU (the size depends on the value of strideD).\n
-              The diagonal elements of B_j.
+    D           pointer to real type. Array on the GPU (the size depends on the value of strideD).\n
+                The diagonal elements of B_j.
     @param[in]
-    strideD   rocblas_stride.\n
-              Stride from the start of one vector D_j to the next one D_(j+1).
-              There is no restriction for the value of strideD. Normal use case is strideD >= min(m,n).
+    strideD     rocblas_stride.\n
+                Stride from the start of one vector D_j to the next one D_(j+1).
+                There is no restriction for the value of strideD. Normal use case is strideD >= min(m,n).
     @param[out]
-    E         pointer to real type. Array on the GPU (the size depends on the value of strideE).\n
-              The off-diagonal elements of B_j.
+    E           pointer to real type. Array on the GPU (the size depends on the value of strideE).\n
+                The off-diagonal elements of B_j.
     @param[in]
-    strideE   rocblas_stride.\n
-              Stride from the start of one vector E_j to the next one E_(j+1).
-              There is no restriction for the value of strideE. Normal use case is strideE >= min(m,n)-1.
+    strideE     rocblas_stride.\n
+                Stride from the start of one vector E_j to the next one E_(j+1).
+                There is no restriction for the value of strideE. Normal use case is strideE >= min(m,n)-1.
     @param[out]
-    tauq      pointer to type. Array on the GPU (the size depends on the value of strideQ).\n
-              Contains the vectors tauq_j of Householder scalars associated with matrices Q_j.
+    tauq        pointer to type. Array on the GPU (the size depends on the value of strideQ).\n
+                Contains the vectors tauq_j of Householder scalars associated with matrices Q_j.
     @param[in]
-    strideQ   rocblas_stride.\n
-              Stride from the start of one vector tauq_j to the next one tauq_(j+1).
-              There is no restriction for the value
-              of strideQ. Normal use is strideQ >= min(m,n).
+    strideQ     rocblas_stride.\n
+                Stride from the start of one vector tauq_j to the next one tauq_(j+1).
+                There is no restriction for the value
+                of strideQ. Normal use is strideQ >= min(m,n).
     @param[out]
-    taup      pointer to type. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors taup_j of Householder scalars associated with matrices P_j.
+    taup        pointer to type. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors taup_j of Householder scalars associated with matrices P_j.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector taup_j to the next one taup_(j+1).
-              There is no restriction for the value
-              of strideP. Normal use is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector taup_j to the next one taup_(j+1).
+                There is no restriction for the value
+                of strideP. Normal use is strideP >= min(m,n).
     @param[in]
-    batch_count  rocblas_int. batch_count >= 0.\n
-                 Number of matrices in the batch.
-
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgebd2_strided_batched(rocblas_handle handle,
@@ -7712,40 +7709,39 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgebd2_strided_batched(rocblas_handle 
     while the first i-1 elements of the Householder vector \f$u_i\f$ are zero, and \f$u_i[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of the matrix A.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of the matrix A.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of the matrix A.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of the matrix A.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrix to be factored.
-              On exit, the elements on the diagonal and superdiagonal (if m >= n), or
-              subdiagonal (if m < n) contain the bidiagonal form B.
-              If m >= n, the elements below the diagonal are the last m - i elements
-              of Householder vector v_i, and the elements above the
-              superdiagonal are the last n - i - 1 elements of Householder vector u_i.
-              If m < n, the elements below the subdiagonal are the last m - i - 1
-              elements of Householder vector v_i, and the elements above the
-              diagonal are the last n - i elements of Householder vector u_i.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrix to be factored.
+                On exit, the elements on the diagonal and superdiagonal (if m >= n), or
+                subdiagonal (if m < n) contain the bidiagonal form B.
+                If m >= n, the elements below the diagonal are the last m - i elements
+                of Householder vector v_i, and the elements above the
+                superdiagonal are the last n - i - 1 elements of Householder vector u_i.
+                If m < n, the elements below the subdiagonal are the last m - i - 1
+                elements of Householder vector v_i, and the elements above the
+                diagonal are the last n - i elements of Householder vector u_i.
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              specifies the leading dimension of A.
+    lda         rocblas_int. lda >= m.\n
+                specifies the leading dimension of A.
     @param[out]
-    D         pointer to real type. Array on the GPU of dimension min(m,n).\n
-              The diagonal elements of B.
+    D           pointer to real type. Array on the GPU of dimension min(m,n).\n
+                The diagonal elements of B.
     @param[out]
-    E         pointer to real type. Array on the GPU of dimension min(m,n)-1.\n
-              The off-diagonal elements of B.
+    E           pointer to real type. Array on the GPU of dimension min(m,n)-1.\n
+                The off-diagonal elements of B.
     @param[out]
-    tauq      pointer to type. Array on the GPU of dimension min(m,n).\n
-              The Householder scalars associated with matrix Q.
+    tauq        pointer to type. Array on the GPU of dimension min(m,n).\n
+                The Householder scalars associated with matrix Q.
     @param[out]
-    taup      pointer to type. Array on the GPU of dimension min(m,n).\n
-              The Householder scalars associated with matrix P.
-
+    taup        pointer to type. Array on the GPU of dimension min(m,n).\n
+                The Householder scalars associated with matrix P.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgebrd(rocblas_handle handle,
@@ -7827,61 +7823,60 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgebrd(rocblas_handle handle,
     while the first i-1 elements of the Householder vector \f$u_{j_i}\f$ are zero, and \f$u_{j_i}[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all the matrices A_j in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all the matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all the matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all the matrices A_j in the batch.
     @param[inout]
-    A         Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrices A_j to be factored.
-              On exit, the elements on the diagonal and superdiagonal (if m >= n), or
-              subdiagonal (if m < n) contain the bidiagonal form B_j.
-              If m >= n, the elements below the diagonal are the last m - i elements
-              of Householder vector v_(j_i), and the elements above the
-              superdiagonal are the last n - i - 1 elements of Householder vector u_(j_i).
-              If m < n, the elements below the subdiagonal are the last m - i - 1
-              elements of Householder vector v_(j_i), and the elements above the
-              diagonal are the last n - i elements of Householder vector u_(j_i).
+    A           Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the elements on the diagonal and superdiagonal (if m >= n), or
+                subdiagonal (if m < n) contain the bidiagonal form B_j.
+                If m >= n, the elements below the diagonal are the last m - i elements
+                of Householder vector v_(j_i), and the elements above the
+                superdiagonal are the last n - i - 1 elements of Householder vector u_(j_i).
+                If m < n, the elements below the subdiagonal are the last m - i - 1
+                elements of Householder vector v_(j_i), and the elements above the
+                diagonal are the last n - i elements of Householder vector u_(j_i).
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[out]
-    D         pointer to real type. Array on the GPU (the size depends on the value of strideD).\n
-              The diagonal elements of B_j.
+    D           pointer to real type. Array on the GPU (the size depends on the value of strideD).\n
+                The diagonal elements of B_j.
     @param[in]
-    strideD   rocblas_stride.\n
-              Stride from the start of one vector D_j to the next one D_(j+1).
-              There is no restriction for the value of strideD. Normal use case is strideD >= min(m,n).
+    strideD     rocblas_stride.\n
+                Stride from the start of one vector D_j to the next one D_(j+1).
+                There is no restriction for the value of strideD. Normal use case is strideD >= min(m,n).
     @param[out]
-    E         pointer to real type. Array on the GPU (the size depends on the value of strideE).\n
-              The off-diagonal elements of B_j.
+    E           pointer to real type. Array on the GPU (the size depends on the value of strideE).\n
+                The off-diagonal elements of B_j.
     @param[in]
-    strideE   rocblas_stride.\n
-              Stride from the start of one vector E_j to the next one E_(j+1).
-              There is no restriction for the value of strideE. Normal use case is strideE >= min(m,n)-1.
+    strideE     rocblas_stride.\n
+                Stride from the start of one vector E_j to the next one E_(j+1).
+                There is no restriction for the value of strideE. Normal use case is strideE >= min(m,n)-1.
     @param[out]
-    tauq      pointer to type. Array on the GPU (the size depends on the value of strideQ).\n
-              Contains the vectors tauq_j of Householder scalars associated with matrices Q_j.
+    tauq        pointer to type. Array on the GPU (the size depends on the value of strideQ).\n
+                Contains the vectors tauq_j of Householder scalars associated with matrices Q_j.
     @param[in]
-    strideQ   rocblas_stride.\n
-              Stride from the start of one vector tauq_j to the next one tauq_(j+1).
-              There is no restriction for the value
-              of strideQ. Normal use is strideQ >= min(m,n).
+    strideQ     rocblas_stride.\n
+                Stride from the start of one vector tauq_j to the next one tauq_(j+1).
+                There is no restriction for the value
+                of strideQ. Normal use is strideQ >= min(m,n).
     @param[out]
-    taup      pointer to type. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors taup_j of Householder scalars associated with matrices P_j.
+    taup        pointer to type. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors taup_j of Householder scalars associated with matrices P_j.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector taup_j to the next one taup_(j+1).
-              There is no restriction for the value
-              of strideP. Normal use is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector taup_j to the next one taup_(j+1).
+                There is no restriction for the value
+                of strideP. Normal use is strideP >= min(m,n).
     @param[in]
-    batch_count  rocblas_int. batch_count >= 0.\n
-                 Number of matrices in the batch.
-
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgebrd_batched(rocblas_handle handle,
@@ -7983,65 +7978,64 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgebrd_batched(rocblas_handle handle,
     while the first i-1 elements of the Householder vector \f$u_{j_i}\f$ are zero, and \f$u_{j_i}[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all the matrices A_j in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all the matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all the matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all the matrices A_j in the batch.
     @param[inout]
-    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
-              On entry, the m-by-n matrices A_j to be factored.
-              On exit, the elements on the diagonal and superdiagonal (if m >= n), or
-              subdiagonal (if m < n) contain the bidiagonal form B_j.
-              If m >= n, the elements below the diagonal are the last m - i elements
-              of Householder vector v_(j_i), and the elements above the
-              superdiagonal are the last n - i - 1 elements of Householder vector u_(j_i).
-              If m < n, the elements below the subdiagonal are the last m - i - 1
-              elements of Householder vector v_(j_i), and the elements above the
-              diagonal are the last n - i elements of Householder vector u_(j_i).
+    A           pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the elements on the diagonal and superdiagonal (if m >= n), or
+                subdiagonal (if m < n) contain the bidiagonal form B_j.
+                If m >= n, the elements below the diagonal are the last m - i elements
+                of Householder vector v_(j_i), and the elements above the
+                superdiagonal are the last n - i - 1 elements of Householder vector u_(j_i).
+                If m < n, the elements below the subdiagonal are the last m - i - 1
+                elements of Householder vector v_(j_i), and the elements above the
+                diagonal are the last n - i elements of Householder vector u_(j_i).
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[in]
-    strideA   rocblas_stride.\n
-              Stride from the start of one matrix A_j to the next one A_(j+1).
-              There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
+    strideA     rocblas_stride.\n
+                Stride from the start of one matrix A_j to the next one A_(j+1).
+                There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
     @param[out]
-    D         pointer to real type. Array on the GPU (the size depends on the value of strideD).\n
-              The diagonal elements of B_j.
+    D           pointer to real type. Array on the GPU (the size depends on the value of strideD).\n
+                The diagonal elements of B_j.
     @param[in]
-    strideD   rocblas_stride.\n
-              Stride from the start of one vector D_j to the next one D_(j+1).
-              There is no restriction for the value of strideD. Normal use case is strideD >= min(m,n).
+    strideD     rocblas_stride.\n
+                Stride from the start of one vector D_j to the next one D_(j+1).
+                There is no restriction for the value of strideD. Normal use case is strideD >= min(m,n).
     @param[out]
-    E         pointer to real type. Array on the GPU (the size depends on the value of strideE).\n
-              The off-diagonal elements of B_j.
+    E           pointer to real type. Array on the GPU (the size depends on the value of strideE).\n
+                The off-diagonal elements of B_j.
     @param[in]
-    strideE   rocblas_stride.\n
-              Stride from the start of one vector E_j to the next one E_(j+1).
-              There is no restriction for the value of strideE. Normal use case is strideE >= min(m,n)-1.
+    strideE     rocblas_stride.\n
+                Stride from the start of one vector E_j to the next one E_(j+1).
+                There is no restriction for the value of strideE. Normal use case is strideE >= min(m,n)-1.
     @param[out]
-    tauq      pointer to type. Array on the GPU (the size depends on the value of strideQ).\n
-              Contains the vectors tauq_j of Householder scalars associated with matrices Q_j.
+    tauq        pointer to type. Array on the GPU (the size depends on the value of strideQ).\n
+                Contains the vectors tauq_j of Householder scalars associated with matrices Q_j.
     @param[in]
-    strideQ   rocblas_stride.\n
-              Stride from the start of one vector tauq_j to the next one tauq_(j+1).
-              There is no restriction for the value
-              of strideQ. Normal use is strideQ >= min(m,n).
+    strideQ     rocblas_stride.\n
+                Stride from the start of one vector tauq_j to the next one tauq_(j+1).
+                There is no restriction for the value
+                of strideQ. Normal use is strideQ >= min(m,n).
     @param[out]
-    taup      pointer to type. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors taup_j of Householder scalars associated with matrices P_j.
+    taup        pointer to type. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors taup_j of Householder scalars associated with matrices P_j.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector taup_j to the next one taup_(j+1).
-              There is no restriction for the value
-              of strideP. Normal use is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector taup_j to the next one taup_(j+1).
+                There is no restriction for the value
+                of strideP. Normal use is strideP >= min(m,n).
     @param[in]
-    batch_count  rocblas_int. batch_count >= 0.\n
-                 Number of matrices in the batch.
-
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgebrd_strided_batched(rocblas_handle handle,

--- a/library/include/rocsolver-functions.h
+++ b/library/include/rocsolver-functions.h
@@ -3930,26 +3930,26 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zstedc(rocblas_handle handle,
     If numerical accuracy is compromised, use the legacy-LAPACK-like API \ref rocsolver_sgetf2 "GETF2" routines instead.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of the matrix A.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of the matrix A.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of the matrix A.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of the matrix A.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrix A to be factored.
-              On exit, the factors L and U from the factorization.
-              The unit diagonal elements of L are not stored.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrix A to be factored.
+                On exit, the factors L and U from the factorization.
+                The unit diagonal elements of L are not stored.
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of A.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of A.
     @param[out]
-    info      pointer to a rocblas_int on the GPU.\n
-              If info = 0, successful exit.
-              If info = j > 0, U is singular. U[j,j] is the first zero element in the diagonal. The factorization from
-              this point might be incomplete.
+    info        pointer to a rocblas_int on the GPU.\n
+                If info = 0, successful exit.
+                If info = i > 0, U is singular. U[i,i] is the first zero element in the diagonal. The factorization from
+                this point might be incomplete.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgetf2_npvt(rocblas_handle handle,
@@ -3990,40 +3990,40 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgetf2_npvt(rocblas_handle handle,
     could be executed with small and mid-size matrices if optimizations are enabled (default option). For more details, see the
     "Tuning rocSOLVER performance" section of the Library Design Guide).
 
-    The factorization of matrix \f$A_i\f$ in the batch has the form
+    The factorization of matrix \f$A_j\f$ in the batch has the form
 
     \f[
-        A_i = L_iU_i
+        A_j = L_jU_j
     \f]
 
-    where \f$L_i\f$ is lower triangular with unit
-    diagonal elements (lower trapezoidal if m > n), and \f$U_i\f$ is upper
+    where \f$L_j\f$ is lower triangular with unit
+    diagonal elements (lower trapezoidal if m > n), and \f$U_j\f$ is upper
     triangular (upper trapezoidal if m < n).
 
     Note: Although this routine can offer better performance, Gaussian elimination without pivoting is not backward stable.
     If numerical accuracy is compromised, use the legacy-LAPACK-like API \ref rocsolver_sgetf2_batched "GETF2_BATCHED" routines instead.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all matrices A_i in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all matrices A_i in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all matrices A_j in the batch.
     @param[inout]
-    A         array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrices A_i to be factored.
-              On exit, the factors L_i and U_i from the factorizations.
-              The unit diagonal elements of L_i are not stored.
+    A           array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the factors L_j and U_j from the factorizations.
+                The unit diagonal elements of L_j are not stored.
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_i.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[i] = 0, successful exit for factorization of A_i.
-              If info[i] = j > 0, U_i is singular. U_i[j,j] is the first zero element in the diagonal. The factorization from
-              this point might be incomplete.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful exit for factorization of A_j.
+                If info[j] = i > 0, U_j is singular. U_j[i,i] is the first zero element in the diagonal. The factorization from
+                this point might be incomplete.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.
@@ -4071,44 +4071,44 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgetf2_npvt_batched(rocblas_handle han
     could be executed with small and mid-size matrices if optimizations are enabled (default option). For more details, see the
     "Tuning rocSOLVER performance" section of the Library Design Guide).
 
-    The factorization of matrix \f$A_i\f$ in the batch has the form
+    The factorization of matrix \f$A_j\f$ in the batch has the form
 
     \f[
-        A_i = L_iU_i
+        A_j = L_jU_j
     \f]
 
-    where \f$L_i\f$ is lower triangular with unit
-    diagonal elements (lower trapezoidal if m > n), and \f$U_i\f$ is upper
+    where \f$L_j\f$ is lower triangular with unit
+    diagonal elements (lower trapezoidal if m > n), and \f$U_j\f$ is upper
     triangular (upper trapezoidal if m < n).
 
     Note: Although this routine can offer better performance, Gaussian elimination without pivoting is not backward stable.
     If numerical accuracy is compromised, use the legacy-LAPACK-like API \ref rocsolver_sgetf2_strided_batched "GETF2_STRIDED_BATCHED" routines instead.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all matrices A_i in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all matrices A_i in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all matrices A_j in the batch.
     @param[inout]
-    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
-              On entry, the m-by-n matrices A_i to be factored.
-              On exit, the factors L_i and U_i from the factorization.
-              The unit diagonal elements of L_i are not stored.
+    A           pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the factors L_j and U_j from the factorization.
+                The unit diagonal elements of L_j are not stored.
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_i.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[in]
-    strideA   rocblas_stride.\n
-              Stride from the start of one matrix A_i to the next one A_(i+1).
-              There is no restriction for the value of strideA. Normal use case is strideA >= lda*n
+    strideA     rocblas_stride.\n
+                Stride from the start of one matrix A_j to the next one A_(j+1).
+                There is no restriction for the value of strideA. Normal use case is strideA >= lda*n
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[i] = 0, successful exit for factorization of A_i.
-              If info[i] = j > 0, U_i is singular. U_i[j,j] is the first zero element in the diagonal. The factorization from
-              this point might be incomplete.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful exit for factorization of A_j.
+                If info[j] = i > 0, U_j is singular. U_j[i,i] is the first zero element in the diagonal. The factorization from
+                this point might be incomplete.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.
@@ -4174,26 +4174,26 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgetf2_npvt_strided_batched(rocblas_ha
     If numerical accuracy is compromised, use the legacy-LAPACK-like API \ref rocsolver_sgetrf "GETRF" routines instead.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of the matrix A.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of the matrix A.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of the matrix A.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of the matrix A.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrix A to be factored.
-              On exit, the factors L and U from the factorization.
-              The unit diagonal elements of L are not stored.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrix A to be factored.
+                On exit, the factors L and U from the factorization.
+                The unit diagonal elements of L are not stored.
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of A.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of A.
     @param[out]
-    info      pointer to a rocblas_int on the GPU.\n
-              If info = 0, successful exit.
-              If info = j > 0, U is singular. U[j,j] is the first zero element in the diagonal. The factorization from
-              this point might be incomplete.
+    info        pointer to a rocblas_int on the GPU.\n
+                If info = 0, successful exit.
+                If info = i > 0, U is singular. U[i,i] is the first zero element in the diagonal. The factorization from
+                this point might be incomplete.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgetrf_npvt(rocblas_handle handle,
@@ -4234,40 +4234,40 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgetrf_npvt(rocblas_handle handle,
     could be executed with mid-size matrices if optimizations are enabled (default option). For more details, see the
     "Tuning rocSOLVER performance" section of the Library Design Guide).
 
-    The factorization of matrix \f$A_i\f$ in the batch has the form
+    The factorization of matrix \f$A_j\f$ in the batch has the form
 
     \f[
-        A_i = L_iU_i
+        A_j = L_jU_j
     \f]
 
-    where \f$L_i\f$ is lower triangular with unit
-    diagonal elements (lower trapezoidal if m > n), and \f$U_i\f$ is upper
+    where \f$L_j\f$ is lower triangular with unit
+    diagonal elements (lower trapezoidal if m > n), and \f$U_j\f$ is upper
     triangular (upper trapezoidal if m < n).
 
     Note: Although this routine can offer better performance, Gaussian elimination without pivoting is not backward stable.
     If numerical accuracy is compromised, use the legacy-LAPACK-like API \ref rocsolver_sgetrf_batched "GETRF_BATCHED" routines instead.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all matrices A_i in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all matrices A_i in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all matrices A_j in the batch.
     @param[inout]
-    A         array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrices A_i to be factored.
-              On exit, the factors L_i and U_i from the factorizations.
-              The unit diagonal elements of L_i are not stored.
+    A           array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the factors L_j and U_j from the factorizations.
+                The unit diagonal elements of L_j are not stored.
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_i.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[i] = 0, successful exit for factorization of A_i.
-              If info[i] = j > 0, U_i is singular. U_i[j,j] is the first zero element in the diagonal. The factorization from
-              this point might be incomplete.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful exit for factorization of A_j.
+                If info[j] = i > 0, U_j is singular. U_j[i,i] is the first zero element in the diagonal. The factorization from
+                this point might be incomplete.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.
@@ -4316,44 +4316,44 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgetrf_npvt_batched(rocblas_handle han
     could be executed with mid-size matrices if optimizations are enabled (default option). For more details, see the
     "Tuning rocSOLVER performance" section of the Library Design Guide).
 
-    The factorization of matrix \f$A_i\f$ in the batch has the form
+    The factorization of matrix \f$A_j\f$ in the batch has the form
 
     \f[
-        A_i = L_iU_i
+        A_j = L_jU_j
     \f]
 
-    where \f$L_i\f$ is lower triangular with unit
-    diagonal elements (lower trapezoidal if m > n), and \f$U_i\f$ is upper
+    where \f$L_j\f$ is lower triangular with unit
+    diagonal elements (lower trapezoidal if m > n), and \f$U_j\f$ is upper
     triangular (upper trapezoidal if m < n).
 
     Note: Although this routine can offer better performance, Gaussian elimination without pivoting is not backward stable.
     If numerical accuracy is compromised, use the legacy-LAPACK-like API \ref rocsolver_sgetrf_strided_batched "GETRF_STRIDED_BATCHED" routines instead.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all matrices A_i in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all matrices A_i in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all matrices A_j in the batch.
     @param[inout]
-    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
-              On entry, the m-by-n matrices A_i to be factored.
-              On exit, the factors L_i and U_i from the factorization.
-              The unit diagonal elements of L_i are not stored.
+    A           pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the factors L_j and U_j from the factorization.
+                The unit diagonal elements of L_j are not stored.
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_i.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[in]
-    strideA   rocblas_stride.\n
-              Stride from the start of one matrix A_i to the next one A_(i+1).
-              There is no restriction for the value of strideA. Normal use case is strideA >= lda*n
+    strideA     rocblas_stride.\n
+                Stride from the start of one matrix A_j to the next one A_(j+1).
+                There is no restriction for the value of strideA. Normal use case is strideA >= lda*n
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[i] = 0, successful exit for factorization of A_i.
-              If info[i] = j > 0, U_i is singular. U_i[j,j] is the first zero element in the diagonal. The factorization from
-              this point might be incomplete.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful exit for factorization of A_j.
+                If info[j] = i > 0, U_j is singular. U_j[i,i] is the first zero element in the diagonal. The factorization from
+                this point might be incomplete.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.
@@ -4417,31 +4417,31 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgetrf_npvt_strided_batched(rocblas_ha
     triangular (upper trapezoidal if m < n).
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of the matrix A.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of the matrix A.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of the matrix A.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of the matrix A.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrix A to be factored.
-              On exit, the factors L and U from the factorization.
-              The unit diagonal elements of L are not stored.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrix A to be factored.
+                On exit, the factors L and U from the factorization.
+                The unit diagonal elements of L are not stored.
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of A.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of A.
     @param[out]
-    ipiv      pointer to rocblas_int. Array on the GPU of dimension min(m,n).\n
-              The vector of pivot indices. Elements of ipiv are 1-based indices.
-              For 1 <= i <= min(m,n), the row i of the
-              matrix was interchanged with row ipiv[i].
-              Matrix P of the factorization can be derived from ipiv.
+    ipiv        pointer to rocblas_int. Array on the GPU of dimension min(m,n).\n
+                The vector of pivot indices. Elements of ipiv are 1-based indices.
+                For 1 <= i <= min(m,n), the row i of the
+                matrix was interchanged with row ipiv[i].
+                Matrix P of the factorization can be derived from ipiv.
     @param[out]
-    info      pointer to a rocblas_int on the GPU.\n
-              If info = 0, successful exit.
-              If info = j > 0, U is singular. U[j,j] is the first zero pivot.
+    info        pointer to a rocblas_int on the GPU.\n
+                If info = 0, successful exit.
+                If info = i > 0, U is singular. U[i,i] is the first zero pivot.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgetf2(rocblas_handle handle,
@@ -4486,48 +4486,48 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgetf2(rocblas_handle handle,
     could be executed with small and mid-size matrices if optimizations are enabled (default option). For more details, see the
     "Tuning rocSOLVER performance" section of the Library Design Guide).
 
-    The factorization of matrix \f$A_i\f$ in the batch has the form
+    The factorization of matrix \f$A_j\f$ in the batch has the form
 
     \f[
-        A_i = P_iL_iU_i
+        A_j = P_jL_jU_j
     \f]
 
-    where \f$P_i\f$ is a permutation matrix, \f$L_i\f$ is lower triangular with unit
-    diagonal elements (lower trapezoidal if m > n), and \f$U_i\f$ is upper
+    where \f$P_j\f$ is a permutation matrix, \f$L_j\f$ is lower triangular with unit
+    diagonal elements (lower trapezoidal if m > n), and \f$U_j\f$ is upper
     triangular (upper trapezoidal if m < n).
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all matrices A_i in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all matrices A_i in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all matrices A_j in the batch.
     @param[inout]
-    A         array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrices A_i to be factored.
-              On exit, the factors L_i and U_i from the factorizations.
-              The unit diagonal elements of L_i are not stored.
+    A           array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the factors L_j and U_j from the factorizations.
+                The unit diagonal elements of L_j are not stored.
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_i.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[out]
-    ipiv      pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors of pivot indices ipiv_i (corresponding to A_i).
-              Dimension of ipiv_i is min(m,n).
-              Elements of ipiv_i are 1-based indices.
-              For each instance A_i in the batch and for 1 <= j <= min(m,n), the row j of the
-              matrix A_i was interchanged with row ipiv_i[j].
-              Matrix P_i of the factorization can be derived from ipiv_i.
+    ipiv        pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors of pivot indices ipiv_j (corresponding to A_j).
+                Dimension of ipiv_j is min(m,n).
+                Elements of ipiv_j are 1-based indices.
+                For each instance A_j in the batch and for 1 <= i <= min(m,n), the row i of the
+                matrix A_j was interchanged with row ipiv_j[i].
+                Matrix P_j of the factorization can be derived from ipiv_j.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector ipiv_i to the next one ipiv_(i+1).
-              There is no restriction for the value of strideP. Normal use case is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
+                There is no restriction for the value of strideP. Normal use case is strideP >= min(m,n).
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[i] = 0, successful exit for factorization of A_i.
-              If info[i] = j > 0, U_i is singular. U_i[j,j] is the first zero pivot.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful exit for factorization of A_j.
+                If info[j] = i > 0, U_j is singular. U_j[i,i] is the first zero pivot.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.
@@ -4583,52 +4583,52 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgetf2_batched(rocblas_handle handle,
     could be executed with small and mid-size matrices if optimizations are enabled (default option). For more details, see the
     "Tuning rocSOLVER performance" section of the Library Design Guide).
 
-    The factorization of matrix \f$A_i\f$ in the batch has the form
+    The factorization of matrix \f$A_j\f$ in the batch has the form
 
     \f[
-        A_i = P_iL_iU_i
+        A_j = P_jL_jU_j
     \f]
 
-    where \f$P_i\f$ is a permutation matrix, \f$L_i\f$ is lower triangular with unit
-    diagonal elements (lower trapezoidal if m > n), and \f$U_i\f$ is upper
+    where \f$P_j\f$ is a permutation matrix, \f$L_j\f$ is lower triangular with unit
+    diagonal elements (lower trapezoidal if m > n), and \f$U_j\f$ is upper
     triangular (upper trapezoidal if m < n).
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all matrices A_i in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all matrices A_i in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all matrices A_j in the batch.
     @param[inout]
-    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
-              On entry, the m-by-n matrices A_i to be factored.
-              On exit, the factors L_i and U_i from the factorization.
-              The unit diagonal elements of L_i are not stored.
+    A           pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the factors L_j and U_j from the factorization.
+                The unit diagonal elements of L_j are not stored.
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_i.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[in]
-    strideA   rocblas_stride.\n
-              Stride from the start of one matrix A_i to the next one A_(i+1).
-              There is no restriction for the value of strideA. Normal use case is strideA >= lda*n
+    strideA     rocblas_stride.\n
+                Stride from the start of one matrix A_j to the next one A_(j+1).
+                There is no restriction for the value of strideA. Normal use case is strideA >= lda*n
     @param[out]
-    ipiv      pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors of pivots indices ipiv_i (corresponding to A_i).
-              Dimension of ipiv_i is min(m,n).
-              Elements of ipiv_i are 1-based indices.
-              For each instance A_i in the batch and for 1 <= j <= min(m,n), the row j of the
-              matrix A_i was interchanged with row ipiv_i[j].
-              Matrix P_i of the factorization can be derived from ipiv_i.
+    ipiv        pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors of pivots indices ipiv_j (corresponding to A_j).
+                Dimension of ipiv_j is min(m,n).
+                Elements of ipiv_j are 1-based indices.
+                For each instance A_j in the batch and for 1 <= i <= min(m,n), the row i of the
+                matrix A_j was interchanged with row ipiv_j[i].
+                Matrix P_j of the factorization can be derived from ipiv_j.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector ipiv_i to the next one ipiv_(i+1).
-              There is no restriction for the value of strideP. Normal use case is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
+                There is no restriction for the value of strideP. Normal use case is strideP >= min(m,n).
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[i] = 0, successful exit for factorization of A_i.
-              If info[i] = j > 0, U_i is singular. U_i[j,j] is the first zero pivot.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful exit for factorization of A_j.
+                If info[j] = i > 0, U_j is singular. U_j[i,i] is the first zero pivot.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.
@@ -4699,31 +4699,31 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgetf2_strided_batched(rocblas_handle 
     triangular (upper trapezoidal if m < n).
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of the matrix A.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of the matrix A.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of the matrix A.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of the matrix A.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrix A to be factored.
-              On exit, the factors L and U from the factorization.
-              The unit diagonal elements of L are not stored.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrix A to be factored.
+                On exit, the factors L and U from the factorization.
+                The unit diagonal elements of L are not stored.
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of A.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of A.
     @param[out]
-    ipiv      pointer to rocblas_int. Array on the GPU of dimension min(m,n).\n
-              The vector of pivot indices. Elements of ipiv are 1-based indices.
-              For 1 <= i <= min(m,n), the row i of the
-              matrix was interchanged with row ipiv[i].
-              Matrix P of the factorization can be derived from ipiv.
+    ipiv        pointer to rocblas_int. Array on the GPU of dimension min(m,n).\n
+                The vector of pivot indices. Elements of ipiv are 1-based indices.
+                For 1 <= i <= min(m,n), the row i of the
+                matrix was interchanged with row ipiv[i].
+                Matrix P of the factorization can be derived from ipiv.
     @param[out]
-    info      pointer to a rocblas_int on the GPU.\n
-              If info = 0, successful exit.
-              If info = j > 0, U is singular. U[j,j] is the first zero pivot.
+    info        pointer to a rocblas_int on the GPU.\n
+                If info = 0, successful exit.
+                If info = i > 0, U is singular. U[i,i] is the first zero pivot.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgetrf(rocblas_handle handle,
@@ -4768,48 +4768,48 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgetrf(rocblas_handle handle,
     could be executed with mid-size matrices if optimizations are enabled (default option). For more details, see the
     "Tuning rocSOLVER performance" section of the Library Design Guide).
 
-    The factorization of matrix \f$A_i\f$ in the batch has the form
+    The factorization of matrix \f$A_j\f$ in the batch has the form
 
     \f[
-        A_i = P_iL_iU_i
+        A_j = P_jL_jU_j
     \f]
 
-    where \f$P_i\f$ is a permutation matrix, \f$L_i\f$ is lower triangular with unit
-    diagonal elements (lower trapezoidal if m > n), and \f$U_i\f$ is upper
+    where \f$P_j\f$ is a permutation matrix, \f$L_j\f$ is lower triangular with unit
+    diagonal elements (lower trapezoidal if m > n), and \f$U_j\f$ is upper
     triangular (upper trapezoidal if m < n).
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all matrices A_i in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all matrices A_i in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all matrices A_j in the batch.
     @param[inout]
-    A         array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrices A_i to be factored.
-              On exit, the factors L_i and U_i from the factorizations.
-              The unit diagonal elements of L_i are not stored.
+    A           array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the factors L_j and U_j from the factorizations.
+                The unit diagonal elements of L_j are not stored.
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_i.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[out]
-    ipiv      pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors of pivot indices ipiv_i (corresponding to A_i).
-              Dimension of ipiv_i is min(m,n).
-              Elements of ipiv_i are 1-based indices.
-              For each instance A_i in the batch and for 1 <= j <= min(m,n), the row j of the
-              matrix A_i was interchanged with row ipiv_i[j].
-              Matrix P_i of the factorization can be derived from ipiv_i.
+    ipiv        pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors of pivot indices ipiv_j (corresponding to A_j).
+                Dimension of ipiv_j is min(m,n).
+                Elements of ipiv_j are 1-based indices.
+                For each instance A_j in the batch and for 1 <= i <= min(m,n), the row i of the
+                matrix A_j was interchanged with row ipiv_j[i].
+                Matrix P_j of the factorization can be derived from ipiv_j.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector ipiv_i to the next one ipiv_(i+1).
-              There is no restriction for the value of strideP. Normal use case is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
+                There is no restriction for the value of strideP. Normal use case is strideP >= min(m,n).
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[i] = 0, successful exit for factorization of A_i.
-              If info[i] = j > 0, U_i is singular. U_i[j,j] is the first zero pivot.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful exit for factorization of A_j.
+                If info[j] = i > 0, U_j is singular. U_j[i,i] is the first zero pivot.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.
@@ -4865,52 +4865,52 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgetrf_batched(rocblas_handle handle,
     could be executed with mid-size matrices if optimizations are enabled (default option). For more details, see the
     "Tuning rocSOLVER performance" section of the Library Design Guide).
 
-    The factorization of matrix \f$A_i\f$ in the batch has the form
+    The factorization of matrix \f$A_j\f$ in the batch has the form
 
     \f[
-        A_i = P_iL_iU_i
+        A_j = P_jL_jU_j
     \f]
 
-    where \f$P_i\f$ is a permutation matrix, \f$L_i\f$ is lower triangular with unit
-    diagonal elements (lower trapezoidal if m > n), and \f$U_i\f$ is upper
+    where \f$P_j\f$ is a permutation matrix, \f$L_j\f$ is lower triangular with unit
+    diagonal elements (lower trapezoidal if m > n), and \f$U_j\f$ is upper
     triangular (upper trapezoidal if m < n).
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all matrices A_i in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all matrices A_i in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all matrices A_j in the batch.
     @param[inout]
-    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
-              On entry, the m-by-n matrices A_i to be factored.
-              On exit, the factors L_i and U_i from the factorization.
-              The unit diagonal elements of L_i are not stored.
+    A           pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the factors L_j and U_j from the factorization.
+                The unit diagonal elements of L_j are not stored.
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_i.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[in]
-    strideA   rocblas_stride.\n
-              Stride from the start of one matrix A_i to the next one A_(i+1).
-              There is no restriction for the value of strideA. Normal use case is strideA >= lda*n
+    strideA     rocblas_stride.\n
+                Stride from the start of one matrix A_j to the next one A_(j+1).
+                There is no restriction for the value of strideA. Normal use case is strideA >= lda*n
     @param[out]
-    ipiv      pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors of pivots indices ipiv_i (corresponding to A_i).
-              Dimension of ipiv_i is min(m,n).
-              Elements of ipiv_i are 1-based indices.
-              For each instance A_i in the batch and for 1 <= j <= min(m,n), the row j of the
-              matrix A_i was interchanged with row ipiv_i[j].
-              Matrix P_i of the factorization can be derived from ipiv_i.
+    ipiv        pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors of pivots indices ipiv_j (corresponding to A_j).
+                Dimension of ipiv_j is min(m,n).
+                Elements of ipiv_j are 1-based indices.
+                For each instance A_j in the batch and for 1 <= i <= min(m,n), the row i of the
+                matrix A_j was interchanged with row ipiv_j[i].
+                Matrix P_j of the factorization can be derived from ipiv_j.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector ipiv_i to the next one ipiv_(i+1).
-              There is no restriction for the value of strideP. Normal use case is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
+                There is no restriction for the value of strideP. Normal use case is strideP >= min(m,n).
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[i] = 0, successful exit for factorization of A_i.
-              If info[i] = j > 0, U_i is singular. U_i[j,j] is the first zero pivot.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful exit for factorization of A_j.
+                If info[j] = i > 0, U_j is singular. U_j[i,i] is the first zero pivot.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.

--- a/library/include/rocsolver-functions.h
+++ b/library/include/rocsolver-functions.h
@@ -8147,7 +8147,6 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgebrd_strided_batched(rocblas_handle 
     @param[in]
     ldb         rocblas_int. ldb >= n.\n
                 The leading dimension of B.
-
    ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgetrs(rocblas_handle handle,
@@ -8243,7 +8242,6 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgetrs(rocblas_handle handle,
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of instances (systems) in the batch.
-
    ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgetrs_batched(rocblas_handle handle,
@@ -8355,7 +8353,6 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgetrs_batched(rocblas_handle handle,
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of instances (systems) in the batch.
-
    ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgetrs_strided_batched(rocblas_handle handle,
@@ -8460,7 +8457,6 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgetrs_strided_batched(rocblas_handle 
                 If info = 0, successful exit.
                 If info = i > 0, U is singular, and the solution could not be computed.
                 U[i,i] is the first zero element in the diagonal.
-
    ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgesv(rocblas_handle handle,
@@ -8557,7 +8553,6 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgesv(rocblas_handle handle,
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of instances (systems) in the batch.
-
    ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgesv_batched(rocblas_handle handle,
@@ -8621,7 +8616,8 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgesv_batched(rocblas_handle handle,
     \f]
 
     where \f$A_j\f$ is a general n-by-n matrix. Matrix \f$A_j\f$ is first factorized in triangular factors \f$L_j\f$ and \f$U_j\f$
-    using \ref rocsolver_sgetrf_strided_batched "GETRF_STRIDED_BATCHED"; then, the solutions are computed with \ref rocsolver_sgetrs_strided_batched "GETRS_STRIDED_BATCHED".
+    using \ref rocsolver_sgetrf_strided_batched "GETRF_STRIDED_BATCHED"; then, the solutions are computed with
+    \ref rocsolver_sgetrs_strided_batched "GETRS_STRIDED_BATCHED".
 
     @param[in]
     handle      rocblas_handle.
@@ -8670,7 +8666,6 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgesv_batched(rocblas_handle handle,
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of instances (systems) in the batch.
-
    ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgesv_strided_batched(rocblas_handle handle,
@@ -8745,25 +8740,24 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgesv_strided_batched(rocblas_handle h
     upper triangular factor.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of rows and columns of the matrix A.
+    n           rocblas_int. n >= 0.\n
+                The number of rows and columns of the matrix A.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the factors L and U of the factorization A = P*L*U returned by \ref rocsolver_sgetrf "GETRF".
-              On exit, the inverse of A if info = 0; otherwise undefined.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the factors L and U of the factorization A = P*L*U returned by \ref rocsolver_sgetrf "GETRF".
+                On exit, the inverse of A if info = 0; otherwise undefined.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              Specifies the leading dimension of A.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of A.
     @param[in]
-    ipiv      pointer to rocblas_int. Array on the GPU of dimension n.\n
-              The pivot indices returned by \ref rocsolver_sgetrf "GETRF".
+    ipiv        pointer to rocblas_int. Array on the GPU of dimension n.\n
+                The pivot indices returned by \ref rocsolver_sgetrf "GETRF".
     @param[out]
-    info      pointer to a rocblas_int on the GPU.\n
-              If info = 0, successful exit.
-              If info = i > 0, U is singular. U[i,i] is the first zero pivot.
-
+    info        pointer to a rocblas_int on the GPU.\n
+                If info = 0, successful exit.
+                If info = i > 0, U is singular. U[i,i] is the first zero pivot.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgetri(rocblas_handle handle,
@@ -8810,33 +8804,32 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgetri(rocblas_handle handle,
     upper triangular factor.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of rows and columns of all matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of rows and columns of all matrices A_j in the batch.
     @param[inout]
-    A         array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
-              On entry, the factors L_j and U_j of the factorization A = P_j*L_j*U_j returned by
-              \ref rocsolver_sgetrf_batched "GETRF_BATCHED".
-              On exit, the inverses of A_j if info[j] = 0; otherwise undefined.
+    A           array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+                On entry, the factors L_j and U_j of the factorization A = P_j*L_j*U_j returned by
+                \ref rocsolver_sgetrf_batched "GETRF_BATCHED".
+                On exit, the inverses of A_j if info[j] = 0; otherwise undefined.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of matrices A_j.
     @param[in]
-    ipiv      pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).\n
-              The pivot indices returned by \ref rocsolver_sgetrf_batched "GETRF_BATCHED".
+    ipiv        pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).\n
+                The pivot indices returned by \ref rocsolver_sgetrf_batched "GETRF_BATCHED".
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector ipiv_j to the next one ipiv_(i+j).
-              There is no restriction for the value of strideP. Normal use case is strideP >= n.
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector ipiv_j to the next one ipiv_(i+j).
+                There is no restriction for the value of strideP. Normal use case is strideP >= n.
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[j] = 0, successful exit for inversion of A_j.
-              If info[j] = i > 0, U_j is singular. U_j[i,i] is the first zero pivot.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful exit for inversion of A_j.
+                If info[j] = i > 0, U_j is singular. U_j[i,i] is the first zero pivot.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.
-
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgetri_batched(rocblas_handle handle,
@@ -8891,37 +8884,36 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgetri_batched(rocblas_handle handle,
     upper triangular factor.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of rows and columns of all matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of rows and columns of all matrices A_j in the batch.
     @param[inout]
-    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
-              On entry, the factors L_j and U_j of the factorization A_j = P_j*L_j*U_j returned by
-              \ref rocsolver_sgetrf_strided_batched "GETRF_STRIDED_BATCHED".
-              On exit, the inverses of A_j if info[j] = 0; otherwise undefined.
+    A           pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+                On entry, the factors L_j and U_j of the factorization A_j = P_j*L_j*U_j returned by
+                \ref rocsolver_sgetrf_strided_batched "GETRF_STRIDED_BATCHED".
+                On exit, the inverses of A_j if info[j] = 0; otherwise undefined.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of matrices A_j.
     @param[in]
-    strideA   rocblas_stride.\n
-              Stride from the start of one matrix A_j to the next one A_(j+1).
-              There is no restriction for the value of strideA. Normal use case is strideA >= lda*n
+    strideA     rocblas_stride.\n
+                Stride from the start of one matrix A_j to the next one A_(j+1).
+                There is no restriction for the value of strideA. Normal use case is strideA >= lda*n
     @param[in]
-    ipiv      pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).\n
-              The pivot indices returned by \ref rocsolver_sgetrf_strided_batched "GETRF_STRIDED_BATCHED".
+    ipiv        pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).\n
+                The pivot indices returned by \ref rocsolver_sgetrf_strided_batched "GETRF_STRIDED_BATCHED".
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
-              There is no restriction for the value of strideP. Normal use case is strideP >= n.
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
+                There is no restriction for the value of strideP. Normal use case is strideP >= n.
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[j] = 0, successful exit for inversion of A_j.
-              If info[j] = i > 0, U_j is singular. U_j[i,i] is the first zero pivot.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful exit for inversion of A_j.
+                If info[j] = i > 0, U_j is singular. U_j[i,i] is the first zero pivot.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.
-
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgetri_strided_batched(rocblas_handle handle,
@@ -8980,22 +8972,21 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgetri_strided_batched(rocblas_handle 
     upper triangular factor.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of rows and columns of the matrix A.
+    n           rocblas_int. n >= 0.\n
+                The number of rows and columns of the matrix A.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the factors L and U of the factorization A = L*U returned by \ref rocsolver_sgetrf_npvt "GETRF_NPVT".
-              On exit, the inverse of A if info = 0; otherwise undefined.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the factors L and U of the factorization A = L*U returned by \ref rocsolver_sgetrf_npvt "GETRF_NPVT".
+                On exit, the inverse of A if info = 0; otherwise undefined.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              Specifies the leading dimension of A.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of A.
     @param[out]
-    info      pointer to a rocblas_int on the GPU.\n
-              If info = 0, successful exit.
-              If info = i > 0, U is singular. U[i,i] is the first zero pivot.
-
+    info        pointer to a rocblas_int on the GPU.\n
+                If info = 0, successful exit.
+                If info = i > 0, U is singular. U[i,i] is the first zero pivot.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgetri_npvt(rocblas_handle handle,
@@ -9038,26 +9029,25 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgetri_npvt(rocblas_handle handle,
     upper triangular factor.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of rows and columns of all matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of rows and columns of all matrices A_j in the batch.
     @param[inout]
-    A         array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
-              On entry, the factors L_j and U_j of the factorization A = L_j*U_j returned by
-              \ref rocsolver_sgetrf_npvt_batched "GETRF_NPVT_BATCHED".
-              On exit, the inverses of A_j if info[j] = 0; otherwise undefined.
+    A           array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+                On entry, the factors L_j and U_j of the factorization A = L_j*U_j returned by
+                \ref rocsolver_sgetrf_npvt_batched "GETRF_NPVT_BATCHED".
+                On exit, the inverses of A_j if info[j] = 0; otherwise undefined.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of matrices A_j.
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[j] = 0, successful exit for inversion of A_j.
-              If info[j] = i > 0, U_j is singular. U_j[i,i] is the first zero pivot.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful exit for inversion of A_j.
+                If info[j] = i > 0, U_j is singular. U_j[i,i] is the first zero pivot.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.
-
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgetri_npvt_batched(rocblas_handle handle,
@@ -9104,30 +9094,29 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgetri_npvt_batched(rocblas_handle han
     upper triangular factor.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of rows and columns of all matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of rows and columns of all matrices A_j in the batch.
     @param[inout]
-    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
-              On entry, the factors L_j and U_j of the factorization A_j = L_j*U_j returned by
-              \ref rocsolver_sgetrf_npvt_strided_batched "GETRF_NPVT_STRIDED_BATCHED".
-              On exit, the inverses of A_j if info[j] = 0; otherwise undefined.
+    A           pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+                On entry, the factors L_j and U_j of the factorization A_j = L_j*U_j returned by
+                \ref rocsolver_sgetrf_npvt_strided_batched "GETRF_NPVT_STRIDED_BATCHED".
+                On exit, the inverses of A_j if info[j] = 0; otherwise undefined.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of matrices A_j.
     @param[in]
-    strideA   rocblas_stride.\n
-              Stride from the start of one matrix A_j to the next one A_(j+1).
-              There is no restriction for the value of strideA. Normal use case is strideA >= lda*n
+    strideA     rocblas_stride.\n
+                Stride from the start of one matrix A_j to the next one A_(j+1).
+                There is no restriction for the value of strideA. Normal use case is strideA >= lda*n
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[j] = 0, successful exit for inversion of A_j.
-              If info[j] = i > 0, U_j is singular. U_j[i,i] is the first zero pivot.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful exit for inversion of A_j.
+                If info[j] = i > 0, U_j is singular. U_j[i,i] is the first zero pivot.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.
-
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgetri_npvt_strided_batched(rocblas_handle handle,

--- a/library/include/rocsolver-functions.h
+++ b/library/include/rocsolver-functions.h
@@ -4992,26 +4992,25 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgetrf_strided_batched(rocblas_handle 
     where the first i-1 elements of the Householder vector \f$v_i\f$ are zero, and \f$v_i[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of the matrix A.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of the matrix A.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of the matrix A.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of the matrix A.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrix to be factored.
-              On exit, the elements on and above the diagonal contain the
-              factor R; the elements below the diagonal are the last m - i elements
-              of Householder vector v_i.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrix to be factored.
+                On exit, the elements on and above the diagonal contain the
+                factor R; the elements below the diagonal are the last m - i elements
+                of Householder vector v_i.
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of A.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of A.
     @param[out]
-    ipiv      pointer to type. Array on the GPU of dimension min(m,n).\n
-              The Householder scalars.
-
+    ipiv        pointer to type. Array on the GPU of dimension min(m,n).\n
+                The Householder scalars.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgeqr2(rocblas_handle handle,
@@ -5075,34 +5074,33 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgeqr2(rocblas_handle handle,
     where the first i-1 elements of Householder vector \f$v_{j_i}\f$ are zero, and \f$v_{j_i}[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all the matrices A_j in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all the matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all the matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all the matrices A_j in the batch.
     @param[inout]
-    A         Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrices A_j to be factored.
-              On exit, the elements on and above the diagonal contain the
-              factor R_j. The elements below the diagonal are the last m - i elements
-              of Householder vector v_(j_i).
+    A           Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the elements on and above the diagonal contain the
+                factor R_j. The elements below the diagonal are the last m - i elements
+                of Householder vector v_(j_i).
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[out]
-    ipiv      pointer to type. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors ipiv_j of corresponding Householder scalars.
+    ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors ipiv_j of corresponding Householder scalars.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
-              There is no restriction for the value
-              of strideP. Normal use is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
+                There is no restriction for the value
+                of strideP. Normal use is strideP >= min(m,n).
     @param[in]
-    batch_count  rocblas_int. batch_count >= 0.\n
-                 Number of matrices in the batch.
-
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgeqr2_batched(rocblas_handle handle,
@@ -5174,38 +5172,37 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgeqr2_batched(rocblas_handle handle,
     where the first i-1 elements of Householder vector \f$v_{j_i}\f$ are zero, and \f$v_{j_i}[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all the matrices A_j in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all the matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all the matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all the matrices A_j in the batch.
     @param[inout]
-    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
-              On entry, the m-by-n matrices A_j to be factored.
-              On exit, the elements on and above the diagonal contain the
-              factor R_j. The elements below the diagonal are the last m - i elements
-              of Householder vector v_(j_i).
+    A           pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the elements on and above the diagonal contain the
+                factor R_j. The elements below the diagonal are the last m - i elements
+                of Householder vector v_(j_i).
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[in]
-    strideA   rocblas_stride.\n
-              Stride from the start of one matrix A_j to the next one A_(j+1).
-              There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
+    strideA     rocblas_stride.\n
+                Stride from the start of one matrix A_j to the next one A_(j+1).
+                There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
     @param[out]
-    ipiv      pointer to type. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors ipiv_j of corresponding Householder scalars.
+    ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors ipiv_j of corresponding Householder scalars.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
-              There is no restriction for the value
-              of strideP. Normal use is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
+                There is no restriction for the value
+                of strideP. Normal use is strideP >= min(m,n).
     @param[in]
-    batch_count  rocblas_int. batch_count >= 0.\n
-                 Number of matrices in the batch.
-
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgeqr2_strided_batched(rocblas_handle handle,
@@ -5279,27 +5276,26 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgeqr2_strided_batched(rocblas_handle 
     where the last n-i elements of the Householder vector \f$v_i\f$ are zero, and \f$v_i[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of the matrix A.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of the matrix A.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of the matrix A.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of the matrix A.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrix to be factored.
-              On exit, the elements on and above the (m-n)-th subdiagonal (when
-              m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
-              factor R; the elements below the sub/superdiagonal are the first i - 1
-              elements of Householder vector v_i.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrix to be factored.
+                On exit, the elements on and above the (m-n)-th subdiagonal (when
+                m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
+                factor R; the elements below the sub/superdiagonal are the first i - 1
+                elements of Householder vector v_i.
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of A.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of A.
     @param[out]
-    ipiv      pointer to type. Array on the GPU of dimension min(m,n).\n
-              The Householder scalars.
-
+    ipiv        pointer to type. Array on the GPU of dimension min(m,n).\n
+                The Householder scalars.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgerq2(rocblas_handle handle,
@@ -5362,34 +5358,34 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgerq2(rocblas_handle handle,
     where the last n-i elements of Householder vector \f$v_{j_i}\f$ are zero, and \f$v_{j_i}[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all the matrices A_j in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all the matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all the matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all the matrices A_j in the batch.
     @param[inout]
-    A         Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrices A_j to be factored.
-              On exit, the elements on and above the (m-n)-th subdiagonal (when
-              m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
-              factor R_j; the elements below the sub/superdiagonal are the first i - 1
-              elements of Householder vector v_(j_i).
+    A           Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the elements on and above the (m-n)-th subdiagonal (when
+                m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
+                factor R_j; the elements below the sub/superdiagonal are the first i - 1
+                elements of Householder vector v_(j_i).
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[out]
-    ipiv      pointer to type. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors ipiv_j of corresponding Householder scalars.
+    ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors ipiv_j of corresponding Householder scalars.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
-              There is no restriction for the value
-              of strideP. Normal use is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
+                There is no restriction for the value
+                of strideP. Normal use is strideP >= min(m,n).
     @param[in]
-    batch_count  rocblas_int. batch_count >= 0.\n
-                 Number of matrices in the batch.
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgerq2_batched(rocblas_handle handle,
@@ -5460,39 +5456,38 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgerq2_batched(rocblas_handle handle,
     where the last n-i elements of Householder vector \f$v_{j_i}\f$ are zero, and \f$v_{j_i}[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all the matrices A_j in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all the matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all the matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all the matrices A_j in the batch.
     @param[inout]
-    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
-              On entry, the m-by-n matrices A_j to be factored.
-              On exit, the elements on and above the (m-n)-th subdiagonal (when
-              m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
-              factor R_j; the elements below the sub/superdiagonal are the first i - 1
-              elements of Householder vector v_(j_i).
+    A           pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the elements on and above the (m-n)-th subdiagonal (when
+                m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
+                factor R_j; the elements below the sub/superdiagonal are the first i - 1
+                elements of Householder vector v_(j_i).
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[in]
-    strideA   rocblas_stride.\n
-              Stride from the start of one matrix A_j to the next one A_(j+1).
-              There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
+    strideA     rocblas_stride.\n
+                Stride from the start of one matrix A_j to the next one A_(j+1).
+                There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
     @param[out]
-    ipiv      pointer to type. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors ipiv_j of corresponding Householder scalars.
+    ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors ipiv_j of corresponding Householder scalars.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
-              There is no restriction for the value
-              of strideP. Normal use is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
+                There is no restriction for the value
+                of strideP. Normal use is strideP >= min(m,n).
     @param[in]
-    batch_count  rocblas_int. batch_count >= 0.\n
-                 Number of matrices in the batch.
-
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgerq2_strided_batched(rocblas_handle handle,
@@ -5567,27 +5562,26 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgerq2_strided_batched(rocblas_handle 
     where the last m-i elements of the Householder vector \f$v_i\f$ are zero, and \f$v_i[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of the matrix A.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of the matrix A.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of the matrix A.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of the matrix A.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrix to be factored.
-              On exit, the elements on and below the (m-n)-th subdiagonal (when
-              m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
-              factor L; the elements above the sub/superdiagonal are the first i - 1
-              elements of Householder vector v_i.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrix to be factored.
+                On exit, the elements on and below the (m-n)-th subdiagonal (when
+                m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
+                factor L; the elements above the sub/superdiagonal are the first i - 1
+                elements of Householder vector v_i.
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of A.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of A.
     @param[out]
-    ipiv      pointer to type. Array on the GPU of dimension min(m,n).\n
-              The Householder scalars.
-
+    ipiv        pointer to type. Array on the GPU of dimension min(m,n).\n
+                The Householder scalars.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgeql2(rocblas_handle handle,
@@ -5651,35 +5645,34 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgeql2(rocblas_handle handle,
     where the last m-i elements of the Householder vector \f$v_{j_i}\f$ are zero, and \f$v_{j_i}[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all the matrices A_j in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all the matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all the matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all the matrices A_j in the batch.
     @param[inout]
-    A         Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrices A_j to be factored.
-              On exit, the elements on and below the (m-n)-th subdiagonal (when
-              m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
-              factor L_j; the elements above the sub/superdiagonal are the first i - 1
-              elements of Householder vector v_(j_i).
+    A           Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the elements on and below the (m-n)-th subdiagonal (when
+                m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
+                factor L_j; the elements above the sub/superdiagonal are the first i - 1
+                elements of Householder vector v_(j_i).
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[out]
-    ipiv      pointer to type. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors ipiv_j of corresponding Householder scalars.
+    ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors ipiv_j of corresponding Householder scalars.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
-              There is no restriction for the value
-              of strideP. Normal use is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
+                There is no restriction for the value
+                of strideP. Normal use is strideP >= min(m,n).
     @param[in]
-    batch_count  rocblas_int. batch_count >= 0.\n
-                 Number of matrices in the batch.
-
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgeql2_batched(rocblas_handle handle,
@@ -5751,38 +5744,38 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgeql2_batched(rocblas_handle handle,
     where the last m-i elements of the Householder vector \f$v_{j_i}\f$ are zero, and \f$v_{j_i}[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all the matrices A_j in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all the matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all the matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all the matrices A_j in the batch.
     @param[inout]
-    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
-              On entry, the m-by-n matrices A_j to be factored.
-              On exit, the elements on and below the (m-n)-th subdiagonal (when
-              m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
-              factor L_j; the elements above the sub/superdiagonal are the first i - 1
-              elements of Householder vector v_(j_i).
+    A           pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the elements on and below the (m-n)-th subdiagonal (when
+                m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
+                factor L_j; the elements above the sub/superdiagonal are the first i - 1
+                elements of Householder vector v_(j_i).
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[in]
-    strideA   rocblas_stride.\n
-              Stride from the start of one matrix A_j to the next one A_(j+1).
-              There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
+    strideA     rocblas_stride.\n
+                Stride from the start of one matrix A_j to the next one A_(j+1).
+                There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
     @param[out]
-    ipiv      pointer to type. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors ipiv_j of corresponding Householder scalars.
+    ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors ipiv_j of corresponding Householder scalars.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
-              There is no restriction for the value
-              of strideP. Normal use is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
+                There is no restriction for the value
+                of strideP. Normal use is strideP >= min(m,n).
     @param[in]
-    batch_count  rocblas_int. batch_count >= 0.\n
-                 Number of matrices in the batch.
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgeql2_strided_batched(rocblas_handle handle,
@@ -5856,26 +5849,25 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgeql2_strided_batched(rocblas_handle 
     where the first i-1 elements of the Householder vector \f$v_i\f$ are zero, and \f$v_i[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of the matrix A.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of the matrix A.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of the matrix A.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of the matrix A.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrix to be factored.
-              On exit, the elements on and below the diagonal contain the
-              factor L; the elements above the diagonal are the last n - i elements
-              of Householder vector v_i.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrix to be factored.
+                On exit, the elements on and below the diagonal contain the
+                factor L; the elements above the diagonal are the last n - i elements
+                of Householder vector v_i.
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of A.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of A.
     @param[out]
-    ipiv      pointer to type. Array on the GPU of dimension min(m,n).\n
-              The Householder scalars.
-
+    ipiv        pointer to type. Array on the GPU of dimension min(m,n).\n
+                The Householder scalars.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgelq2(rocblas_handle handle,
@@ -5938,33 +5930,33 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgelq2(rocblas_handle handle,
     where the first i-1 elements of Householder vector \f$v_{j_i}\f$ are zero, and \f$v_{j_i}[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all the matrices A_j in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all the matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all the matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all the matrices A_j in the batch.
     @param[inout]
-    A         Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrices A_j to be factored.
-              On exit, the elements on and below the diagonal contain the
-              factor L_j. The elements above the diagonal are the last n - i elements
-              of Householder vector v_(j_i).
+    A           Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the elements on and below the diagonal contain the
+                factor L_j. The elements above the diagonal are the last n - i elements
+                of Householder vector v_(j_i).
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[out]
-    ipiv      pointer to type. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors ipiv_j of corresponding Householder scalars.
+    ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors ipiv_j of corresponding Householder scalars.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
-              There is no restriction for the value
-              of strideP. Normal use is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
+                There is no restriction for the value
+                of strideP. Normal use is strideP >= min(m,n).
     @param[in]
-    batch_count  rocblas_int. batch_count >= 0.\n
-                 Number of matrices in the batch.
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgelq2_batched(rocblas_handle handle,
@@ -6037,36 +6029,35 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgelq2_batched(rocblas_handle handle,
     @param[in]
     handle    rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all the matrices A_j in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all the matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all the matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all the matrices A_j in the batch.
     @param[inout]
-    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
-              On entry, the m-by-n matrices A_j to be factored.
-              On exit, the elements on and below the diagonal contain the
-              factor L_j. The elements above the diagonal are the last n - i elements
-              of Householder vector v_(j_i).
+    A           pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the elements on and below the diagonal contain the
+                factor L_j. The elements above the diagonal are the last n - i elements
+                of Householder vector v_(j_i).
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[in]
-    strideA   rocblas_stride.\n
-              Stride from the start of one matrix A_j to the next one A_(j+1).
-              There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
+    strideA     rocblas_stride.\n
+                Stride from the start of one matrix A_j to the next one A_(j+1).
+                There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
     @param[out]
-    ipiv      pointer to type. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors ipiv_j of corresponding Householder scalars.
+    ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors ipiv_j of corresponding Householder scalars.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
-              There is no restriction for the value
-              of strideP. Normal use is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
+                There is no restriction for the value
+                of strideP. Normal use is strideP >= min(m,n).
     @param[in]
-    batch_count  rocblas_int. batch_count >= 0.\n
-                 Number of matrices in the batch.
-
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgelq2_strided_batched(rocblas_handle handle,
@@ -6141,26 +6132,25 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgelq2_strided_batched(rocblas_handle 
     where the first i-1 elements of the Householder vector \f$v_i\f$ are zero, and \f$v_i[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of the matrix A.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of the matrix A.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of the matrix A.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of the matrix A.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrix to be factored.
-              On exit, the elements on and above the diagonal contain the
-              factor R; the elements below the diagonal are the last m - i elements
-              of Householder vector v_i.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrix to be factored.
+                On exit, the elements on and above the diagonal contain the
+                factor R; the elements below the diagonal are the last m - i elements
+                of Householder vector v_i.
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of A.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of A.
     @param[out]
-    ipiv      pointer to type. Array on the GPU of dimension min(m,n).\n
-              The Householder scalars.
-
+    ipiv        pointer to type. Array on the GPU of dimension min(m,n).\n
+                The Householder scalars.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgeqrf(rocblas_handle handle,
@@ -6224,33 +6214,33 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgeqrf(rocblas_handle handle,
     where the first i-1 elements of Householder vector \f$v_{j_i}\f$ are zero, and \f$v_{j_i}[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all the matrices A_j in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all the matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all the matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all the matrices A_j in the batch.
     @param[inout]
-    A         Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrices A_j to be factored.
-              On exit, the elements on and above the diagonal contain the
-              factor R_j. The elements below the diagonal are the last m - i elements
-              of Householder vector v_(j_i).
+    A           Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the elements on and above the diagonal contain the
+                factor R_j. The elements below the diagonal are the last m - i elements
+                of Householder vector v_(j_i).
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[out]
-    ipiv      pointer to type. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors ipiv_j of corresponding Householder scalars.
+    ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors ipiv_j of corresponding Householder scalars.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
-              There is no restriction for the value
-              of strideP. Normal use is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
+                There is no restriction for the value
+                of strideP. Normal use is strideP >= min(m,n).
     @param[in]
-    batch_count  rocblas_int. batch_count >= 0.\n
-                 Number of matrices in the batch.
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgeqrf_batched(rocblas_handle handle,
@@ -6322,37 +6312,37 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgeqrf_batched(rocblas_handle handle,
     where the first i-1 elements of Householder vector \f$v_{j_i}\f$ are zero, and \f$v_{j_i}[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all the matrices A_j in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all the matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all the matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all the matrices A_j in the batch.
     @param[inout]
-    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
-              On entry, the m-by-n matrices A_j to be factored.
-              On exit, the elements on and above the diagonal contain the
-              factor R_j. The elements below the diagonal are the last m - i elements
-              of Householder vector v_(j_i).
+    A           pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the elements on and above the diagonal contain the
+                factor R_j. The elements below the diagonal are the last m - i elements
+                of Householder vector v_(j_i).
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[in]
-    strideA   rocblas_stride.\n
-              Stride from the start of one matrix A_j to the next one A_(j+1).
-              There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
+    strideA     rocblas_stride.\n
+                Stride from the start of one matrix A_j to the next one A_(j+1).
+                There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
     @param[out]
-    ipiv      pointer to type. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors ipiv_j of corresponding Householder scalars.
+    ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors ipiv_j of corresponding Householder scalars.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
-              There is no restriction for the value
-              of strideP. Normal use is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
+                There is no restriction for the value
+                of strideP. Normal use is strideP >= min(m,n).
     @param[in]
-    batch_count  rocblas_int. batch_count >= 0.\n
-                 Number of matrices in the batch.
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgeqrf_strided_batched(rocblas_handle handle,
@@ -6426,27 +6416,26 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgeqrf_strided_batched(rocblas_handle 
     where the last n-i elements of the Householder vector \f$v_i\f$ are zero, and \f$v_i[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of the matrix A.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of the matrix A.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of the matrix A.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of the matrix A.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrix to be factored.
-              On exit, the elements on and above the (m-n)-th subdiagonal (when
-              m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
-              factor R; the elements below the sub/superdiagonal are the first i - 1
-              elements of Householder vector v_i.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrix to be factored.
+                On exit, the elements on and above the (m-n)-th subdiagonal (when
+                m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
+                factor R; the elements below the sub/superdiagonal are the first i - 1
+                elements of Householder vector v_i.
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of A.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of A.
     @param[out]
-    ipiv      pointer to type. Array on the GPU of dimension min(m,n).\n
-              The Householder scalars.
-
+    ipiv        pointer to type. Array on the GPU of dimension min(m,n).\n
+                The Householder scalars.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgerqf(rocblas_handle handle,
@@ -6509,34 +6498,34 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgerqf(rocblas_handle handle,
     where the last n-i elements of Householder vector \f$v_{j_i}\f$ are zero, and \f$v_{j_i}[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all the matrices A_j in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all the matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all the matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all the matrices A_j in the batch.
     @param[inout]
-    A         Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrices A_j to be factored.
-              On exit, the elements on and above the (m-n)-th subdiagonal (when
-              m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
-              factor R_j; the elements below the sub/superdiagonal are the first i - 1
-              elements of Householder vector v_(j_i).
+    A           Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the elements on and above the (m-n)-th subdiagonal (when
+                m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
+                factor R_j; the elements below the sub/superdiagonal are the first i - 1
+                elements of Householder vector v_(j_i).
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[out]
-    ipiv      pointer to type. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors ipiv_j of corresponding Householder scalars.
+    ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors ipiv_j of corresponding Householder scalars.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
-              There is no restriction for the value
-              of strideP. Normal use is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
+                There is no restriction for the value
+                of strideP. Normal use is strideP >= min(m,n).
     @param[in]
-    batch_count  rocblas_int. batch_count >= 0.\n
-                 Number of matrices in the batch.
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgerqf_batched(rocblas_handle handle,
@@ -6607,39 +6596,38 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgerqf_batched(rocblas_handle handle,
     where the last n-i elements of Householder vector \f$v_{j_i}\f$ are zero, and \f$v_{j_i}[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all the matrices A_j in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all the matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all the matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all the matrices A_j in the batch.
     @param[inout]
-    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
-              On entry, the m-by-n matrices A_j to be factored.
-              On exit, the elements on and above the (m-n)-th subdiagonal (when
-              m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
-              factor R_j; the elements below the sub/superdiagonal are the first i - 1
-              elements of Householder vector v_(j_i).
+    A           pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the elements on and above the (m-n)-th subdiagonal (when
+                m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
+                factor R_j; the elements below the sub/superdiagonal are the first i - 1
+                elements of Householder vector v_(j_i).
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[in]
-    strideA   rocblas_stride.\n
-              Stride from the start of one matrix A_j to the next one A_(j+1).
-              There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
+    strideA     rocblas_stride.\n
+                Stride from the start of one matrix A_j to the next one A_(j+1).
+                There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
     @param[out]
-    ipiv      pointer to type. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors ipiv_j of corresponding Householder scalars.
+    ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors ipiv_j of corresponding Householder scalars.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
-              There is no restriction for the value
-              of strideP. Normal use is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
+                There is no restriction for the value
+                of strideP. Normal use is strideP >= min(m,n).
     @param[in]
-    batch_count  rocblas_int. batch_count >= 0.\n
-                 Number of matrices in the batch.
-
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgerqf_strided_batched(rocblas_handle handle,
@@ -6714,26 +6702,26 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgerqf_strided_batched(rocblas_handle 
     where the last m-i elements of the Householder vector \f$v_i\f$ are zero, and \f$v_i[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of the matrix A.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of the matrix A.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of the matrix A.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of the matrix A.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrix to be factored.
-              On exit, the elements on and below the (m-n)-th subdiagonal (when
-              m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
-              factor L; the elements above the sub/superdiagonal are the first i - 1
-              elements of Householder vector v_i.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrix to be factored.
+                On exit, the elements on and below the (m-n)-th subdiagonal (when
+                m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
+                factor L; the elements above the sub/superdiagonal are the first i - 1
+                elements of Householder vector v_i.
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of A.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of A.
     @param[out]
-    ipiv      pointer to type. Array on the GPU of dimension min(m,n).\n
-              The Householder scalars.
+    ipiv        pointer to type. Array on the GPU of dimension min(m,n).\n
+                The Householder scalars.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgeqlf(rocblas_handle handle,
@@ -6797,34 +6785,34 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgeqlf(rocblas_handle handle,
     where the last m-i elements of the Householder vector \f$v_{j_i}\f$ are zero, and \f$v_{j_i}[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all the matrices A_j in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all the matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all the matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all the matrices A_j in the batch.
     @param[inout]
-    A         Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrices A_j to be factored.
-              On exit, the elements on and below the (m-n)-th subdiagonal (when
-              m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
-              factor L_j; the elements above the sub/superdiagonal are the first i - 1
-              elements of Householder vector v_(j_i).
+    A           Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the elements on and below the (m-n)-th subdiagonal (when
+                m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
+                factor L_j; the elements above the sub/superdiagonal are the first i - 1
+                elements of Householder vector v_(j_i).
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[out]
-    ipiv      pointer to type. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors ipiv_j of corresponding Householder scalars.
+    ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors ipiv_j of corresponding Householder scalars.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
-              There is no restriction for the value
-              of strideP. Normal use is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
+                There is no restriction for the value
+                of strideP. Normal use is strideP >= min(m,n).
     @param[in]
-    batch_count  rocblas_int. batch_count >= 0.\n
-                 Number of matrices in the batch.
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgeqlf_batched(rocblas_handle handle,
@@ -6896,38 +6884,38 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgeqlf_batched(rocblas_handle handle,
     where the last m-i elements of the Householder vector \f$v_{j_i}\f$ are zero, and \f$v_{j_i}[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all the matrices A_j in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all the matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all the matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all the matrices A_j in the batch.
     @param[inout]
-    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
-              On entry, the m-by-n matrices A_j to be factored.
-              On exit, the elements on and below the (m-n)-th subdiagonal (when
-              m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
-              factor L_j; the elements above the sub/superdiagonal are the first i - 1
-              elements of Householder vector v_(j_i).
+    A           pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the elements on and below the (m-n)-th subdiagonal (when
+                m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
+                factor L_j; the elements above the sub/superdiagonal are the first i - 1
+                elements of Householder vector v_(j_i).
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[in]
-    strideA   rocblas_stride.\n
-              Stride from the start of one matrix A_j to the next one A_(j+1).
-              There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
+    strideA     rocblas_stride.\n
+                Stride from the start of one matrix A_j to the next one A_(j+1).
+                There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
     @param[out]
-    ipiv      pointer to type. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors ipiv_j of corresponding Householder scalars.
+    ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors ipiv_j of corresponding Householder scalars.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
-              There is no restriction for the value
-              of strideP. Normal use is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
+                There is no restriction for the value
+                of strideP. Normal use is strideP >= min(m,n).
     @param[in]
-    batch_count  rocblas_int. batch_count >= 0.\n
-                 Number of matrices in the batch.
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgeqlf_strided_batched(rocblas_handle handle,
@@ -7001,26 +6989,25 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgeqlf_strided_batched(rocblas_handle 
     where the first i-1 elements of the Householder vector \f$v_i\f$ are zero, and \f$v_i[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of the matrix A.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of the matrix A.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of the matrix A.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of the matrix A.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrix to be factored.
-              On exit, the elements on and below the diagonal contain the
-              factor L; the elements above the diagonal are the last n - i elements
-              of Householder vector v_i.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrix to be factored.
+                On exit, the elements on and below the diagonal contain the
+                factor L; the elements above the diagonal are the last n - i elements
+                of Householder vector v_i.
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of A.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of A.
     @param[out]
-    ipiv      pointer to type. Array on the GPU of dimension min(m,n).\n
-              The Householder scalars.
-
+    ipiv        pointer to type. Array on the GPU of dimension min(m,n).\n
+                The Householder scalars.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgelqf(rocblas_handle handle,
@@ -7083,34 +7070,33 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgelqf(rocblas_handle handle,
     where the first i-1 elements of Householder vector \f$v_{j_i}\f$ are zero, and \f$v_{j_i}[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all the matrices A_j in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all the matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all the matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all the matrices A_j in the batch.
     @param[inout]
-    A         Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
-              On entry, the m-by-n matrices A_j to be factored.
-              On exit, the elements on and below the diagonal contain the
-              factor L_j. The elements above the diagonal are the last n - i elements
-              of Householder vector v_(j_i).
+    A           Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the elements on and below the diagonal contain the
+                factor L_j. The elements above the diagonal are the last n - i elements
+                of Householder vector v_(j_i).
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[out]
-    ipiv      pointer to type. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors ipiv_j of corresponding Householder scalars.
+    ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors ipiv_j of corresponding Householder scalars.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
-              There is no restriction for the value
-              of strideP. Normal use is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
+                There is no restriction for the value
+                of strideP. Normal use is strideP >= min(m,n).
     @param[in]
-    batch_count  rocblas_int. batch_count >= 0.\n
-                 Number of matrices in the batch.
-
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgelqf_batched(rocblas_handle handle,
@@ -7181,37 +7167,37 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgelqf_batched(rocblas_handle handle,
     where the first i-1 elements of Householder vector \f$v_{j_i}\f$ are zero, and \f$v_{j_i}[i] = 1\f$.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all the matrices A_j in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all the matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all the matrices A_j in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all the matrices A_j in the batch.
     @param[inout]
-    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
-              On entry, the m-by-n matrices A_j to be factored.
-              On exit, the elements on and below the diagonal contain the
-              factor L_j. The elements above the diagonal are the last n - i elements
-              of Householder vector v_(j_i).
+    A           pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+                On entry, the m-by-n matrices A_j to be factored.
+                On exit, the elements on and below the diagonal contain the
+                factor L_j. The elements above the diagonal are the last n - i elements
+                of Householder vector v_(j_i).
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_j.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[in]
-    strideA   rocblas_stride.\n
-              Stride from the start of one matrix A_j to the next one A_(j+1).
-              There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
+    strideA     rocblas_stride.\n
+                Stride from the start of one matrix A_j to the next one A_(j+1).
+                There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
     @param[out]
-    ipiv      pointer to type. Array on the GPU (the size depends on the value of strideP).\n
-              Contains the vectors ipiv_j of corresponding Householder scalars.
+    ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).\n
+                Contains the vectors ipiv_j of corresponding Householder scalars.
     @param[in]
-    strideP   rocblas_stride.\n
-              Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
-              There is no restriction for the value
-              of strideP. Normal use is strideP >= min(m,n).
+    strideP     rocblas_stride.\n
+                Stride from the start of one vector ipiv_j to the next one ipiv_(j+1).
+                There is no restriction for the value
+                of strideP. Normal use is strideP >= min(m,n).
     @param[in]
-    batch_count  rocblas_int. batch_count >= 0.\n
-                 Number of matrices in the batch.
+    batch_count rocblas_int. batch_count >= 0.\n
+                Number of matrices in the batch.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgelqf_strided_batched(rocblas_handle handle,

--- a/library/include/rocsolver-functions.h
+++ b/library/include/rocsolver-functions.h
@@ -9178,41 +9178,40 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgetri_npvt_strided_batched(rocblas_ha
     and a unique solution for X is chosen such that \f$|| X ||\f$ is minimal.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    trans     rocblas_operation.\n
-              Specifies the form of the system of equations.
+    trans       rocblas_operation.\n
+                Specifies the form of the system of equations.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of matrix A.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of matrix A.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of matrix A.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of matrix A.
     @param[in]
-    nrhs      rocblas_int. nrhs >= 0.\n
-              The number of columns of matrices B and X;
-              i.e., the columns on the right hand side.
+    nrhs        rocblas_int. nrhs >= 0.\n
+                The number of columns of matrices B and X;
+                i.e., the columns on the right hand side.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the matrix A.
-              On exit, the QR (or LQ) factorization of A as returned by \ref rocsolver_sgeqrf "GEQRF" (or \ref rocsolver_sgelqf "GELQF").
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the matrix A.
+                On exit, the QR (or LQ) factorization of A as returned by \ref rocsolver_sgeqrf "GEQRF" (or \ref rocsolver_sgelqf "GELQF").
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrix A.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrix A.
     @param[inout]
-    B         pointer to type. Array on the GPU of dimension ldb*nrhs.\n
-              On entry, the matrix B.
-              On exit, when info = 0, B is overwritten by the solution vectors (and the residuals in
-              the overdetermined cases) stored as columns.
+    B           pointer to type. Array on the GPU of dimension ldb*nrhs.\n
+                On entry, the matrix B.
+                On exit, when info = 0, B is overwritten by the solution vectors (and the residuals in
+                the overdetermined cases) stored as columns.
     @param[in]
-    ldb       rocblas_int. ldb >= max(m,n).\n
-              Specifies the leading dimension of matrix B.
+    ldb         rocblas_int. ldb >= max(m,n).\n
+                Specifies the leading dimension of matrix B.
     @param[out]
-    info      pointer to rocblas_int on the GPU.\n
-              If info = 0, successful exit.
-              If info = j > 0, the solution could not be computed because input matrix A is
-              rank deficient; the j-th diagonal element of its triangular factor is zero.
-
+    info        pointer to rocblas_int on the GPU.\n
+                If info = 0, successful exit.
+                If info = i > 0, the solution could not be computed because input matrix A is
+                rank deficient; the i-th diagonal element of its triangular factor is zero.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgels(rocblas_handle handle,
@@ -9262,7 +9261,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgels(rocblas_handle handle,
 
 /*! @{
     \brief GELS_BATCHED solves a batch of overdetermined (or underdetermined) linear systems
-    defined by a set of m-by-n matrices \f$A_i\f$, and corresponding matrices \f$B_i\f$, using the
+    defined by a set of m-by-n matrices \f$A_j\f$, and corresponding matrices \f$B_j\f$, using the
     QR factorizations computed by \ref rocsolver_sgeqrf_batched "GEQRF_BATCHED" (or the LQ factorizations computed by \ref rocsolver_sgelqf_batched "GELQF_BATCHED").
 
     \details
@@ -9270,60 +9269,60 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgels(rocblas_handle handle,
 
     \f[
         \begin{array}{cl}
-        A_i X_i = B_i & \: \text{not transposed, or}\\
-        A_i' X_i = B_i & \: \text{transposed if real, or conjugate transposed if complex}
+        A_j X_j = B_j & \: \text{not transposed, or}\\
+        A_j' X_j = B_j & \: \text{transposed if real, or conjugate transposed if complex}
         \end{array}
     \f]
 
     If m >= n (or m < n in the case of transpose/conjugate transpose), the system is overdetermined
-    and a least-squares solution approximating X_i is found by minimizing
+    and a least-squares solution approximating X_j is found by minimizing
 
     \f[
-        || B_i - A_i  X_i || \quad \text{(or} \: || B_i - A_i' X_i ||\text{)}
+        || B_j - A_j  X_j || \quad \text{(or} \: || B_j - A_j' X_j ||\text{)}
     \f]
 
     If m < n (or m >= n in the case of transpose/conjugate transpose), the system is underdetermined
-    and a unique solution for X_i is chosen such that \f$|| X_i ||\f$ is minimal.
+    and a unique solution for X_j is chosen such that \f$|| X_j ||\f$ is minimal.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    trans     rocblas_operation.\n
-              Specifies the form of the system of equations.
+    trans       rocblas_operation.\n
+                Specifies the form of the system of equations.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all matrices A_i in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all matrices A_i in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all matrices A_j in the batch.
     @param[in]
-    nrhs      rocblas_int. nrhs >= 0.\n
-              The number of columns of all matrices B_i and X_i in the batch;
-              i.e., the columns on the right hand side.
+    nrhs        rocblas_int. nrhs >= 0.\n
+                The number of columns of all matrices B_j and X_j in the batch;
+                i.e., the columns on the right hand side.
     @param[inout]
-    A         array of pointer to type. Each pointer points to an array on the GPU of dimension lda*n.\n
-              On entry, the matrices A_i.
-              On exit, the QR (or LQ) factorizations of A_i as returned by \ref rocsolver_sgeqrf_batched "GEQRF_BATCHED" (or \ref rocsolver_sgelqf_batched "GELQF_BATCHED").
+    A           array of pointer to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+                On entry, the matrices A_j.
+                On exit, the QR (or LQ) factorizations of A_j as returned by \ref rocsolver_sgeqrf_batched "GEQRF_BATCHED"
+                (or \ref rocsolver_sgelqf_batched "GELQF_BATCHED").
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_i.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[inout]
-    B         array of pointer to type. Each pointer points to an array on the GPU of dimension ldb*nrhs.\n
-              On entry, the matrices B_i.
-              On exit, when info[i] = 0, B_i is overwritten by the solution vectors (and the residuals in
-              the overdetermined cases) stored as columns.
+    B           array of pointer to type. Each pointer points to an array on the GPU of dimension ldb*nrhs.\n
+                On entry, the matrices B_j.
+                On exit, when info[j] = 0, B_j is overwritten by the solution vectors (and the residuals in
+                the overdetermined cases) stored as columns.
     @param[in]
-    ldb       rocblas_int. ldb >= max(m,n).\n
-              Specifies the leading dimension of matrices B_i.
+    ldb         rocblas_int. ldb >= max(m,n).\n
+                Specifies the leading dimension of matrices B_j.
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[i] = 0, successful exit for solution of A_i.
-              If info[i] = j > 0, the solution of A_i could not be computed because input
-              matrix A_i is rank deficient; the j-th diagonal element of its triangular factor is zero.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful exit for solution of A_j.
+                If info[j] = i > 0, the solution of A_j could not be computed because input
+                matrix A_j is rank deficient; the i-th diagonal element of its triangular factor is zero.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
-              Number of matrices in the batch.
-
+                Number of matrices in the batch.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgels_batched(rocblas_handle handle,
@@ -9377,7 +9376,7 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgels_batched(rocblas_handle handle,
 
 /*! @{
     \brief GELS_STRIDED_BATCHED solves a batch of overdetermined (or underdetermined) linear
-    systems defined by a set of m-by-n matrices \f$A_i\f$, and corresponding matrices \f$B_i\f$,
+    systems defined by a set of m-by-n matrices \f$A_j\f$, and corresponding matrices \f$B_j\f$,
     using the QR factorizations computed by \ref rocsolver_sgeqrf_strided_batched "GEQRF_STRIDED_BATCHED"
     (or the LQ factorizations computed by \ref rocsolver_sgelqf_strided_batched "GELQF_STRIDED_BATCHED").
 
@@ -9386,69 +9385,68 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgels_batched(rocblas_handle handle,
 
     \f[
         \begin{array}{cl}
-        A_i X_i = B_i & \: \text{not transposed, or}\\
-        A_i' X_i = B_i & \: \text{transposed if real, or conjugate transposed if complex}
+        A_j X_j = B_j & \: \text{not transposed, or}\\
+        A_j' X_j = B_j & \: \text{transposed if real, or conjugate transposed if complex}
         \end{array}
     \f]
 
     If m >= n (or m < n in the case of transpose/conjugate transpose), the system is overdetermined
-    and a least-squares solution approximating X_i is found by minimizing
+    and a least-squares solution approximating X_j is found by minimizing
 
     \f[
-        || B_i - A_i  X_i || \quad \text{(or} \: || B_i - A_i' X_i ||\text{)}
+        || B_j - A_j  X_j || \quad \text{(or} \: || B_j - A_j' X_j ||\text{)}
     \f]
 
     If m < n (or m >= n in the case of transpose/conjugate transpose), the system is underdetermined
-    and a unique solution for X_i is chosen such that \f$|| X_i ||\f$ is minimal.
+    and a unique solution for X_j is chosen such that \f$|| X_j ||\f$ is minimal.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    trans     rocblas_operation.\n
-              Specifies the form of the system of equations.
+    trans       rocblas_operation.\n
+                Specifies the form of the system of equations.
     @param[in]
-    m         rocblas_int. m >= 0.\n
-              The number of rows of all matrices A_i in the batch.
+    m           rocblas_int. m >= 0.\n
+                The number of rows of all matrices A_j in the batch.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of columns of all matrices A_i in the batch.
+    n           rocblas_int. n >= 0.\n
+                The number of columns of all matrices A_j in the batch.
     @param[in]
-    nrhs      rocblas_int. nrhs >= 0.\n
-              The number of columns of all matrices B_i and X_i in the batch;
-              i.e., the columns on the right hand side.
+    nrhs        rocblas_int. nrhs >= 0.\n
+                The number of columns of all matrices B_j and X_j in the batch;
+                i.e., the columns on the right hand side.
     @param[inout]
-    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
-              On entry, the matrices A_i.
-              On exit, the QR (or LQ) factorizations of A_i as returned by \ref rocsolver_sgeqrf_strided_batched "GEQRF_STRIDED_BATCHED"
-              (or \ref rocsolver_sgelqf_strided_batched "GELQF_STRIDED_BATCHED").
+    A           pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+                On entry, the matrices A_j.
+                On exit, the QR (or LQ) factorizations of A_j as returned by \ref rocsolver_sgeqrf_strided_batched "GEQRF_STRIDED_BATCHED"
+                (or \ref rocsolver_sgelqf_strided_batched "GELQF_STRIDED_BATCHED").
     @param[in]
-    lda       rocblas_int. lda >= m.\n
-              Specifies the leading dimension of matrices A_i.
+    lda         rocblas_int. lda >= m.\n
+                Specifies the leading dimension of matrices A_j.
     @param[in]
-    strideA   rocblas_stride.\n
-              Stride from the start of one matrix A_i to the next one A_(i+1).
-              There is no restriction for the value of strideA. Normal use case is strideA >= lda*n
+    strideA     rocblas_stride.\n
+                Stride from the start of one matrix A_j to the next one A_(j+1).
+                There is no restriction for the value of strideA. Normal use case is strideA >= lda*n
     @param[inout]
-    B         pointer to type. Array on the GPU (the size depends on the value of strideB).\n
-              On entry, the matrices B_i.
-              On exit, when info = 0, each B_i is overwritten by the solution vectors (and the residuals in
-              the overdetermined cases) stored as columns.
+    B           pointer to type. Array on the GPU (the size depends on the value of strideB).\n
+                On entry, the matrices B_j.
+                On exit, when info[j] = 0, each B_j is overwritten by the solution vectors (and the residuals in
+                the overdetermined cases) stored as columns.
     @param[in]
-    ldb       rocblas_int. ldb >= max(m,n).\n
-              Specifies the leading dimension of matrices B_i.
+    ldb         rocblas_int. ldb >= max(m,n).\n
+                Specifies the leading dimension of matrices B_j.
     @param[in]
-    strideB   rocblas_stride.\n
-              Stride from the start of one matrix B_i to the next one B_(i+1).
-              There is no restriction for the value of strideB. Normal use case is strideB >= ldb*nrhs
+    strideB     rocblas_stride.\n
+                Stride from the start of one matrix B_j to the next one B_(j+1).
+                There is no restriction for the value of strideB. Normal use case is strideB >= ldb*nrhs
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[i] = 0, successful exit for solution of A_i.
-              If info[i] = j > 0, the solution of A_i could not be computed because input
-              matrix A_i is rank deficient; the j-th diagonal element of its triangular factor is zero.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful exit for solution of A_j.
+                If info[j] = i > 0, the solution of A_j could not be computed because input
+                matrix A_j is rank deficient; the i-th diagonal element of its triangular factor is zero.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
-              Number of matrices in the batch.
-
+                Number of matrices in the batch.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sgels_strided_batched(rocblas_handle handle,

--- a/library/include/rocsolver-functions.h
+++ b/library/include/rocsolver-functions.h
@@ -9525,25 +9525,25 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zgels_strided_batched(rocblas_handle h
     U is an upper triangular matrix and L is lower triangular.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    uplo      rocblas_fill.\n
-              Specifies whether the factorization is upper or lower triangular.
-              If uplo indicates lower (or upper), then the upper (or lower) part of A is not used.
+    uplo        rocblas_fill.\n
+                Specifies whether the factorization is upper or lower triangular.
+                If uplo indicates lower (or upper), then the upper (or lower) part of A is not used.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of rows and columns of matrix A.
+    n           rocblas_int. n >= 0.\n
+                The number of rows and columns of matrix A.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the matrix A to be factored. On exit, the lower or upper triangular factor.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the matrix A to be factored. On exit, the lower or upper triangular factor.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              specifies the leading dimension of A.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of A.
     @param[out]
-    info      pointer to a rocblas_int on the GPU.\n
-              If info = 0, successful factorization of matrix A.
-              If info = j > 0, the leading minor of order j of A is not positive definite.
-              The factorization stopped at this point.
+    info        pointer to a rocblas_int on the GPU.\n
+                If info = 0, successful factorization of matrix A.
+                If info = i > 0, the leading minor of order i of A is not positive definite.
+                The factorization stopped at this point.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_spotf2(rocblas_handle handle,
@@ -9582,37 +9582,37 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zpotf2(rocblas_handle handle,
     \details
     (This is the unblocked version of the algorithm).
 
-    The factorization of matrix \f$A_i\f$ in the batch has the form:
+    The factorization of matrix \f$A_j\f$ in the batch has the form:
 
     \f[
         \begin{array}{cl}
-        A_i = U_i'U_i & \: \text{if uplo is upper, or}\\
-        A_i = L_iL_i' & \: \text{if uplo is lower.}
+        A_j = U_j'U_j & \: \text{if uplo is upper, or}\\
+        A_j = L_jL_j' & \: \text{if uplo is lower.}
         \end{array}
     \f]
 
-    \f$U_i\f$ is an upper triangular matrix and \f$L_i\f$ is lower triangular.
+    \f$U_j\f$ is an upper triangular matrix and \f$L_j\f$ is lower triangular.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    uplo      rocblas_fill.\n
-              Specifies whether the factorization is upper or lower triangular.
-              If uplo indicates lower (or upper), then the upper (or lower) part of A is not used.
+    uplo        rocblas_fill.\n
+                Specifies whether the factorization is upper or lower triangular.
+                If uplo indicates lower (or upper), then the upper (or lower) part of A is not used.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of rows and columns of matrix A_i.
+    n           rocblas_int. n >= 0.\n
+                The number of rows and columns of matrix A_j.
     @param[inout]
-    A         array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
-              On entry, the matrices A_i to be factored. On exit, the upper or lower triangular factors.
+    A           array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+                On entry, the matrices A_j to be factored. On exit, the upper or lower triangular factors.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              specifies the leading dimension of A_i.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of A_j.
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[i] = 0, successful factorization of matrix A_i.
-              If info[i] = j > 0, the leading minor of order j of A_i is not positive definite.
-              The i-th factorization stopped at this point.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful factorization of matrix A_j.
+                If info[j] = i > 0, the leading minor of order i of A_j is not positive definite.
+                The j-th factorization stopped at this point.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.
@@ -9658,41 +9658,41 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zpotf2_batched(rocblas_handle handle,
     \details
     (This is the unblocked version of the algorithm).
 
-    The factorization of matrix \f$A_i\f$ in the batch has the form:
+    The factorization of matrix \f$A_j\f$ in the batch has the form:
 
     \f[
         \begin{array}{cl}
-        A_i = U_i'U_i & \: \text{if uplo is upper, or}\\
-        A_i = L_iL_i' & \: \text{if uplo is lower.}
+        A_j = U_j'U_j & \: \text{if uplo is upper, or}\\
+        A_j = L_jL_j' & \: \text{if uplo is lower.}
         \end{array}
     \f]
 
-    \f$U_i\f$ is an upper triangular matrix and \f$L_i\f$ is lower triangular.
+    \f$U_j\f$ is an upper triangular matrix and \f$L_j\f$ is lower triangular.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    uplo      rocblas_fill.\n
-              Specifies whether the factorization is upper or lower triangular.
-              If uplo indicates lower (or upper), then the upper (or lower) part of A is not used.
+    uplo        rocblas_fill.\n
+                Specifies whether the factorization is upper or lower triangular.
+                If uplo indicates lower (or upper), then the upper (or lower) part of A is not used.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of rows and columns of matrix A_i.
+    n           rocblas_int. n >= 0.\n
+                The number of rows and columns of matrix A_j.
     @param[inout]
-    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
-              On entry, the matrices A_i to be factored. On exit, the upper or lower triangular factors.
+    A           pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+                On entry, the matrices A_j to be factored. On exit, the upper or lower triangular factors.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              specifies the leading dimension of A_i.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of A_j.
     @param[in]
-    strideA   rocblas_stride.\n
-              Stride from the start of one matrix A_i to the next one A_(i+1).
-              There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
+    strideA    rocblas_stride.\n
+                Stride from the start of one matrix A_j to the next one A_(j+1).
+                There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[i] = 0, successful factorization of matrix A_i.
-              If info[i] = j > 0, the leading minor of order j of A_i is not positive definite.
-              The i-th factorization stopped at this point.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful factorization of matrix A_j.
+                If info[j] = i > 0, the leading minor of order i of A_j is not positive definite.
+                The j-th factorization stopped at this point.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.
@@ -9754,25 +9754,25 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zpotf2_strided_batched(rocblas_handle 
     U is an upper triangular matrix and L is lower triangular.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    uplo      rocblas_fill.\n
-              Specifies whether the factorization is upper or lower triangular.
-              If uplo indicates lower (or upper), then the upper (or lower) part of A is not used.
+    uplo        rocblas_fill.\n
+                Specifies whether the factorization is upper or lower triangular.
+                If uplo indicates lower (or upper), then the upper (or lower) part of A is not used.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of rows and columns of matrix A.
+    n           rocblas_int. n >= 0.\n
+                The number of rows and columns of matrix A.
     @param[inout]
-    A         pointer to type. Array on the GPU of dimension lda*n.\n
-              On entry, the matrix A to be factored. On exit, the lower or upper triangular factor.
+    A           pointer to type. Array on the GPU of dimension lda*n.\n
+                On entry, the matrix A to be factored. On exit, the lower or upper triangular factor.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              specifies the leading dimension of A.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of A.
     @param[out]
-    info      pointer to a rocblas_int on the GPU.\n
-              If info = 0, successful factorization of matrix A.
-              If info = j > 0, the leading minor of order j of A is not positive definite.
-              The factorization stopped at this point.
+    info        pointer to a rocblas_int on the GPU.\n
+                If info = 0, successful factorization of matrix A.
+                If info = i > 0, the leading minor of order i of A is not positive definite.
+                The factorization stopped at this point.
     ********************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_spotrf(rocblas_handle handle,
@@ -9811,37 +9811,37 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zpotrf(rocblas_handle handle,
     \details
     (This is the blocked version of the algorithm).
 
-    The factorization of matrix \f$A_i\f$ in the batch has the form:
+    The factorization of matrix \f$A_j\f$ in the batch has the form:
 
     \f[
         \begin{array}{cl}
-        A_i = U_i'U_i & \: \text{if uplo is upper, or}\\
-        A_i = L_iL_i' & \: \text{if uplo is lower.}
+        A_j = U_j'U_j & \: \text{if uplo is upper, or}\\
+        A_j = L_jL_j' & \: \text{if uplo is lower.}
         \end{array}
     \f]
 
-    \f$U_i\f$ is an upper triangular matrix and \f$L_i\f$ is lower triangular.
+    \f$U_j\f$ is an upper triangular matrix and \f$L_j\f$ is lower triangular.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    uplo      rocblas_fill.\n
-              Specifies whether the factorization is upper or lower triangular.
-              If uplo indicates lower (or upper), then the upper (or lower) part of A is not used.
+    uplo        rocblas_fill.\n
+                Specifies whether the factorization is upper or lower triangular.
+                If uplo indicates lower (or upper), then the upper (or lower) part of A is not used.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of rows and columns of matrix A_i.
+    n           rocblas_int. n >= 0.\n
+                The number of rows and columns of matrix A_j.
     @param[inout]
-    A         array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
-              On entry, the matrices A_i to be factored. On exit, the upper or lower triangular factors.
+    A           array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.\n
+                On entry, the matrices A_j to be factored. On exit, the upper or lower triangular factors.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              specifies the leading dimension of A_i.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of A_j.
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[i] = 0, successful factorization of matrix A_i.
-              If info[i] = j > 0, the leading minor of order j of A_i is not positive definite.
-              The i-th factorization stopped at this point.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful factorization of matrix A_j.
+                If info[j] = i > 0, the leading minor of order i of A_j is not positive definite.
+                The j-th factorization stopped at this point.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.
@@ -9887,41 +9887,41 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zpotrf_batched(rocblas_handle handle,
     \details
     (This is the blocked version of the algorithm).
 
-    The factorization of matrix \f$A_i\f$ in the batch has the form:
+    The factorization of matrix \f$A_j\f$ in the batch has the form:
 
     \f[
         \begin{array}{cl}
-        A_i = U_i'U_i & \: \text{if uplo is upper, or}\\
-        A_i = L_iL_i' & \: \text{if uplo is lower.}
+        A_j = U_j'U_j & \: \text{if uplo is upper, or}\\
+        A_j = L_jL_j' & \: \text{if uplo is lower.}
         \end{array}
     \f]
 
-    \f$U_i\f$ is an upper triangular matrix and \f$L_i\f$ is lower triangular.
+    \f$U_j\f$ is an upper triangular matrix and \f$L_j\f$ is lower triangular.
 
     @param[in]
-    handle    rocblas_handle.
+    handle      rocblas_handle.
     @param[in]
-    uplo      rocblas_fill.\n
-              Specifies whether the factorization is upper or lower triangular.
-              If uplo indicates lower (or upper), then the upper (or lower) part of A is not used.
+    uplo        rocblas_fill.\n
+                Specifies whether the factorization is upper or lower triangular.
+                If uplo indicates lower (or upper), then the upper (or lower) part of A is not used.
     @param[in]
-    n         rocblas_int. n >= 0.\n
-              The number of rows and columns of matrix A_i.
+    n           rocblas_int. n >= 0.\n
+                The number of rows and columns of matrix A_j.
     @param[inout]
-    A         pointer to type. Array on the GPU (the size depends on the value of strideA).\n
-              On entry, the matrices A_i to be factored. On exit, the upper or lower triangular factors.
+    A           pointer to type. Array on the GPU (the size depends on the value of strideA).\n
+                On entry, the matrices A_j to be factored. On exit, the upper or lower triangular factors.
     @param[in]
-    lda       rocblas_int. lda >= n.\n
-              specifies the leading dimension of A_i.
+    lda         rocblas_int. lda >= n.\n
+                Specifies the leading dimension of A_j.
     @param[in]
-    strideA   rocblas_stride.\n
-              Stride from the start of one matrix A_i to the next one A_(i+1).
-              There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
+    strideA     rocblas_stride.\n
+                Stride from the start of one matrix A_j to the next one A_(j+1).
+                There is no restriction for the value of strideA. Normal use case is strideA >= lda*n.
     @param[out]
-    info      pointer to rocblas_int. Array of batch_count integers on the GPU.\n
-              If info[i] = 0, successful factorization of matrix A_i.
-              If info[i] = j > 0, the leading minor of order j of A_i is not positive definite.
-              The i-th factorization stopped at this point.
+    info        pointer to rocblas_int. Array of batch_count integers on the GPU.\n
+                If info[j] = 0, successful factorization of matrix A_j.
+                If info[j] = i > 0, the leading minor of order i of A_j is not positive definite.
+                The j-th factorization stopped at this point.
     @param[in]
     batch_count rocblas_int. batch_count >= 0.\n
                 Number of matrices in the batch.


### PR DESCRIPTION
This PR applies the documentation changes in https://github.com/ROCmSoftwarePlatform/rocSOLVER/pull/380 to other functions, up to and including potrf. Namely, I've aligned the parameter descriptions and ensured that `j` is always the batch index.

Most of the change is adding or removing whitespace. The indexing changes apply only to getf2/getrf, gels, and potf2/potrf.