### PR TITLE
Generic CMake plumbing for install.sh and rmake.py

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -81,7 +81,14 @@ Options:
                               (Default build type is Release)
 
   --cmake-arg <argument>      Forward the given argument to CMake when configuring the build.
+
   --rm-legacy-include-dir     Remove legacy include dir Packaging added for file/folder reorg backward compatibility.
+
+    -D <arg>                         Pass '-D <arg>' to CMake during configuration.
+
+    -G <arg>                         Pass '-G <arg>' to CMake during configuration.
+
+    -C <arg>                         Pass '-C <arg>' to CMake during configuration.
 EOF
 }
 
@@ -345,7 +352,7 @@ declare -a cmake_client_options
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,package,clients,clients-only,dependencies,cleanup,debug,hip-clang,codecoverage,relwithdebinfo,build_dir:,rocblas_dir:,rocsolver_dir:,lib_dir:,install_dir:,architecture:,static,relocatable,no-optimizations,docs,address-sanitizer,cmake-arg:,rm-legacy-include-dir --options hipcdgsrnka: -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,package,clients,clients-only,dependencies,cleanup,debug,hip-clang,codecoverage,relwithdebinfo,build_dir:,rocblas_dir:,rocsolver_dir:,lib_dir:,install_dir:,architecture:,static,relocatable,no-optimizations,docs,address-sanitizer,cmake-arg:,rm-legacy-include-dir --options hipcdgsrnka:D:G:C: -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -434,6 +441,15 @@ while true; do
         shift ;;
     --cmake-arg)
         cmake_common_options+=("${2}")
+        shift 2 ;;
+    -D)
+        cmake_common_options+=('-D' "${2}")
+        shift 2 ;;
+    -G)
+        cmake_common_options+=('-G' "${2}")
+        shift 2 ;;
+    -C)
+        cmake_common_options+=('-C' "${2}")
         shift 2 ;;
     --) shift ; break ;;
     *)
@@ -627,7 +643,7 @@ check_exit_code "$?"
 # #################################################
 # installing through package manager, which makes uninstalling easy
 if [[ "${build_package}" == true ]]; then
-  make package
+  cmake --build . --target package
   check_exit_code "$?"
 
   if [[ "${install_package}" == true ]]; then

--- a/rmake.py
+++ b/rmake.py
@@ -33,8 +33,14 @@ def parse_args():
                         help='Generate all client builds (optional, default: False)')
     parser.add_argument('-i', '--install', required=False, default = False, dest='install', action='store_true',
                         help='Install after build (optional, default: False)')
-    parser.add_argument(      '--cmake-darg', required=False, dest='cmake_dargs', action='append', default=[],
-                        help='List of additional cmake defines for builds (optional, e.g. CMAKE)')
+    parser.add_argument('-D', '--cmake-darg', required=False, dest='cmake_dargs', action='append', default=[],
+                        help='Additional cmake defines for builds (optional, e.g. CMAKE)')
+    parser.add_argument('-G', required=False, dest='generator',
+                        help="Pass '-G <arg>' to CMake during configuration. (optional)")
+    parser.add_argument('-C', required=False, dest='initial_cache',
+                        help="Pass '-C <arg>' to CMake during configuration. (optional)")
+    parser.add_argument(      '--cmake-arg', required=False, dest='cmake_args', action='append', default=[],
+                        help='Additional cmake arguments to pass during configuration (optional, e.g. --debug-find)')
     parser.add_argument('-v', '--verbose', required=False, default = False, action='store_true',
                         help='Verbose build (optional, default: False)')
     # rocsolver
@@ -116,7 +122,8 @@ def config_cmd():
         cmake_options.append("-DCMAKE_STATIC_LIBRARY_PREFIX=static_")
         cmake_options.append("-DCMAKE_SHARED_LIBRARY_SUFFIX=.dll")
         cmake_options.append("-DCMAKE_SHARED_LIBRARY_PREFIX=")
-        cmake_options.append("-G Ninja")
+        if not args.generator:
+            cmake_options.append('-G Ninja')
     else:
         rocm_path = os.getenv( 'ROCM_PATH', "/opt/rocm")
         cmake_executable = "cmake"
@@ -188,6 +195,14 @@ def config_cmd():
     if args.cmake_dargs:
         for i in args.cmake_dargs:
           cmake_options.append( f"-D{i}" )
+
+    cmake_options.extend(args.cmake_args)
+
+    if args.initial_cache:
+        cmake_options.append("-C {}".format(args.initial_cache))
+
+    if args.generator:
+        cmake_options.append("-G {}".format(args.generator))
 
     cmake_options.append( f"{src_path}")
     cmd_opts = " ".join(cmake_options)


### PR DESCRIPTION
This change adds generic options to install.sh and rmake.py that will hopefully prevent the need for bespoke options that just forward a particular value to CMake (e.g., [`ROCM_PKGTYPE`](https://github.com/RadeonOpenCompute/rocm-cmake/pull/70#issuecomment-1021622532), [`--rm-legacy-include-dir`](https://github.com/ROCmSoftwarePlatform/rocSOLVER/pull/388)).