### PR TITLE
Revert "Add gfx1011 support"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ rocm_check_target_ids(OPTIONAL_AMDGPU_TARGETS
 
 # Set this before finding hip so that hip::device has the required arch flags
 # added as usage requirements on its interface
-set(AMDGPU_TARGETS "gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx1010;gfx1011;gfx1030;${OPTIONAL_AMDGPU_TARGETS}"
+set(AMDGPU_TARGETS "gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx1010;gfx1030;${OPTIONAL_AMDGPU_TARGETS}"
   CACHE STRING "List of specific machine types for library to target")
 
 # Find HIP dependencies


### PR DESCRIPTION
The gfx1011 target was dropped from the rocBLAS default architecture list in https://github.com/ROCmSoftwarePlatform/rocBLAS/commit/f3b45f701048bef8e7190d5a710b845354319169. While both libraries can still be built for gxf1011 with `./install.sh -a gfx1011` or `cmake -DAMDGPU_TARGETS=gfx1011`, they will no longer be built for gfx1011 by default.

Reverts ROCmSoftwarePlatform/rocSOLVER#374