### PR TITLE
Fix ./install.sh --clients-only

### DIFF
--- a/clients/extras/CMakeLists.txt
+++ b/clients/extras/CMakeLists.txt
@@ -15,21 +15,23 @@ set_target_properties(test-header PROPERTIES
 )
 
 if(UNIX AND BUILD_SHARED_LIBS)
-  add_executable(test-rocsolver-dlopen
-    test_dlopen_main.cpp
-  )
-  target_compile_definitions(test-rocsolver-dlopen PRIVATE
-    ROCSOLVER_LIB_NAME="$<TARGET_FILE:rocsolver>"
-  )
-  target_link_libraries(test-rocsolver-dlopen PRIVATE
-    GTest::GTest
-    ${CMAKE_DL_LIBS}
-  )
+  if(TARGET rocsolver)
+    add_executable(test-rocsolver-dlopen
+      test_dlopen_main.cpp
+    )
+    target_compile_definitions(test-rocsolver-dlopen PRIVATE
+      ROCSOLVER_LIB_NAME="$<TARGET_FILE:rocsolver>"
+    )
+    target_link_libraries(test-rocsolver-dlopen PRIVATE
+      GTest::GTest
+      ${CMAKE_DL_LIBS}
+    )
 
-  add_test(
-    NAME test-rocsolver-dlopen
-    COMMAND test-rocsolver-dlopen
-  )
+    add_test(
+      NAME test-rocsolver-dlopen
+      COMMAND test-rocsolver-dlopen
+    )
+  endif()
 
   if(TARGET rocsolver-bench)
     find_package(Python3 COMPONENTS Interpreter)


### PR DESCRIPTION
The `rocsolver` target does not exist when the library is skipped, causing a build failure in the dlopen test.