### PR TITLE
Reorg Changes with rocm-cmake wrapper usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 ## (Unreleased) rocSOLVER
 ### Added
 - Added tests for multi-level logging
+- File/Folder Reorg
+  - Added File/Folder Reorg Changes with backward compatibility support using ROCM-CMAKE wrapper functions.
 
 ### Optimized
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ include(ROCMInstallTargets)
 include(ROCMPackageConfigHelpers)
 include(ROCMInstallSymlinks)
 include(ROCMCheckTargetIds)
+include(ROCMHeaderWrapper)
 
 include(os-detection)
 get_os_id(OS_ID)
@@ -108,6 +109,18 @@ cmake_dependent_option(BUILD_CLIENTS_EXTRA_TESTS "Build extra tests" OFF BUILD_T
 option(BUILD_ADDRESS_SANITIZER "Build with address sanitizer enabled" OFF)
 option(BUILD_CODE_COVERAGE "Build rocSOLVER with code coverage enabled" OFF)
 option(WERROR "Treat warnings as errors" OFF)
+
+# FOR HANDLING ENABLE/DISABLE OPTIONAL BACKWARD COMPATIBILITY for FILE/FOLDER REORG
+option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY "Build with file/folder reorg with backward compatibility enabled" ON)
+if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
+  rocm_wrap_header_dir(
+    ${CMAKE_SOURCE_DIR}/library/include
+    PATTERNS "*.h"
+    GUARDS SYMLINK WRAPPER
+    WRAPPER_LOCATIONS include
+  )
+endif()
+
 
 message(STATUS "Tests: ${BUILD_CLIENTS_TESTS}")
 message(STATUS "Benchmarks: ${BUILD_CLIENTS_BENCHMARKS}")

--- a/cmake/get-rocm-cmake.cmake
+++ b/cmake/get-rocm-cmake.cmake
@@ -8,7 +8,7 @@ if(NOT ROCM_PATH)
   set(ROCM_PATH /opt/rocm)
 endif()
 
-find_package(ROCM 0.6 CONFIG QUIET PATHS ${ROCM_PATH})
+find_package(ROCM 0.7.3 CONFIG QUIET PATHS ${ROCM_PATH})
 if(NOT ROCM_FOUND)
   set(rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download")
   set(rocm_cmake_url "https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip")
@@ -35,5 +35,5 @@ if(NOT ROCM_FOUND)
   execute_process( COMMAND ${CMAKE_COMMAND} --build rocm-cmake-${rocm_cmake_tag} --target install
     WORKING_DIRECTORY ${PROJECT_EXTERN_DIR})
 
-  find_package( ROCM 0.6 REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR}/rocm-cmake )
+  find_package( ROCM 0.7.3 REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR}/rocm-cmake )
 endif()

--- a/install.sh
+++ b/install.sh
@@ -81,6 +81,7 @@ Options:
                               (Default build type is Release)
 
   --cmake-arg <argument>      Forward the given argument to CMake when configuring the build.
+  --rm-legacy-include-dir     Remove legacy include dir Packaging added for file/folder reorg backward compatibility.
 EOF
 }
 
@@ -330,6 +331,7 @@ optimal=true
 cleanup=false
 build_sanitizer=false
 build_codecoverage=false
+build_freorg_bkwdcomp=true
 unset architecture
 unset rocblas_dir
 unset rocsolver_dir
@@ -343,7 +345,7 @@ declare -a cmake_client_options
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,package,clients,clients-only,dependencies,cleanup,debug,hip-clang,codecoverage,relwithdebinfo,build_dir:,rocblas_dir:,rocsolver_dir:,lib_dir:,install_dir:,architecture:,static,relocatable,no-optimizations,docs,address-sanitizer,cmake-arg: --options hipcdgsrnka: -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,package,clients,clients-only,dependencies,cleanup,debug,hip-clang,codecoverage,relwithdebinfo,build_dir:,rocblas_dir:,rocsolver_dir:,lib_dir:,install_dir:,architecture:,static,relocatable,no-optimizations,docs,address-sanitizer,cmake-arg:,rm-legacy-include-dir --options hipcdgsrnka: -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -426,6 +428,9 @@ while true; do
         shift ;;
     -k|--relwithdebinfo)
         build_type=RelWithDebInfo
+        shift ;;
+    --rm-legacy-include-dir)
+        build_freorg_bkwdcomp=false
         shift ;;
     --cmake-arg)
         cmake_common_options+=("${2}")
@@ -573,6 +578,12 @@ fi
 
 if [[ "${build_library}" == false ]]; then
   cmake_client_options+=('-DBUILD_LIBRARY=OFF')
+fi
+
+if [[ "${build_freorg_bkwdcomp}" == true ]]; then
+  cmake_common_options+=('-DBUILD_FILE_REORG_BACKWARD_COMPATIBILITY=ON')
+else
+  cmake_common_options+=('-DBUILD_FILE_REORG_BACKWARD_COMPATIBILITY=OFF')
 fi
 
 rocm_rpath=""

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -8,8 +8,6 @@ set(rocsolver_SOVERSION 0.1)
 # Create version header from templated .in file using CMake info
 configure_file(include/rocsolver-version.h.in "${PROJECT_BINARY_DIR}/include/rocsolver/rocsolver-version.h")
 
-
-
 set(rocsolver_headers_public
   include/rocsolver.h
   include/rocsolver-extra-types.h

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -6,15 +6,17 @@
 set(rocsolver_SOVERSION 0.1)
 
 # Create version header from templated .in file using CMake info
-configure_file(include/rocsolver-version.h.in "${PROJECT_BINARY_DIR}/include/rocsolver-version.h")
+configure_file(include/rocsolver-version.h.in "${PROJECT_BINARY_DIR}/include/rocsolver/rocsolver-version.h")
+
+
 
 set(rocsolver_headers_public
   include/rocsolver.h
   include/rocsolver-extra-types.h
   include/rocsolver-aliases.h
   include/rocsolver-functions.h
-  ${PROJECT_BINARY_DIR}/include/rocsolver-version.h
-  ${PROJECT_BINARY_DIR}/include/rocsolver-export.h
+  ${PROJECT_BINARY_DIR}/include/rocsolver/rocsolver-version.h
+  ${PROJECT_BINARY_DIR}/include/rocsolver/rocsolver-export.h
 )
 
 # For IDE integration

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -289,18 +289,7 @@ endif()
 
 ############################################################
 # Installation
-#execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/library/include ${PROJECT_BINARY_DIR}/include/rocsolver)
-
-rocm_install(
-	DIRECTORY
-	${PROJECT_SOURCE_DIR}/library/include
-	DESTINATION
-	${PROJECT_BINARY_DIR}/include/rocsolver
-	FILES_MATCHING
-	PATTERN *.h
-	PATTERN *.hpp
-	PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
-	)
+execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/library/include ${PROJECT_BINARY_DIR}/include/rocsolver)
 
 rocm_install_targets(
   TARGETS ${package_targets}

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -245,7 +245,15 @@ set_target_properties(rocsolver PROPERTIES
   CXX_VISIBILITY_PRESET "hidden"
   VISIBILITY_INLINES_HIDDEN ON
 )
-generate_export_header(rocsolver EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/rocsolver-export.h)
+generate_export_header(rocsolver EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/rocsolver/rocsolver-export.h)
+
+if (BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
+  rocm_wrap_header_file(
+    rocsolver-version.h rocsolver-export.h
+    GUARDS SYMLINK WRAPPER
+    WRAPPER_LOCATIONS include rocsolver/include
+  )
+endif( )
 
 # Following Boost conventions of prefixing 'lib' on static built libraries, across all platforms
 if(NOT BUILD_SHARED_LIBS)
@@ -281,22 +289,39 @@ endif()
 
 ############################################################
 # Installation
+#execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/library/include ${PROJECT_BINARY_DIR}/include/rocsolver)
+
+rocm_install(
+	DIRECTORY
+	${PROJECT_SOURCE_DIR}/library/include
+	DESTINATION
+	${PROJECT_BINARY_DIR}/include/rocsolver
+	FILES_MATCHING
+	PATTERN *.h
+	PATTERN *.hpp
+	PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
+	)
 
 rocm_install_targets(
   TARGETS ${package_targets}
   INCLUDE
     ${CMAKE_SOURCE_DIR}/library/include
     ${CMAKE_BINARY_DIR}/include
-  PREFIX rocsolver
 )
 
 rocm_export_targets(
   TARGETS roc::rocsolver
-  PREFIX rocsolver
   DEPENDS
     PACKAGE hip
     PACKAGE rocblas
   NAMESPACE roc::
 )
 
-rocm_install_symlink_subdir(rocsolver)
+if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
+  rocm_install(
+    DIRECTORY
+       "${PROJECT_BINARY_DIR}/rocsolver"
+        DESTINATION "." )
+  message( STATUS "Backward Compatible Sym Link Created for include directories" )
+endif()
+


### PR DESCRIPTION
- File/Folder Reorg Changes
- Backward Support enabled (rocm-cmake wrapper)
- Replacement of https://github.com/ROCmSoftwarePlatform/rocSOLVER/pull/379 with all comments