### PR TITLE
Use printable_char to improve gtest messages

### DIFF
--- a/clients/gtest/gels_gtest.cpp
+++ b/clients/gtest/gels_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -13,7 +13,7 @@ using ::testing::ValuesIn;
 using namespace std;
 
 typedef std::tuple<int, int, int, int, int> gels_params_A;
-typedef std::tuple<int, rocsolver_op_char> gels_params_B;
+typedef std::tuple<int, printable_char> gels_params_B;
 
 typedef std::tuple<gels_params_A, gels_params_B> gels_tuple;
 

--- a/clients/gtest/orgtr_ungtr_gtest.cpp
+++ b/clients/gtest/orgtr_ungtr_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -11,14 +11,14 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, int> orgtr_tuple;
+typedef std::tuple<vector<int>, printable_char> orgtr_tuple;
 
 // each size_range vector is a {n, lda}
 
 // case when n = 0 and uplo = 'U' will also execute the bad arguments test
 // (null handle, null pointers and invalid values)
 
-const vector<int> uplo_range = {0, 1};
+const vector<printable_char> uplo_range = {'L', 'U'};
 
 // for checkin_lapack tests
 const vector<vector<int>> size_range = {
@@ -39,14 +39,14 @@ const vector<vector<int>> large_size_range = {{192, 192}, {500, 600}, {640, 640}
 Arguments orgtr_setup_arguments(orgtr_tuple tup)
 {
     vector<int> size = std::get<0>(tup);
-    int uplo = std::get<1>(tup);
+    char uplo = std::get<1>(tup);
 
     Arguments arg;
 
     arg.set<rocblas_int>("n", size[0]);
     arg.set<rocblas_int>("lda", size[1]);
 
-    arg.set<char>("uplo", uplo == 1 ? 'U' : 'L');
+    arg.set<char>("uplo", uplo);
 
     arg.timing = 0;
 

--- a/clients/gtest/potf2_potrf_gtest.cpp
+++ b/clients/gtest/potf2_potrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -11,7 +11,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, char> potrf_tuple;
+typedef std::tuple<vector<int>, printable_char> potrf_tuple;
 
 // each size_range vector is a {N, lda, singular}
 // if singular = 1, then the used matrix for the tests is not positive definite
@@ -21,7 +21,7 @@ typedef std::tuple<vector<int>, char> potrf_tuple;
 // case when n = 0 and uplo = L will also execute the bad arguments test
 // (null handle, null pointers and invalid values)
 
-const vector<char> uplo_range = {'L', 'U'};
+const vector<printable_char> uplo_range = {'L', 'U'};
 
 // for checkin_lapack tests
 const vector<vector<int>> matrix_size_range = {

--- a/clients/gtest/potri_gtest.cpp
+++ b/clients/gtest/potri_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -11,7 +11,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, char> potri_tuple;
+typedef std::tuple<vector<int>, printable_char> potri_tuple;
 
 // each matrix_size_range vector is a {n, lda, singular}
 // if singular = 1, then the used matrix for the tests is singular
@@ -21,7 +21,7 @@ typedef std::tuple<vector<int>, char> potri_tuple;
 // case when n = 0 and uplo = L will also execute the bad arguments test
 // (null handle, null pointers and invalid values)
 
-const vector<char> uplo_range = {'L', 'U'};
+const vector<printable_char> uplo_range = {'L', 'U'};
 
 // for checkin_lapack tests
 const vector<vector<int>> matrix_size_range = {

--- a/clients/gtest/stedc_gtest.cpp
+++ b/clients/gtest/stedc_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -11,19 +11,16 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, vector<int>> stedc_tuple;
+typedef std::tuple<vector<int>, printable_char> stedc_tuple;
 
 // each size_range vector is a {N, ldc}
 
 // each op_range vector is a {e}
-// if e = 0, then evect = 'N'
-// if e = 1, then evect = 'I'
-// if e = 2, then evect = 'V'
 
 // case when N == 0 and evect == N will also execute the bad arguments test
 // (null handle, null pointers and invalid values)
 
-const vector<vector<int>> op_range = {{0}, {1}, {2}};
+const vector<printable_char> op_range = {'N', 'I', 'V'};
 
 // for checkin_lapack tests
 const vector<vector<int>> matrix_size_range = {
@@ -44,14 +41,14 @@ const vector<vector<int>> large_matrix_size_range = {{192, 192}, {256, 270}, {30
 Arguments stedc_setup_arguments(stedc_tuple tup)
 {
     vector<int> size = std::get<0>(tup);
-    vector<int> op = std::get<1>(tup);
+    char op = std::get<1>(tup);
 
     Arguments arg;
 
     arg.set<rocblas_int>("n", size[0]);
     arg.set<rocblas_int>("ldc", size[1]);
 
-    arg.set<char>("evect", (op[0] == 0 ? 'N' : (op[0] == 1 ? 'I' : 'V')));
+    arg.set<char>("evect", op);
 
     arg.timing = 0;
 

--- a/clients/gtest/steqr_gtest.cpp
+++ b/clients/gtest/steqr_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -11,19 +11,16 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, vector<int>> steqr_tuple;
+typedef std::tuple<vector<int>, printable_char> steqr_tuple;
 
 // each size_range vector is a {N, ldc}
 
 // each op_range vector is a {e}
-// if e = 0, then evect = 'N'
-// if e = 1, then evect = 'I'
-// if e = 2, then evect = 'V'
 
 // case when N == 0 and evect == N will also execute the bad arguments test
 // (null handle, null pointers and invalid values)
 
-const vector<vector<int>> op_range = {{0}, {1}, {2}};
+const vector<printable_char> op_range = {'N', 'I', 'V'};
 
 // for checkin_lapack tests
 const vector<vector<int>> matrix_size_range = {
@@ -44,14 +41,14 @@ const vector<vector<int>> large_matrix_size_range = {{192, 192}, {256, 270}, {30
 Arguments steqr_setup_arguments(steqr_tuple tup)
 {
     vector<int> size = std::get<0>(tup);
-    vector<int> op = std::get<1>(tup);
+    char op = std::get<1>(tup);
 
     Arguments arg;
 
     arg.set<rocblas_int>("n", size[0]);
     arg.set<rocblas_int>("ldc", size[1]);
 
-    arg.set<char>("evect", (op[0] == 0 ? 'N' : (op[0] == 1 ? 'I' : 'V')));
+    arg.set<char>("evect", op);
 
     arg.timing = 0;
 

--- a/clients/gtest/syev_heev_gtest.cpp
+++ b/clients/gtest/syev_heev_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -11,7 +11,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, vector<rocsolver_op_char>> syev_heev_tuple;
+typedef std::tuple<vector<int>, vector<printable_char>> syev_heev_tuple;
 
 // each size_range vector is a {n, lda}
 
@@ -20,7 +20,7 @@ typedef std::tuple<vector<int>, vector<rocsolver_op_char>> syev_heev_tuple;
 // case when n == 0, evect == N, and uplo = L will also execute the bad arguments test
 // (null handle, null pointers and invalid values)
 
-const vector<vector<rocsolver_op_char>> op_range = {{'N', 'L'}, {'N', 'U'}, {'V', 'L'}, {'V', 'U'}};
+const vector<vector<printable_char>> op_range = {{'N', 'L'}, {'N', 'U'}, {'V', 'L'}, {'V', 'U'}};
 
 // for checkin_lapack tests
 const vector<vector<int>> size_range = {
@@ -42,7 +42,7 @@ const vector<vector<int>> large_size_range = {{192, 192}, {256, 270}, {300, 300}
 Arguments syev_heev_setup_arguments(syev_heev_tuple tup)
 {
     vector<int> size = std::get<0>(tup);
-    vector<rocsolver_op_char> op = std::get<1>(tup);
+    vector<printable_char> op = std::get<1>(tup);
 
     Arguments arg;
 

--- a/clients/gtest/syevd_heevd_gtest.cpp
+++ b/clients/gtest/syevd_heevd_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -11,7 +11,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, vector<rocsolver_op_char>> syevd_heevd_tuple;
+typedef std::tuple<vector<int>, vector<printable_char>> syevd_heevd_tuple;
 
 // each size_range vector is a {n, lda}
 
@@ -20,7 +20,7 @@ typedef std::tuple<vector<int>, vector<rocsolver_op_char>> syevd_heevd_tuple;
 // case when n == 0, evect == N, and uplo = L will also execute the bad arguments test
 // (null handle, null pointers and invalid values)
 
-const vector<vector<rocsolver_op_char>> op_range = {{'N', 'L'}, {'N', 'U'}, {'V', 'L'}, {'V', 'U'}};
+const vector<vector<printable_char>> op_range = {{'N', 'L'}, {'N', 'U'}, {'V', 'L'}, {'V', 'U'}};
 
 // for checkin_lapack tests
 const vector<vector<int>> size_range = {
@@ -42,7 +42,7 @@ const vector<vector<int>> large_size_range = {{192, 192}, {256, 270}, {300, 300}
 Arguments syevd_heevd_setup_arguments(syevd_heevd_tuple tup)
 {
     vector<int> size = std::get<0>(tup);
-    vector<rocsolver_op_char> op = std::get<1>(tup);
+    vector<printable_char> op = std::get<1>(tup);
 
     Arguments arg;
 

--- a/clients/gtest/sygsx_hegsx_gtest.cpp
+++ b/clients/gtest/sygsx_hegsx_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -11,7 +11,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, vector<char>> sygst_tuple;
+typedef std::tuple<vector<int>, vector<printable_char>> sygst_tuple;
 
 // each matrix_size_range is a {n, lda, ldb}
 
@@ -20,7 +20,7 @@ typedef std::tuple<vector<int>, vector<char>> sygst_tuple;
 // case when n = 0, itype = 1, and uplo = U will also execute the bad arguments test
 // (null handle, null pointers and invalid values)
 
-const vector<vector<char>> type_range = {{'1', 'L'}, {'2', 'L'}, {'1', 'U'}, {'3', 'U'}};
+const vector<vector<printable_char>> type_range = {{'1', 'L'}, {'2', 'L'}, {'1', 'U'}, {'3', 'U'}};
 
 // for checkin_lapack tests
 const vector<vector<int>> matrix_size_range = {
@@ -44,7 +44,7 @@ const vector<vector<int>> large_matrix_size_range = {
 Arguments sygst_setup_arguments(sygst_tuple tup)
 {
     vector<int> matrix_size = std::get<0>(tup);
-    vector<char> type = std::get<1>(tup);
+    vector<printable_char> type = std::get<1>(tup);
 
     Arguments arg;
 

--- a/clients/gtest/sygv_hegv_gtest.cpp
+++ b/clients/gtest/sygv_hegv_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -11,7 +11,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, vector<rocsolver_op_char>> sygv_tuple;
+typedef std::tuple<vector<int>, vector<printable_char>> sygv_tuple;
 
 // each matrix_size_range is a {n, lda, ldb, singular}
 // if singular = 1, then the used matrix for the tests is not positive definite
@@ -21,7 +21,7 @@ typedef std::tuple<vector<int>, vector<rocsolver_op_char>> sygv_tuple;
 // case when n = 0, itype = 1, evect = 'N', and uplo = U will also execute the bad arguments test
 // (null handle, null pointers and invalid values)
 
-const vector<vector<rocsolver_op_char>> type_range
+const vector<vector<printable_char>> type_range
     = {{'1', 'N', 'U'}, {'2', 'N', 'L'}, {'3', 'N', 'U'},
        {'1', 'V', 'L'}, {'2', 'V', 'U'}, {'3', 'V', 'L'}};
 
@@ -47,7 +47,7 @@ const vector<vector<int>> large_matrix_size_range = {
 Arguments sygv_setup_arguments(sygv_tuple tup)
 {
     vector<int> matrix_size = std::get<0>(tup);
-    vector<rocsolver_op_char> type = std::get<1>(tup);
+    vector<printable_char> type = std::get<1>(tup);
 
     Arguments arg;
 

--- a/clients/gtest/sygvd_hegvd_gtest.cpp
+++ b/clients/gtest/sygvd_hegvd_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -11,7 +11,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, vector<rocsolver_op_char>> sygvd_tuple;
+typedef std::tuple<vector<int>, vector<printable_char>> sygvd_tuple;
 
 // each matrix_size_range is a {n, lda, ldb, singular}
 // if singular = 1, then the used matrix for the tests is not positive definite
@@ -21,7 +21,7 @@ typedef std::tuple<vector<int>, vector<rocsolver_op_char>> sygvd_tuple;
 // case when n = 0, itype = 1, evect = 'N', and uplo = U will also execute the bad arguments test
 // (null handle, null pointers and invalid values)
 
-const vector<vector<rocsolver_op_char>> type_range
+const vector<vector<printable_char>> type_range
     = {{'1', 'N', 'U'}, {'2', 'N', 'L'}, {'3', 'N', 'U'},
        {'1', 'V', 'L'}, {'2', 'V', 'U'}, {'3', 'V', 'L'}};
 
@@ -47,7 +47,7 @@ const vector<vector<int>> large_matrix_size_range = {
 Arguments sygvd_setup_arguments(sygvd_tuple tup)
 {
     vector<int> matrix_size = std::get<0>(tup);
-    vector<rocsolver_op_char> type = std::get<1>(tup);
+    vector<printable_char> type = std::get<1>(tup);
 
     Arguments arg;
 

--- a/clients/gtest/sytf2_sytrf_gtest.cpp
+++ b/clients/gtest/sytf2_sytrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -11,7 +11,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, char> sytrf_tuple;
+typedef std::tuple<vector<int>, printable_char> sytrf_tuple;
 
 // each matrix_size_range vector is a {n, lda, singular}
 // if singular = 1, then the used matrix for the tests is singular
@@ -21,7 +21,7 @@ typedef std::tuple<vector<int>, char> sytrf_tuple;
 // case when n = 0 and uplo = L will also execute the bad arguments test
 // (null handle, null pointers and invalid values)
 
-const vector<char> uplo_range = {'L', 'U'};
+const vector<printable_char> uplo_range = {'L', 'U'};
 
 // for checkin_lapack tests
 const vector<vector<int>> matrix_size_range = {

--- a/clients/gtest/sytxx_hetxx_gtest.cpp
+++ b/clients/gtest/sytxx_hetxx_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -11,14 +11,14 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, char> sytrd_tuple;
+typedef std::tuple<vector<int>, printable_char> sytrd_tuple;
 
 // each matrix_size_range is a {n, lda}
 
 // case when n = 0 and uplo = U will also execute the bad arguments test
 // (null handle, null pointers and invalid values)
 
-const vector<char> uplo_range = {'L', 'U'};
+const vector<printable_char> uplo_range = {'L', 'U'};
 
 // for checkin_lapack tests
 const vector<vector<int>> matrix_size_range = {

--- a/clients/gtest/trtri_gtest.cpp
+++ b/clients/gtest/trtri_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -11,7 +11,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, rocsolver_op_char> trtri_tuple;
+typedef std::tuple<vector<int>, printable_char> trtri_tuple;
 
 // each matrix_size_range vector is a {n, lda, singular/diag}
 // if singular = 0, then the used matrix for the tests is triangular unit
@@ -23,7 +23,7 @@ typedef std::tuple<vector<int>, rocsolver_op_char> trtri_tuple;
 // case when n = 0 and uplo = L will also execute the bad arguments test
 // (null handle, null pointers and invalid values)
 
-const vector<rocsolver_op_char> uplo_range = {'L', 'U'};
+const vector<printable_char> uplo_range = {'L', 'U'};
 
 // for checkin_lapack tests
 const vector<vector<int>> matrix_size_range = {

--- a/clients/include/rocsolver_test.hpp
+++ b/clients/include/rocsolver_test.hpp
@@ -7,6 +7,7 @@
 #include <cstdarg>
 #include <cstdio>
 #include <ostream>
+#include <stdexcept>
 
 #include <fmt/core.h>
 #include <fmt/ostream.h>
@@ -89,22 +90,25 @@ inline T sconj(T scalar)
     return std::conj(scalar);
 }
 
-// A struct implicity convertable to and from char, used so we can customize
-// Google Test printing for LAPACK char arguments without affecting the default
-// char output.
-struct rocsolver_op_char
+// A struct implicity convertable to and from char, used so we can customize Google Test
+// output for LAPACK char arguments without affecting the default char output.
+class printable_char
 {
-    rocsolver_op_char(char c)
-        : data(c)
+    char value;
+
+public:
+    printable_char(char c)
+        : value(c)
     {
+        if(c < 0x20 || c >= 0x7F)
+            throw std::invalid_argument(fmt::format(
+                "printable_char must be a printable ASCII character (received {:#x})", c));
     }
 
     operator char() const
     {
-        return data;
+        return value;
     }
-
-    char data;
 };
 
 // gtest printers
@@ -114,7 +118,7 @@ inline std::ostream& operator<<(std::ostream& os, rocblas_status x)
     return os << rocblas_status_to_string(x);
 }
 
-inline std::ostream& operator<<(std::ostream& os, rocsolver_op_char x)
+inline std::ostream& operator<<(std::ostream& os, printable_char x)
 {
-    return os << x.data;
+    return os << char(x);
 }


### PR DESCRIPTION
I split this off from #378, as I think it was one part of the change that everyone liked.

With char:
[  FAILED  ] checkin_lapack/SYTRF.batched__float/10, where GetParam() = ({ 70, 100, 1 }, 'L' (76, 0x4C))

With printable_char:
[  FAILED  ] checkin_lapack/SYTRF.batched__float/10, where GetParam() = ({ 70, 100, 1 }, L)