### PR TITLE
Add profile_kernels argument to rocsolver-bench

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 
 ## (Unreleased) rocSOLVER
 ### Added
+- Added --profile_kernels option to rocsolver-bench, which will include kernel calls in the
+  profile log (if profile logging is enabled with --profile).
+
 ### Optimized
 ### Changed
 ### Deprecated

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -128,6 +128,12 @@ try
             "                           If the argument is unset or <= 0, profile logging is disabled.\n"
             "                           ")
 
+        ("profile_kernels",
+         value<rocblas_int>(&argus.profile_kernels)->default_value(0),
+            "Include kernels in profile logging results? 0 = No, 1 = Yes.\n"
+            "                           Used in conjunction with --profile to include kernels in the profile log.\n"
+            "                           ")
+
         ("singular",
          value<rocblas_int>(&argus.singular)->default_value(0),
             "Test with degenerate matrices? 0 = No, 1 = Yes\n"

--- a/clients/include/rocsolver_arguments.hpp
+++ b/clients/include/rocsolver_arguments.hpp
@@ -32,6 +32,7 @@ public:
     rocblas_int iters = 5;
     rocblas_int mem_query = 0;
     rocblas_int profile = 0;
+    rocblas_int profile_kernels = 0;
     rocblas_int batch_count = 1;
 
     // get and set function arguments
@@ -89,6 +90,7 @@ public:
         to_consume.erase("iters");
         to_consume.erase("mem_query");
         to_consume.erase("profile");
+        to_consume.erase("profile_kernels");
         to_consume.erase("perf");
         to_consume.erase("singular");
         to_consume.erase("device");

--- a/clients/include/testing_bdsqr.hpp
+++ b/clients/include/testing_bdsqr.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -349,6 +349,7 @@ void bdsqr_getPerfData(const rocblas_handle handle,
                        double* cpu_time_used,
                        const rocblas_int hot_calls,
                        const int profile,
+                       const bool profile_kernels,
                        const bool perf)
 {
     using S = decltype(std::real(T{}));
@@ -389,7 +390,11 @@ void bdsqr_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -581,7 +586,7 @@ void testing_bdsqr(Arguments& argus)
 
         bdsqr_getPerfData<T>(handle, uplo, n, nv, nu, nc, dD, dE, dV, ldv, dU, ldu, dC, ldc, dInfo,
                              hD, hE, hV, hU, hC, hInfo, &gpu_time_used, &cpu_time_used, hot_calls,
-                             argus.profile, argus.perf);
+                             argus.profile, argus.profile_kernels, argus.perf);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_gebd2_gebrd.hpp
+++ b/clients/include/testing_gebd2_gebrd.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -350,6 +350,7 @@ void gebd2_gebrd_getPerfData(const rocblas_handle handle,
                              double* cpu_time_used,
                              const rocblas_int hot_calls,
                              const int profile,
+                             const bool profile_kernels,
                              const bool perf)
 {
     std::vector<T> hW(max(m, n));
@@ -391,7 +392,11 @@ void gebd2_gebrd_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -534,10 +539,10 @@ void testing_gebd2_gebrd(Arguments& argus)
 
         // collect performance data
         if(argus.timing)
-            gebd2_gebrd_getPerfData<STRIDED, GEBRD, T>(handle, m, n, dA, lda, stA, dD, stD, dE, stE,
-                                                       dTauq, stQ, dTaup, stP, bc, hA, hD, hE,
-                                                       hTauq, hTaup, &gpu_time_used, &cpu_time_used,
-                                                       hot_calls, argus.profile, argus.perf);
+            gebd2_gebrd_getPerfData<STRIDED, GEBRD, T>(
+                handle, m, n, dA, lda, stA, dD, stD, dE, stE, dTauq, stQ, dTaup, stP, bc, hA, hD,
+                hE, hTauq, hTaup, &gpu_time_used, &cpu_time_used, hot_calls, argus.profile,
+                argus.profile_kernels, argus.perf);
     }
 
     else
@@ -586,10 +591,10 @@ void testing_gebd2_gebrd(Arguments& argus)
 
         // collect performance data
         if(argus.timing)
-            gebd2_gebrd_getPerfData<STRIDED, GEBRD, T>(handle, m, n, dA, lda, stA, dD, stD, dE, stE,
-                                                       dTauq, stQ, dTaup, stP, bc, hA, hD, hE,
-                                                       hTauq, hTaup, &gpu_time_used, &cpu_time_used,
-                                                       hot_calls, argus.profile, argus.perf);
+            gebd2_gebrd_getPerfData<STRIDED, GEBRD, T>(
+                handle, m, n, dA, lda, stA, dD, stD, dE, stE, dTauq, stQ, dTaup, stP, bc, hA, hD,
+                hE, hTauq, hTaup, &gpu_time_used, &cpu_time_used, hot_calls, argus.profile,
+                argus.profile_kernels, argus.perf);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_gelq2_gelqf.hpp
+++ b/clients/include/testing_gelq2_gelqf.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -199,6 +199,7 @@ void gelq2_gelqf_getPerfData(const rocblas_handle handle,
                              double* cpu_time_used,
                              const rocblas_int hot_calls,
                              const int profile,
+                             const bool profile_kernels,
                              const bool perf)
 {
     std::vector<T> hW(m);
@@ -235,7 +236,11 @@ void gelq2_gelqf_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -351,9 +356,9 @@ void testing_gelq2_gelqf(Arguments& argus)
 
         // collect performance data
         if(argus.timing)
-            gelq2_gelqf_getPerfData<STRIDED, GELQF, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc,
-                                                       hA, hIpiv, &gpu_time_used, &cpu_time_used,
-                                                       hot_calls, argus.profile, argus.perf);
+            gelq2_gelqf_getPerfData<STRIDED, GELQF, T>(
+                handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv, &gpu_time_used,
+                &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels, argus.perf);
     }
 
     else
@@ -388,9 +393,9 @@ void testing_gelq2_gelqf(Arguments& argus)
 
         // collect performance data
         if(argus.timing)
-            gelq2_gelqf_getPerfData<STRIDED, GELQF, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc,
-                                                       hA, hIpiv, &gpu_time_used, &cpu_time_used,
-                                                       hot_calls, argus.profile, argus.perf);
+            gelq2_gelqf_getPerfData<STRIDED, GELQF, T>(
+                handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv, &gpu_time_used,
+                &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels, argus.perf);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_gels.hpp
+++ b/clients/include/testing_gels.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -290,6 +290,7 @@ void gels_getPerfData(const rocblas_handle handle,
                       double* cpu_time_used,
                       const rocblas_int hot_calls,
                       const int profile,
+                      const bool profile_kernels,
                       const bool perf,
                       const bool singular)
 {
@@ -326,7 +327,11 @@ void gels_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -475,7 +480,8 @@ void testing_gels(Arguments& argus)
         if(argus.timing)
             gels_getPerfData<STRIDED, T>(handle, trans, m, n, nrhs, dA, lda, stA, dB, ldb, stB,
                                          dInfo, bc, hA, hB, hInfo, &gpu_time_used, &cpu_time_used,
-                                         hot_calls, argus.profile, argus.perf, argus.singular);
+                                         hot_calls, argus.profile, argus.profile_kernels,
+                                         argus.perf, argus.singular);
     }
     else
     {
@@ -516,7 +522,8 @@ void testing_gels(Arguments& argus)
         if(argus.timing)
             gels_getPerfData<STRIDED, T>(handle, trans, m, n, nrhs, dA, lda, stA, dB, ldb, stB,
                                          dInfo, bc, hA, hB, hInfo, &gpu_time_used, &cpu_time_used,
-                                         hot_calls, argus.profile, argus.perf, argus.singular);
+                                         hot_calls, argus.profile, argus.profile_kernels,
+                                         argus.perf, argus.singular);
     }
     // validate results for rocsolver-test
     // using max(m,n) * machine_precision as tolerance

--- a/clients/include/testing_gels_outofplace.hpp
+++ b/clients/include/testing_gels_outofplace.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -336,6 +336,7 @@ void gels_outofplace_getPerfData(const rocblas_handle handle,
                                  double* cpu_time_used,
                                  const rocblas_int hot_calls,
                                  const int profile,
+                                 const bool profile_kernels,
                                  const bool perf,
                                  const bool singular)
 {
@@ -378,7 +379,11 @@ void gels_outofplace_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -544,10 +549,10 @@ void testing_gels_outofplace(Arguments& argus)
 
         // collect performance data
         if(argus.timing)
-            gels_outofplace_getPerfData<STRIDED, T>(handle, trans, m, n, nrhs, dA, lda, stA, dB,
-                                                    ldb, stB, dX, ldx, stX, dInfo, bc, hA, hB, hX,
-                                                    hInfo, &gpu_time_used, &cpu_time_used, hot_calls,
-                                                    argus.profile, argus.perf, argus.singular);
+            gels_outofplace_getPerfData<STRIDED, T>(
+                handle, trans, m, n, nrhs, dA, lda, stA, dB, ldb, stB, dX, ldx, stX, dInfo, bc, hA,
+                hB, hX, hInfo, &gpu_time_used, &cpu_time_used, hot_calls, argus.profile,
+                argus.profile_kernels, argus.perf, argus.singular);
     }
     else
     {
@@ -593,10 +598,10 @@ void testing_gels_outofplace(Arguments& argus)
 
         // collect performance data
         if(argus.timing)
-            gels_outofplace_getPerfData<STRIDED, T>(handle, trans, m, n, nrhs, dA, lda, stA, dB,
-                                                    ldb, stB, dX, ldx, stX, dInfo, bc, hA, hB, hX,
-                                                    hInfo, &gpu_time_used, &cpu_time_used, hot_calls,
-                                                    argus.profile, argus.perf, argus.singular);
+            gels_outofplace_getPerfData<STRIDED, T>(
+                handle, trans, m, n, nrhs, dA, lda, stA, dB, ldb, stB, dX, ldx, stX, dInfo, bc, hA,
+                hB, hX, hInfo, &gpu_time_used, &cpu_time_used, hot_calls, argus.profile,
+                argus.profile_kernels, argus.perf, argus.singular);
     }
     // validate results for rocsolver-test
     // using max(m,n) * machine_precision as tolerance

--- a/clients/include/testing_geql2_geqlf.hpp
+++ b/clients/include/testing_geql2_geqlf.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -199,6 +199,7 @@ void geql2_geqlf_getPerfData(const rocblas_handle handle,
                              double* cpu_time_used,
                              const rocblas_int hot_calls,
                              const int profile,
+                             const bool profile_kernels,
                              const bool perf)
 {
     std::vector<T> hW(n);
@@ -235,7 +236,11 @@ void geql2_geqlf_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -351,9 +356,9 @@ void testing_geql2_geqlf(Arguments& argus)
 
         // collect performance data
         if(argus.timing)
-            geql2_geqlf_getPerfData<STRIDED, GEQLF, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc,
-                                                       hA, hIpiv, &gpu_time_used, &cpu_time_used,
-                                                       hot_calls, argus.profile, argus.perf);
+            geql2_geqlf_getPerfData<STRIDED, GEQLF, T>(
+                handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv, &gpu_time_used,
+                &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels, argus.perf);
     }
 
     else
@@ -388,9 +393,9 @@ void testing_geql2_geqlf(Arguments& argus)
 
         // collect performance data
         if(argus.timing)
-            geql2_geqlf_getPerfData<STRIDED, GEQLF, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc,
-                                                       hA, hIpiv, &gpu_time_used, &cpu_time_used,
-                                                       hot_calls, argus.profile, argus.perf);
+            geql2_geqlf_getPerfData<STRIDED, GEQLF, T>(
+                handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv, &gpu_time_used,
+                &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels, argus.perf);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_geqr2_geqrf.hpp
+++ b/clients/include/testing_geqr2_geqrf.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -199,6 +199,7 @@ void geqr2_geqrf_getPerfData(const rocblas_handle handle,
                              double* cpu_time_used,
                              const rocblas_int hot_calls,
                              const int profile,
+                             const bool profile_kernels,
                              const bool perf)
 {
     std::vector<T> hW(n);
@@ -235,7 +236,11 @@ void geqr2_geqrf_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -351,9 +356,9 @@ void testing_geqr2_geqrf(Arguments& argus)
 
         // collect performance data
         if(argus.timing)
-            geqr2_geqrf_getPerfData<STRIDED, GEQRF, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc,
-                                                       hA, hIpiv, &gpu_time_used, &cpu_time_used,
-                                                       hot_calls, argus.profile, argus.perf);
+            geqr2_geqrf_getPerfData<STRIDED, GEQRF, T>(
+                handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv, &gpu_time_used,
+                &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels, argus.perf);
     }
 
     else if(BATCHED)
@@ -388,9 +393,9 @@ void testing_geqr2_geqrf(Arguments& argus)
 
         // collect performance data
         if(argus.timing)
-            geqr2_geqrf_getPerfData<STRIDED, GEQRF, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc,
-                                                       hA, hIpiv, &gpu_time_used, &cpu_time_used,
-                                                       hot_calls, argus.profile, argus.perf);
+            geqr2_geqrf_getPerfData<STRIDED, GEQRF, T>(
+                handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv, &gpu_time_used,
+                &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels, argus.perf);
     }
 
     else
@@ -425,9 +430,9 @@ void testing_geqr2_geqrf(Arguments& argus)
 
         // collect performance data
         if(argus.timing)
-            geqr2_geqrf_getPerfData<STRIDED, GEQRF, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc,
-                                                       hA, hIpiv, &gpu_time_used, &cpu_time_used,
-                                                       hot_calls, argus.profile, argus.perf);
+            geqr2_geqrf_getPerfData<STRIDED, GEQRF, T>(
+                handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv, &gpu_time_used,
+                &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels, argus.perf);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_gerq2_gerqf.hpp
+++ b/clients/include/testing_gerq2_gerqf.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -199,6 +199,7 @@ void gerq2_gerqf_getPerfData(const rocblas_handle handle,
                              double* cpu_time_used,
                              const rocblas_int hot_calls,
                              const int profile,
+                             const bool profile_kernels,
                              const bool perf)
 {
     std::vector<T> hW(m);
@@ -235,7 +236,11 @@ void gerq2_gerqf_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -351,9 +356,9 @@ void testing_gerq2_gerqf(Arguments& argus)
 
         // collect performance data
         if(argus.timing)
-            gerq2_gerqf_getPerfData<STRIDED, GERQF, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc,
-                                                       hA, hIpiv, &gpu_time_used, &cpu_time_used,
-                                                       hot_calls, argus.profile, argus.perf);
+            gerq2_gerqf_getPerfData<STRIDED, GERQF, T>(
+                handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv, &gpu_time_used,
+                &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels, argus.perf);
     }
 
     else
@@ -388,9 +393,9 @@ void testing_gerq2_gerqf(Arguments& argus)
 
         // collect performance data
         if(argus.timing)
-            gerq2_gerqf_getPerfData<STRIDED, GERQF, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc,
-                                                       hA, hIpiv, &gpu_time_used, &cpu_time_used,
-                                                       hot_calls, argus.profile, argus.perf);
+            gerq2_gerqf_getPerfData<STRIDED, GERQF, T>(
+                handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv, &gpu_time_used,
+                &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels, argus.perf);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_gesv.hpp
+++ b/clients/include/testing_gesv.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -267,6 +267,7 @@ void gesv_getPerfData(const rocblas_handle handle,
                       double* cpu_time_used,
                       const rocblas_int hot_calls,
                       const int profile,
+                      const bool profile_kernels,
                       const bool perf,
                       const bool singular)
 {
@@ -304,7 +305,11 @@ void gesv_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -439,8 +444,8 @@ void testing_gesv(Arguments& argus)
         if(argus.timing)
             gesv_getPerfData<STRIDED, T>(handle, n, nrhs, dA, lda, stA, dIpiv, stP, dB, ldb, stB,
                                          dInfo, bc, hA, hIpiv, hB, hInfo, &gpu_time_used,
-                                         &cpu_time_used, hot_calls, argus.profile, argus.perf,
-                                         argus.singular);
+                                         &cpu_time_used, hot_calls, argus.profile,
+                                         argus.profile_kernels, argus.perf, argus.singular);
     }
 
     else
@@ -487,8 +492,8 @@ void testing_gesv(Arguments& argus)
         if(argus.timing)
             gesv_getPerfData<STRIDED, T>(handle, n, nrhs, dA, lda, stA, dIpiv, stP, dB, ldb, stB,
                                          dInfo, bc, hA, hIpiv, hB, hInfo, &gpu_time_used,
-                                         &cpu_time_used, hot_calls, argus.profile, argus.perf,
-                                         argus.singular);
+                                         &cpu_time_used, hot_calls, argus.profile,
+                                         argus.profile_kernels, argus.perf, argus.singular);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_gesv_outofplace.hpp
+++ b/clients/include/testing_gesv_outofplace.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -294,6 +294,7 @@ void gesv_outofplace_getPerfData(const rocblas_handle handle,
                                  double* cpu_time_used,
                                  const rocblas_int hot_calls,
                                  const int profile,
+                                 const bool profile_kernels,
                                  const bool perf,
                                  const bool singular)
 {
@@ -332,7 +333,11 @@ void gesv_outofplace_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -475,10 +480,10 @@ void testing_gesv_outofplace(Arguments& argus)
 
         // collect performance data
         if(argus.timing)
-            gesv_outofplace_getPerfData<STRIDED, T>(handle, n, nrhs, dA, lda, stA, dIpiv, stP, dB,
-                                                    ldb, stB, dX, ldx, stX, dInfo, bc, hA, hIpiv, hB,
-                                                    hInfo, &gpu_time_used, &cpu_time_used, hot_calls,
-                                                    argus.profile, argus.perf, argus.singular);
+            gesv_outofplace_getPerfData<STRIDED, T>(
+                handle, n, nrhs, dA, lda, stA, dIpiv, stP, dB, ldb, stB, dX, ldx, stX, dInfo, bc,
+                hA, hIpiv, hB, hInfo, &gpu_time_used, &cpu_time_used, hot_calls, argus.profile,
+                argus.profile_kernels, argus.perf, argus.singular);
     }
 
     else
@@ -527,10 +532,10 @@ void testing_gesv_outofplace(Arguments& argus)
 
         // collect performance data
         if(argus.timing)
-            gesv_outofplace_getPerfData<STRIDED, T>(handle, n, nrhs, dA, lda, stA, dIpiv, stP, dB,
-                                                    ldb, stB, dX, ldx, stX, dInfo, bc, hA, hIpiv, hB,
-                                                    hInfo, &gpu_time_used, &cpu_time_used, hot_calls,
-                                                    argus.profile, argus.perf, argus.singular);
+            gesv_outofplace_getPerfData<STRIDED, T>(
+                handle, n, nrhs, dA, lda, stA, dIpiv, stP, dB, ldb, stB, dX, ldx, stX, dInfo, bc,
+                hA, hIpiv, hB, hInfo, &gpu_time_used, &cpu_time_used, hot_calls, argus.profile,
+                argus.profile_kernels, argus.perf, argus.singular);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_gesvd.hpp
+++ b/clients/include/testing_gesvd.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -408,6 +408,7 @@ void gesvd_getPerfData(const rocblas_handle handle,
                        double* cpu_time_used,
                        const rocblas_int hot_calls,
                        const int profile,
+                       const bool profile_kernels,
                        const bool perf)
 {
     rocblas_int lwork = 5 * max(m, n);
@@ -445,7 +446,11 @@ void gesvd_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -743,9 +748,9 @@ void testing_gesvd(Arguments& argus)
         if(argus.timing)
         {
             gesvd_getPerfData<STRIDED, T>(handle, leftv, rightv, m, n, dA, lda, stA, dS, stS, dU,
-                                          ldu, stU, dV, ldv, stV, dE, stE, fa, dinfo, bc, hA, hS,
-                                          hU, hV, hE, hinfo, &gpu_time_used, &cpu_time_used,
-                                          hot_calls, argus.profile, argus.perf);
+                                          ldu, stU, dV, ldv, stV, dE, stE, fa, dinfo, bc, hA, hS, hU,
+                                          hV, hE, hinfo, &gpu_time_used, &cpu_time_used, hot_calls,
+                                          argus.profile, argus.profile_kernels, argus.perf);
         }
     }
 
@@ -785,9 +790,9 @@ void testing_gesvd(Arguments& argus)
         if(argus.timing)
         {
             gesvd_getPerfData<STRIDED, T>(handle, leftv, rightv, m, n, dA, lda, stA, dS, stS, dU,
-                                          ldu, stU, dV, ldv, stV, dE, stE, fa, dinfo, bc, hA, hS,
-                                          hU, hV, hE, hinfo, &gpu_time_used, &cpu_time_used,
-                                          hot_calls, argus.profile, argus.perf);
+                                          ldu, stU, dV, ldv, stV, dE, stE, fa, dinfo, bc, hA, hS, hU,
+                                          hV, hE, hinfo, &gpu_time_used, &cpu_time_used, hot_calls,
+                                          argus.profile, argus.profile_kernels, argus.perf);
         }
     }
 

--- a/clients/include/testing_getf2_getrf.hpp
+++ b/clients/include/testing_getf2_getrf.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -270,6 +270,7 @@ void getf2_getrf_getPerfData(const rocblas_handle handle,
                              double* cpu_time_used,
                              const rocblas_int hot_calls,
                              const int profile,
+                             const bool profile_kernels,
                              const bool perf,
                              const bool singular)
 {
@@ -308,7 +309,11 @@ void getf2_getrf_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -438,7 +443,8 @@ void testing_getf2_getrf(Arguments& argus)
         if(argus.timing)
             getf2_getrf_getPerfData<STRIDED, GETRF, T>(
                 handle, m, n, dA, lda, stA, dIpiv, stP, dInfo, bc, hA, hIpiv, hInfo, &gpu_time_used,
-                &cpu_time_used, hot_calls, argus.profile, argus.perf, argus.singular);
+                &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels, argus.perf,
+                argus.singular);
     }
 
     else
@@ -481,7 +487,8 @@ void testing_getf2_getrf(Arguments& argus)
         if(argus.timing)
             getf2_getrf_getPerfData<STRIDED, GETRF, T>(
                 handle, m, n, dA, lda, stA, dIpiv, stP, dInfo, bc, hA, hIpiv, hInfo, &gpu_time_used,
-                &cpu_time_used, hot_calls, argus.profile, argus.perf, argus.singular);
+                &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels, argus.perf,
+                argus.singular);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_getf2_getrf_npvt.hpp
+++ b/clients/include/testing_getf2_getrf_npvt.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -228,6 +228,7 @@ void getf2_getrf_npvt_getPerfData(const rocblas_handle handle,
                                   double* cpu_time_used,
                                   const rocblas_int hot_calls,
                                   const int profile,
+                                  const bool profile_kernels,
                                   const bool perf,
                                   const bool singular)
 {
@@ -266,7 +267,11 @@ void getf2_getrf_npvt_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
@@ -387,7 +392,8 @@ void testing_getf2_getrf_npvt(Arguments& argus)
         if(argus.timing)
             getf2_getrf_npvt_getPerfData<STRIDED, GETRF, T>(
                 handle, m, n, dA, lda, stA, dinfo, bc, hA, hIpiv, hinfo, &gpu_time_used,
-                &cpu_time_used, hot_calls, argus.profile, argus.perf, argus.singular);
+                &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels, argus.perf,
+                argus.singular);
     }
 
     else
@@ -426,7 +432,8 @@ void testing_getf2_getrf_npvt(Arguments& argus)
         if(argus.timing)
             getf2_getrf_npvt_getPerfData<STRIDED, GETRF, T>(
                 handle, m, n, dA, lda, stA, dinfo, bc, hA, hIpiv, hinfo, &gpu_time_used,
-                &cpu_time_used, hot_calls, argus.profile, argus.perf, argus.singular);
+                &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels, argus.perf,
+                argus.singular);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_getri.hpp
+++ b/clients/include/testing_getri.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -250,6 +250,7 @@ void getri_getPerfData(const rocblas_handle handle,
                        double* cpu_time_used,
                        const rocblas_int hot_calls,
                        const int profile,
+                       const bool profile_kernels,
                        const bool perf,
                        const bool singular)
 {
@@ -287,7 +288,11 @@ void getri_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -408,7 +413,8 @@ void testing_getri(Arguments& argus)
         if(argus.timing)
             getri_getPerfData<STRIDED, T>(handle, n, dA, lda, stA, dIpiv, stP, dInfo, bc, hA, hIpiv,
                                           hInfo, &gpu_time_used, &cpu_time_used, hot_calls,
-                                          argus.profile, argus.perf, argus.singular);
+                                          argus.profile, argus.profile_kernels, argus.perf,
+                                          argus.singular);
     }
 
     else
@@ -449,7 +455,8 @@ void testing_getri(Arguments& argus)
         if(argus.timing)
             getri_getPerfData<STRIDED, T>(handle, n, dA, lda, stA, dIpiv, stP, dInfo, bc, hA, hIpiv,
                                           hInfo, &gpu_time_used, &cpu_time_used, hot_calls,
-                                          argus.profile, argus.perf, argus.singular);
+                                          argus.profile, argus.profile_kernels, argus.perf,
+                                          argus.singular);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_getri_npvt.hpp
+++ b/clients/include/testing_getri_npvt.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -217,6 +217,7 @@ void getri_npvt_getPerfData(const rocblas_handle handle,
                             double* cpu_time_used,
                             const rocblas_int hot_calls,
                             const int profile,
+                            const bool profile_kernels,
                             const bool perf,
                             const bool singular)
 {
@@ -254,7 +255,11 @@ void getri_npvt_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -370,7 +375,8 @@ void testing_getri_npvt(Arguments& argus)
         if(argus.timing)
             getri_npvt_getPerfData<STRIDED, T>(handle, n, dA, lda, stA, dInfo, bc, hA, hIpiv, hInfo,
                                                &gpu_time_used, &cpu_time_used, hot_calls,
-                                               argus.profile, argus.perf, argus.singular);
+                                               argus.profile, argus.profile_kernels, argus.perf,
+                                               argus.singular);
     }
 
     else
@@ -408,7 +414,8 @@ void testing_getri_npvt(Arguments& argus)
         if(argus.timing)
             getri_npvt_getPerfData<STRIDED, T>(handle, n, dA, lda, stA, dInfo, bc, hA, hIpiv, hInfo,
                                                &gpu_time_used, &cpu_time_used, hot_calls,
-                                               argus.profile, argus.perf, argus.singular);
+                                               argus.profile, argus.profile_kernels, argus.perf,
+                                               argus.singular);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_getri_npvt_outofplace.hpp
+++ b/clients/include/testing_getri_npvt_outofplace.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -242,6 +242,7 @@ void getri_npvt_outofplace_getPerfData(const rocblas_handle handle,
                                        double* cpu_time_used,
                                        const rocblas_int hot_calls,
                                        const int profile,
+                                       const bool profile_kernels,
                                        const bool perf,
                                        const bool singular)
 {
@@ -282,7 +283,11 @@ void getri_npvt_outofplace_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -412,7 +417,8 @@ void testing_getri_npvt_outofplace(Arguments& argus)
         if(argus.timing)
             getri_npvt_outofplace_getPerfData<STRIDED, T>(
                 handle, n, dA, lda, stA, dC, ldc, stC, dInfo, bc, hA, hIpiv, hInfo, &gpu_time_used,
-                &cpu_time_used, hot_calls, argus.profile, argus.perf, argus.singular);
+                &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels, argus.perf,
+                argus.singular);
     }
 
     else
@@ -455,7 +461,8 @@ void testing_getri_npvt_outofplace(Arguments& argus)
         if(argus.timing)
             getri_npvt_outofplace_getPerfData<STRIDED, T>(
                 handle, n, dA, lda, stA, dC, ldc, stC, dInfo, bc, hA, hIpiv, hInfo, &gpu_time_used,
-                &cpu_time_used, hot_calls, argus.profile, argus.perf, argus.singular);
+                &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels, argus.perf,
+                argus.singular);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_getri_outofplace.hpp
+++ b/clients/include/testing_getri_outofplace.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -272,6 +272,7 @@ void getri_outofplace_getPerfData(const rocblas_handle handle,
                                   double* cpu_time_used,
                                   const rocblas_int hot_calls,
                                   const int profile,
+                                  const bool profile_kernels,
                                   const bool perf,
                                   const bool singular)
 {
@@ -313,7 +314,11 @@ void getri_outofplace_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -445,10 +450,10 @@ void testing_getri_outofplace(Arguments& argus)
 
         // collect performance data
         if(argus.timing)
-            getri_outofplace_getPerfData<STRIDED, T>(handle, n, dA, lda, stA, dIpiv, stP, dC, ldc,
-                                                     stC, dInfo, bc, hA, hIpiv, hInfo,
-                                                     &gpu_time_used, &cpu_time_used, hot_calls,
-                                                     argus.profile, argus.perf, argus.singular);
+            getri_outofplace_getPerfData<STRIDED, T>(
+                handle, n, dA, lda, stA, dIpiv, stP, dC, ldc, stC, dInfo, bc, hA, hIpiv, hInfo,
+                &gpu_time_used, &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels,
+                argus.perf, argus.singular);
     }
 
     else
@@ -492,10 +497,10 @@ void testing_getri_outofplace(Arguments& argus)
 
         // collect performance data
         if(argus.timing)
-            getri_outofplace_getPerfData<STRIDED, T>(handle, n, dA, lda, stA, dIpiv, stP, dC, ldc,
-                                                     stC, dInfo, bc, hA, hIpiv, hInfo,
-                                                     &gpu_time_used, &cpu_time_used, hot_calls,
-                                                     argus.profile, argus.perf, argus.singular);
+            getri_outofplace_getPerfData<STRIDED, T>(
+                handle, n, dA, lda, stA, dIpiv, stP, dC, ldc, stC, dInfo, bc, hA, hIpiv, hInfo,
+                &gpu_time_used, &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels,
+                argus.perf, argus.singular);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_getrs.hpp
+++ b/clients/include/testing_getrs.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -238,6 +238,7 @@ void getrs_getPerfData(const rocblas_handle handle,
                        double* cpu_time_used,
                        const rocblas_int hot_calls,
                        const int profile,
+                       const bool profile_kernels,
                        const bool perf)
 {
     if(!perf)
@@ -274,7 +275,11 @@ void getrs_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -404,7 +409,8 @@ void testing_getrs(Arguments& argus)
         if(argus.timing)
             getrs_getPerfData<STRIDED, T>(handle, trans, n, nrhs, dA, lda, stA, dIpiv, stP, dB, ldb,
                                           stB, bc, hA, hIpiv, hB, &gpu_time_used, &cpu_time_used,
-                                          hot_calls, argus.profile, argus.perf);
+                                          hot_calls, argus.profile, argus.profile_kernels,
+                                          argus.perf);
     }
 
     else
@@ -445,7 +451,8 @@ void testing_getrs(Arguments& argus)
         if(argus.timing)
             getrs_getPerfData<STRIDED, T>(handle, trans, n, nrhs, dA, lda, stA, dIpiv, stP, dB, ldb,
                                           stB, bc, hA, hIpiv, hB, &gpu_time_used, &cpu_time_used,
-                                          hot_calls, argus.profile, argus.perf);
+                                          hot_calls, argus.profile, argus.profile_kernels,
+                                          argus.perf);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_labrd.hpp
+++ b/clients/include/testing_labrd.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -234,6 +234,7 @@ void labrd_getPerfData(const rocblas_handle handle,
                        double* cpu_time_used,
                        const rocblas_int hot_calls,
                        const int profile,
+                       const bool profile_kernels,
                        const bool perf)
 {
     if(!perf)
@@ -271,7 +272,11 @@ void labrd_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -410,7 +415,7 @@ void testing_labrd(Arguments& argus)
     if(argus.timing)
         labrd_getPerfData<T>(handle, m, n, nb, dA, lda, dD, dE, dTauq, dTaup, dX, ldx, dY, ldy, hA,
                              hD, hE, hTauq, hTaup, hX, hY, &gpu_time_used, &cpu_time_used,
-                             hot_calls, argus.profile, argus.perf);
+                             hot_calls, argus.profile, argus.profile_kernels, argus.perf);
 
     // validate results for rocsolver-test
     // using nb * max(m,n) * machine_precision as tolerance

--- a/clients/include/testing_lacgv.hpp
+++ b/clients/include/testing_lacgv.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -103,6 +103,7 @@ void lacgv_getPerfData(const rocblas_handle handle,
                        double* cpu_time_used,
                        const rocblas_int hot_calls,
                        const int profile,
+                       const bool profile_kernels,
                        const bool perf)
 {
     if(!perf)
@@ -132,7 +133,11 @@ void lacgv_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -221,7 +226,7 @@ void testing_lacgv(Arguments& argus)
     // collect performance data
     if(argus.timing)
         lacgv_getPerfData<T>(handle, n, dA, inc, hA, &gpu_time_used, &cpu_time_used, hot_calls,
-                             argus.profile, argus.perf);
+                             argus.profile, argus.profile_kernels, argus.perf);
 
     // validate results for rocsolver-test
     // no tolerance

--- a/clients/include/testing_larf.hpp
+++ b/clients/include/testing_larf.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -169,6 +169,7 @@ void larf_getPerfData(const rocblas_handle handle,
                       double* cpu_time_used,
                       const rocblas_int hot_calls,
                       const int profile,
+                      const bool profile_kernels,
                       const bool perf)
 {
     size_t size_w = (side == rocblas_side_left) ? size_t(n) : size_t(m);
@@ -202,7 +203,11 @@ void larf_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -320,7 +325,8 @@ void testing_larf(Arguments& argus)
     // collect performance data
     if(argus.timing)
         larf_getPerfData<T>(handle, side, m, n, dx, inc, dt, dA, lda, xx, hx, ht, hA,
-                            &gpu_time_used, &cpu_time_used, hot_calls, argus.profile, argus.perf);
+                            &gpu_time_used, &cpu_time_used, hot_calls, argus.profile,
+                            argus.profile_kernels, argus.perf);
 
     // validate results for rocsolver-test
     // using size_x * machine_precision as tolerance

--- a/clients/include/testing_larfb.hpp
+++ b/clients/include/testing_larfb.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -291,6 +291,7 @@ void larfb_getPerfData(const rocblas_handle handle,
                        double* cpu_time_used,
                        const rocblas_int hot_calls,
                        const int profile,
+                       const bool profile_kernels,
                        const bool perf)
 {
     bool left = (side == rocblas_side_left);
@@ -330,7 +331,11 @@ void larfb_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -466,7 +471,7 @@ void testing_larfb(Arguments& argus)
     if(argus.timing)
         larfb_getPerfData<T>(handle, side, trans, direct, storev, m, n, k, dV, ldv, dT, ldt, dA,
                              lda, hV, hT, hA, &gpu_time_used, &cpu_time_used, hot_calls,
-                             argus.profile, argus.perf);
+                             argus.profile, argus.profile_kernels, argus.perf);
 
     // validate results for rocsolver-test
     // using s * machine_precision as tolerance

--- a/clients/include/testing_larfg.hpp
+++ b/clients/include/testing_larfg.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -129,6 +129,7 @@ void larfg_getPerfData(const rocblas_handle handle,
                        double* cpu_time_used,
                        const rocblas_int hot_calls,
                        const int profile,
+                       const bool profile_kernels,
                        const bool perf)
 {
     if(!perf)
@@ -158,7 +159,11 @@ void larfg_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -259,7 +264,7 @@ void testing_larfg(Arguments& argus)
     // collect performance data
     if(argus.timing)
         larfg_getPerfData<T>(handle, n, da, dx, inc, dt, ha, hx, ht, &gpu_time_used, &cpu_time_used,
-                             hot_calls, argus.profile, argus.perf);
+                             hot_calls, argus.profile, argus.profile_kernels, argus.perf);
 
     // validate results for rocsolver-test
     // using n * machine_precision as tolerance

--- a/clients/include/testing_larft.hpp
+++ b/clients/include/testing_larft.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -201,6 +201,7 @@ void larft_getPerfData(const rocblas_handle handle,
                        double* cpu_time_used,
                        const rocblas_int hot_calls,
                        const int profile,
+                       const bool profile_kernels,
                        const bool perf)
 {
     size_t size_w = size_t(k);
@@ -237,7 +238,11 @@ void larft_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -349,7 +354,8 @@ void testing_larft(Arguments& argus)
     // collect performance data
     if(argus.timing)
         larft_getPerfData<T>(handle, direct, storev, n, k, dV, ldv, dt, dT, ldt, hV, ht, hT,
-                             &gpu_time_used, &cpu_time_used, hot_calls, argus.profile, argus.perf);
+                             &gpu_time_used, &cpu_time_used, hot_calls, argus.profile,
+                             argus.profile_kernels, argus.perf);
 
     // validate results for rocsolver-test
     // using n * machine_precision as tolerance

--- a/clients/include/testing_laswp.hpp
+++ b/clients/include/testing_laswp.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -145,6 +145,7 @@ void laswp_getPerfData(const rocblas_handle handle,
                        double* cpu_time_used,
                        const rocblas_int hot_calls,
                        const int profile,
+                       const bool profile_kernels,
                        const bool perf)
 {
     if(!perf)
@@ -174,7 +175,11 @@ void laswp_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -274,7 +279,8 @@ void testing_laswp(Arguments& argus)
     // collect performance data
     if(argus.timing)
         laswp_getPerfData<T>(handle, n, dA, lda, k1, k2, dIpiv, inc, hA, hIpiv, &gpu_time_used,
-                             &cpu_time_used, hot_calls, argus.profile, argus.perf);
+                             &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels,
+                             argus.perf);
 
     // validate results for rocsolver-test
     // no tolerance

--- a/clients/include/testing_lasyf.hpp
+++ b/clients/include/testing_lasyf.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -242,6 +242,7 @@ void lasyf_getPerfData(const rocblas_handle handle,
                        double* cpu_time_used,
                        const rocblas_int hot_calls,
                        const int profile,
+                       const bool profile_kernels,
                        const bool perf,
                        const bool singular)
 {
@@ -277,7 +278,11 @@ void lasyf_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -398,8 +403,8 @@ void testing_lasyf(Arguments& argus)
     // collect performance data
     if(argus.timing)
         lasyf_getPerfData<T>(handle, uplo, n, nb, dKB, dA, lda, dIpiv, dInfo, hKB, hA, hIpiv, hInfo,
-                             &gpu_time_used, &cpu_time_used, hot_calls, argus.profile, argus.perf,
-                             argus.singular);
+                             &gpu_time_used, &cpu_time_used, hot_calls, argus.profile,
+                             argus.profile_kernels, argus.perf, argus.singular);
 
     // validate results for rocsolver-test
     // using n * machine_precision as tolerance

--- a/clients/include/testing_latrd.hpp
+++ b/clients/include/testing_latrd.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -203,6 +203,7 @@ void latrd_getPerfData(const rocblas_handle handle,
                        double* cpu_time_used,
                        const rocblas_int hot_calls,
                        const int profile,
+                       const bool profile_kernels,
                        const bool perf)
 {
     if(!perf)
@@ -234,7 +235,11 @@ void latrd_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -360,7 +365,8 @@ void testing_latrd(Arguments& argus)
     // collect performance data
     if(argus.timing)
         latrd_getPerfData<T>(handle, uplo, n, k, dA, lda, dE, dTau, dW, ldw, hA, hE, hTau, hW,
-                             &gpu_time_used, &cpu_time_used, hot_calls, argus.profile, argus.perf);
+                             &gpu_time_used, &cpu_time_used, hot_calls, argus.profile,
+                             argus.profile_kernels, argus.perf);
 
     // validate results for rocsolver-test
     // using k*n * machine_precision as tolerance

--- a/clients/include/testing_managed_malloc.hpp
+++ b/clients/include/testing_managed_malloc.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -125,6 +125,7 @@ void managed_malloc_getPerfData(const rocblas_handle handle,
                                 double* cpu_time_used,
                                 const rocblas_int hot_calls,
                                 const int profile,
+                                const bool profile_kernels,
                                 const bool perf)
 {
     if(!perf)
@@ -156,7 +157,11 @@ void managed_malloc_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -281,7 +286,7 @@ void testing_managed_malloc(Arguments& argus)
     if(argus.timing)
         managed_malloc_getPerfData<T>(handle, m, n, nb, dA, dARes, lda, dD, dE, dTauq, dTaup, dX,
                                       dXRes, ldx, dY, dYRes, ldy, &gpu_time_used, &cpu_time_used,
-                                      hot_calls, argus.profile, argus.perf);
+                                      hot_calls, argus.profile, argus.profile_kernels, argus.perf);
 
     // free memory
     hipFree(dA);

--- a/clients/include/testing_orgbr_ungbr.hpp
+++ b/clients/include/testing_orgbr_ungbr.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -183,6 +183,7 @@ void orgbr_ungbr_getPerfData(const rocblas_handle handle,
                              double* cpu_time_used,
                              const rocblas_int hot_calls,
                              const int profile,
+                             const bool profile_kernels,
                              const bool perf)
 {
     size_t size_W = max(max(m, n), k);
@@ -219,7 +220,11 @@ void orgbr_ungbr_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -336,8 +341,9 @@ void testing_orgbr_ungbr(Arguments& argus)
 
     // collect performance data
     if(argus.timing)
-        orgbr_ungbr_getPerfData<T>(handle, storev, m, n, k, dA, lda, dIpiv, hA, hIpiv, &gpu_time_used,
-                                   &cpu_time_used, hot_calls, argus.profile, argus.perf);
+        orgbr_ungbr_getPerfData<T>(handle, storev, m, n, k, dA, lda, dIpiv, hA, hIpiv,
+                                   &gpu_time_used, &cpu_time_used, hot_calls, argus.profile,
+                                   argus.profile_kernels, argus.perf);
 
     // validate results for rocsolver-test
     // using s * machine_precision as tolerance

--- a/clients/include/testing_orglx_unglx.hpp
+++ b/clients/include/testing_orglx_unglx.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -151,6 +151,7 @@ void orglx_unglx_getPerfData(const rocblas_handle handle,
                              double* cpu_time_used,
                              const rocblas_int hot_calls,
                              const int profile,
+                             const bool profile_kernels,
                              const bool perf)
 {
     size_t size_W = size_t(m);
@@ -184,7 +185,11 @@ void orglx_unglx_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -283,7 +288,8 @@ void testing_orglx_unglx(Arguments& argus)
     // collect performance data
     if(argus.timing)
         orglx_unglx_getPerfData<GLQ, T>(handle, m, n, k, dA, lda, dIpiv, hA, hIpiv, &gpu_time_used,
-                                        &cpu_time_used, hot_calls, argus.profile, argus.perf);
+                                        &cpu_time_used, hot_calls, argus.profile,
+                                        argus.profile_kernels, argus.perf);
 
     // validate results for rocsolver-test
     // using n * machine_precision as tolerance

--- a/clients/include/testing_orgtr_ungtr.hpp
+++ b/clients/include/testing_orgtr_ungtr.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -149,6 +149,7 @@ void orgtr_ungtr_getPerfData(const rocblas_handle handle,
                              double* cpu_time_used,
                              const rocblas_int hot_calls,
                              const int profile,
+                             const bool profile_kernels,
                              const bool perf)
 {
     size_t size_W = n * 32;
@@ -181,7 +182,11 @@ void orgtr_ungtr_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -282,7 +287,8 @@ void testing_orgtr_ungtr(Arguments& argus)
     // collect performance data
     if(argus.timing)
         orgtr_ungtr_getPerfData<T>(handle, uplo, n, dA, lda, dIpiv, hA, hIpiv, &gpu_time_used,
-                                   &cpu_time_used, hot_calls, argus.profile, argus.perf);
+                                   &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels,
+                                   argus.perf);
 
     // validate results for rocsolver-test
     // using n * machine_precision as tolerance

--- a/clients/include/testing_orgxl_ungxl.hpp
+++ b/clients/include/testing_orgxl_ungxl.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -151,6 +151,7 @@ void orgxl_ungxl_getPerfData(const rocblas_handle handle,
                              double* cpu_time_used,
                              const rocblas_int hot_calls,
                              const int profile,
+                             const bool profile_kernels,
                              const bool perf)
 {
     size_t size_W = size_t(n);
@@ -184,7 +185,11 @@ void orgxl_ungxl_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -283,7 +288,8 @@ void testing_orgxl_ungxl(Arguments& argus)
     // collect performance data
     if(argus.timing)
         orgxl_ungxl_getPerfData<GQL, T>(handle, m, n, k, dA, lda, dIpiv, hA, hIpiv, &gpu_time_used,
-                                        &cpu_time_used, hot_calls, argus.profile, argus.perf);
+                                        &cpu_time_used, hot_calls, argus.profile,
+                                        argus.profile_kernels, argus.perf);
 
     // validate results for rocsolver-test
     // using n * machine_precision as tolerance

--- a/clients/include/testing_orgxr_ungxr.hpp
+++ b/clients/include/testing_orgxr_ungxr.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -151,6 +151,7 @@ void orgxr_ungxr_getPerfData(const rocblas_handle handle,
                              double* cpu_time_used,
                              const rocblas_int hot_calls,
                              const int profile,
+                             const bool profile_kernels,
                              const bool perf)
 {
     size_t size_W = size_t(n);
@@ -184,7 +185,11 @@ void orgxr_ungxr_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -283,7 +288,8 @@ void testing_orgxr_ungxr(Arguments& argus)
     // collect performance data
     if(argus.timing)
         orgxr_ungxr_getPerfData<GQR, T>(handle, m, n, k, dA, lda, dIpiv, hA, hIpiv, &gpu_time_used,
-                                        &cpu_time_used, hot_calls, argus.profile, argus.perf);
+                                        &cpu_time_used, hot_calls, argus.profile,
+                                        argus.profile_kernels, argus.perf);
 
     // validate results for rocsolver-test
     // using m * machine_precision as tolerance

--- a/clients/include/testing_ormbr_unmbr.hpp
+++ b/clients/include/testing_ormbr_unmbr.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -238,6 +238,7 @@ void ormbr_unmbr_getPerfData(const rocblas_handle handle,
                              double* cpu_time_used,
                              const rocblas_int hot_calls,
                              const int profile,
+                             const bool profile_kernels,
                              const bool perf)
 {
     size_t size_W = max(max(m, n), k);
@@ -275,7 +276,11 @@ void ormbr_unmbr_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -418,7 +423,7 @@ void testing_ormbr_unmbr(Arguments& argus)
     if(argus.timing)
         ormbr_unmbr_getPerfData<T>(handle, storev, side, trans, m, n, k, dA, lda, dIpiv, dC, ldc,
                                    hA, hIpiv, hC, &gpu_time_used, &cpu_time_used, hot_calls,
-                                   argus.profile, argus.perf);
+                                   argus.profile, argus.profile_kernels, argus.perf);
 
     // validate results for rocsolver-test
     // using n * machine_precision as tolerance

--- a/clients/include/testing_ormlx_unmlx.hpp
+++ b/clients/include/testing_ormlx_unmlx.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -208,6 +208,7 @@ void ormlx_unmlx_getPerfData(const rocblas_handle handle,
                              double* cpu_time_used,
                              const rocblas_int hot_calls,
                              const int profile,
+                             const bool profile_kernels,
                              const bool perf)
 {
     size_t size_W = max(max(m, n), k);
@@ -246,7 +247,11 @@ void ormlx_unmlx_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -385,7 +390,7 @@ void testing_ormlx_unmlx(Arguments& argus)
     if(argus.timing)
         ormlx_unmlx_getPerfData<MLQ, T>(handle, side, trans, m, n, k, dA, lda, dIpiv, dC, ldc, hA,
                                         hIpiv, hC, &gpu_time_used, &cpu_time_used, hot_calls,
-                                        argus.profile, argus.perf);
+                                        argus.profile, argus.profile_kernels, argus.perf);
 
     // validate results for rocsolver-test
     // using s * machine_precision as tolerance

--- a/clients/include/testing_ormtr_unmtr.hpp
+++ b/clients/include/testing_ormtr_unmtr.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -210,6 +210,7 @@ void ormtr_unmtr_getPerfData(const rocblas_handle handle,
                              double* cpu_time_used,
                              const rocblas_int hot_calls,
                              const int profile,
+                             const bool profile_kernels,
                              const bool perf)
 {
     size_t size_W = (side == rocblas_side_left ? m : n) * 32;
@@ -247,7 +248,11 @@ void ormtr_unmtr_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -387,7 +392,7 @@ void testing_ormtr_unmtr(Arguments& argus)
     if(argus.timing)
         ormtr_unmtr_getPerfData<T>(handle, side, uplo, trans, m, n, dA, lda, dIpiv, dC, ldc, hA,
                                    hIpiv, hC, &gpu_time_used, &cpu_time_used, hot_calls,
-                                   argus.profile, argus.perf);
+                                   argus.profile, argus.profile_kernels, argus.perf);
 
     // validate results for rocsolver-test
     // using s * machine_precision as tolerance

--- a/clients/include/testing_ormxl_unmxl.hpp
+++ b/clients/include/testing_ormxl_unmxl.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -208,6 +208,7 @@ void ormxl_unmxl_getPerfData(const rocblas_handle handle,
                              double* cpu_time_used,
                              const rocblas_int hot_calls,
                              const int profile,
+                             const bool profile_kernels,
                              const bool perf)
 {
     size_t size_W = max(max(m, n), k);
@@ -246,7 +247,11 @@ void ormxl_unmxl_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -385,7 +390,7 @@ void testing_ormxl_unmxl(Arguments& argus)
     if(argus.timing)
         ormxl_unmxl_getPerfData<MQL, T>(handle, side, trans, m, n, k, dA, lda, dIpiv, dC, ldc, hA,
                                         hIpiv, hC, &gpu_time_used, &cpu_time_used, hot_calls,
-                                        argus.profile, argus.perf);
+                                        argus.profile, argus.profile_kernels, argus.perf);
 
     // validate results for rocsolver-test
     // using s * machine_precision as tolerance

--- a/clients/include/testing_ormxr_unmxr.hpp
+++ b/clients/include/testing_ormxr_unmxr.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -208,6 +208,7 @@ void ormxr_unmxr_getPerfData(const rocblas_handle handle,
                              double* cpu_time_used,
                              const rocblas_int hot_calls,
                              const int profile,
+                             const bool profile_kernels,
                              const bool perf)
 {
     size_t size_W = max(max(m, n), k);
@@ -246,7 +247,11 @@ void ormxr_unmxr_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -385,7 +390,7 @@ void testing_ormxr_unmxr(Arguments& argus)
     if(argus.timing)
         ormxr_unmxr_getPerfData<MQR, T>(handle, side, trans, m, n, k, dA, lda, dIpiv, dC, ldc, hA,
                                         hIpiv, hC, &gpu_time_used, &cpu_time_used, hot_calls,
-                                        argus.profile, argus.perf);
+                                        argus.profile, argus.profile_kernels, argus.perf);
 
     // validate results for rocsolver-test
     // using s * machine_precision as tolerance

--- a/clients/include/testing_posv.hpp
+++ b/clients/include/testing_posv.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -243,6 +243,7 @@ void posv_getPerfData(const rocblas_handle handle,
                       double* cpu_time_used,
                       const rocblas_int hot_calls,
                       const int profile,
+                      const bool profile_kernels,
                       const bool perf,
                       const bool singular)
 {
@@ -280,7 +281,11 @@ void posv_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -423,7 +428,8 @@ void testing_posv(Arguments& argus)
         if(argus.timing)
             posv_getPerfData<STRIDED, T>(handle, uplo, n, nrhs, dA, lda, stA, dB, ldb, stB, dInfo,
                                          bc, hA, hB, hInfo, &gpu_time_used, &cpu_time_used,
-                                         hot_calls, argus.profile, argus.perf, argus.singular);
+                                         hot_calls, argus.profile, argus.profile_kernels,
+                                         argus.perf, argus.singular);
     }
 
     else
@@ -464,7 +470,8 @@ void testing_posv(Arguments& argus)
         if(argus.timing)
             posv_getPerfData<STRIDED, T>(handle, uplo, n, nrhs, dA, lda, stA, dB, ldb, stB, dInfo,
                                          bc, hA, hB, hInfo, &gpu_time_used, &cpu_time_used,
-                                         hot_calls, argus.profile, argus.perf, argus.singular);
+                                         hot_calls, argus.profile, argus.profile_kernels,
+                                         argus.perf, argus.singular);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_potf2_potrf.hpp
+++ b/clients/include/testing_potf2_potrf.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -222,6 +222,7 @@ void potf2_potrf_getPerfData(const rocblas_handle handle,
                              double* cpu_time_used,
                              const rocblas_int hot_calls,
                              const int profile,
+                             const bool profile_kernels,
                              const bool perf,
                              const bool singular)
 {
@@ -260,7 +261,11 @@ void potf2_potrf_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -395,7 +400,7 @@ void testing_potf2_potrf(Arguments& argus)
         if(argus.timing)
             potf2_potrf_getPerfData<STRIDED, POTRF, T>(
                 handle, uplo, n, dA, lda, stA, dInfo, bc, hA, hInfo, &gpu_time_used, &cpu_time_used,
-                hot_calls, argus.profile, argus.perf, argus.singular);
+                hot_calls, argus.profile, argus.profile_kernels, argus.perf, argus.singular);
     }
 
     else
@@ -433,7 +438,7 @@ void testing_potf2_potrf(Arguments& argus)
         if(argus.timing)
             potf2_potrf_getPerfData<STRIDED, POTRF, T>(
                 handle, uplo, n, dA, lda, stA, dInfo, bc, hA, hInfo, &gpu_time_used, &cpu_time_used,
-                hot_calls, argus.profile, argus.perf, argus.singular);
+                hot_calls, argus.profile, argus.profile_kernels, argus.perf, argus.singular);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_potri.hpp
+++ b/clients/include/testing_potri.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -212,6 +212,7 @@ void potri_getPerfData(const rocblas_handle handle,
                        double* cpu_time_used,
                        const rocblas_int hot_calls,
                        const int profile,
+                       const bool profile_kernels,
                        const bool perf,
                        const bool singular)
 {
@@ -246,7 +247,11 @@ void potri_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -376,7 +381,7 @@ void testing_potri(Arguments& argus)
         if(argus.timing)
             potri_getPerfData<STRIDED, T>(handle, uplo, n, dA, lda, stA, dInfo, bc, hA, hInfo,
                                           &gpu_time_used, &cpu_time_used, hot_calls, argus.profile,
-                                          argus.perf, argus.singular);
+                                          argus.profile_kernels, argus.perf, argus.singular);
     }
 
     else
@@ -413,7 +418,7 @@ void testing_potri(Arguments& argus)
         if(argus.timing)
             potri_getPerfData<STRIDED, T>(handle, uplo, n, dA, lda, stA, dInfo, bc, hA, hInfo,
                                           &gpu_time_used, &cpu_time_used, hot_calls, argus.profile,
-                                          argus.perf, argus.singular);
+                                          argus.profile_kernels, argus.perf, argus.singular);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_potrs.hpp
+++ b/clients/include/testing_potrs.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -206,6 +206,7 @@ void potrs_getPerfData(const rocblas_handle handle,
                        double* cpu_time_used,
                        const rocblas_int hot_calls,
                        const int profile,
+                       const bool profile_kernels,
                        const bool perf)
 {
     if(!perf)
@@ -239,7 +240,11 @@ void potrs_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -373,7 +378,7 @@ void testing_potrs(Arguments& argus)
         if(argus.timing)
             potrs_getPerfData<STRIDED, T>(handle, uplo, n, nrhs, dA, lda, stA, dB, ldb, stB, bc, hA,
                                           hB, &gpu_time_used, &cpu_time_used, hot_calls,
-                                          argus.profile, argus.perf);
+                                          argus.profile, argus.profile_kernels, argus.perf);
     }
 
     else
@@ -410,7 +415,7 @@ void testing_potrs(Arguments& argus)
         if(argus.timing)
             potrs_getPerfData<STRIDED, T>(handle, uplo, n, nrhs, dA, lda, stA, dB, ldb, stB, bc, hA,
                                           hB, &gpu_time_used, &cpu_time_used, hot_calls,
-                                          argus.profile, argus.perf);
+                                          argus.profile, argus.profile_kernels, argus.perf);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_stebz.hpp
+++ b/clients/include/testing_stebz.hpp
@@ -263,6 +263,7 @@ void stebz_getPerfData(const rocblas_handle handle,
                        double* cpu_time_used,
                        const rocblas_int hot_calls,
                        const int profile,
+                       const bool profile_kernels,
                        const bool perf)
 {
     if(!perf)
@@ -300,7 +301,11 @@ void stebz_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -451,7 +456,7 @@ void testing_stebz(Arguments& argus)
         stebz_getPerfData<T>(handle, range, order, n, vl, vu, il, iu, abstol, dD, dE, dnev, dnsplit,
                              dW, dIblock, dIsplit, dinfo, hD, hE, hnev, hnsplit, hW, hIblock,
                              hIsplit, hinfo, &gpu_time_used, &cpu_time_used, hot_calls,
-                             argus.profile, argus.perf);
+                             argus.profile, argus.profile_kernels, argus.perf);
 
     // validate results for rocsolver-test
     // using n * machine_precision as tolerance

--- a/clients/include/testing_stedc.hpp
+++ b/clients/include/testing_stedc.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -254,6 +254,7 @@ void stedc_getPerfData(const rocblas_handle handle,
                        double* cpu_time_used,
                        const rocblas_int hot_calls,
                        const int profile,
+                       const bool profile_kernels,
                        const bool perf)
 {
     constexpr bool COMPLEX = is_complex<T>;
@@ -296,7 +297,11 @@ void stedc_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -411,7 +416,8 @@ void testing_stedc(Arguments& argus)
     // collect performance data
     if(argus.timing)
         stedc_getPerfData<T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo,
-                             &gpu_time_used, &cpu_time_used, hot_calls, argus.profile, argus.perf);
+                             &gpu_time_used, &cpu_time_used, hot_calls, argus.profile,
+                             argus.profile_kernels, argus.perf);
 
     // validate results for rocsolver-test
     // using n * machine_precision as tolerance

--- a/clients/include/testing_stein.hpp
+++ b/clients/include/testing_stein.hpp
@@ -305,6 +305,7 @@ void stein_getPerfData(const rocblas_handle handle,
                        double* cpu_time_used,
                        const rocblas_int hot_calls,
                        const int profile,
+                       const bool profile_kernels,
                        const bool perf)
 {
     using S = decltype(std::real(T{}));
@@ -348,7 +349,11 @@ void stein_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -494,7 +499,8 @@ void testing_stein(Arguments& argus)
     if(argus.timing)
         stein_getPerfData<T>(handle, n, nev, dD, dE, dNev, dW, dIblock, dIsplit, dZ, ldz, dIfail,
                              dInfo, hD, hE, hNev, hW, hIblock, hIsplit, hZ, hIfail, hInfo,
-                             &gpu_time_used, &cpu_time_used, hot_calls, argus.profile, argus.perf);
+                             &gpu_time_used, &cpu_time_used, hot_calls, argus.profile,
+                             argus.profile_kernels, argus.perf);
 
     // validate results for rocsolver-test
     // using 2 * n * machine_precision as tolerance

--- a/clients/include/testing_steqr.hpp
+++ b/clients/include/testing_steqr.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -247,6 +247,7 @@ void steqr_getPerfData(const rocblas_handle handle,
                        double* cpu_time_used,
                        const rocblas_int hot_calls,
                        const int profile,
+                       const bool profile_kernels,
                        const bool perf)
 {
     using S = decltype(std::real(T{}));
@@ -282,7 +283,11 @@ void steqr_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -397,7 +402,8 @@ void testing_steqr(Arguments& argus)
     // collect performance data
     if(argus.timing)
         steqr_getPerfData<T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo,
-                             &gpu_time_used, &cpu_time_used, hot_calls, argus.profile, argus.perf);
+                             &gpu_time_used, &cpu_time_used, hot_calls, argus.profile,
+                             argus.profile_kernels, argus.perf);
 
     // validate results for rocsolver-test
     // using n * machine_precision as tolerance

--- a/clients/include/testing_sterf.hpp
+++ b/clients/include/testing_sterf.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -131,6 +131,7 @@ void sterf_getPerfData(const rocblas_handle handle,
                        double* cpu_time_used,
                        const rocblas_int hot_calls,
                        const int profile,
+                       const bool profile_kernels,
                        const bool perf)
 {
     if(!perf)
@@ -160,7 +161,11 @@ void sterf_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -258,8 +263,8 @@ void testing_sterf(Arguments& argus)
 
     // collect performance data
     if(argus.timing)
-        sterf_getPerfData<T>(handle, n, dD, dE, dInfo, hD, hE, hInfo, &gpu_time_used,
-                             &cpu_time_used, hot_calls, argus.profile, argus.perf);
+        sterf_getPerfData<T>(handle, n, dD, dE, dInfo, hD, hE, hInfo, &gpu_time_used, &cpu_time_used,
+                             hot_calls, argus.profile, argus.profile_kernels, argus.perf);
 
     // validate results for rocsolver-test
     // using n * machine_precision as tolerance

--- a/clients/include/testing_syev_heev.hpp
+++ b/clients/include/testing_syev_heev.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -289,6 +289,7 @@ void syev_heev_getPerfData(const rocblas_handle handle,
                            double* cpu_time_used,
                            const rocblas_int hot_calls,
                            const int profile,
+                           const bool profile_kernels,
                            const bool perf)
 {
     constexpr bool COMPLEX = is_complex<T>;
@@ -330,7 +331,11 @@ void syev_heev_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -491,7 +496,8 @@ void testing_syev_heev(Arguments& argus)
         {
             syev_heev_getPerfData<STRIDED, T>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE,
                                               stE, dinfo, bc, hA, hD, hinfo, &gpu_time_used,
-                                              &cpu_time_used, hot_calls, argus.profile, argus.perf);
+                                              &cpu_time_used, hot_calls, argus.profile,
+                                              argus.profile_kernels, argus.perf);
         }
     }
 
@@ -530,7 +536,8 @@ void testing_syev_heev(Arguments& argus)
         {
             syev_heev_getPerfData<STRIDED, T>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE,
                                               stE, dinfo, bc, hA, hD, hinfo, &gpu_time_used,
-                                              &cpu_time_used, hot_calls, argus.profile, argus.perf);
+                                              &cpu_time_used, hot_calls, argus.profile,
+                                              argus.profile_kernels, argus.perf);
         }
     }
 

--- a/clients/include/testing_syevd_heevd.hpp
+++ b/clients/include/testing_syevd_heevd.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -301,6 +301,7 @@ void syevd_heevd_getPerfData(const rocblas_handle handle,
                              double* cpu_time_used,
                              const rocblas_int hot_calls,
                              const int profile,
+                             const bool profile_kernels,
                              const bool perf)
 {
     constexpr bool COMPLEX = is_complex<T>;
@@ -354,7 +355,11 @@ void syevd_heevd_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -515,7 +520,8 @@ void testing_syevd_heevd(Arguments& argus)
         {
             syevd_heevd_getPerfData<STRIDED, T>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE,
                                                 stE, dinfo, bc, hA, hD, hinfo, &gpu_time_used,
-                                                &cpu_time_used, hot_calls, argus.profile, argus.perf);
+                                                &cpu_time_used, hot_calls, argus.profile,
+                                                argus.profile_kernels, argus.perf);
         }
     }
 
@@ -554,7 +560,8 @@ void testing_syevd_heevd(Arguments& argus)
         {
             syevd_heevd_getPerfData<STRIDED, T>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE,
                                                 stE, dinfo, bc, hA, hD, hinfo, &gpu_time_used,
-                                                &cpu_time_used, hot_calls, argus.profile, argus.perf);
+                                                &cpu_time_used, hot_calls, argus.profile,
+                                                argus.profile_kernels, argus.perf);
         }
     }
 

--- a/clients/include/testing_sygsx_hegsx.hpp
+++ b/clients/include/testing_sygsx_hegsx.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -217,6 +217,7 @@ void sygsx_hegsx_getPerfData(const rocblas_handle handle,
                              double* cpu_time_used,
                              const rocblas_int hot_calls,
                              const int profile,
+                             const bool profile_kernels,
                              const bool perf)
 {
     if(!perf)
@@ -254,7 +255,11 @@ void sygsx_hegsx_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -399,7 +404,7 @@ void testing_sygsx_hegsx(Arguments& argus)
         if(argus.timing)
             sygsx_hegsx_getPerfData<STRIDED, SYGST, T>(
                 handle, itype, uplo, n, dA, lda, stA, dB, ldb, stB, bc, hA, hB, &gpu_time_used,
-                &cpu_time_used, hot_calls, argus.profile, argus.perf);
+                &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels, argus.perf);
     }
 
     else
@@ -437,7 +442,7 @@ void testing_sygsx_hegsx(Arguments& argus)
         if(argus.timing)
             sygsx_hegsx_getPerfData<STRIDED, SYGST, T>(
                 handle, itype, uplo, n, dA, lda, stA, dB, ldb, stB, bc, hA, hB, &gpu_time_used,
-                &cpu_time_used, hot_calls, argus.profile, argus.perf);
+                &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels, argus.perf);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_sygv_hegv.hpp
+++ b/clients/include/testing_sygv_hegv.hpp
@@ -401,6 +401,7 @@ void sygv_hegv_getPerfData(const rocblas_handle handle,
                            double* cpu_time_used,
                            const rocblas_int hot_calls,
                            const int profile,
+                           const bool profile_kernels,
                            const bool perf,
                            const bool singular)
 {
@@ -450,7 +451,11 @@ void sygv_hegv_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -625,10 +630,10 @@ void testing_sygv_hegv(Arguments& argus)
 
         // collect performance data
         if(argus.timing)
-            sygv_hegv_getPerfData<STRIDED, T>(handle, itype, evect, uplo, n, dA, lda, stA, dB, ldb,
-                                              stB, dD, stD, dE, stE, dInfo, bc, hA, hB, hD, hInfo,
-                                              &gpu_time_used, &cpu_time_used, hot_calls,
-                                              argus.profile, argus.perf, argus.singular);
+            sygv_hegv_getPerfData<STRIDED, T>(
+                handle, itype, evect, uplo, n, dA, lda, stA, dB, ldb, stB, dD, stD, dE, stE, dInfo,
+                bc, hA, hB, hD, hInfo, &gpu_time_used, &cpu_time_used, hot_calls, argus.profile,
+                argus.profile_kernels, argus.perf, argus.singular);
     }
 
     else
@@ -666,10 +671,10 @@ void testing_sygv_hegv(Arguments& argus)
 
         // collect performance data
         if(argus.timing)
-            sygv_hegv_getPerfData<STRIDED, T>(handle, itype, evect, uplo, n, dA, lda, stA, dB, ldb,
-                                              stB, dD, stD, dE, stE, dInfo, bc, hA, hB, hD, hInfo,
-                                              &gpu_time_used, &cpu_time_used, hot_calls,
-                                              argus.profile, argus.perf, argus.singular);
+            sygv_hegv_getPerfData<STRIDED, T>(
+                handle, itype, evect, uplo, n, dA, lda, stA, dB, ldb, stB, dD, stD, dE, stE, dInfo,
+                bc, hA, hB, hD, hInfo, &gpu_time_used, &cpu_time_used, hot_calls, argus.profile,
+                argus.profile_kernels, argus.perf, argus.singular);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_sygvd_hegvd.hpp
+++ b/clients/include/testing_sygvd_hegvd.hpp
@@ -417,6 +417,7 @@ void sygvd_hegvd_getPerfData(const rocblas_handle handle,
                              double* cpu_time_used,
                              const rocblas_int hot_calls,
                              const int profile,
+                             const bool profile_kernels,
                              const bool perf,
                              const bool singular)
 {
@@ -478,7 +479,11 @@ void sygvd_hegvd_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -653,10 +658,10 @@ void testing_sygvd_hegvd(Arguments& argus)
 
         // collect performance data
         if(argus.timing)
-            sygvd_hegvd_getPerfData<STRIDED, T>(handle, itype, evect, uplo, n, dA, lda, stA, dB,
-                                                ldb, stB, dD, stD, dE, stE, dInfo, bc, hA, hB, hD,
-                                                hInfo, &gpu_time_used, &cpu_time_used, hot_calls,
-                                                argus.profile, argus.perf, argus.singular);
+            sygvd_hegvd_getPerfData<STRIDED, T>(
+                handle, itype, evect, uplo, n, dA, lda, stA, dB, ldb, stB, dD, stD, dE, stE, dInfo,
+                bc, hA, hB, hD, hInfo, &gpu_time_used, &cpu_time_used, hot_calls, argus.profile,
+                argus.profile_kernels, argus.perf, argus.singular);
     }
 
     else
@@ -694,10 +699,10 @@ void testing_sygvd_hegvd(Arguments& argus)
 
         // collect performance data
         if(argus.timing)
-            sygvd_hegvd_getPerfData<STRIDED, T>(handle, itype, evect, uplo, n, dA, lda, stA, dB,
-                                                ldb, stB, dD, stD, dE, stE, dInfo, bc, hA, hB, hD,
-                                                hInfo, &gpu_time_used, &cpu_time_used, hot_calls,
-                                                argus.profile, argus.perf, argus.singular);
+            sygvd_hegvd_getPerfData<STRIDED, T>(
+                handle, itype, evect, uplo, n, dA, lda, stA, dB, ldb, stB, dD, stD, dE, stE, dInfo,
+                bc, hA, hB, hD, hInfo, &gpu_time_used, &cpu_time_used, hot_calls, argus.profile,
+                argus.profile_kernels, argus.perf, argus.singular);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_sytf2_sytrf.hpp
+++ b/clients/include/testing_sytf2_sytrf.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -280,6 +280,7 @@ void sytf2_sytrf_getPerfData(const rocblas_handle handle,
                              double* cpu_time_used,
                              const rocblas_int hot_calls,
                              const int profile,
+                             const bool profile_kernels,
                              const bool perf,
                              const bool singular)
 {
@@ -321,7 +322,11 @@ void sytf2_sytrf_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -467,10 +472,10 @@ void testing_sytf2_sytrf(Arguments& argus)
 
         // collect performance data
         if(argus.timing)
-            sytf2_sytrf_getPerfData<STRIDED, SYTRF, T>(handle, uplo, n, dA, lda, stA, dIpiv, stP,
-                                                       dInfo, bc, hA, hIpiv, hInfo, &gpu_time_used,
-                                                       &cpu_time_used, hot_calls, argus.profile,
-                                                       argus.perf, argus.singular);
+            sytf2_sytrf_getPerfData<STRIDED, SYTRF, T>(
+                handle, uplo, n, dA, lda, stA, dIpiv, stP, dInfo, bc, hA, hIpiv, hInfo,
+                &gpu_time_used, &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels,
+                argus.perf, argus.singular);
     }
 
     else
@@ -511,10 +516,10 @@ void testing_sytf2_sytrf(Arguments& argus)
 
         // collect performance data
         if(argus.timing)
-            sytf2_sytrf_getPerfData<STRIDED, SYTRF, T>(handle, uplo, n, dA, lda, stA, dIpiv, stP,
-                                                       dInfo, bc, hA, hIpiv, hInfo, &gpu_time_used,
-                                                       &cpu_time_used, hot_calls, argus.profile,
-                                                       argus.perf, argus.singular);
+            sytf2_sytrf_getPerfData<STRIDED, SYTRF, T>(
+                handle, uplo, n, dA, lda, stA, dIpiv, stP, dInfo, bc, hA, hIpiv, hInfo,
+                &gpu_time_used, &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels,
+                argus.perf, argus.singular);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_sytxx_hetxx.hpp
+++ b/clients/include/testing_sytxx_hetxx.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -330,6 +330,7 @@ void sytxx_hetxx_getPerfData(const rocblas_handle handle,
                              double* cpu_time_used,
                              const rocblas_int hot_calls,
                              const int profile,
+                             const bool profile_kernels,
                              const bool perf)
 {
     std::vector<T> hW(32 * n);
@@ -368,7 +369,11 @@ void sytxx_hetxx_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -527,7 +532,8 @@ void testing_sytxx_hetxx(Arguments& argus)
         if(argus.timing)
             sytxx_hetxx_getPerfData<STRIDED, SYTRD, T>(
                 handle, uplo, n, dA, lda, stA, dD, stD, dE, stE, dTau, stP, bc, hA, hD, hE, hTau,
-                &gpu_time_used, &cpu_time_used, hot_calls, argus.profile, argus.perf);
+                &gpu_time_used, &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels,
+                argus.perf);
     }
 
     else
@@ -562,7 +568,8 @@ void testing_sytxx_hetxx(Arguments& argus)
         if(argus.timing)
             sytxx_hetxx_getPerfData<STRIDED, SYTRD, T>(
                 handle, uplo, n, dA, lda, stA, dD, stD, dE, stE, dTau, stP, bc, hA, hD, hE, hTau,
-                &gpu_time_used, &cpu_time_used, hot_calls, argus.profile, argus.perf);
+                &gpu_time_used, &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels,
+                argus.perf);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_trtri.hpp
+++ b/clients/include/testing_trtri.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -223,6 +223,7 @@ void trtri_getPerfData(const rocblas_handle handle,
                        double* cpu_time_used,
                        const rocblas_int hot_calls,
                        const int profile,
+                       const bool profile_kernels,
                        const bool perf,
                        const bool singular)
 {
@@ -257,7 +258,11 @@ void trtri_getPerfData(const rocblas_handle handle,
 
     if(profile > 0)
     {
-        rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
 
@@ -388,7 +393,7 @@ void testing_trtri(Arguments& argus)
         if(argus.timing)
             trtri_getPerfData<STRIDED, T>(handle, uplo, diag, n, dA, lda, stA, dInfo, bc, hA, hInfo,
                                           &gpu_time_used, &cpu_time_used, hot_calls, argus.profile,
-                                          argus.perf, argus.singular);
+                                          argus.profile_kernels, argus.perf, argus.singular);
     }
 
     else
@@ -425,7 +430,7 @@ void testing_trtri(Arguments& argus)
         if(argus.timing)
             trtri_getPerfData<STRIDED, T>(handle, uplo, diag, n, dA, lda, stA, dInfo, bc, hA, hInfo,
                                           &gpu_time_used, &cpu_time_used, hot_calls, argus.profile,
-                                          argus.perf, argus.singular);
+                                          argus.profile_kernels, argus.perf, argus.singular);
     }
 
     // validate results for rocsolver-test


### PR DESCRIPTION
This PR follows-up on the comment at https://github.com/ROCmSoftwarePlatform/rocSOLVER/pull/324#issuecomment-953169500. Used in conjunction with the --profile argument, a non-zero --profile_kernels argument will indicate that kernel calls should be included in the profile log.