### PR TITLE
Added syevx_inplace

### DIFF
--- a/clients/include/rocsolver.hpp
+++ b/clients/include/rocsolver.hpp
@@ -153,6 +153,70 @@ rocblas_status rocsolver_zgels_outofplace(rocblas_handle handle,
                                           const rocblas_int ldx,
                                           rocblas_int* info);
 
+rocblas_status rocsolver_ssyevx_inplace(rocblas_handle handle,
+                                        const rocblas_evect evect,
+                                        const rocblas_erange erange,
+                                        const rocblas_fill uplo,
+                                        const rocblas_int n,
+                                        float* A,
+                                        const rocblas_int lda,
+                                        const float vl,
+                                        const float vu,
+                                        const rocblas_int il,
+                                        const rocblas_int iu,
+                                        const float abstol,
+                                        rocblas_int* nev,
+                                        float* W,
+                                        rocblas_int* info);
+
+rocblas_status rocsolver_dsyevx_inplace(rocblas_handle handle,
+                                        const rocblas_evect evect,
+                                        const rocblas_erange erange,
+                                        const rocblas_fill uplo,
+                                        const rocblas_int n,
+                                        double* A,
+                                        const rocblas_int lda,
+                                        const double vl,
+                                        const double vu,
+                                        const rocblas_int il,
+                                        const rocblas_int iu,
+                                        const double abstol,
+                                        rocblas_int* nev,
+                                        double* W,
+                                        rocblas_int* info);
+
+rocblas_status rocsolver_cheevx_inplace(rocblas_handle handle,
+                                        const rocblas_evect evect,
+                                        const rocblas_erange erange,
+                                        const rocblas_fill uplo,
+                                        const rocblas_int n,
+                                        rocblas_float_complex* A,
+                                        const rocblas_int lda,
+                                        const float vl,
+                                        const float vu,
+                                        const rocblas_int il,
+                                        const rocblas_int iu,
+                                        const float abstol,
+                                        rocblas_int* nev,
+                                        float* W,
+                                        rocblas_int* info);
+
+rocblas_status rocsolver_zheevx_inplace(rocblas_handle handle,
+                                        const rocblas_evect evect,
+                                        const rocblas_erange erange,
+                                        const rocblas_fill uplo,
+                                        const rocblas_int n,
+                                        rocblas_double_complex* A,
+                                        const rocblas_int lda,
+                                        const double vl,
+                                        const double vu,
+                                        const rocblas_int il,
+                                        const rocblas_int iu,
+                                        const double abstol,
+                                        rocblas_int* nev,
+                                        double* W,
+                                        rocblas_int* info);
+
 #ifdef __cplusplus
 }
 #endif
@@ -5897,7 +5961,8 @@ inline rocblas_status rocsolver_syevx_heevx_inplace(bool STRIDED,
 {
     return STRIDED
         ? rocblas_status_not_implemented // rocsolver_ssyevx_inplace_strided_batched(handle, evect, erange, uplo, n, A, lda, stA, vl, vu, il, iu, abstol, nev, W, stW, info, bc)
-        : rocblas_status_not_implemented; // rocsolver_ssyevx_inplace(handle, evect, erange, uplo, n, A, lda, vl, vu, il, iu, abstol, nev, W, info);
+        : rocsolver_ssyevx_inplace(handle, evect, erange, uplo, n, A, lda, vl, vu, il, iu, abstol,
+                                   nev, W, info);
 }
 
 inline rocblas_status rocsolver_syevx_heevx_inplace(bool STRIDED,
@@ -5922,7 +5987,8 @@ inline rocblas_status rocsolver_syevx_heevx_inplace(bool STRIDED,
 {
     return STRIDED
         ? rocblas_status_not_implemented // rocsolver_dsyevx_inplace_strided_batched(handle, evect, erange, uplo, n, A, lda, stA, vl, vu, il, iu, abstol, nev, W, stW, info, bc)
-        : rocblas_status_not_implemented; // rocsolver_dsyevx_inplace(handle, evect, erange, uplo, n, A, lda, vl, vu, il, iu, abstol, nev, W, info);
+        : rocsolver_dsyevx_inplace(handle, evect, erange, uplo, n, A, lda, vl, vu, il, iu, abstol,
+                                   nev, W, info);
 }
 
 inline rocblas_status rocsolver_syevx_heevx_inplace(bool STRIDED,
@@ -5947,7 +6013,8 @@ inline rocblas_status rocsolver_syevx_heevx_inplace(bool STRIDED,
 {
     return STRIDED
         ? rocblas_status_not_implemented // rocsolver_cheevx_inplace_strided_batched(handle, evect, erange, uplo, n, A, lda, stA, vl, vu, il, iu, abstol, nev, W, stW, info, bc)
-        : rocblas_status_not_implemented; // rocsolver_cheevx_inplace(handle, evect, erange, uplo, n, A, lda, vl, vu, il, iu, abstol, nev, W, info);
+        : rocsolver_cheevx_inplace(handle, evect, erange, uplo, n, A, lda, vl, vu, il, iu, abstol,
+                                   nev, W, info);
 }
 
 inline rocblas_status rocsolver_syevx_heevx_inplace(bool STRIDED,
@@ -5972,7 +6039,8 @@ inline rocblas_status rocsolver_syevx_heevx_inplace(bool STRIDED,
 {
     return STRIDED
         ? rocblas_status_not_implemented // rocsolver_zheevx_inplace_strided_batched(handle, evect, erange, uplo, n, A, lda, stA, vl, vu, il, iu, abstol, nev, W, stW, info, bc)
-        : rocblas_status_not_implemented; // rocsolver_zheevx_inplace(handle, evect, erange, uplo, n, A, lda, vl, vu, il, iu, abstol, nev, W, info);
+        : rocsolver_zheevx_inplace(handle, evect, erange, uplo, n, A, lda, vl, vu, il, iu, abstol,
+                                   nev, W, info);
 }
 
 // batched

--- a/clients/include/rocsolver.hpp
+++ b/clients/include/rocsolver.hpp
@@ -5873,6 +5873,202 @@ inline rocblas_status rocsolver_syevx_heevx(bool STRIDED,
 }
 /********************************************************/
 
+/******************** SYEVX/HEEVX_INPLACE ********************/
+// normal and strided_batched
+inline rocblas_status rocsolver_syevx_heevx_inplace(bool STRIDED,
+                                                    rocblas_handle handle,
+                                                    rocblas_evect evect,
+                                                    rocblas_erange erange,
+                                                    rocblas_fill uplo,
+                                                    rocblas_int n,
+                                                    float* A,
+                                                    rocblas_int lda,
+                                                    rocblas_stride stA,
+                                                    float vl,
+                                                    float vu,
+                                                    rocblas_int il,
+                                                    rocblas_int iu,
+                                                    float abstol,
+                                                    rocblas_int* nev,
+                                                    float* W,
+                                                    rocblas_stride stW,
+                                                    rocblas_int* info,
+                                                    rocblas_int bc)
+{
+    return STRIDED
+        ? rocblas_status_not_implemented // rocsolver_ssyevx_inplace_strided_batched(handle, evect, erange, uplo, n, A, lda, stA, vl, vu, il, iu, abstol, nev, W, stW, info, bc)
+        : rocblas_status_not_implemented; // rocsolver_ssyevx_inplace(handle, evect, erange, uplo, n, A, lda, vl, vu, il, iu, abstol, nev, W, info);
+}
+
+inline rocblas_status rocsolver_syevx_heevx_inplace(bool STRIDED,
+                                                    rocblas_handle handle,
+                                                    rocblas_evect evect,
+                                                    rocblas_erange erange,
+                                                    rocblas_fill uplo,
+                                                    rocblas_int n,
+                                                    double* A,
+                                                    rocblas_int lda,
+                                                    rocblas_stride stA,
+                                                    double vl,
+                                                    double vu,
+                                                    rocblas_int il,
+                                                    rocblas_int iu,
+                                                    double abstol,
+                                                    rocblas_int* nev,
+                                                    double* W,
+                                                    rocblas_stride stW,
+                                                    rocblas_int* info,
+                                                    rocblas_int bc)
+{
+    return STRIDED
+        ? rocblas_status_not_implemented // rocsolver_dsyevx_inplace_strided_batched(handle, evect, erange, uplo, n, A, lda, stA, vl, vu, il, iu, abstol, nev, W, stW, info, bc)
+        : rocblas_status_not_implemented; // rocsolver_dsyevx_inplace(handle, evect, erange, uplo, n, A, lda, vl, vu, il, iu, abstol, nev, W, info);
+}
+
+inline rocblas_status rocsolver_syevx_heevx_inplace(bool STRIDED,
+                                                    rocblas_handle handle,
+                                                    rocblas_evect evect,
+                                                    rocblas_erange erange,
+                                                    rocblas_fill uplo,
+                                                    rocblas_int n,
+                                                    rocblas_float_complex* A,
+                                                    rocblas_int lda,
+                                                    rocblas_stride stA,
+                                                    float vl,
+                                                    float vu,
+                                                    rocblas_int il,
+                                                    rocblas_int iu,
+                                                    float abstol,
+                                                    rocblas_int* nev,
+                                                    float* W,
+                                                    rocblas_stride stW,
+                                                    rocblas_int* info,
+                                                    rocblas_int bc)
+{
+    return STRIDED
+        ? rocblas_status_not_implemented // rocsolver_cheevx_inplace_strided_batched(handle, evect, erange, uplo, n, A, lda, stA, vl, vu, il, iu, abstol, nev, W, stW, info, bc)
+        : rocblas_status_not_implemented; // rocsolver_cheevx_inplace(handle, evect, erange, uplo, n, A, lda, vl, vu, il, iu, abstol, nev, W, info);
+}
+
+inline rocblas_status rocsolver_syevx_heevx_inplace(bool STRIDED,
+                                                    rocblas_handle handle,
+                                                    rocblas_evect evect,
+                                                    rocblas_erange erange,
+                                                    rocblas_fill uplo,
+                                                    rocblas_int n,
+                                                    rocblas_double_complex* A,
+                                                    rocblas_int lda,
+                                                    rocblas_stride stA,
+                                                    double vl,
+                                                    double vu,
+                                                    rocblas_int il,
+                                                    rocblas_int iu,
+                                                    double abstol,
+                                                    rocblas_int* nev,
+                                                    double* W,
+                                                    rocblas_stride stW,
+                                                    rocblas_int* info,
+                                                    rocblas_int bc)
+{
+    return STRIDED
+        ? rocblas_status_not_implemented // rocsolver_zheevx_inplace_strided_batched(handle, evect, erange, uplo, n, A, lda, stA, vl, vu, il, iu, abstol, nev, W, stW, info, bc)
+        : rocblas_status_not_implemented; // rocsolver_zheevx_inplace(handle, evect, erange, uplo, n, A, lda, vl, vu, il, iu, abstol, nev, W, info);
+}
+
+// batched
+inline rocblas_status rocsolver_syevx_heevx_inplace(bool STRIDED,
+                                                    rocblas_handle handle,
+                                                    rocblas_evect evect,
+                                                    rocblas_erange erange,
+                                                    rocblas_fill uplo,
+                                                    rocblas_int n,
+                                                    float* const A[],
+                                                    rocblas_int lda,
+                                                    rocblas_stride stA,
+                                                    float vl,
+                                                    float vu,
+                                                    rocblas_int il,
+                                                    rocblas_int iu,
+                                                    float abstol,
+                                                    rocblas_int* nev,
+                                                    float* W,
+                                                    rocblas_stride stW,
+                                                    rocblas_int* info,
+                                                    rocblas_int bc)
+{
+    return rocblas_status_not_implemented; // rocsolver_ssyevx_inplace_batched(handle, evect, erange, uplo, n, A, lda, vl, vu, il, iu, abstol, nev, W, stW, info, bc);
+}
+
+inline rocblas_status rocsolver_syevx_heevx_inplace(bool STRIDED,
+                                                    rocblas_handle handle,
+                                                    rocblas_evect evect,
+                                                    rocblas_erange erange,
+                                                    rocblas_fill uplo,
+                                                    rocblas_int n,
+                                                    double* const A[],
+                                                    rocblas_int lda,
+                                                    rocblas_stride stA,
+                                                    double vl,
+                                                    double vu,
+                                                    rocblas_int il,
+                                                    rocblas_int iu,
+                                                    double abstol,
+                                                    rocblas_int* nev,
+                                                    double* W,
+                                                    rocblas_stride stW,
+                                                    rocblas_int* info,
+                                                    rocblas_int bc)
+{
+    return rocblas_status_not_implemented; // rocsolver_dsyevx_inplace_batched(handle, evect, erange, uplo, n, A, lda, vl, vu, il, iu, abstol, nev, W, stW, info, bc);
+}
+
+inline rocblas_status rocsolver_syevx_heevx_inplace(bool STRIDED,
+                                                    rocblas_handle handle,
+                                                    rocblas_evect evect,
+                                                    rocblas_erange erange,
+                                                    rocblas_fill uplo,
+                                                    rocblas_int n,
+                                                    rocblas_float_complex* const A[],
+                                                    rocblas_int lda,
+                                                    rocblas_stride stA,
+                                                    float vl,
+                                                    float vu,
+                                                    rocblas_int il,
+                                                    rocblas_int iu,
+                                                    float abstol,
+                                                    rocblas_int* nev,
+                                                    float* W,
+                                                    rocblas_stride stW,
+                                                    rocblas_int* info,
+                                                    rocblas_int bc)
+{
+    return rocblas_status_not_implemented; // rocsolver_cheevx_inplace_batched(handle, evect, erange, uplo, n, A, lda, vl, vu, il, iu, abstol, nev, W, stW, info, bc);
+}
+
+inline rocblas_status rocsolver_syevx_heevx_inplace(bool STRIDED,
+                                                    rocblas_handle handle,
+                                                    rocblas_evect evect,
+                                                    rocblas_erange erange,
+                                                    rocblas_fill uplo,
+                                                    rocblas_int n,
+                                                    rocblas_double_complex* const A[],
+                                                    rocblas_int lda,
+                                                    rocblas_stride stA,
+                                                    double vl,
+                                                    double vu,
+                                                    rocblas_int il,
+                                                    rocblas_int iu,
+                                                    double abstol,
+                                                    rocblas_int* nev,
+                                                    double* W,
+                                                    rocblas_stride stW,
+                                                    rocblas_int* info,
+                                                    rocblas_int bc)
+{
+    return rocblas_status_not_implemented; // rocsolver_zheevx_inplace_batched(handle, evect, erange, uplo, n, A, lda, vl, vu, il, iu, abstol, nev, W, stW, info, bc);
+}
+/********************************************************/
+
 /******************** SYGV_HEGV ********************/
 // normal and strided_batched
 inline rocblas_status rocsolver_sygv_hegv(bool STRIDED,

--- a/clients/include/testing_syevx_heevx.hpp
+++ b/clients/include/testing_syevx_heevx.hpp
@@ -723,9 +723,9 @@ void testing_syevx_heevx(Arguments& argus)
             if(BATCHED)
             {
                 rocsolver_bench_output("evect", "erange", "uplo", "n", "lda", "vl", "vu", "il",
-                                       "iu", "abstol", "strideW", "strideF", "ldz", "batch_c");
+                                       "iu", "abstol", "strideW", "ldz", "strideF", "batch_c");
                 rocsolver_bench_output(evectC, erangeC, uploC, n, lda, vl, vu, il, iu, abstol, stW,
-                                       stF, ldz, bc);
+                                       ldz, stF, bc);
             }
             else if(STRIDED)
             {

--- a/clients/include/testing_syevx_heevx_inplace.hpp
+++ b/clients/include/testing_syevx_heevx_inplace.hpp
@@ -25,7 +25,7 @@ void syevx_heevx_inplace_checkBadArgs(const rocblas_handle handle,
                                       const rocblas_int il,
                                       const rocblas_int iu,
                                       const SS abstol,
-                                      U dNev,
+                                      U hNev,
                                       S dW,
                                       const rocblas_stride stW,
                                       U dinfo,
@@ -33,53 +33,53 @@ void syevx_heevx_inplace_checkBadArgs(const rocblas_handle handle,
 {
     // handle
     EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, nullptr, evect, erange, uplo, n,
-                                                        dA, lda, stA, vl, vu, il, iu, abstol, dNev,
+                                                        dA, lda, stA, vl, vu, il, iu, abstol, hNev,
                                                         dW, stW, dinfo, bc),
                           rocblas_status_invalid_handle);
 
     // values
     EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, handle, rocblas_evect(-1), erange,
                                                         uplo, n, dA, lda, stA, vl, vu, il, iu,
-                                                        abstol, dNev, dW, stW, dinfo, bc),
+                                                        abstol, hNev, dW, stW, dinfo, bc),
                           rocblas_status_invalid_value);
     EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, rocblas_erange(-1),
                                                         uplo, n, dA, lda, stA, vl, vu, il, iu,
-                                                        abstol, dNev, dW, stW, dinfo, bc),
+                                                        abstol, hNev, dW, stW, dinfo, bc),
                           rocblas_status_invalid_value);
     EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, erange,
                                                         rocblas_fill_full, n, dA, lda, stA, vl, vu,
-                                                        il, iu, abstol, dNev, dW, stW, dinfo, bc),
+                                                        il, iu, abstol, hNev, dW, stW, dinfo, bc),
                           rocblas_status_invalid_value);
 
     // sizes (only check batch_count if applicable)
     if(STRIDED)
         EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, erange, uplo, n,
                                                             dA, lda, stA, vl, vu, il, iu, abstol,
-                                                            dNev, dW, stW, dinfo, -1),
+                                                            hNev, dW, stW, dinfo, -1),
                               rocblas_status_invalid_size);
 
     // pointers
     EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, erange, uplo, n,
                                                         (T) nullptr, lda, stA, vl, vu, il, iu,
-                                                        abstol, dNev, dW, stW, dinfo, bc),
+                                                        abstol, hNev, dW, stW, dinfo, bc),
                           rocblas_status_invalid_pointer);
     EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, erange, uplo, n, dA,
                                                         lda, stA, vl, vu, il, iu, abstol,
                                                         (U) nullptr, dW, stW, dinfo, bc),
                           rocblas_status_invalid_pointer);
     EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, erange, uplo, n, dA,
-                                                        lda, stA, vl, vu, il, iu, abstol, dNev,
+                                                        lda, stA, vl, vu, il, iu, abstol, hNev,
                                                         (S) nullptr, stW, dinfo, bc),
                           rocblas_status_invalid_pointer);
     EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, erange, uplo, n, dA,
-                                                        lda, stA, vl, vu, il, iu, abstol, dNev, dW,
+                                                        lda, stA, vl, vu, il, iu, abstol, hNev, dW,
                                                         stW, (U) nullptr, bc),
                           rocblas_status_invalid_pointer);
 
     // quick return with invalid pointers
     EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, erange, uplo, 0,
                                                         (T) nullptr, lda, stA, vl, vu, il, iu,
-                                                        abstol, dNev, (S) nullptr, stW, dinfo, bc),
+                                                        abstol, hNev, (S) nullptr, stW, dinfo, bc),
                           rocblas_status_success);
 
     // quick return with zero batch_count if applicable
@@ -117,16 +117,15 @@ void testing_syevx_heevx_inplace_bad_arg()
         // memory allocations
         device_batch_vector<T> dA(1, 1, 1);
         device_strided_batch_vector<S> dW(1, 1, 1, 1);
-        device_strided_batch_vector<rocblas_int> dNev(1, 1, 1, 1);
+        host_strided_batch_vector<rocblas_int> hNev(1, 1, 1, 1);
         device_strided_batch_vector<rocblas_int> dinfo(1, 1, 1, 1);
         CHECK_HIP_ERROR(dA.memcheck());
         CHECK_HIP_ERROR(dW.memcheck());
-        CHECK_HIP_ERROR(dNev.memcheck());
         CHECK_HIP_ERROR(dinfo.memcheck());
 
         // check bad arguments
         syevx_heevx_inplace_checkBadArgs<STRIDED>(handle, evect, erange, uplo, n, dA.data(), lda,
-                                                  stA, vl, vu, il, iu, abstol, dNev.data(),
+                                                  stA, vl, vu, il, iu, abstol, hNev.data(),
                                                   dW.data(), stW, dinfo.data(), bc);
     }
     else
@@ -134,16 +133,15 @@ void testing_syevx_heevx_inplace_bad_arg()
         // memory allocations
         device_strided_batch_vector<T> dA(1, 1, 1, 1);
         device_strided_batch_vector<S> dW(1, 1, 1, 1);
-        device_strided_batch_vector<rocblas_int> dNev(1, 1, 1, 1);
+        host_strided_batch_vector<rocblas_int> hNev(1, 1, 1, 1);
         device_strided_batch_vector<rocblas_int> dinfo(1, 1, 1, 1);
         CHECK_HIP_ERROR(dA.memcheck());
         CHECK_HIP_ERROR(dW.memcheck());
-        CHECK_HIP_ERROR(dNev.memcheck());
         CHECK_HIP_ERROR(dinfo.memcheck());
 
         // check bad arguments
         syevx_heevx_inplace_checkBadArgs<STRIDED>(handle, evect, erange, uplo, n, dA.data(), lda,
-                                                  stA, vl, vu, il, iu, abstol, dNev.data(),
+                                                  stA, vl, vu, il, iu, abstol, hNev.data(),
                                                   dW.data(), stW, dinfo.data(), bc);
     }
 }
@@ -210,7 +208,7 @@ void syevx_heevx_inplace_getError(const rocblas_handle handle,
                                   const rocblas_int il,
                                   const rocblas_int iu,
                                   const S abstol,
-                                  Id& dNev,
+                                  Ih& hNevRes,
                                   Sd& dW,
                                   const rocblas_stride stW,
                                   Id& dinfo,
@@ -218,7 +216,6 @@ void syevx_heevx_inplace_getError(const rocblas_handle handle,
                                   Th& hA,
                                   Th& hARes,
                                   Ih& hNev,
-                                  Ih& hNevRes,
                                   Sh& hW,
                                   Sh& hWRes,
                                   Ih& hinfo,
@@ -244,11 +241,10 @@ void syevx_heevx_inplace_getError(const rocblas_handle handle,
 
     // execute computations
     // GPU lapack
-    CHECK_ROCBLAS_ERROR(rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, erange, uplo, n,
-                                                      dA.data(), lda, stA, vl, vu, il, iu, abstol,
-                                                      dNev.data(), dW.data(), stW, dinfo.data(), bc));
+    CHECK_ROCBLAS_ERROR(rocsolver_syevx_heevx_inplace(
+        STRIDED, handle, evect, erange, uplo, n, dA.data(), lda, stA, vl, vu, il, iu, abstol,
+        hNevRes.data(), dW.data(), stW, dinfo.data(), bc));
 
-    CHECK_HIP_ERROR(hNevRes.transfer_from(dNev));
     CHECK_HIP_ERROR(hWRes.transfer_from(dW));
     CHECK_HIP_ERROR(hinfoRes.transfer_from(dinfo));
     if(evect == rocblas_evect_original)
@@ -331,7 +327,7 @@ void syevx_heevx_inplace_getPerfData(const rocblas_handle handle,
                                      const rocblas_int il,
                                      const rocblas_int iu,
                                      const S abstol,
-                                     Id& dNev,
+                                     Ih& hNevRes,
                                      Sd& dW,
                                      const rocblas_stride stW,
                                      Id& dinfo,
@@ -386,7 +382,7 @@ void syevx_heevx_inplace_getPerfData(const rocblas_handle handle,
 
         CHECK_ROCBLAS_ERROR(rocsolver_syevx_heevx_inplace(
             STRIDED, handle, evect, erange, uplo, n, dA.data(), lda, stA, vl, vu, il, iu, abstol,
-            dNev.data(), dW.data(), stW, dinfo.data(), bc));
+            hNevRes.data(), dW.data(), stW, dinfo.data(), bc));
     }
 
     // gpu-lapack performance
@@ -410,7 +406,7 @@ void syevx_heevx_inplace_getPerfData(const rocblas_handle handle,
 
         start = get_time_us_sync(stream);
         rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, erange, uplo, n, dA.data(), lda, stA,
-                                      vl, vu, il, iu, abstol, dNev.data(), dW.data(), stW,
+                                      vl, vu, il, iu, abstol, hNevRes.data(), dW.data(), stW,
                                       dinfo.data(), bc);
         *gpu_time_used += get_time_us_sync(stream) - start;
     }
@@ -532,10 +528,8 @@ void testing_syevx_heevx_inplace(Arguments& argus)
     host_strided_batch_vector<rocblas_int> hinfo(1, 1, 1, bc);
     host_strided_batch_vector<rocblas_int> hinfoRes(1, 1, 1, bc);
     // device
-    device_strided_batch_vector<rocblas_int> dNev(1, 1, 1, bc);
     device_strided_batch_vector<S> dW(size_W, 1, stW, bc);
     device_strided_batch_vector<rocblas_int> dinfo(1, 1, 1, bc);
-    CHECK_HIP_ERROR(dNev.memcheck());
     if(size_W)
         CHECK_HIP_ERROR(dW.memcheck());
     CHECK_HIP_ERROR(dinfo.memcheck());
@@ -554,7 +548,7 @@ void testing_syevx_heevx_inplace(Arguments& argus)
         {
             EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, erange,
                                                                 uplo, n, dA.data(), lda, stA, vl,
-                                                                vu, il, iu, abstol, dNev.data(),
+                                                                vu, il, iu, abstol, hNevRes.data(),
                                                                 dW.data(), stW, dinfo.data(), bc),
                                   rocblas_status_success);
             if(argus.timing)
@@ -567,16 +561,16 @@ void testing_syevx_heevx_inplace(Arguments& argus)
         if(argus.unit_check || argus.norm_check)
         {
             syevx_heevx_inplace_getError<STRIDED, T>(
-                handle, evect, erange, uplo, n, dA, lda, stA, vl, vu, il, iu, abstol, dNev, dW, stW,
-                dinfo, bc, hA, hARes, hNev, hNevRes, hW, hWres, hinfo, hinfoRes, &max_error);
+                handle, evect, erange, uplo, n, dA, lda, stA, vl, vu, il, iu, abstol, hNevRes, dW,
+                stW, dinfo, bc, hA, hARes, hNev, hW, hWres, hinfo, hinfoRes, &max_error);
         }
 
         // collect performance data
         if(argus.timing)
         {
             syevx_heevx_inplace_getPerfData<STRIDED, T>(
-                handle, evect, erange, uplo, n, dA, lda, stA, vl, vu, il, iu, abstol, dNev, dW, stW,
-                dinfo, bc, hA, hNev, hW, hinfo, &gpu_time_used, &cpu_time_used, hot_calls,
+                handle, evect, erange, uplo, n, dA, lda, stA, vl, vu, il, iu, abstol, hNevRes, dW,
+                stW, dinfo, bc, hA, hNev, hW, hinfo, &gpu_time_used, &cpu_time_used, hot_calls,
                 argus.profile, argus.profile_kernels, argus.perf);
         }
     }
@@ -595,7 +589,7 @@ void testing_syevx_heevx_inplace(Arguments& argus)
         {
             EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, erange,
                                                                 uplo, n, dA.data(), lda, stA, vl,
-                                                                vu, il, iu, abstol, dNev.data(),
+                                                                vu, il, iu, abstol, hNevRes.data(),
                                                                 dW.data(), stW, dinfo.data(), bc),
                                   rocblas_status_success);
             if(argus.timing)
@@ -608,16 +602,16 @@ void testing_syevx_heevx_inplace(Arguments& argus)
         if(argus.unit_check || argus.norm_check)
         {
             syevx_heevx_inplace_getError<STRIDED, T>(
-                handle, evect, erange, uplo, n, dA, lda, stA, vl, vu, il, iu, abstol, dNev, dW, stW,
-                dinfo, bc, hA, hARes, hNev, hNevRes, hW, hWres, hinfo, hinfoRes, &max_error);
+                handle, evect, erange, uplo, n, dA, lda, stA, vl, vu, il, iu, abstol, hNevRes, dW,
+                stW, dinfo, bc, hA, hARes, hNev, hW, hWres, hinfo, hinfoRes, &max_error);
         }
 
         // collect performance data
         if(argus.timing)
         {
             syevx_heevx_inplace_getPerfData<STRIDED, T>(
-                handle, evect, erange, uplo, n, dA, lda, stA, vl, vu, il, iu, abstol, dNev, dW, stW,
-                dinfo, bc, hA, hNev, hW, hinfo, &gpu_time_used, &cpu_time_used, hot_calls,
+                handle, evect, erange, uplo, n, dA, lda, stA, vl, vu, il, iu, abstol, hNevRes, dW,
+                stW, dinfo, bc, hA, hNev, hW, hinfo, &gpu_time_used, &cpu_time_used, hot_calls,
                 argus.profile, argus.profile_kernels, argus.perf);
         }
     }

--- a/clients/include/testing_syevx_heevx_inplace.hpp
+++ b/clients/include/testing_syevx_heevx_inplace.hpp
@@ -1,0 +1,680 @@
+/* ************************************************************************
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#pragma once
+
+#include "clientcommon.hpp"
+#include "lapack_host_reference.hpp"
+#include "norm.hpp"
+#include "rocsolver.hpp"
+#include "rocsolver_arguments.hpp"
+#include "rocsolver_test.hpp"
+
+template <bool STRIDED, typename T, typename S, typename SS, typename U>
+void syevx_heevx_inplace_checkBadArgs(const rocblas_handle handle,
+                                      const rocblas_evect evect,
+                                      const rocblas_erange erange,
+                                      const rocblas_fill uplo,
+                                      const rocblas_int n,
+                                      T dA,
+                                      const rocblas_int lda,
+                                      const rocblas_stride stA,
+                                      const SS vl,
+                                      const SS vu,
+                                      const rocblas_int il,
+                                      const rocblas_int iu,
+                                      const SS abstol,
+                                      U dNev,
+                                      S dW,
+                                      const rocblas_stride stW,
+                                      U dinfo,
+                                      const rocblas_int bc)
+{
+    // handle
+    EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, nullptr, evect, erange, uplo, n,
+                                                        dA, lda, stA, vl, vu, il, iu, abstol, dNev,
+                                                        dW, stW, dinfo, bc),
+                          rocblas_status_invalid_handle);
+
+    // values
+    EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, handle, rocblas_evect(-1), erange,
+                                                        uplo, n, dA, lda, stA, vl, vu, il, iu,
+                                                        abstol, dNev, dW, stW, dinfo, bc),
+                          rocblas_status_invalid_value);
+    EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, rocblas_erange(-1),
+                                                        uplo, n, dA, lda, stA, vl, vu, il, iu,
+                                                        abstol, dNev, dW, stW, dinfo, bc),
+                          rocblas_status_invalid_value);
+    EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, erange,
+                                                        rocblas_fill_full, n, dA, lda, stA, vl, vu,
+                                                        il, iu, abstol, dNev, dW, stW, dinfo, bc),
+                          rocblas_status_invalid_value);
+
+    // sizes (only check batch_count if applicable)
+    if(STRIDED)
+        EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, erange, uplo, n,
+                                                            dA, lda, stA, vl, vu, il, iu, abstol,
+                                                            dNev, dW, stW, dinfo, -1),
+                              rocblas_status_invalid_size);
+
+    // pointers
+    EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, erange, uplo, n,
+                                                        (T) nullptr, lda, stA, vl, vu, il, iu,
+                                                        abstol, dNev, dW, stW, dinfo, bc),
+                          rocblas_status_invalid_pointer);
+    EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, erange, uplo, n, dA,
+                                                        lda, stA, vl, vu, il, iu, abstol,
+                                                        (U) nullptr, dW, stW, dinfo, bc),
+                          rocblas_status_invalid_pointer);
+    EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, erange, uplo, n, dA,
+                                                        lda, stA, vl, vu, il, iu, abstol, dNev,
+                                                        (S) nullptr, stW, dinfo, bc),
+                          rocblas_status_invalid_pointer);
+    EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, erange, uplo, n, dA,
+                                                        lda, stA, vl, vu, il, iu, abstol, dNev, dW,
+                                                        stW, (U) nullptr, bc),
+                          rocblas_status_invalid_pointer);
+
+    // quick return with invalid pointers
+    EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, erange, uplo, 0,
+                                                        (T) nullptr, lda, stA, vl, vu, il, iu,
+                                                        abstol, dNev, (S) nullptr, stW, dinfo, bc),
+                          rocblas_status_success);
+
+    // quick return with zero batch_count if applicable
+    if(STRIDED)
+        EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, erange, uplo, n,
+                                                            dA, lda, stA, vl, vu, il, iu, abstol,
+                                                            (U) nullptr, dW, stW, (U) nullptr, 0),
+                              rocblas_status_success);
+}
+
+template <bool BATCHED, bool STRIDED, typename T>
+void testing_syevx_heevx_inplace_bad_arg()
+{
+    using S = decltype(std::real(T{}));
+
+    // safe arguments
+    rocblas_local_handle handle;
+    rocblas_evect evect = rocblas_evect_original;
+    rocblas_erange erange = rocblas_erange_value;
+    rocblas_fill uplo = rocblas_fill_lower;
+    rocblas_int n = 1;
+    rocblas_int lda = 1;
+    rocblas_stride stA = 1;
+    rocblas_stride stW = 1;
+    rocblas_int bc = 1;
+
+    S vl = 0.0;
+    S vu = 1.0;
+    rocblas_int il = 0;
+    rocblas_int iu = 0;
+    S abstol = 0;
+
+    if(BATCHED)
+    {
+        // memory allocations
+        device_batch_vector<T> dA(1, 1, 1);
+        device_strided_batch_vector<S> dW(1, 1, 1, 1);
+        device_strided_batch_vector<rocblas_int> dNev(1, 1, 1, 1);
+        device_strided_batch_vector<rocblas_int> dinfo(1, 1, 1, 1);
+        CHECK_HIP_ERROR(dA.memcheck());
+        CHECK_HIP_ERROR(dW.memcheck());
+        CHECK_HIP_ERROR(dNev.memcheck());
+        CHECK_HIP_ERROR(dinfo.memcheck());
+
+        // check bad arguments
+        syevx_heevx_inplace_checkBadArgs<STRIDED>(handle, evect, erange, uplo, n, dA.data(), lda,
+                                                  stA, vl, vu, il, iu, abstol, dNev.data(),
+                                                  dW.data(), stW, dinfo.data(), bc);
+    }
+    else
+    {
+        // memory allocations
+        device_strided_batch_vector<T> dA(1, 1, 1, 1);
+        device_strided_batch_vector<S> dW(1, 1, 1, 1);
+        device_strided_batch_vector<rocblas_int> dNev(1, 1, 1, 1);
+        device_strided_batch_vector<rocblas_int> dinfo(1, 1, 1, 1);
+        CHECK_HIP_ERROR(dA.memcheck());
+        CHECK_HIP_ERROR(dW.memcheck());
+        CHECK_HIP_ERROR(dNev.memcheck());
+        CHECK_HIP_ERROR(dinfo.memcheck());
+
+        // check bad arguments
+        syevx_heevx_inplace_checkBadArgs<STRIDED>(handle, evect, erange, uplo, n, dA.data(), lda,
+                                                  stA, vl, vu, il, iu, abstol, dNev.data(),
+                                                  dW.data(), stW, dinfo.data(), bc);
+    }
+}
+
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void syevx_heevx_inplace_initData(const rocblas_handle handle,
+                                  const rocblas_evect evect,
+                                  const rocblas_int n,
+                                  Td& dA,
+                                  const rocblas_int lda,
+                                  const rocblas_int bc,
+                                  Th& hA,
+                                  std::vector<T>& A,
+                                  bool test = true)
+{
+    if(CPU)
+    {
+        rocblas_init<T>(hA, true);
+
+        // scale A to avoid singularities
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            for(rocblas_int i = 0; i < n; i++)
+            {
+                for(rocblas_int j = 0; j < n; j++)
+                {
+                    if(i == j)
+                        hA[b][i + j * lda] += 400;
+                    else
+                        hA[b][i + j * lda] -= 5;
+                }
+            }
+
+            // make copy of original data to test vectors if required
+            if(test && evect == rocblas_evect_original)
+            {
+                for(rocblas_int i = 0; i < n; i++)
+                {
+                    for(rocblas_int j = 0; j < n; j++)
+                        A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
+                }
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+    }
+}
+
+template <bool STRIDED, typename T, typename S, typename Sd, typename Td, typename Id, typename Sh, typename Th, typename Ih>
+void syevx_heevx_inplace_getError(const rocblas_handle handle,
+                                  const rocblas_evect evect,
+                                  const rocblas_erange erange,
+                                  const rocblas_fill uplo,
+                                  const rocblas_int n,
+                                  Td& dA,
+                                  const rocblas_int lda,
+                                  const rocblas_stride stA,
+                                  const S vl,
+                                  const S vu,
+                                  const rocblas_int il,
+                                  const rocblas_int iu,
+                                  const S abstol,
+                                  Id& dNev,
+                                  Sd& dW,
+                                  const rocblas_stride stW,
+                                  Id& dinfo,
+                                  const rocblas_int bc,
+                                  Th& hA,
+                                  Th& hARes,
+                                  Ih& hNev,
+                                  Ih& hNevRes,
+                                  Sh& hW,
+                                  Sh& hWRes,
+                                  Ih& hinfo,
+                                  Ih& hinfoRes,
+                                  double* max_err)
+{
+    constexpr bool COMPLEX = is_complex<T>;
+
+    int lwork = !COMPLEX ? 35 * n : 33 * n;
+    int lrwork = !COMPLEX ? 0 : 7 * n;
+    int liwork = 5 * n;
+    int ldz = n;
+
+    std::vector<T> work(lwork);
+    std::vector<S> rwork(lrwork);
+    std::vector<int> iwork(liwork);
+    std::vector<T> A(lda * n * bc);
+    std::vector<T> Z(ldz * n);
+    std::vector<int> ifail(n);
+
+    // input data initialization
+    syevx_heevx_inplace_initData<true, true, T>(handle, evect, n, dA, lda, bc, hA, A);
+
+    // execute computations
+    // GPU lapack
+    CHECK_ROCBLAS_ERROR(rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, erange, uplo, n,
+                                                      dA.data(), lda, stA, vl, vu, il, iu, abstol,
+                                                      dNev.data(), dW.data(), stW, dinfo.data(), bc));
+
+    CHECK_HIP_ERROR(hNevRes.transfer_from(dNev));
+    CHECK_HIP_ERROR(hWRes.transfer_from(dW));
+    CHECK_HIP_ERROR(hinfoRes.transfer_from(dinfo));
+    if(evect == rocblas_evect_original)
+        CHECK_HIP_ERROR(hARes.transfer_from(dA));
+
+    // CPU lapack
+    // abstol = 0 ensures max accuracy in rocsolver; for lapack we should use 2*safemin
+    S atol = (abstol == 0) ? 2 * get_safemin<S>() : abstol;
+    for(rocblas_int b = 0; b < bc; ++b)
+        cblas_syevx_heevx<T>(evect, erange, uplo, n, hA[b], lda, vl, vu, il, iu, atol, hNev[b],
+                             hW[b], Z.data(), ldz, work.data(), lwork, rwork.data(), iwork.data(),
+                             ifail.data(), hinfo[b]);
+
+    // Check info for non-convergence
+    *max_err = 0;
+    for(rocblas_int b = 0; b < bc; ++b)
+        if(hinfo[b][0] != hinfoRes[b][0])
+            *max_err += 1;
+
+    // Check number of returned eigenvalues
+    double err = 0;
+    for(rocblas_int b = 0; b < bc; ++b)
+        if(hNev[b][0] != hNevRes[b][0])
+            err++;
+    *max_err = err > *max_err ? err : *max_err;
+
+    // (We expect the used input matrices to always converge. Testing
+    // implicitly the equivalent non-converged matrix is very complicated and it boils
+    // down to essentially run the algorithm again and until convergence is achieved).
+
+    for(rocblas_int b = 0; b < bc; ++b)
+    {
+        if(evect != rocblas_evect_original)
+        {
+            // only eigenvalues needed; can compare with LAPACK
+
+            // error is ||hW - hWRes|| / ||hW||
+            // using frobenius norm
+            if(hinfo[b][0] == 0)
+                err = norm_error('F', 1, hNev[b][0], 1, hW[b], hWRes[b]);
+            *max_err = err > *max_err ? err : *max_err;
+        }
+        else
+        {
+            // both eigenvalues and eigenvectors needed; need to implicitly test
+            // eigenvectors due to non-uniqueness of eigenvectors under scaling
+            if(hinfo[b][0] == 0)
+            {
+                // multiply A with each of the nev eigenvectors and divide by corresponding
+                // eigenvalues
+                T alpha;
+                T beta = 0;
+                for(int j = 0; j < hNev[b][0]; j++)
+                {
+                    alpha = T(1) / hWRes[b][j];
+                    cblas_symv_hemv(uplo, n, alpha, A.data() + b * lda * n, lda, hARes[b] + j * lda,
+                                    1, beta, hA[b] + j * lda, 1);
+                }
+
+                // error is ||hZ - hZRes|| / ||hZ||
+                // using frobenius norm
+                err = norm_error('F', n, hNev[b][0], lda, hA[b], hARes[b]);
+                *max_err = err > *max_err ? err : *max_err;
+            }
+        }
+    }
+}
+
+template <bool STRIDED, typename T, typename S, typename Sd, typename Td, typename Id, typename Sh, typename Th, typename Ih>
+void syevx_heevx_inplace_getPerfData(const rocblas_handle handle,
+                                     const rocblas_evect evect,
+                                     const rocblas_erange erange,
+                                     const rocblas_fill uplo,
+                                     const rocblas_int n,
+                                     Td& dA,
+                                     const rocblas_int lda,
+                                     const rocblas_stride stA,
+                                     const S vl,
+                                     const S vu,
+                                     const rocblas_int il,
+                                     const rocblas_int iu,
+                                     const S abstol,
+                                     Id& dNev,
+                                     Sd& dW,
+                                     const rocblas_stride stW,
+                                     Id& dinfo,
+                                     const rocblas_int bc,
+                                     Th& hA,
+                                     Ih& hNev,
+                                     Sh& hW,
+                                     Ih& hinfo,
+                                     double* gpu_time_used,
+                                     double* cpu_time_used,
+                                     const rocblas_int hot_calls,
+                                     const int profile,
+                                     const bool profile_kernels,
+                                     const bool perf)
+{
+    constexpr bool COMPLEX = is_complex<T>;
+
+    int lwork = !COMPLEX ? 35 * n : 33 * n;
+    int lrwork = !COMPLEX ? 0 : 7 * n;
+    int liwork = 5 * n;
+    int ldz = n;
+
+    std::vector<T> work(lwork);
+    std::vector<S> rwork(lrwork);
+    std::vector<int> iwork(liwork);
+    std::vector<T> A;
+    std::vector<T> Z(ldz * n);
+    std::vector<int> ifail(n);
+
+    // abstol = 0 ensures max accuracy in rocsolver; for lapack we should use 2*safemin
+    S atol = (abstol == 0) ? 2 * get_safemin<S>() : abstol;
+
+    if(!perf)
+    {
+        syevx_heevx_inplace_initData<true, false, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
+
+        // cpu-lapack performance (only if not in perf mode)
+        *cpu_time_used = get_time_us_no_sync();
+        for(rocblas_int b = 0; b < bc; ++b)
+            cblas_syevx_heevx<T>(evect, erange, uplo, n, hA[b], lda, vl, vu, il, iu, atol, hNev[b],
+                                 hW[b], Z.data(), ldz, work.data(), lwork, rwork.data(),
+                                 iwork.data(), ifail.data(), hinfo[b]);
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
+    }
+
+    syevx_heevx_inplace_initData<true, false, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
+
+    // cold calls
+    for(int iter = 0; iter < 2; iter++)
+    {
+        syevx_heevx_inplace_initData<false, true, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
+
+        CHECK_ROCBLAS_ERROR(rocsolver_syevx_heevx_inplace(
+            STRIDED, handle, evect, erange, uplo, n, dA.data(), lda, stA, vl, vu, il, iu, abstol,
+            dNev.data(), dW.data(), stW, dinfo.data(), bc));
+    }
+
+    // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
+    double start;
+
+    if(profile > 0)
+    {
+        if(profile_kernels)
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile
+                                         | rocblas_layer_mode_ex_log_kernel);
+        else
+            rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
+        rocsolver_log_set_max_levels(profile);
+    }
+
+    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    {
+        syevx_heevx_inplace_initData<false, true, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
+
+        start = get_time_us_sync(stream);
+        rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, erange, uplo, n, dA.data(), lda, stA,
+                                      vl, vu, il, iu, abstol, dNev.data(), dW.data(), stW,
+                                      dinfo.data(), bc);
+        *gpu_time_used += get_time_us_sync(stream) - start;
+    }
+    *gpu_time_used /= hot_calls;
+}
+
+template <bool BATCHED, bool STRIDED, typename T>
+void testing_syevx_heevx_inplace(Arguments& argus)
+{
+    using S = decltype(std::real(T{}));
+
+    // get arguments
+    rocblas_local_handle handle;
+    char evectC = argus.get<char>("evect");
+    char erangeC = argus.get<char>("erange");
+    char uploC = argus.get<char>("uplo");
+    rocblas_int n = argus.get<rocblas_int>("n");
+    rocblas_int lda = argus.get<rocblas_int>("lda", n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stW = argus.get<rocblas_stride>("strideW", n);
+
+    S vl = argus.get<S>("vl", 0);
+    S vu = argus.get<S>("vu", erangeC == 'V' ? 1 : 0);
+    rocblas_int il = argus.get<rocblas_int>("il", erangeC == 'I' ? 1 : 0);
+    rocblas_int iu = argus.get<rocblas_int>("iu", erangeC == 'I' ? 1 : 0);
+    S abstol = argus.get<S>("abstol", 0);
+
+    rocblas_evect evect = char2rocblas_evect(evectC);
+    rocblas_erange erange = char2rocblas_erange(erangeC);
+    rocblas_fill uplo = char2rocblas_fill(uploC);
+    rocblas_int bc = argus.batch_count;
+    rocblas_int hot_calls = argus.iters;
+
+    // check non-supported values
+    if(uplo == rocblas_fill_full || evect == rocblas_evect_tridiagonal)
+    {
+        if(BATCHED)
+            EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(
+                                      STRIDED, handle, evect, erange, uplo, n, (T* const*)nullptr,
+                                      lda, stA, vl, vu, il, iu, abstol, (rocblas_int*)nullptr,
+                                      (S*)nullptr, stW, (rocblas_int*)nullptr, bc),
+                                  rocblas_status_invalid_value);
+        else
+            EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(
+                                      STRIDED, handle, evect, erange, uplo, n, (T*)nullptr, lda,
+                                      stA, vl, vu, il, iu, abstol, (rocblas_int*)nullptr,
+                                      (S*)nullptr, stW, (rocblas_int*)nullptr, bc),
+                                  rocblas_status_invalid_value);
+
+        if(argus.timing)
+            rocsolver_bench_inform(inform_invalid_args);
+
+        return;
+    }
+
+    // determine sizes
+    size_t size_A = size_t(lda) * n;
+    size_t size_W = n;
+    size_t size_ARes = (argus.unit_check || argus.norm_check) ? size_A : 0;
+    size_t size_WRes = (argus.unit_check || argus.norm_check) ? size_W : 0;
+
+    double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
+
+    // check invalid sizes
+    bool invalid_size = (n < 0 || lda < n || bc < 0 || (erange == rocblas_erange_value && vl >= vu)
+                         || (erange == rocblas_erange_index && (il < 1 || iu < 0))
+                         || (erange == rocblas_erange_index && (iu > n || (n > 0 && il > iu))));
+    if(invalid_size)
+    {
+        if(BATCHED)
+            EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(
+                                      STRIDED, handle, evect, erange, uplo, n, (T* const*)nullptr,
+                                      lda, stA, vl, vu, il, iu, abstol, (rocblas_int*)nullptr,
+                                      (S*)nullptr, stW, (rocblas_int*)nullptr, bc),
+                                  rocblas_status_invalid_size);
+        else
+            EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(
+                                      STRIDED, handle, evect, erange, uplo, n, (T*)nullptr, lda,
+                                      stA, vl, vu, il, iu, abstol, (rocblas_int*)nullptr,
+                                      (S*)nullptr, stW, (rocblas_int*)nullptr, bc),
+                                  rocblas_status_invalid_size);
+
+        if(argus.timing)
+            rocsolver_bench_inform(inform_invalid_size);
+
+        return;
+    }
+
+    // memory size query is necessary
+    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        if(BATCHED)
+            CHECK_ALLOC_QUERY(rocsolver_syevx_heevx_inplace(
+                STRIDED, handle, evect, erange, uplo, n, (T* const*)nullptr, lda, stA, vl, vu, il,
+                iu, abstol, (rocblas_int*)nullptr, (S*)nullptr, stW, (rocblas_int*)nullptr, bc));
+        else
+            CHECK_ALLOC_QUERY(rocsolver_syevx_heevx_inplace(
+                STRIDED, handle, evect, erange, uplo, n, (T*)nullptr, lda, stA, vl, vu, il, iu,
+                abstol, (rocblas_int*)nullptr, (S*)nullptr, stW, (rocblas_int*)nullptr, bc));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+        if(argus.mem_query)
+        {
+            rocsolver_bench_inform(inform_mem_query, size);
+            return;
+        }
+
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
+    // memory allocations (all cases)
+    // host
+    host_strided_batch_vector<rocblas_int> hNev(1, 1, 1, bc);
+    host_strided_batch_vector<rocblas_int> hNevRes(1, 1, 1, bc);
+    host_strided_batch_vector<S> hW(size_W, 1, stW, bc);
+    host_strided_batch_vector<S> hWres(size_WRes, 1, stW, bc);
+    host_strided_batch_vector<rocblas_int> hinfo(1, 1, 1, bc);
+    host_strided_batch_vector<rocblas_int> hinfoRes(1, 1, 1, bc);
+    // device
+    device_strided_batch_vector<rocblas_int> dNev(1, 1, 1, bc);
+    device_strided_batch_vector<S> dW(size_W, 1, stW, bc);
+    device_strided_batch_vector<rocblas_int> dinfo(1, 1, 1, bc);
+    CHECK_HIP_ERROR(dNev.memcheck());
+    if(size_W)
+        CHECK_HIP_ERROR(dW.memcheck());
+    CHECK_HIP_ERROR(dinfo.memcheck());
+
+    if(BATCHED)
+    {
+        // memory allocations
+        host_batch_vector<T> hA(size_A, 1, bc);
+        host_batch_vector<T> hARes(size_ARes, 1, bc);
+        device_batch_vector<T> dA(size_A, 1, bc);
+        if(size_A)
+            CHECK_HIP_ERROR(dA.memcheck());
+
+        // check quick return
+        if(n == 0 || bc == 0)
+        {
+            EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, erange,
+                                                                uplo, n, dA.data(), lda, stA, vl,
+                                                                vu, il, iu, abstol, dNev.data(),
+                                                                dW.data(), stW, dinfo.data(), bc),
+                                  rocblas_status_success);
+            if(argus.timing)
+                rocsolver_bench_inform(inform_quick_return);
+
+            return;
+        }
+
+        // check computations
+        if(argus.unit_check || argus.norm_check)
+        {
+            syevx_heevx_inplace_getError<STRIDED, T>(
+                handle, evect, erange, uplo, n, dA, lda, stA, vl, vu, il, iu, abstol, dNev, dW, stW,
+                dinfo, bc, hA, hARes, hNev, hNevRes, hW, hWres, hinfo, hinfoRes, &max_error);
+        }
+
+        // collect performance data
+        if(argus.timing)
+        {
+            syevx_heevx_inplace_getPerfData<STRIDED, T>(
+                handle, evect, erange, uplo, n, dA, lda, stA, vl, vu, il, iu, abstol, dNev, dW, stW,
+                dinfo, bc, hA, hNev, hW, hinfo, &gpu_time_used, &cpu_time_used, hot_calls,
+                argus.profile, argus.profile_kernels, argus.perf);
+        }
+    }
+
+    else
+    {
+        // memory allocations
+        host_strided_batch_vector<T> hA(size_A, 1, stA, bc);
+        host_strided_batch_vector<T> hARes(size_ARes, 1, stA, bc);
+        device_strided_batch_vector<T> dA(size_A, 1, stA, bc);
+        if(size_A)
+            CHECK_HIP_ERROR(dA.memcheck());
+
+        // check quick return
+        if(n == 0 || bc == 0)
+        {
+            EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx_inplace(STRIDED, handle, evect, erange,
+                                                                uplo, n, dA.data(), lda, stA, vl,
+                                                                vu, il, iu, abstol, dNev.data(),
+                                                                dW.data(), stW, dinfo.data(), bc),
+                                  rocblas_status_success);
+            if(argus.timing)
+                rocsolver_bench_inform(inform_quick_return);
+
+            return;
+        }
+
+        // check computations
+        if(argus.unit_check || argus.norm_check)
+        {
+            syevx_heevx_inplace_getError<STRIDED, T>(
+                handle, evect, erange, uplo, n, dA, lda, stA, vl, vu, il, iu, abstol, dNev, dW, stW,
+                dinfo, bc, hA, hARes, hNev, hNevRes, hW, hWres, hinfo, hinfoRes, &max_error);
+        }
+
+        // collect performance data
+        if(argus.timing)
+        {
+            syevx_heevx_inplace_getPerfData<STRIDED, T>(
+                handle, evect, erange, uplo, n, dA, lda, stA, vl, vu, il, iu, abstol, dNev, dW, stW,
+                dinfo, bc, hA, hNev, hW, hinfo, &gpu_time_used, &cpu_time_used, hot_calls,
+                argus.profile, argus.profile_kernels, argus.perf);
+        }
+    }
+
+    // validate results for rocsolver-test
+    // using 2 * n * machine_precision as tolerance
+    if(argus.unit_check)
+        ROCSOLVER_TEST_CHECK(T, max_error, 2 * n);
+
+    // output results for rocsolver-bench
+    if(argus.timing)
+    {
+        if(!argus.perf)
+        {
+            rocsolver_bench_header("Arguments:");
+            if(BATCHED)
+            {
+                rocsolver_bench_output("evect", "erange", "uplo", "n", "lda", "vl", "vu", "il",
+                                       "iu", "abstol", "strideW", "batch_c");
+                rocsolver_bench_output(evectC, erangeC, uploC, n, lda, vl, vu, il, iu, abstol, stW,
+                                       bc);
+            }
+            else if(STRIDED)
+            {
+                rocsolver_bench_output("evect", "erange", "uplo", "n", "lda", "strideA", "vl", "vu",
+                                       "il", "iu", "abstol", "strideW", "batch_c");
+                rocsolver_bench_output(evectC, erangeC, uploC, n, lda, stA, vl, vu, il, iu, abstol,
+                                       stW, bc);
+            }
+            else
+            {
+                rocsolver_bench_output("evect", "erange", "uplo", "n", "lda", "vl", "vu", "il",
+                                       "iu", "abstol");
+                rocsolver_bench_output(evectC, erangeC, uploC, n, lda, vl, vu, il, iu, abstol);
+            }
+            rocsolver_bench_header("Results:");
+            if(argus.norm_check)
+            {
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
+                rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
+            }
+            else
+            {
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
+                rocsolver_bench_output(cpu_time_used, gpu_time_used);
+            }
+            rocsolver_bench_endl();
+        }
+        else
+        {
+            if(argus.norm_check)
+                rocsolver_bench_output(gpu_time_used, max_error);
+            else
+                rocsolver_bench_output(gpu_time_used);
+        }
+    }
+
+    // ensure all arguments were consumed
+    argus.validate_consumed();
+}

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -115,6 +115,7 @@ set(rocsolver_lapack_source
   lapack/roclapack_syevx_heevx.cpp
   lapack/roclapack_syevx_heevx_batched.cpp
   lapack/roclapack_syevx_heevx_strided_batched.cpp
+  lapack/roclapack_syevx_heevx_inplace.cpp
   lapack/roclapack_sygv_hegv.cpp
   lapack/roclapack_sygv_hegv_batched.cpp
   lapack/roclapack_sygv_hegv_strided_batched.cpp

--- a/library/src/auxiliary/rocauxiliary_stein.hpp
+++ b/library/src/auxiliary/rocauxiliary_stein.hpp
@@ -93,8 +93,9 @@ __device__ void run_stein(const int tid,
     // zero info and ifail
     if(tid == 0)
         _info = 0;
-    for(i = tid; i < nev; i += MAX_THDS)
-        ifail[i] = 0;
+    if(ifail)
+        for(i = tid; i < nev; i += MAX_THDS)
+            ifail[i] = 0;
 
     // iterate over submatrix blocks
     for(rocblas_int nblk = 0; nblk < iblock[nev - 1]; nblk++)
@@ -202,7 +203,7 @@ __device__ void run_stein(const int tid,
                     iters++;
                 }
 
-                if(tid == 0 && nrmchk < STEIN_MAX_NRMCHK)
+                if(ifail && tid == 0 && nrmchk < STEIN_MAX_NRMCHK)
                 {
                     ifail[_info] = j + 1;
                     _info++;

--- a/library/src/lapack/roclapack_syevx_heevx.hpp
+++ b/library/src/lapack/roclapack_syevx_heevx.hpp
@@ -68,7 +68,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(BS1) syevx_sort_eigs(const rocblas_int n
 
                 swap(Z[tid + i * ldz], Z[tid + j * ldz]);
 
-                if(tid < info)
+                if(ifail && tid < info)
                 {
                     if(ifail[tid] == i + 1)
                         ifail[tid] = j + 1;

--- a/library/src/lapack/roclapack_syevx_heevx_inplace.cpp
+++ b/library/src/lapack/roclapack_syevx_heevx_inplace.cpp
@@ -1,0 +1,192 @@
+/* ************************************************************************
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include "roclapack_syevx_heevx_inplace.hpp"
+
+/*
+ * ===========================================================================
+ *    syevx/heevx_inplace is not intended for inclusion in the public API. It
+ *    exists to provide a syevx/heevx method with a signature identical to
+ *    the cuSOLVER implementation, for use exclusively in hipSOLVER.
+ * ===========================================================================
+ */
+
+template <typename T, typename S, typename U>
+rocblas_status rocsolver_syevx_heevx_inplace_impl(rocblas_handle handle,
+                                                  const rocblas_evect evect,
+                                                  const rocblas_erange erange,
+                                                  const rocblas_fill uplo,
+                                                  const rocblas_int n,
+                                                  U A,
+                                                  const rocblas_int lda,
+                                                  const S vl,
+                                                  const S vu,
+                                                  const rocblas_int il,
+                                                  const rocblas_int iu,
+                                                  const S abstol,
+                                                  rocblas_int* nev,
+                                                  S* W,
+                                                  rocblas_int* info)
+{
+    const char* name = (!is_complex<T> ? "syevx_inplace" : "heevx_inplace");
+    ROCSOLVER_ENTER_TOP(name, "--evect", evect, "--erange", erange, "--uplo", uplo, "-n", n, "--lda",
+                        lda, "--vl", vl, "--vu", vu, "--il", il, "--iu", iu, "--abstol", abstol);
+
+    if(!handle)
+        return rocblas_status_invalid_handle;
+
+    // argument checking
+    rocblas_status st = rocsolver_syevx_heevx_inplace_argCheck(handle, evect, erange, uplo, n, A,
+                                                               lda, vl, vu, il, iu, nev, W, info);
+    if(st != rocblas_status_continue)
+        return st;
+
+    // working with unshifted arrays
+    rocblas_int shiftA = 0;
+
+    // normal (non-batched non-strided) execution
+    rocblas_stride strideA = 0;
+    rocblas_stride strideW = 0;
+    rocblas_int batch_count = 1;
+
+    // memory workspace sizes:
+    // size for constants in rocblas calls
+    size_t size_scalars;
+    // size of reusable workspaces (for calling SYTRD/HETRD, STEBZ, STEIN, and ORMTR/UNMTR)
+    size_t size_work1, size_work2, size_work3, size_work4, size_work5, size_work6;
+    // size for temporary arrays
+    size_t size_D, size_E, size_iblock, size_isplit, size_tau, size_nsplit_workArr;
+
+    rocsolver_syevx_heevx_inplace_getMemorySize<false, T, S>(
+        evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
+        &size_work4, &size_work5, &size_work6, &size_D, &size_E, &size_iblock, &size_isplit,
+        &size_tau, &size_nsplit_workArr);
+
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_set_optimal_device_memory_size(
+            handle, size_scalars, size_work1, size_work2, size_work3, size_work4, size_work5,
+            size_work6, size_D, size_E, size_iblock, size_isplit, size_tau, size_nsplit_workArr);
+
+    // memory workspace allocation
+    void *scalars, *work1, *work2, *work3, *work4, *work5, *work6, *D, *E, *iblock, *isplit, *tau,
+        *nsplit_workArr;
+    rocblas_device_malloc mem(handle, size_scalars, size_work1, size_work2, size_work3, size_work4,
+                              size_work5, size_work6, size_D, size_E, size_iblock, size_isplit,
+                              size_tau, size_nsplit_workArr);
+
+    if(!mem)
+        return rocblas_status_memory_error;
+
+    scalars = mem[0];
+    work1 = mem[1];
+    work2 = mem[2];
+    work3 = mem[3];
+    work4 = mem[4];
+    work5 = mem[5];
+    work6 = mem[6];
+    D = mem[7];
+    E = mem[8];
+    iblock = mem[9];
+    isplit = mem[10];
+    tau = mem[11];
+    nsplit_workArr = mem[12];
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
+
+    // execution
+    return rocsolver_syevx_heevx_inplace_template<false, false, T>(
+        handle, evect, erange, uplo, n, A, shiftA, lda, strideA, vl, vu, il, iu, abstol, nev, W,
+        strideW, info, batch_count, (T*)scalars, work1, work2, work3, work4, work5, work6, (S*)D,
+        (S*)E, (rocblas_int*)iblock, (rocblas_int*)isplit, (T*)tau, nsplit_workArr);
+}
+
+/*
+ * ===========================================================================
+ *    C wrapper
+ * ===========================================================================
+ */
+
+extern "C" {
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_ssyevx_inplace(rocblas_handle handle,
+                                                         const rocblas_evect evect,
+                                                         const rocblas_erange erange,
+                                                         const rocblas_fill uplo,
+                                                         const rocblas_int n,
+                                                         float* A,
+                                                         const rocblas_int lda,
+                                                         const float vl,
+                                                         const float vu,
+                                                         const rocblas_int il,
+                                                         const rocblas_int iu,
+                                                         const float abstol,
+                                                         rocblas_int* nev,
+                                                         float* W,
+                                                         rocblas_int* info)
+{
+    return rocsolver_syevx_heevx_inplace_impl<float>(handle, evect, erange, uplo, n, A, lda, vl, vu,
+                                                     il, iu, abstol, nev, W, info);
+}
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_dsyevx_inplace(rocblas_handle handle,
+                                                         const rocblas_evect evect,
+                                                         const rocblas_erange erange,
+                                                         const rocblas_fill uplo,
+                                                         const rocblas_int n,
+                                                         double* A,
+                                                         const rocblas_int lda,
+                                                         const double vl,
+                                                         const double vu,
+                                                         const rocblas_int il,
+                                                         const rocblas_int iu,
+                                                         const double abstol,
+                                                         rocblas_int* nev,
+                                                         double* W,
+                                                         rocblas_int* info)
+{
+    return rocsolver_syevx_heevx_inplace_impl<double>(handle, evect, erange, uplo, n, A, lda, vl,
+                                                      vu, il, iu, abstol, nev, W, info);
+}
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_cheevx_inplace(rocblas_handle handle,
+                                                         const rocblas_evect evect,
+                                                         const rocblas_erange erange,
+                                                         const rocblas_fill uplo,
+                                                         const rocblas_int n,
+                                                         rocblas_float_complex* A,
+                                                         const rocblas_int lda,
+                                                         const float vl,
+                                                         const float vu,
+                                                         const rocblas_int il,
+                                                         const rocblas_int iu,
+                                                         const float abstol,
+                                                         rocblas_int* nev,
+                                                         float* W,
+                                                         rocblas_int* info)
+{
+    return rocsolver_syevx_heevx_inplace_impl<rocblas_float_complex>(
+        handle, evect, erange, uplo, n, A, lda, vl, vu, il, iu, abstol, nev, W, info);
+}
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_zheevx_inplace(rocblas_handle handle,
+                                                         const rocblas_evect evect,
+                                                         const rocblas_erange erange,
+                                                         const rocblas_fill uplo,
+                                                         const rocblas_int n,
+                                                         rocblas_double_complex* A,
+                                                         const rocblas_int lda,
+                                                         const double vl,
+                                                         const double vu,
+                                                         const rocblas_int il,
+                                                         const rocblas_int iu,
+                                                         const double abstol,
+                                                         rocblas_int* nev,
+                                                         double* W,
+                                                         rocblas_int* info)
+{
+    return rocsolver_syevx_heevx_inplace_impl<rocblas_double_complex>(
+        handle, evect, erange, uplo, n, A, lda, vl, vu, il, iu, abstol, nev, W, info);
+}
+
+} // extern C

--- a/library/src/lapack/roclapack_syevx_heevx_inplace.hpp
+++ b/library/src/lapack/roclapack_syevx_heevx_inplace.hpp
@@ -1,0 +1,262 @@
+/************************************************************************
+ * Derived from the BSD3-licensed
+ * LAPACK routine (version 3.7.0) --
+ *     Univ. of Tennessee, Univ. of California Berkeley,
+ *     Univ. of Colorado Denver and NAG Ltd..
+ *     December 2016
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
+ * ***********************************************************************/
+
+#pragma once
+
+#include "auxiliary/rocauxiliary_ormtr_unmtr.hpp"
+#include "auxiliary/rocauxiliary_stebz.hpp"
+#include "auxiliary/rocauxiliary_stein.hpp"
+#include "rocblas.hpp"
+#include "roclapack_syevx_heevx.hpp"
+#include "roclapack_sytrd_hetrd.hpp"
+#include "rocsolver.h"
+
+/** Argument checking **/
+template <typename T, typename S>
+rocblas_status rocsolver_syevx_heevx_inplace_argCheck(rocblas_handle handle,
+                                                      const rocblas_evect evect,
+                                                      const rocblas_erange erange,
+                                                      const rocblas_fill uplo,
+                                                      const rocblas_int n,
+                                                      T A,
+                                                      const rocblas_int lda,
+                                                      const S vl,
+                                                      const S vu,
+                                                      const rocblas_int il,
+                                                      const rocblas_int iu,
+                                                      rocblas_int* nev,
+                                                      S* W,
+                                                      rocblas_int* info,
+                                                      const rocblas_int batch_count = 1)
+{
+    // order is important for unit tests:
+
+    // 1. invalid/non-supported values
+    if(evect != rocblas_evect_original && evect != rocblas_evect_none)
+        return rocblas_status_invalid_value;
+    if(erange != rocblas_erange_all && erange != rocblas_erange_value
+       && erange != rocblas_erange_index)
+        return rocblas_status_invalid_value;
+    if(uplo != rocblas_fill_lower && uplo != rocblas_fill_upper)
+        return rocblas_status_invalid_value;
+
+    // 2. invalid size
+    if(n < 0 || lda < n || batch_count < 0)
+        return rocblas_status_invalid_size;
+    if(erange == rocblas_erange_value && vl >= vu)
+        return rocblas_status_invalid_size;
+    if(erange == rocblas_erange_index && (il < 1 || iu < 0))
+        return rocblas_status_invalid_size;
+    if(erange == rocblas_erange_index && (iu > n || (n > 0 && il > iu)))
+        return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
+
+    // 3. invalid pointers
+    if((n && !A) || (n && !W) || (batch_count && !nev) || (batch_count && !info))
+        return rocblas_status_invalid_pointer;
+
+    return rocblas_status_continue;
+}
+
+/** Helper to calculate workspace sizes **/
+template <bool BATCHED, typename T, typename S>
+void rocsolver_syevx_heevx_inplace_getMemorySize(const rocblas_evect evect,
+                                                 const rocblas_fill uplo,
+                                                 const rocblas_int n,
+                                                 const rocblas_int batch_count,
+                                                 size_t* size_scalars,
+                                                 size_t* size_work1,
+                                                 size_t* size_work2,
+                                                 size_t* size_work3,
+                                                 size_t* size_work4,
+                                                 size_t* size_work5,
+                                                 size_t* size_work6,
+                                                 size_t* size_D,
+                                                 size_t* size_E,
+                                                 size_t* size_iblock,
+                                                 size_t* size_isplit,
+                                                 size_t* size_tau,
+                                                 size_t* size_nsplit_workArr)
+{
+    // if quick return, set workspace to zero
+    if(n == 0 || batch_count == 0)
+    {
+        *size_scalars = 0;
+        *size_work1 = 0;
+        *size_work2 = 0;
+        *size_work3 = 0;
+        *size_work4 = 0;
+        *size_work5 = 0;
+        *size_work6 = 0;
+        *size_D = 0;
+        *size_E = 0;
+        *size_iblock = 0;
+        *size_isplit = 0;
+        *size_tau = 0;
+        *size_nsplit_workArr = 0;
+        return;
+    }
+
+    size_t unused;
+    size_t a1 = 0, a2 = 0, a3 = 0, a4 = 0;
+    size_t b1 = 0, b2 = 0, b3 = 0, b4 = 0;
+    size_t c1 = 0, c2 = 0, c3 = 0;
+
+    // requirements for tridiagonalization (sytrd/hetrd)
+    rocsolver_sytrd_hetrd_getMemorySize<BATCHED, T>(n, batch_count, size_scalars, &a1, &b1, &c1,
+                                                    size_nsplit_workArr);
+
+    // extra requirements for computing the eigenvalues (stebz)
+    rocsolver_stebz_getMemorySize<T>(n, batch_count, &a2, &b2, &c2, size_work4, size_work5,
+                                     size_work6);
+
+    if(evect == rocblas_evect_original)
+    {
+        // extra requirements for ormtr/unmtr
+        rocsolver_ormtr_unmtr_getMemorySize<BATCHED, T>(rocblas_side_left, uplo, n, n, batch_count,
+                                                        &unused, &a3, &b3, &c3, &unused);
+
+        // extra requirements for computing the eigenvectors (stein)
+        rocsolver_stein_getMemorySize<T, S>(n, batch_count, &a4, &b4);
+
+        // extra space to store A
+        *size_work4 = max(*size_work4, sizeof(T) * n * n * batch_count);
+    }
+
+    // get max values
+    *size_work1 = std::max({a1, a2, a3, a4});
+    *size_work2 = std::max({b1, b2, b3, b4});
+    *size_work3 = std::max({c1, c2, c3});
+
+    // size of arrays for temporary tridiagonal elements
+    *size_D = sizeof(S) * n * batch_count;
+    *size_E = sizeof(S) * n * batch_count;
+
+    // size of arrays for temporary submatrix indices
+    *size_iblock = sizeof(rocblas_int) * n * batch_count;
+    *size_isplit = sizeof(rocblas_int) * n * batch_count;
+
+    // size of array for temporary householder scalars
+    *size_tau = sizeof(T) * n * batch_count;
+
+    // size of array for temporary split off block sizes
+    *size_nsplit_workArr = max(*size_nsplit_workArr, sizeof(rocblas_int) * batch_count);
+}
+
+template <bool BATCHED, bool STRIDED, typename T, typename S, typename U>
+rocblas_status rocsolver_syevx_heevx_inplace_template(rocblas_handle handle,
+                                                      const rocblas_evect evect,
+                                                      const rocblas_erange erange,
+                                                      const rocblas_fill uplo,
+                                                      const rocblas_int n,
+                                                      U A,
+                                                      const rocblas_int shiftA,
+                                                      const rocblas_int lda,
+                                                      const rocblas_stride strideA,
+                                                      const S vl,
+                                                      const S vu,
+                                                      const rocblas_int il,
+                                                      const rocblas_int iu,
+                                                      const S abstol,
+                                                      rocblas_int* nev,
+                                                      S* W,
+                                                      const rocblas_stride strideW,
+                                                      rocblas_int* info,
+                                                      const rocblas_int batch_count,
+                                                      T* scalars,
+                                                      void* work1,
+                                                      void* work2,
+                                                      void* work3,
+                                                      void* work4,
+                                                      void* work5,
+                                                      void* work6,
+                                                      S* D,
+                                                      S* E,
+                                                      rocblas_int* iblock,
+                                                      rocblas_int* isplit,
+                                                      T* tau,
+                                                      void* nsplit_workArr)
+{
+    ROCSOLVER_ENTER("syevx_heevx_inplace", "evect:", evect, "erange:", erange, "uplo:", uplo,
+                    "n:", n, "shiftA:", shiftA, "lda:", lda, "vl:", vl, "vu:", vu, "il:", il,
+                    "iu:", iu, "abstol:", abstol, "bc:", batch_count);
+
+    // quick return
+    if(batch_count == 0)
+        return rocblas_status_success;
+
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    // quick return with info = 0 and nev = 0
+    if(n == 0)
+    {
+        rocblas_int blocksReset = (batch_count - 1) / BS1 + 1;
+        dim3 gridReset(blocksReset, 1, 1);
+        dim3 threads(BS1, 1, 1);
+
+        ROCSOLVER_LAUNCH_KERNEL(reset_info, gridReset, threads, 0, stream, info, batch_count, 0);
+        ROCSOLVER_LAUNCH_KERNEL(reset_info, gridReset, threads, 0, stream, nev, batch_count, 0);
+        return rocblas_status_success;
+    }
+
+    // TODO: Scale the matrix
+
+    const rocblas_stride stride = n;
+
+    // reduce A to tridiagonal form
+    rocsolver_sytrd_hetrd_template<BATCHED, T>(handle, uplo, n, A, shiftA, lda, strideA, D, stride,
+                                               E, stride, tau, stride, batch_count, scalars,
+                                               (T*)work1, (T*)work2, (T*)work3, (T**)nsplit_workArr);
+
+    // compute eigenvalues
+    rocblas_eorder eorder
+        = (evect == rocblas_evect_none ? rocblas_eorder_entire : rocblas_eorder_blocks);
+    rocsolver_stebz_template<S>(handle, erange, eorder, n, vl, vu, il, iu, abstol, D, 0, stride, E,
+                                0, stride, nev, (rocblas_int*)nsplit_workArr, W, strideW, iblock,
+                                stride, isplit, stride, info, batch_count, (rocblas_int*)work1,
+                                (S*)work2, (S*)work3, (S*)work4, (S*)work5, (rocblas_int*)work6);
+
+    if(evect != rocblas_evect_none)
+    {
+        // kernel dimensions
+        rocblas_int blocks1 = (n - 1) / BS1 + 1;
+        rocblas_int blocks2 = (n - 1) / BS2 + 1;
+        dim3 grid1(blocks1, batch_count, 1);
+        dim3 grid2(blocks2, blocks2, batch_count);
+        dim3 threads1(BS1, 1, 1);
+        dim3 threads2(BS2, BS2, 1);
+
+        // copy A to work4
+        ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, grid2, threads2, 0, stream, copymat_to_buffer, n, n, A,
+                                shiftA, lda, strideA, (T*)work4);
+
+        // compute eigenvectors
+        rocsolver_stein_template<T>(handle, n, D, 0, stride, E, 0, stride, nev, W, 0, strideW,
+                                    iblock, stride, isplit, stride, A, shiftA, lda, strideA,
+                                    (rocblas_int*)nullptr, 0, info, batch_count, (S*)work1,
+                                    (rocblas_int*)work2);
+
+        // apply unitary matrix to eigenvectors
+        rocblas_int h_nev = (erange == rocblas_erange_index ? iu - il + 1 : n);
+        rocsolver_ormtr_unmtr_template<BATCHED, STRIDED>(
+            handle, rocblas_side_left, uplo, rocblas_operation_none, n, h_nev, (T*)work4, 0, n,
+            n * n, tau, stride, A, shiftA, lda, strideA, batch_count, scalars, (T*)work1, (T*)work2,
+            (T*)work3, (T**)nsplit_workArr);
+
+        // sort eigenvalues and eigenvectors
+        ROCSOLVER_LAUNCH_KERNEL(syevx_sort_eigs<T>, grid1, threads1, 0, stream, n, nev, W, strideW,
+                                A, shiftA, lda, strideA, (rocblas_int*)nullptr, 0, info);
+    }
+
+    return rocblas_status_success;
+}


### PR DESCRIPTION
This PR adds syevx_inplace to rocSOLVER's private API, for use by hipSOLVER.

The method and its test are largely the same as for syevx, with the following changes:
- The matrix Z is removed; eigenvectors are instead returned in the matrix A
- The array ifail is removed
- The array nev, which contains the number of returned eigenvalues/vectors, is now a host pointer rather than a device pointer. A device synchronization is required to read nev from the device (where it is calculated) to the host.