### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing
+
+## Philosophy
+
+AMD welcomes contributions from the community. Whether those contributions are bug reports,
+bug fixes, documentation additions, performance notes, or other improvements, we value
+collaboration with our users. We can build better solutions together.
+
+## License agreement
+
+Contributors must agree to the following terms:
+
+1. The code I am contributing is mine, and I have the right to license it.
+
+2. By submitting a pull request for this project I am granting you a license to distribute
+   said code under the BSD License for the project.
+
+# Submitting a Pull Request
+
+To contribute changes to rocSOLVER, open a pull request targeting the `develop` branch. Pull
+requests will be tested and reviewed by the AMD development team. AMD may request changes or
+modify the submission before acceptance.
+
+## Interface requirements
+
+The public interface must be:
+
+- C99 compatible
+- Source and binary compatible with previous releases
+- Fully documented with Doxygen and Sphinx
+
+All identifiers in the public headers must be prefixed with `rocblas`, `ROCBLAS`, `rocsolver`,
+or `ROCSOLVER`. The prefixes `_ROCLAPACK` and `_ROCSOLVER` are deprecated and should not be used
+in new code.
+
+All user-visible symbols must be prefixed with `rocblas` or `rocsolver`.
+
+## Style guide
+
+In general, follow the style of the surrounding code. All code is auto-formatted using clang-format.
+To apply the rocsolver formatting, run `clang-format -i -style=file <files>` on any files you've
+changed. You can install git hooks to do this automatically upon commit by running
+`scripts/install-hooks --get-clang-format`. If you find you'd rather not use the hooks, they can
+be removed using `scripts/uninstall-hooks`.
+
+## Tests
+
+To run the rocSOLVER test suite, first build the rocSOLVER test client following the instructions in
+[Building and Installation][1]. Then, run the `rocsolver-test` binary. For a typical build, the test
+binary will be found at `./build/release/clients/staging/rocsolver-test`.
+
+The full test suite is quite large and may take a long time to complete, so passing the
+[`--gtest_filter=<pattern>`][2] option to rocsolver-test may be useful during development.
+
+## Rejected contributions
+
+Unfortunately, sometimes a contribution cannot be accepted. The rationale for a decision may or may
+not be disclosed.
+
+
+[1]: https://rocsolver.readthedocs.io/en/latest/userguide_install.html
+[2]: https://github.com/google/googletest/blob/release-1.10.0/googletest/docs/advanced.md#running-a-subset-of-the-tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,9 @@ To run the rocSOLVER test suite, first build the rocSOLVER test client following
 binary will be found at `./build/release/clients/staging/rocsolver-test`.
 
 The full test suite is quite large and may take a long time to complete, so passing the
-[`--gtest_filter=<pattern>`][2] option to rocsolver-test may be useful during development.
+[`--gtest_filter=<pattern>`][2] option to rocsolver-test may be useful during development. A fast
+subset of tests can be run with `--gtest_filter='checkin*'`, while the extended tests can be run
+with `--gtest_filter='daily*'`.
 
 ## Rejected contributions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,15 +6,6 @@ AMD welcomes contributions from the community. Whether those contributions are b
 bug fixes, documentation additions, performance notes, or other improvements, we value
 collaboration with our users. We can build better solutions together.
 
-## License agreement
-
-Contributors must agree to the following terms:
-
-1. The code I am contributing is mine, and I have the right to license it.
-
-2. By submitting a pull request for this project I am granting you a license to distribute
-   said code under the BSD License for the project.
-
 # Submitting a Pull Request
 
 To contribute changes to rocSOLVER, open a pull request targeting the `develop` branch. Pull

--- a/docs/source/design_contribute.rst
+++ b/docs/source/design_contribute.rst
@@ -10,8 +10,10 @@ Contributing Guidelines
    :local:
    :backlinks: top
 
+AMD welcomes contributions from the community. Whether those contributions are bug reports,
+bug fixes, documentation additions, performance notes, or other improvements, we value
+collaboration with our users. We can build better solutions together.
 
-More to come later...
-
-
-
+For the most up-to-date guidelines, please refer to
+`CONTRIBUTING.md <https://github.com/ROCmSoftwarePlatform/rocSOLVER/blob/develop/CONTRIBUTING.md>`_
+on the ``develop`` branch of the rocSOLVER GitHub repository.

--- a/docs/source/design_contribute.rst
+++ b/docs/source/design_contribute.rst
@@ -14,6 +14,6 @@ AMD welcomes contributions from the community. Whether those contributions are b
 bug fixes, documentation additions, performance notes, or other improvements, we value
 collaboration with our users. We can build better solutions together.
 
-For the most up-to-date guidelines, please refer to
-`CONTRIBUTING.md <https://github.com/ROCmSoftwarePlatform/rocSOLVER/blob/develop/CONTRIBUTING.md>`_
-on the ``develop`` branch of the rocSOLVER GitHub repository.
+For the most up-to-date guidelines, please refer to the ``CONTRIBUTING``
+document on the ``develop`` branch of the
+`rocSOLVER GitHub repository <https://github.com/ROCmSoftwarePlatform/rocSOLVER>`_.


### PR DESCRIPTION
I wasn't certain of the best way to split the document between the docs and the repository. There's a few benefits of using a contributing file in the project root, but one of the main ones is that this is a special file that [GitHub understands and displays to new contributors](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors).

There's still lots more we can do to make the project more welcoming for new contributors. I hope this is a useful start that we can continue to build upon.