### PR TITLE
Disable rtest logfile parsing

### DIFF
--- a/clients/gtest/logging_gtest.cpp
+++ b/clients/gtest/logging_gtest.cpp
@@ -364,7 +364,7 @@ TEST_F(checkin_misc_LOGGING, rocblas_layer_mode_log_bench_tree)
     verify_file(log_filepath, expected_lines);
 }
 
-TEST_F(checkin_misc_LOGGING, trace_file_open_failure)
+TEST_F(checkin_misc_LOGGING, trace_invalid_file_open)
 {
     scoped_envvar logpath_variable("ROCSOLVER_LOG_TRACE_PATH",
                                    invalid_log_filepath.generic_string().c_str());
@@ -374,7 +374,7 @@ TEST_F(checkin_misc_LOGGING, trace_file_open_failure)
     ASSERT_EQ(rocsolver_log_end(), rocblas_status_success);
 }
 
-TEST_F(checkin_misc_LOGGING, profile_file_open_failure)
+TEST_F(checkin_misc_LOGGING, profile_invalid_file_open)
 {
     scoped_envvar logpath_variable("ROCSOLVER_LOG_PROFILE_PATH",
                                    invalid_log_filepath.generic_string().c_str());
@@ -384,7 +384,7 @@ TEST_F(checkin_misc_LOGGING, profile_file_open_failure)
     ASSERT_EQ(rocsolver_log_end(), rocblas_status_success);
 }
 
-TEST_F(checkin_misc_LOGGING, bench_file_open_failure)
+TEST_F(checkin_misc_LOGGING, bench_invalid_file_open)
 {
     scoped_envvar logpath_variable("ROCSOLVER_LOG_BENCH_PATH",
                                    invalid_log_filepath.generic_string().c_str());
@@ -394,7 +394,7 @@ TEST_F(checkin_misc_LOGGING, bench_file_open_failure)
     ASSERT_EQ(rocsolver_log_end(), rocblas_status_success);
 }
 
-TEST_F(checkin_misc_LOGGING, begin_twice_failure)
+TEST_F(checkin_misc_LOGGING, begin_twice)
 {
     ASSERT_EQ(rocsolver_log_begin(), rocblas_status_success);
     EXPECT_EQ(rocsolver_log_begin(), rocblas_status_internal_error);
@@ -402,14 +402,14 @@ TEST_F(checkin_misc_LOGGING, begin_twice_failure)
     ASSERT_EQ(rocsolver_log_end(), rocblas_status_success);
 }
 
-TEST_F(checkin_misc_LOGGING, end_twice_failure)
+TEST_F(checkin_misc_LOGGING, end_twice)
 {
     ASSERT_EQ(rocsolver_log_begin(), rocblas_status_success);
     EXPECT_EQ(rocsolver_log_end(), rocblas_status_success);
     ASSERT_EQ(rocsolver_log_end(), rocblas_status_internal_error);
 }
 
-TEST_F(checkin_misc_LOGGING, end_before_begin_failure)
+TEST_F(checkin_misc_LOGGING, end_before_begin)
 {
     ASSERT_EQ(rocsolver_log_end(), rocblas_status_internal_error);
 }

--- a/clients/gtest/logging_gtest.cpp
+++ b/clients/gtest/logging_gtest.cpp
@@ -364,7 +364,7 @@ TEST_F(checkin_misc_LOGGING, rocblas_layer_mode_log_bench_tree)
     verify_file(log_filepath, expected_lines);
 }
 
-TEST_F(checkin_misc_LOGGING, trace_invalid_file_open)
+TEST_F(checkin_misc_LOGGING, invalid_trace_file_open)
 {
     scoped_envvar logpath_variable("ROCSOLVER_LOG_TRACE_PATH",
                                    invalid_log_filepath.generic_string().c_str());
@@ -374,7 +374,7 @@ TEST_F(checkin_misc_LOGGING, trace_invalid_file_open)
     ASSERT_EQ(rocsolver_log_end(), rocblas_status_success);
 }
 
-TEST_F(checkin_misc_LOGGING, profile_invalid_file_open)
+TEST_F(checkin_misc_LOGGING, invalid_profile_file_open)
 {
     scoped_envvar logpath_variable("ROCSOLVER_LOG_PROFILE_PATH",
                                    invalid_log_filepath.generic_string().c_str());
@@ -384,7 +384,7 @@ TEST_F(checkin_misc_LOGGING, profile_invalid_file_open)
     ASSERT_EQ(rocsolver_log_end(), rocblas_status_success);
 }
 
-TEST_F(checkin_misc_LOGGING, bench_invalid_file_open)
+TEST_F(checkin_misc_LOGGING, invalid_bench_file_open)
 {
     scoped_envvar logpath_variable("ROCSOLVER_LOG_BENCH_PATH",
                                    invalid_log_filepath.generic_string().c_str());

--- a/rtest.xml
+++ b/rtest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testset>
+<testset failure-regex="$.^">
     <var name="COMMAND">rocsolver-test --gtest_color=yes </var>
     <test sets="psdb">
         <run name="all-psdb">{COMMAND} --gtest_filter=checkin*-*known_bug* --gtest_output=xml </run>


### PR DESCRIPTION
By default, rtest.py will parse the test log and mark the build as a
failure if it contains the strings "fail" or "error". This causes the
test suite to be marked as failure even when all tests pass when
executing the checkin tests, due to tests added in 3c3c865 with
problem names like 'checkin_misc_LOGGING.profile_file_open_failure'.

This log-parsing behaviour is unnecessary, so we can disable it by
setting a regex for an impossible pattern that can never match
any string.