### PR TITLE
Add units to rocsolver-bench results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 
 ### Optimized
 ### Changed
+- Changed rocsolver-bench result labels `cpu_time` and `gpu_time` to
+  `cpu_time_us` and `gpu_time_us`, respectively.
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/clients/extras/test_rocsolver_bench.py
+++ b/clients/extras/test_rocsolver_bench.py
@@ -214,131 +214,55 @@ class TestRocsolverBench(unittest.TestCase):
         self.assertEqual(exitcode, 0)
         self.assertGreaterEqual(float(out), 0)
 
-    def test_gels(self):
-        out, err, exitcode = call_rocsolver_bench('-f gels -n 10 -m 15')
+def generate_parameterized_test(command_options, expected_args):
+    def test_function_output(self):
+        out, err, exitcode = call_rocsolver_bench(command_options)
         self.assertEqual(err, '')
         self.assertEqual(exitcode, 0)
 
         args = self.parse_arguments(out)
-        expected_args = {
-            'trans': 'N',
-            'm': '15',
-            'n': '10',
-            'nrhs': '10',
-            'lda': '15',
-            'ldb': '15',
-        }
         self.assertEqual(args, expected_args)
 
         results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
+        self.assertGreaterEqual(float(results['cpu_time_us']), 0)
+        self.assertGreaterEqual(float(results['gpu_time_us']), 0)
+    return test_function_output
 
-    def test_gels_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f gels_batched -n 10 -m 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
-            'trans': 'N',
-            'm': '15',
-            'n': '10',
-            'nrhs': '10',
-            'lda': '15',
-            'ldb': '15',
-            'batch_c': '1',
-        }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gels_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f gels_strided_batched -n 10 -m 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
-            'trans': 'N',
-            'm': '15',
-            'n': '10',
-            'nrhs': '10',
-            'lda': '15',
-            'ldb': '15',
-            'strideA': '150',
-            'strideB': '150',
-            'batch_c': '1',
-        }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_laswp(self):
-        out, err, exitcode = call_rocsolver_bench('-f laswp -n 10 --k1 15 --k2 20')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+parameters = [
+    (
+        'laswp',
+        '-f laswp -n 10 --k1 15 --k2 20',
+        {
             'n': '10',
             'lda': '20',
             'k1': '15',
             'k2': '20',
             'inc': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_larfg(self):
-        out, err, exitcode = call_rocsolver_bench('-f larfg -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'larfg',
+        '-f larfg -n 10',
+        {
             'n': '10',
             'inc': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_larf(self):
-        out, err, exitcode = call_rocsolver_bench('-f larf -m 10 --side L')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'larf',
+        '-f larf -m 10 --side L',
+        {
             'side': 'L',
             'm': '10',
             'n': '10',
             'inc': '1',
             'lda': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_larft(self):
-        out, err, exitcode = call_rocsolver_bench('-f larft -n 10 --storev C -k 5')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'larft',
+        '-f larft -n 10 --storev C -k 5',
+        {
             'direct': 'F',
             'storev': 'C',
             'n': '10',
@@ -346,19 +270,11 @@ class TestRocsolverBench(unittest.TestCase):
             'ldv': '10',
             'ldt': '5',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_larfb(self):
-        out, err, exitcode = call_rocsolver_bench('-f larfb -n 10 -m 15 --direct F --side L --storev C -k 5')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'larfb',
+        '-f larfb -n 10 -m 15 --direct F --side L --storev C -k 5',
+        {
             'side': 'L',
             'trans': 'N',
             'direct': 'F',
@@ -370,38 +286,22 @@ class TestRocsolverBench(unittest.TestCase):
             'ldt': '5',
             'lda': '15',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_latrd(self):
-        out, err, exitcode = call_rocsolver_bench('-f latrd -n 10 -k 5')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'latrd',
+        '-f latrd -n 10 -k 5',
+        {
             'uplo': 'U',
             'n': '10',
             'k': '5',
             'lda': '10',
             'ldw': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_labrd(self):
-        out, err, exitcode = call_rocsolver_bench('-f labrd -n 10 -m 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'labrd',
+        '-f labrd -n 10 -m 15',
+        {
             'm': '15',
             'n': '10',
             'nb': '10',
@@ -409,19 +309,11 @@ class TestRocsolverBench(unittest.TestCase):
             'ldx': '15',
             'ldy': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_bdsqr(self):
-        out, err, exitcode = call_rocsolver_bench('-f bdsqr --uplo U -n 15 --nu 10 --nv 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'bdsqr',
+        '-f bdsqr --uplo U -n 15 --nu 10 --nv 10',
+        {
             'uplo': 'U',
             'n': '15',
             'nv': '10',
@@ -431,215 +323,119 @@ class TestRocsolverBench(unittest.TestCase):
             'ldu': '10',
             'ldc': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_steqr(self):
-        out, err, exitcode = call_rocsolver_bench('-f steqr -n 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'steqr',
+        '-f steqr -n 15',
+        {
             'evect': 'N',
             'n': '15',
             'ldc': '15',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_stedc(self):
-        out, err, exitcode = call_rocsolver_bench('-f stedc -n 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'stedc',
+        '-f stedc -n 15',
+        {
             'evect': 'N',
             'n': '15',
             'ldc': '15',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_stein(self):
-        out, err, exitcode = call_rocsolver_bench('-f stein -n 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'stein',
+        '-f stein -n 15',
+        {
             'n': '15',
             'nev': '5',
             'ldz': '15',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_lasyf(self):
-        out, err, exitcode = call_rocsolver_bench('-f lasyf -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'lasyf',
+        '-f lasyf -n 10',
+        {
             'uplo': 'U',
             'n': '10',
             'nb': '10',
             'lda': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_potf2(self):
-        out, err, exitcode = call_rocsolver_bench('-f potf2 -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'potf2',
+        '-f potf2 -n 10',
+        {
             'uplo': 'U',
             'n': '10',
             'lda': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_potf2_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f potf2_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'potf2_batched',
+        '-f potf2_batched -n 10',
+        {
             'uplo': 'U',
             'n': '10',
             'lda': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_potf2_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f potf2_strided_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'potf2_strided_batched',
+        '-f potf2_strided_batched -n 10',
+        {
             'uplo': 'U',
             'n': '10',
             'lda': '10',
             'strideA': '100',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_potrf(self):
-        out, err, exitcode = call_rocsolver_bench('-f potrf -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'potrf',
+        '-f potrf -n 10',
+        {
             'uplo': 'U',
             'n': '10',
             'lda': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_potrf_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f potrf_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'potrf_batched',
+        '-f potrf_batched -n 10',
+        {
             'uplo': 'U',
             'n': '10',
             'lda': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_potrf_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f potrf_strided_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'potrf_strided_batched',
+        '-f potrf_strided_batched -n 10',
+        {
             'uplo': 'U',
             'n': '10',
             'lda': '10',
             'strideA': '100',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_potrs(self):
-        out, err, exitcode = call_rocsolver_bench('-f potrs -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'potrs',
+        '-f potrs -n 10',
+        {
             'uplo': 'U',
             'n': '10',
             'nrhs': '10',
             'lda': '10',
             'ldb': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_potrs_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f potrs_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'potrs_batched',
+        '-f potrs_batched -n 10',
+        {
             'uplo': 'U',
             'n': '10',
             'nrhs': '10',
@@ -647,19 +443,11 @@ class TestRocsolverBench(unittest.TestCase):
             'ldb': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_potrs_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f potrs_strided_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'potrs_strided_batched',
+        '-f potrs_strided_batched -n 10',
+        {
             'uplo': 'U',
             'n': '10',
             'nrhs': '10',
@@ -669,38 +457,22 @@ class TestRocsolverBench(unittest.TestCase):
             'strideB': '100',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_posv(self):
-        out, err, exitcode = call_rocsolver_bench('-f posv -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'posv',
+        '-f posv -n 10',
+        {
             'uplo': 'U',
             'n': '10',
             'nrhs': '10',
             'lda': '10',
             'ldb': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_posv_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f posv_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'posv_batched',
+        '-f posv_batched -n 10',
+        {
             'uplo': 'U',
             'n': '10',
             'nrhs': '10',
@@ -708,19 +480,11 @@ class TestRocsolverBench(unittest.TestCase):
             'ldb': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_posv_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f posv_strided_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'posv_strided_batched',
+        '-f posv_strided_batched -n 10',
+        {
             'uplo': 'U',
             'n': '10',
             'nrhs': '10',
@@ -730,217 +494,121 @@ class TestRocsolverBench(unittest.TestCase):
             'strideB': '100',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_potri(self):
-        out, err, exitcode = call_rocsolver_bench('-f potri -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'potri',
+        '-f potri -n 10',
+        {
             'uplo': 'U',
             'n': '10',
             'lda': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_potri_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f potri_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'potri_batched',
+        '-f potri_batched -n 10',
+        {
             'uplo': 'U',
             'n': '10',
             'lda': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_potri_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f potri_strided_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'potri_strided_batched',
+        '-f potri_strided_batched -n 10',
+        {
             'uplo': 'U',
             'n': '10',
             'lda': '10',
             'strideA': '100',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getf2_npvt(self):
-        out, err, exitcode = call_rocsolver_bench('-f getf2_npvt -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getf2_npvt',
+        '-f getf2_npvt -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getf2_npvt_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f getf2_npvt_batched -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getf2_npvt_batched',
+        '-f getf2_npvt_batched -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getf2_npvt_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f getf2_npvt_strided_batched -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getf2_npvt_strided_batched',
+        '-f getf2_npvt_strided_batched -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
             'strideA': '100',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getrf_npvt(self):
-        out, err, exitcode = call_rocsolver_bench('-f getrf_npvt -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getrf_npvt',
+        '-f getrf_npvt -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getrf_npvt_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f getrf_npvt_batched -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getrf_npvt_batched',
+        '-f getrf_npvt_batched -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getrf_npvt_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f getrf_npvt_strided_batched -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getrf_npvt_strided_batched',
+        '-f getrf_npvt_strided_batched -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
             'strideA': '100',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getrf(self):
-        out, err, exitcode = call_rocsolver_bench('-f getrf -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getrf',
+        '-f getrf -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getrf_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f getrf_batched -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getrf_batched',
+        '-f getrf_batched -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getrf_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f getrf_strided_batched -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getrf_strided_batched',
+        '-f getrf_strided_batched -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
@@ -948,55 +616,31 @@ class TestRocsolverBench(unittest.TestCase):
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getf2(self):
-        out, err, exitcode = call_rocsolver_bench('-f getf2 -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getf2',
+        '-f getf2 -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getf2_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f getf2_batched -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getf2_batched',
+        '-f getf2_batched -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getf2_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f getf2_strided_batched -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getf2_strided_batched',
+        '-f getf2_strided_batched -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
@@ -1004,55 +648,31 @@ class TestRocsolverBench(unittest.TestCase):
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_geqr2(self):
-        out, err, exitcode = call_rocsolver_bench('-f geqr2 -n 10 -m 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'geqr2',
+        '-f geqr2 -n 10 -m 15',
+        {
             'm': '15',
             'n': '10',
             'lda': '15',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_geqr2_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f geqr2_batched -n 10 -m 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'geqr2_batched',
+        '-f geqr2_batched -n 10 -m 15',
+        {
             'm': '15',
             'n': '10',
             'lda': '15',
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_geqr2_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f geqr2_strided_batched -n 10 -m 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'geqr2_strided_batched',
+        '-f geqr2_strided_batched -n 10 -m 15',
+        {
             'm': '15',
             'n': '10',
             'lda': '15',
@@ -1060,55 +680,31 @@ class TestRocsolverBench(unittest.TestCase):
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_geqrf(self):
-        out, err, exitcode = call_rocsolver_bench('-f geqrf -n 10 -m 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'geqrf',
+        '-f geqrf -n 10 -m 15',
+        {
             'm': '15',
             'n': '10',
             'lda': '15',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_geqrf_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f geqrf_batched -n 10 -m 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'geqrf_batched',
+        '-f geqrf_batched -n 10 -m 15',
+        {
             'm': '15',
             'n': '10',
             'lda': '15',
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_geqrf_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f geqrf_strided_batched -n 10 -m 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'geqrf_strided_batched',
+        '-f geqrf_strided_batched -n 10 -m 15',
+        {
             'm': '15',
             'n': '10',
             'lda': '15',
@@ -1116,74 +712,42 @@ class TestRocsolverBench(unittest.TestCase):
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_geqrf_ptr_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f geqrf_ptr_batched -n 10 -m 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'geqrf_ptr_batched',
+        '-f geqrf_ptr_batched -n 10 -m 15',
+        {
             'm': '15',
             'n': '10',
             'lda': '15',
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gerq2(self):
-        out, err, exitcode = call_rocsolver_bench('-f gerq2 -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gerq2',
+        '-f gerq2 -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gerq2_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f gerq2_batched -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gerq2_batched',
+        '-f gerq2_batched -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gerq2_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f gerq2_strided_batched -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gerq2_strided_batched',
+        '-f gerq2_strided_batched -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
@@ -1191,55 +755,31 @@ class TestRocsolverBench(unittest.TestCase):
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gerqf(self):
-        out, err, exitcode = call_rocsolver_bench('-f gerqf -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gerqf',
+        '-f gerqf -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gerqf_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f gerqf_batched -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gerqf_batched',
+        '-f gerqf_batched -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gerqf_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f gerqf_strided_batched -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gerqf_strided_batched',
+        '-f gerqf_strided_batched -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
@@ -1247,55 +787,31 @@ class TestRocsolverBench(unittest.TestCase):
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_geql2(self):
-        out, err, exitcode = call_rocsolver_bench('-f geql2 -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'geql2',
+        '-f geql2 -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_geql2_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f geql2_batched -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'geql2_batched',
+        '-f geql2_batched -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_geql2_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f geql2_strided_batched -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'geql2_strided_batched',
+        '-f geql2_strided_batched -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
@@ -1303,55 +819,31 @@ class TestRocsolverBench(unittest.TestCase):
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_geqlf(self):
-        out, err, exitcode = call_rocsolver_bench('-f geqlf -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'geqlf',
+        '-f geqlf -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_geqlf_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f geqlf_batched -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'geqlf_batched',
+        '-f geqlf_batched -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_geqlf_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f geqlf_strided_batched -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'geqlf_strided_batched',
+        '-f geqlf_strided_batched -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
@@ -1359,55 +851,31 @@ class TestRocsolverBench(unittest.TestCase):
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gelq2(self):
-        out, err, exitcode = call_rocsolver_bench('-f gelq2 -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gelq2',
+        '-f gelq2 -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gelq2_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f gelq2_batched -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gelq2_batched',
+        '-f gelq2_batched -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gelq2_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f gelq2_strided_batched -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gelq2_strided_batched',
+        '-f gelq2_strided_batched -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
@@ -1415,55 +883,31 @@ class TestRocsolverBench(unittest.TestCase):
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gelqf(self):
-        out, err, exitcode = call_rocsolver_bench('-f gelqf -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gelqf',
+        '-f gelqf -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gelqf_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f gelqf_batched -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gelqf_batched',
+        '-f gelqf_batched -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gelqf_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f gelqf_strided_batched -m 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gelqf_strided_batched',
+        '-f gelqf_strided_batched -m 10',
+        {
             'm': '10',
             'n': '10',
             'lda': '10',
@@ -1471,38 +915,22 @@ class TestRocsolverBench(unittest.TestCase):
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getrs(self):
-        out, err, exitcode = call_rocsolver_bench('-f getrs -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getrs',
+        '-f getrs -n 10',
+        {
             'trans': 'N',
             'n': '10',
             'nrhs': '10',
             'lda': '10',
             'ldb': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getrs_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f getrs_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getrs_batched',
+        '-f getrs_batched -n 10',
+        {
             'trans': 'N',
             'n': '10',
             'nrhs': '10',
@@ -1511,19 +939,11 @@ class TestRocsolverBench(unittest.TestCase):
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getrs_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f getrs_strided_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getrs_strided_batched',
+        '-f getrs_strided_batched -n 10',
+        {
             'trans': 'N',
             'n': '10',
             'nrhs': '10',
@@ -1534,37 +954,21 @@ class TestRocsolverBench(unittest.TestCase):
             'strideB': '100',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gesv(self):
-        out, err, exitcode = call_rocsolver_bench('-f gesv -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gesv',
+        '-f gesv -n 10',
+        {
             'n': '10',
             'nrhs': '10',
             'lda': '10',
             'ldb': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gesv_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f gesv_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gesv_batched',
+        '-f gesv_batched -n 10',
+        {
             'n': '10',
             'nrhs': '10',
             'lda': '10',
@@ -1572,19 +976,11 @@ class TestRocsolverBench(unittest.TestCase):
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gesv_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f gesv_strided_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gesv_strided_batched',
+        '-f gesv_strided_batched -n 10',
+        {
             'n': '10',
             'nrhs': '10',
             'lda': '10',
@@ -1594,19 +990,11 @@ class TestRocsolverBench(unittest.TestCase):
             'strideB': '100',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gesvd(self):
-        out, err, exitcode = call_rocsolver_bench('-f gesvd -n 10 -m 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gesvd',
+        '-f gesvd -n 10 -m 15',
+        {
             'left_svect': 'N',
             'right_svect': 'N',
             'm': '15',
@@ -1615,19 +1003,11 @@ class TestRocsolverBench(unittest.TestCase):
             'ldu': '15',
             'ldv': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
- 
-    def test_gesvd_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f gesvd_batched -n 10 -m 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gesvd_batched',
+        '-f gesvd_batched -n 10 -m 15',
+        {
             'left_svect': 'N',
             'right_svect': 'N',
             'm': '15',
@@ -1641,19 +1021,11 @@ class TestRocsolverBench(unittest.TestCase):
             'strideE': '9',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gesvd_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f gesvd_strided_batched -n 10 -m 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gesvd_strided_batched',
+        '-f gesvd_strided_batched -n 10 -m 15',
+        {
             'left_svect': 'N',
             'right_svect': 'N',
             'm': '15',
@@ -1668,56 +1040,32 @@ class TestRocsolverBench(unittest.TestCase):
             'strideE': '9',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_trtri(self):
-        out, err, exitcode = call_rocsolver_bench('-f trtri -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'trtri',
+        '-f trtri -n 10',
+        {
             'uplo': 'U',
             'diag': 'N',
             'n': '10',
             'lda': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_trtri_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f trtri_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'trtri_batched',
+        '-f trtri_batched -n 10',
+        {
             'uplo': 'U',
             'diag': 'N',
             'n': '10',
             'lda': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_trtri_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f trtri_strided_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'trtri_strided_batched',
+        '-f trtri_strided_batched -n 10',
+        {
             'uplo': 'U',
             'diag': 'N',
             'n': '10',
@@ -1725,159 +1073,87 @@ class TestRocsolverBench(unittest.TestCase):
             'strideA': '100',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getri(self):
-        out, err, exitcode = call_rocsolver_bench('-f getri -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getri',
+        '-f getri -n 10',
+        {
             'n': '10',
             'lda': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getri_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f getri_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getri_batched',
+        '-f getri_batched -n 10',
+        {
             'n': '10',
             'lda': '10',
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getri_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f getri_strided_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getri_strided_batched',
+        '-f getri_strided_batched -n 10',
+        {
             'n': '10',
             'lda': '10',
             'strideA': '100',
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getri_npvt(self):
-        out, err, exitcode = call_rocsolver_bench('-f getri_npvt -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getri_npvt',
+        '-f getri_npvt -n 10',
+        {
             'n': '10',
             'lda': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getri_npvt_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f getri_npvt_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getri_npvt_batched',
+        '-f getri_npvt_batched -n 10',
+        {
             'n': '10',
             'lda': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getri_npvt_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f getri_npvt_strided_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getri_npvt_strided_batched',
+        '-f getri_npvt_strided_batched -n 10',
+        {
             'n': '10',
             'lda': '10',
             'strideA': '100',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getri_outofplace(self):
-        out, err, exitcode = call_rocsolver_bench('-f getri_outofplace -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getri_outofplace',
+        '-f getri_outofplace -n 10',
+        {
             'n': '10',
             'lda': '10',
             'ldc': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getri_outofplace_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f getri_outofplace_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getri_outofplace_batched',
+        '-f getri_outofplace_batched -n 10',
+        {
             'n': '10',
             'lda': '10',
             'strideP': '10',
             'ldc': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getri_outofplace_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f getri_outofplace_strided_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getri_outofplace_strided_batched',
+        '-f getri_outofplace_strided_batched -n 10',
+        {
             'n': '10',
             'lda': '10',
             'strideA': '100',
@@ -1886,54 +1162,30 @@ class TestRocsolverBench(unittest.TestCase):
             'strideC': '100',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getri_npvt_outofplace(self):
-        out, err, exitcode = call_rocsolver_bench('-f getri_npvt_outofplace -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getri_npvt_outofplace',
+        '-f getri_npvt_outofplace -n 10',
+        {
             'n': '10',
             'lda': '10',
             'ldc': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getri_npvt_outofplace_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f getri_npvt_outofplace_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getri_npvt_outofplace_batched',
+        '-f getri_npvt_outofplace_batched -n 10',
+        {
             'n': '10',
             'lda': '10',
             'ldc': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_getri_npvt_outofplace_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f getri_npvt_outofplace_strided_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'getri_npvt_outofplace_strided_batched',
+        '-f getri_npvt_outofplace_strided_batched -n 10',
+        {
             'n': '10',
             'lda': '10',
             'strideA': '100',
@@ -1941,19 +1193,11 @@ class TestRocsolverBench(unittest.TestCase):
             'strideC': '100',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gels(self):
-        out, err, exitcode = call_rocsolver_bench('-f gels -n 10 -m 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gels',
+        '-f gels -n 10 -m 15',
+        {
             'trans': 'N',
             'm': '15',
             'n': '10',
@@ -1961,19 +1205,11 @@ class TestRocsolverBench(unittest.TestCase):
             'lda': '15',
             'ldb': '15',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gels_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f gels_batched -n 10 -m 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gels_batched',
+        '-f gels_batched -n 10 -m 15',
+        {
             'trans': 'N',
             'm': '15',
             'n': '10',
@@ -1982,19 +1218,11 @@ class TestRocsolverBench(unittest.TestCase):
             'ldb': '15',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gels_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f gels_strided_batched -n 10 -m 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gels_strided_batched',
+        '-f gels_strided_batched -n 10 -m 15',
+        {
             'trans': 'N',
             'm': '15',
             'n': '10',
@@ -2005,55 +1233,31 @@ class TestRocsolverBench(unittest.TestCase):
             'strideB': '150',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gebd2(self):
-        out, err, exitcode = call_rocsolver_bench('-f gebd2 -n 10 -m 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gebd2',
+        '-f gebd2 -n 10 -m 15',
+        {
             'm': '15',
             'n': '10',
             'lda': '15',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gebd2_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f gebd2_batched -n 10 -m 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gebd2_batched',
+        '-f gebd2_batched -n 10 -m 15',
+        {
             'm': '15',
             'n': '10',
             'lda': '15',
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gebd2_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f gebd2_strided_batched -n 10 -m 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gebd2_strided_batched',
+        '-f gebd2_strided_batched -n 10 -m 15',
+        {
             'm': '15',
             'n': '10',
             'lda': '15',
@@ -2061,55 +1265,31 @@ class TestRocsolverBench(unittest.TestCase):
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gebrd(self):
-        out, err, exitcode = call_rocsolver_bench('-f gebrd -n 10 -m 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gebrd',
+        '-f gebrd -n 10 -m 15',
+        {
             'm': '15',
             'n': '10',
             'lda': '15',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gebrd_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f gebrd_batched -n 10 -m 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gebrd_batched',
+        '-f gebrd_batched -n 10 -m 15',
+        {
             'm': '15',
             'n': '10',
             'lda': '15',
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_gebrd_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f gebrd_strided_batched -n 10 -m 15')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'gebrd_strided_batched',
+        '-f gebrd_strided_batched -n 10 -m 15',
+        {
             'm': '15',
             'n': '10',
             'lda': '15',
@@ -2117,55 +1297,31 @@ class TestRocsolverBench(unittest.TestCase):
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_sytf2(self):
-        out, err, exitcode = call_rocsolver_bench('-f sytf2 -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'sytf2',
+        '-f sytf2 -n 10',
+        {
             'uplo': 'U',
             'n': '10',
             'lda': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_sytf2_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f sytf2_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'sytf2_batched',
+        '-f sytf2_batched -n 10',
+        {
             'uplo': 'U',
             'n': '10',
             'lda': '10',
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_sytf2_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f sytf2_strided_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'sytf2_strided_batched',
+        '-f sytf2_strided_batched -n 10',
+        {
             'uplo': 'U',
             'n': '10',
             'lda': '10',
@@ -2173,55 +1329,31 @@ class TestRocsolverBench(unittest.TestCase):
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_sytrf(self):
-        out, err, exitcode = call_rocsolver_bench('-f sytrf -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'sytrf',
+        '-f sytrf -n 10',
+        {
             'uplo': 'U',
             'n': '10',
             'lda': '10',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_sytrf_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f sytrf_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'sytrf_batched',
+        '-f sytrf_batched -n 10',
+        {
             'uplo': 'U',
             'n': '10',
             'lda': '10',
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
-
-    def test_sytrf_strided_batched(self):
-        out, err, exitcode = call_rocsolver_bench('-f sytrf_strided_batched -n 10')
-        self.assertEqual(err, '')
-        self.assertEqual(exitcode, 0)
-
-        args = self.parse_arguments(out)
-        expected_args = {
+    ),
+    (
+        'sytrf_strided_batched',
+        '-f sytrf_strided_batched -n 10',
+        {
             'uplo': 'U',
             'n': '10',
             'lda': '10',
@@ -2229,11 +1361,11 @@ class TestRocsolverBench(unittest.TestCase):
             'strideP': '10',
             'batch_c': '1',
         }
-        self.assertEqual(args, expected_args)
-
-        results = self.parse_results(out)
-        self.assertGreaterEqual(float(results['cpu_time']), 0)
-        self.assertGreaterEqual(float(results['gpu_time']), 0)
+    )
+]
 
 if __name__ == '__main__':
+    for name, command_options, expected_args in parameters:
+        test = generate_parameterized_test(command_options, expected_args)
+        setattr(TestRocsolverBench, f'test_{name}', test)
     unittest.main()

--- a/clients/include/testing_bdsqr.hpp
+++ b/clients/include/testing_bdsqr.hpp
@@ -611,12 +611,12 @@ void testing_bdsqr(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_gebd2_gebrd.hpp
+++ b/clients/include/testing_gebd2_gebrd.hpp
@@ -626,12 +626,12 @@ void testing_gebd2_gebrd(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_gelq2_gelqf.hpp
+++ b/clients/include/testing_gelq2_gelqf.hpp
@@ -428,12 +428,12 @@ void testing_gelq2_gelqf(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_gels.hpp
+++ b/clients/include/testing_gels.hpp
@@ -555,12 +555,12 @@ void testing_gels(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_gels_outofplace.hpp
+++ b/clients/include/testing_gels_outofplace.hpp
@@ -633,12 +633,12 @@ void testing_gels_outofplace(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_geql2_geqlf.hpp
+++ b/clients/include/testing_geql2_geqlf.hpp
@@ -428,12 +428,12 @@ void testing_geql2_geqlf(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_geqr2_geqrf.hpp
+++ b/clients/include/testing_geqr2_geqrf.hpp
@@ -465,12 +465,12 @@ void testing_geqr2_geqrf(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_gerq2_gerqf.hpp
+++ b/clients/include/testing_gerq2_gerqf.hpp
@@ -428,12 +428,12 @@ void testing_gerq2_gerqf(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_gesv.hpp
+++ b/clients/include/testing_gesv.hpp
@@ -526,12 +526,12 @@ void testing_gesv(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_gesv_outofplace.hpp
+++ b/clients/include/testing_gesv_outofplace.hpp
@@ -568,12 +568,12 @@ void testing_gesv_outofplace(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_gesvd.hpp
+++ b/clients/include/testing_gesvd.hpp
@@ -836,12 +836,12 @@ void testing_gesvd(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_getf2_getrf.hpp
+++ b/clients/include/testing_getf2_getrf.hpp
@@ -520,12 +520,12 @@ void testing_getf2_getrf(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_getf2_getrf_npvt.hpp
+++ b/clients/include/testing_getf2_getrf_npvt.hpp
@@ -465,12 +465,12 @@ void testing_getf2_getrf_npvt(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_getri.hpp
+++ b/clients/include/testing_getri.hpp
@@ -488,12 +488,12 @@ void testing_getri(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_getri_npvt.hpp
+++ b/clients/include/testing_getri_npvt.hpp
@@ -447,12 +447,12 @@ void testing_getri_npvt(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_getri_npvt_outofplace.hpp
+++ b/clients/include/testing_getri_npvt_outofplace.hpp
@@ -494,12 +494,12 @@ void testing_getri_npvt_outofplace(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_getri_outofplace.hpp
+++ b/clients/include/testing_getri_outofplace.hpp
@@ -532,12 +532,12 @@ void testing_getri_outofplace(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_getrs.hpp
+++ b/clients/include/testing_getrs.hpp
@@ -485,12 +485,12 @@ void testing_getrs(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_labrd.hpp
+++ b/clients/include/testing_labrd.hpp
@@ -433,12 +433,12 @@ void testing_labrd(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_lacgv.hpp
+++ b/clients/include/testing_lacgv.hpp
@@ -245,12 +245,12 @@ void testing_lacgv(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_larf.hpp
+++ b/clients/include/testing_larf.hpp
@@ -345,12 +345,12 @@ void testing_larf(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_larfb.hpp
+++ b/clients/include/testing_larfb.hpp
@@ -492,12 +492,12 @@ void testing_larfb(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_larfg.hpp
+++ b/clients/include/testing_larfg.hpp
@@ -283,12 +283,12 @@ void testing_larfg(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_larft.hpp
+++ b/clients/include/testing_larft.hpp
@@ -374,12 +374,12 @@ void testing_larft(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_laswp.hpp
+++ b/clients/include/testing_laswp.hpp
@@ -299,12 +299,12 @@ void testing_laswp(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_lasyf.hpp
+++ b/clients/include/testing_lasyf.hpp
@@ -422,12 +422,12 @@ void testing_lasyf(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_latrd.hpp
+++ b/clients/include/testing_latrd.hpp
@@ -384,12 +384,12 @@ void testing_latrd(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_managed_malloc.hpp
+++ b/clients/include/testing_managed_malloc.hpp
@@ -316,12 +316,12 @@ void testing_managed_malloc(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_orgbr_ungbr.hpp
+++ b/clients/include/testing_orgbr_ungbr.hpp
@@ -363,12 +363,12 @@ void testing_orgbr_ungbr(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_orglx_unglx.hpp
+++ b/clients/include/testing_orglx_unglx.hpp
@@ -308,12 +308,12 @@ void testing_orglx_unglx(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_orgtr_ungtr.hpp
+++ b/clients/include/testing_orgtr_ungtr.hpp
@@ -307,12 +307,12 @@ void testing_orgtr_ungtr(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_orgxl_ungxl.hpp
+++ b/clients/include/testing_orgxl_ungxl.hpp
@@ -308,12 +308,12 @@ void testing_orgxl_ungxl(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_orgxr_ungxr.hpp
+++ b/clients/include/testing_orgxr_ungxr.hpp
@@ -308,12 +308,12 @@ void testing_orgxr_ungxr(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_ormbr_unmbr.hpp
+++ b/clients/include/testing_ormbr_unmbr.hpp
@@ -443,12 +443,12 @@ void testing_ormbr_unmbr(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_ormlx_unmlx.hpp
+++ b/clients/include/testing_ormlx_unmlx.hpp
@@ -410,12 +410,12 @@ void testing_ormlx_unmlx(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_ormtr_unmtr.hpp
+++ b/clients/include/testing_ormtr_unmtr.hpp
@@ -412,12 +412,12 @@ void testing_ormtr_unmtr(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_ormxl_unmxl.hpp
+++ b/clients/include/testing_ormxl_unmxl.hpp
@@ -410,12 +410,12 @@ void testing_ormxl_unmxl(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_ormxr_unmxr.hpp
+++ b/clients/include/testing_ormxr_unmxr.hpp
@@ -410,12 +410,12 @@ void testing_ormxr_unmxr(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_posv.hpp
+++ b/clients/include/testing_posv.hpp
@@ -504,12 +504,12 @@ void testing_posv(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_potf2_potrf.hpp
+++ b/clients/include/testing_potf2_potrf.hpp
@@ -470,12 +470,12 @@ void testing_potf2_potrf(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_potri.hpp
+++ b/clients/include/testing_potri.hpp
@@ -450,12 +450,12 @@ void testing_potri(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_potrs.hpp
+++ b/clients/include/testing_potrs.hpp
@@ -448,12 +448,12 @@ void testing_potrs(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_stebz.hpp
+++ b/clients/include/testing_stebz.hpp
@@ -475,12 +475,12 @@ void testing_stebz(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_stedc.hpp
+++ b/clients/include/testing_stedc.hpp
@@ -436,12 +436,12 @@ void testing_stedc(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_stein.hpp
+++ b/clients/include/testing_stein.hpp
@@ -519,12 +519,12 @@ void testing_stein(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_steqr.hpp
+++ b/clients/include/testing_steqr.hpp
@@ -422,12 +422,12 @@ void testing_steqr(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_sterf.hpp
+++ b/clients/include/testing_sterf.hpp
@@ -283,12 +283,12 @@ void testing_sterf(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_syev_heev.hpp
+++ b/clients/include/testing_syev_heev.hpp
@@ -571,12 +571,12 @@ void testing_syev_heev(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_syevd_heevd.hpp
+++ b/clients/include/testing_syevd_heevd.hpp
@@ -595,12 +595,12 @@ void testing_syevd_heevd(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_syevx_heevx.hpp
+++ b/clients/include/testing_syevx_heevx.hpp
@@ -744,12 +744,12 @@ void testing_syevx_heevx(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_sygsx_hegsx.hpp
+++ b/clients/include/testing_sygsx_hegsx.hpp
@@ -475,12 +475,12 @@ void testing_sygsx_hegsx(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_sygv_hegv.hpp
+++ b/clients/include/testing_sygv_hegv.hpp
@@ -708,12 +708,12 @@ void testing_sygv_hegv(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_sygvd_hegvd.hpp
+++ b/clients/include/testing_sygvd_hegvd.hpp
@@ -736,12 +736,12 @@ void testing_sygvd_hegvd(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_sytf2_sytrf.hpp
+++ b/clients/include/testing_sytf2_sytrf.hpp
@@ -551,12 +551,12 @@ void testing_sytf2_sytrf(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_sytxx_hetxx.hpp
+++ b/clients/include/testing_sytxx_hetxx.hpp
@@ -603,12 +603,12 @@ void testing_sytxx_hetxx(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();

--- a/clients/include/testing_trtri.hpp
+++ b/clients/include/testing_trtri.hpp
@@ -462,12 +462,12 @@ void testing_trtri(Arguments& argus)
             rocsolver_bench_header("Results:");
             if(argus.norm_check)
             {
-                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
             }
             else
             {
-                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();


### PR DESCRIPTION
This change renames `cpu_time` and `gpu_time` to `cpu_time_us` and `gpu_time_us`, respectively. There's no actual change to the behaviour aside from adjusting the label to mention the units (microseconds).

I refactored `test_rocsolver_bench.py` to use a parameterized test function, so that these labels only appear in a single place.