### PR TITLE
Use consistent naming for rocblas_erange and rocblas_eorder variables

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -361,7 +361,7 @@ try
             "                           ")
 
         // stebz options
-        ("order",
+        ("eorder",
          value<char>()->default_value('E'),
             "E = entire matrix, B = by blocks.\n"
             "                           Indicates whether the computed eigenvalues are ordered by blocks or for the entire matrix.\n"
@@ -387,7 +387,7 @@ try
             "                           Used in partial eigenvalue decomposition functions.\n"
             "                           ")
 
-        ("range",
+        ("erange",
          value<char>()->default_value('A'),
             "A = all eigenvalues, V = in (vl, vu], I = from the il-th to the iu-th.\n"
             "                           For partial eigenvalue decompositions, it indicates the type of interval in which\n"
@@ -502,8 +502,8 @@ try
     argus.validate_svect("right_svect");
     argus.validate_workmode("fast_alg");
     argus.validate_evect("evect");
-    argus.validate_erange("range");
-    argus.validate_eorder("order");
+    argus.validate_erange("erange");
+    argus.validate_eorder("eorder");
     argus.validate_itype("itype");
 
     // prepare logging infrastructure and ignore environment variables

--- a/clients/common/lapack_host_reference.cpp
+++ b/clients/common/lapack_host_reference.cpp
@@ -6236,8 +6236,8 @@ void cblas_stedc<rocblas_double_complex, double>(rocblas_evect evect,
 
 // stebz
 template <>
-void cblas_stebz<float>(rocblas_erange range,
-                        rocblas_eorder order,
+void cblas_stebz<float>(rocblas_erange erange,
+                        rocblas_eorder eorder,
                         rocblas_int n,
                         float vl,
                         float vu,
@@ -6255,15 +6255,15 @@ void cblas_stebz<float>(rocblas_erange range,
                         rocblas_int* iwork,
                         rocblas_int* info)
 {
-    char erangeC = rocblas2char_erange(range);
-    char eorderC = rocblas2char_eorder(order);
+    char erangeC = rocblas2char_erange(erange);
+    char eorderC = rocblas2char_eorder(eorder);
     sstebz_(&erangeC, &eorderC, &n, &vl, &vu, &il, &iu, &abstol, D, E, m, nsplit, W, iblock, isplit,
             work, iwork, info);
 }
 
 template <>
-void cblas_stebz<double>(rocblas_erange range,
-                         rocblas_eorder order,
+void cblas_stebz<double>(rocblas_erange erange,
+                         rocblas_eorder eorder,
                          rocblas_int n,
                          double vl,
                          double vu,
@@ -6281,8 +6281,8 @@ void cblas_stebz<double>(rocblas_erange range,
                          rocblas_int* iwork,
                          rocblas_int* info)
 {
-    char erangeC = rocblas2char_erange(range);
-    char eorderC = rocblas2char_eorder(order);
+    char erangeC = rocblas2char_erange(erange);
+    char eorderC = rocblas2char_eorder(eorder);
     dstebz_(&erangeC, &eorderC, &n, &vl, &vu, &il, &iu, &abstol, D, E, m, nsplit, W, iblock, isplit,
             work, iwork, info);
 }

--- a/clients/extras/test_rocsolver_bench.py
+++ b/clients/extras/test_rocsolver_bench.py
@@ -173,22 +173,22 @@ class TestRocsolverBench(unittest.TestCase):
     def test_validate_erange(self):
         for erange in 'AVI':
             with self.subTest(erange=erange):
-                out, err, exitcode = call_rocsolver_bench(f'-f stebz --range {erange} -n 10')
+                out, err, exitcode = call_rocsolver_bench(f'-f stebz --erange {erange} -n 10')
                 self.assertEqual(err, '')
                 self.assertEqual(exitcode, 0)
 
-        out, err, exitcode = call_rocsolver_bench('-f stebz --range 0 -n 10')
+        out, err, exitcode = call_rocsolver_bench('-f stebz --erange 0 -n 10')
         self.assertNotEqual(err, '')
         self.assertNotEqual(exitcode, 0)
 
     def test_validate_eorder(self):
         for eorder in 'BE':
             with self.subTest(eorder=eorder):
-                out, err, exitcode = call_rocsolver_bench(f'-f stebz --order {eorder} -n 10')
+                out, err, exitcode = call_rocsolver_bench(f'-f stebz --eorder {eorder} -n 10')
                 self.assertEqual(err, '')
                 self.assertEqual(exitcode, 0)
 
-        out, err, exitcode = call_rocsolver_bench('-f stebz --order 0 -n 10')
+        out, err, exitcode = call_rocsolver_bench('-f stebz --eorder 0 -n 10')
         self.assertNotEqual(err, '')
         self.assertNotEqual(exitcode, 0)
 

--- a/clients/gtest/stebz_gtest.cpp
+++ b/clients/gtest/stebz_gtest.cpp
@@ -72,9 +72,9 @@ Arguments stebz_setup_arguments(stebz_tuple tup)
     vector<int> op = std::get<1>(tup);
 
     arg.set<rocblas_int>("n", size[0]);
-    arg.set<char>("order", (size[1] == 0 ? 'E' : 'B'));
+    arg.set<char>("eorder", (size[1] == 0 ? 'E' : 'B'));
 
-    arg.set<char>("range", (op[0] == 0 ? 'A' : (op[0] == 1 ? 'V' : 'I')));
+    arg.set<char>("erange", (op[0] == 0 ? 'A' : (op[0] == 1 ? 'V' : 'I')));
     arg.set<double>("vl", op[1]);
     arg.set<double>("vu", op[2]);
     arg.set<rocblas_int>("il", op[3]);
@@ -98,8 +98,8 @@ protected:
     {
         Arguments arg = stebz_setup_arguments(GetParam());
 
-        if(arg.peek<rocblas_int>("n") == 0 && arg.peek<char>("order") == 'E'
-           && arg.peek<char>("range") == 'A')
+        if(arg.peek<rocblas_int>("n") == 0 && arg.peek<char>("eorder") == 'E'
+           && arg.peek<char>("erange") == 'A')
             testing_stebz_bad_arg<T>();
 
         testing_stebz<T>(arg);

--- a/clients/gtest/syevx_heevx_gtest.cpp
+++ b/clients/gtest/syevx_heevx_gtest.cpp
@@ -64,7 +64,7 @@ Arguments syevx_heevx_setup_arguments(syevx_heevx_tuple tup)
     arg.set<rocblas_int>("iu", size[6]);
 
     arg.set<char>("evect", op[0]);
-    arg.set<char>("range", op[1]);
+    arg.set<char>("erange", op[1]);
     arg.set<char>("uplo", op[2]);
 
     arg.set<double>("abstol", 0);
@@ -91,7 +91,7 @@ protected:
         Arguments arg = syevx_heevx_setup_arguments<T>(GetParam());
 
         if(arg.peek<rocblas_int>("n") == 0 && arg.peek<char>("evect") == 'N'
-           && arg.peek<char>("range") == 'V' && arg.peek<char>("uplo") == 'L')
+           && arg.peek<char>("erange") == 'V' && arg.peek<char>("uplo") == 'L')
             testing_syevx_heevx_bad_arg<BATCHED, STRIDED, T>();
 
         arg.batch_count = (BATCHED || STRIDED ? 3 : 1);

--- a/clients/gtest/sygvx_hegvx_gtest.cpp
+++ b/clients/gtest/sygvx_hegvx_gtest.cpp
@@ -68,7 +68,7 @@ Arguments sygvx_setup_arguments(sygvx_tuple tup)
 
     arg.set<char>("itype", type[0]);
     arg.set<char>("evect", type[1]);
-    arg.set<char>("range", type[2]);
+    arg.set<char>("erange", type[2]);
     arg.set<char>("uplo", type[3]);
 
     arg.set<double>("abstol", 0);
@@ -94,7 +94,7 @@ protected:
         Arguments arg = sygvx_setup_arguments<T>(GetParam());
 
         if(arg.peek<char>("itype") == '1' && arg.peek<char>("evect") == 'N'
-           && arg.peek<char>("range") == 'A' && arg.peek<char>("uplo") == 'U'
+           && arg.peek<char>("erange") == 'A' && arg.peek<char>("uplo") == 'U'
            && arg.peek<rocblas_int>("n") == 0)
             testing_sygvx_hegvx_bad_arg<BATCHED, STRIDED, T>();
 

--- a/clients/include/lapack_host_reference.hpp
+++ b/clients/include/lapack_host_reference.hpp
@@ -601,8 +601,8 @@ void cblas_stedc(rocblas_evect evect,
                  rocblas_int* info);
 
 template <typename T>
-void cblas_stebz(rocblas_erange range,
-                 rocblas_eorder order,
+void cblas_stebz(rocblas_erange erange,
+                 rocblas_eorder eorder,
                  rocblas_int n,
                  T vl,
                  T vu,

--- a/clients/include/rocsolver.hpp
+++ b/clients/include/rocsolver.hpp
@@ -1268,8 +1268,8 @@ inline rocblas_status
 
 /******************** STEBZ ********************/
 inline rocblas_status rocsolver_stebz(rocblas_handle handle,
-                                      rocblas_erange range,
-                                      rocblas_eorder order,
+                                      rocblas_erange erange,
+                                      rocblas_eorder eorder,
                                       rocblas_int n,
                                       float vl,
                                       float vu,
@@ -1285,13 +1285,13 @@ inline rocblas_status rocsolver_stebz(rocblas_handle handle,
                                       rocblas_int* isplit,
                                       rocblas_int* info)
 {
-    return rocsolver_sstebz(handle, range, order, n, vl, vu, il, iu, abstol, D, E, nev, nsplit, W,
+    return rocsolver_sstebz(handle, erange, eorder, n, vl, vu, il, iu, abstol, D, E, nev, nsplit, W,
                             iblock, isplit, info);
 }
 
 inline rocblas_status rocsolver_stebz(rocblas_handle handle,
-                                      rocblas_erange range,
-                                      rocblas_eorder order,
+                                      rocblas_erange erange,
+                                      rocblas_eorder eorder,
                                       rocblas_int n,
                                       double vl,
                                       double vu,
@@ -1307,7 +1307,7 @@ inline rocblas_status rocsolver_stebz(rocblas_handle handle,
                                       rocblas_int* isplit,
                                       rocblas_int* info)
 {
-    return rocsolver_dstebz(handle, range, order, n, vl, vu, il, iu, abstol, D, E, nev, nsplit, W,
+    return rocsolver_dstebz(handle, erange, eorder, n, vl, vu, il, iu, abstol, D, E, nev, nsplit, W,
                             iblock, isplit, info);
 }
 /********************************************************/

--- a/clients/include/testing_stebz.hpp
+++ b/clients/include/testing_stebz.hpp
@@ -13,8 +13,8 @@
 
 template <typename T, typename U>
 void stebz_checkBadArgs(const rocblas_handle handle,
-                        const rocblas_erange range,
-                        const rocblas_eorder order,
+                        const rocblas_erange erange,
+                        const rocblas_eorder eorder,
                         const rocblas_int n,
                         const T vl,
                         const T vu,
@@ -31,46 +31,46 @@ void stebz_checkBadArgs(const rocblas_handle handle,
                         rocblas_int* dinfo)
 {
     // handle
-    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(nullptr, range, order, n, vl, vu, il, iu, abstol, dD, dE,
-                                          dnev, dnsplit, dW, dIblock, dIsplit, dinfo),
+    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(nullptr, erange, eorder, n, vl, vu, il, iu, abstol, dD,
+                                          dE, dnev, dnsplit, dW, dIblock, dIsplit, dinfo),
                           rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, rocblas_erange(-1), order, n, vl, vu, il, iu,
+    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, rocblas_erange(-1), eorder, n, vl, vu, il, iu,
                                           abstol, dD, dE, dnev, dnsplit, dW, dIblock, dIsplit, dinfo),
                           rocblas_status_invalid_value);
-    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, range, rocblas_eorder(-1), n, vl, vu, il, iu,
+    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, erange, rocblas_eorder(-1), n, vl, vu, il, iu,
                                           abstol, dD, dE, dnev, dnsplit, dW, dIblock, dIsplit, dinfo),
                           rocblas_status_invalid_value);
 
     // pointers
-    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, range, order, n, vl, vu, il, iu, abstol, (U) nullptr,
-                                          dE, dnev, dnsplit, dW, dIblock, dIsplit, dinfo),
+    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, erange, eorder, n, vl, vu, il, iu, abstol,
+                                          (U) nullptr, dE, dnev, dnsplit, dW, dIblock, dIsplit, dinfo),
                           rocblas_status_invalid_pointer);
-    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, range, order, n, vl, vu, il, iu, abstol, dD,
+    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, erange, eorder, n, vl, vu, il, iu, abstol, dD,
                                           (U) nullptr, dnev, dnsplit, dW, dIblock, dIsplit, dinfo),
                           rocblas_status_invalid_pointer);
-    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, range, order, n, vl, vu, il, iu, abstol, dD, dE,
+    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, erange, eorder, n, vl, vu, il, iu, abstol, dD, dE,
                                           (rocblas_int*)nullptr, dnsplit, dW, dIblock, dIsplit, dinfo),
                           rocblas_status_invalid_pointer);
-    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, range, order, n, vl, vu, il, iu, abstol, dD, dE,
+    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, erange, eorder, n, vl, vu, il, iu, abstol, dD, dE,
                                           dnev, (rocblas_int*)nullptr, dW, dIblock, dIsplit, dinfo),
                           rocblas_status_invalid_pointer);
-    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, range, order, n, vl, vu, il, iu, abstol, dD, dE,
+    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, erange, eorder, n, vl, vu, il, iu, abstol, dD, dE,
                                           dnev, dnsplit, (U) nullptr, dIblock, dIsplit, dinfo),
                           rocblas_status_invalid_pointer);
-    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, range, order, n, vl, vu, il, iu, abstol, dD, dE,
+    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, erange, eorder, n, vl, vu, il, iu, abstol, dD, dE,
                                           dnev, dnsplit, dW, (rocblas_int*)nullptr, dIsplit, dinfo),
                           rocblas_status_invalid_pointer);
-    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, range, order, n, vl, vu, il, iu, abstol, dD, dE,
+    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, erange, eorder, n, vl, vu, il, iu, abstol, dD, dE,
                                           dnev, dnsplit, dW, dIblock, (rocblas_int*)nullptr, dinfo),
                           rocblas_status_invalid_pointer);
-    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, range, order, n, vl, vu, il, iu, abstol, dD, dE,
+    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, erange, eorder, n, vl, vu, il, iu, abstol, dD, dE,
                                           dnev, dnsplit, dW, dIblock, dIsplit, (rocblas_int*)nullptr),
                           rocblas_status_invalid_pointer);
 
     // quick return with invalid pointers
-    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, range, order, 0, vl, vu, il, iu, abstol,
+    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, erange, eorder, 0, vl, vu, il, iu, abstol,
                                           (U) nullptr, (U) nullptr, dnev, dnsplit, (U) nullptr,
                                           (rocblas_int*)nullptr, (rocblas_int*)nullptr, dinfo),
                           rocblas_status_success);
@@ -82,8 +82,8 @@ void testing_stebz_bad_arg()
     // safe arguments
     rocblas_local_handle handle;
     rocblas_int n = 2;
-    rocblas_erange range = rocblas_erange_all;
-    rocblas_eorder order = rocblas_eorder_entire;
+    rocblas_erange erange = rocblas_erange_all;
+    rocblas_eorder eorder = rocblas_eorder_entire;
     T vl = 0;
     T vu = 0;
     rocblas_int il = 0;
@@ -109,7 +109,7 @@ void testing_stebz_bad_arg()
     CHECK_HIP_ERROR(dinfo.memcheck());
 
     // check bad arguments
-    stebz_checkBadArgs(handle, range, order, n, vl, vu, il, iu, abstol, dD.data(), dE.data(),
+    stebz_checkBadArgs(handle, erange, eorder, n, vl, vu, il, iu, abstol, dD.data(), dE.data(),
                        dnev.data(), dnsplit.data(), dW.data(), dIblock.data(), dIsplit.data(),
                        dinfo.data());
 }
@@ -145,8 +145,8 @@ void stebz_initData(const rocblas_handle handle, const rocblas_int n, Td& dD, Td
 
 template <typename T, typename Td, typename Ud, typename Th, typename Uh>
 void stebz_getError(const rocblas_handle handle,
-                    const rocblas_erange range,
-                    const rocblas_eorder order,
+                    const rocblas_erange erange,
+                    const rocblas_eorder eorder,
                     const rocblas_int n,
                     const T vl,
                     const T vu,
@@ -185,9 +185,9 @@ void stebz_getError(const rocblas_handle handle,
 
     // execute computations
     // GPU lapack
-    CHECK_ROCBLAS_ERROR(rocsolver_stebz(handle, range, order, n, vl, vu, il, iu, abstol, dD.data(),
-                                        dE.data(), dnev.data(), dnsplit.data(), dW.data(),
-                                        dIblock.data(), dIsplit.data(), dinfo.data()));
+    CHECK_ROCBLAS_ERROR(rocsolver_stebz(handle, erange, eorder, n, vl, vu, il, iu, abstol,
+                                        dD.data(), dE.data(), dnev.data(), dnsplit.data(),
+                                        dW.data(), dIblock.data(), dIsplit.data(), dinfo.data()));
     CHECK_HIP_ERROR(hnevRes.transfer_from(dnev));
     CHECK_HIP_ERROR(hnsplitRes.transfer_from(dnsplit));
     CHECK_HIP_ERROR(hWRes.transfer_from(dW));
@@ -198,8 +198,8 @@ void stebz_getError(const rocblas_handle handle,
     // CPU lapack
     // abstol = 0 ensures max accuracy in rocsolver; for lapack we should use 2*safemin
     double atol = (abstol == 0) ? 2 * get_safemin<T>() : abstol;
-    cblas_stebz<T>(range, order, n, vl, vu, il, iu, atol, hD[0], hE[0], hnev[0], hnsplit[0], hW[0],
-                   hIblock[0], hIsplit[0], work.data(), iwork.data(), hinfo[0]);
+    cblas_stebz<T>(erange, eorder, n, vl, vu, il, iu, atol, hD[0], hE[0], hnev[0], hnsplit[0],
+                   hW[0], hIblock[0], hIsplit[0], work.data(), iwork.data(), hinfo[0]);
 
     // check info
     if(hinfo[0][0] != hinfoRes[0][0])
@@ -235,8 +235,8 @@ void stebz_getError(const rocblas_handle handle,
 
 template <typename T, typename Td, typename Ud, typename Th, typename Uh>
 void stebz_getPerfData(const rocblas_handle handle,
-                       const rocblas_erange range,
-                       const rocblas_eorder order,
+                       const rocblas_erange erange,
+                       const rocblas_eorder eorder,
                        const rocblas_int n,
                        const T vl,
                        const T vu,
@@ -277,7 +277,7 @@ void stebz_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        cblas_stebz<T>(range, order, n, vl, vu, il, iu, atol, hD[0], hE[0], hnev[0], hnsplit[0],
+        cblas_stebz<T>(erange, eorder, n, vl, vu, il, iu, atol, hD[0], hE[0], hnev[0], hnsplit[0],
                        hW[0], hIblock[0], hIsplit[0], work.data(), iwork.data(), hinfo[0]);
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
@@ -289,7 +289,7 @@ void stebz_getPerfData(const rocblas_handle handle,
     {
         stebz_initData<false, true, T>(handle, n, dD, dE, hD, hE);
 
-        CHECK_ROCBLAS_ERROR(rocsolver_stebz(handle, range, order, n, vl, vu, il, iu, abstol,
+        CHECK_ROCBLAS_ERROR(rocsolver_stebz(handle, erange, eorder, n, vl, vu, il, iu, abstol,
                                             dD.data(), dE.data(), dnev.data(), dnsplit.data(),
                                             dW.data(), dIblock.data(), dIsplit.data(), dinfo.data()));
     }
@@ -314,7 +314,7 @@ void stebz_getPerfData(const rocblas_handle handle,
         stebz_initData<false, true, T>(handle, n, dD, dE, hD, hE);
 
         start = get_time_us_sync(stream);
-        rocsolver_stebz(handle, range, order, n, vl, vu, il, iu, abstol, dD.data(), dE.data(),
+        rocsolver_stebz(handle, erange, eorder, n, vl, vu, il, iu, abstol, dD.data(), dE.data(),
                         dnev.data(), dnsplit.data(), dW.data(), dIblock.data(), dIsplit.data(),
                         dinfo.data());
         *gpu_time_used += get_time_us_sync(stream) - start;
@@ -327,17 +327,17 @@ void testing_stebz(Arguments& argus)
 {
     // get arguments
     rocblas_local_handle handle;
-    char rangeC = argus.get<char>("range");
-    char orderC = argus.get<char>("order");
+    char erangeC = argus.get<char>("erange");
+    char eorderC = argus.get<char>("eorder");
     rocblas_int n = argus.get<rocblas_int>("n");
     T vl = T(argus.get<double>("vl", 0));
-    T vu = T(argus.get<double>("vu", rangeC == 'V' ? 1 : 0));
-    rocblas_int il = argus.get<rocblas_int>("il", rangeC == 'I' ? 1 : 0);
-    rocblas_int iu = argus.get<rocblas_int>("iu", rangeC == 'I' ? 1 : 0);
+    T vu = T(argus.get<double>("vu", erangeC == 'V' ? 1 : 0));
+    rocblas_int il = argus.get<rocblas_int>("il", erangeC == 'I' ? 1 : 0);
+    rocblas_int iu = argus.get<rocblas_int>("iu", erangeC == 'I' ? 1 : 0);
     T abstol = T(argus.get<double>("abstol"));
 
-    rocblas_erange range = char2rocblas_erange(rangeC);
-    rocblas_eorder order = char2rocblas_eorder(orderC);
+    rocblas_erange erange = char2rocblas_erange(erangeC);
+    rocblas_eorder eorder = char2rocblas_eorder(eorderC);
     rocblas_int hot_calls = argus.iters;
 
     // check non-supported values
@@ -356,13 +356,13 @@ void testing_stebz(Arguments& argus)
     size_t size_isplitRes = (argus.unit_check || argus.norm_check) ? size_isplit : 0;
 
     // check invalid sizes
-    bool invalid_size = (n < 0) || (range == rocblas_erange_value && vl >= vu)
-        || (range == rocblas_erange_index && (iu > n || (n > 0 && il > iu)))
-        || (range == rocblas_erange_index && (il < 1 || iu < 0));
+    bool invalid_size = (n < 0) || (erange == rocblas_erange_value && vl >= vu)
+        || (erange == rocblas_erange_index && (iu > n || (n > 0 && il > iu)))
+        || (erange == rocblas_erange_index && (il < 1 || iu < 0));
     if(invalid_size)
     {
         EXPECT_ROCBLAS_STATUS(
-            rocsolver_stebz(handle, range, order, n, vl, vu, il, iu, abstol, (T*)nullptr,
+            rocsolver_stebz(handle, erange, eorder, n, vl, vu, il, iu, abstol, (T*)nullptr,
                             (T*)nullptr, (rocblas_int*)nullptr, (rocblas_int*)nullptr, (T*)nullptr,
                             (rocblas_int*)nullptr, (rocblas_int*)nullptr, (rocblas_int*)nullptr),
             rocblas_status_invalid_size);
@@ -377,7 +377,7 @@ void testing_stebz(Arguments& argus)
     if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
-        CHECK_ALLOC_QUERY(rocsolver_stebz(handle, range, order, n, vl, vu, il, iu, abstol,
+        CHECK_ALLOC_QUERY(rocsolver_stebz(handle, erange, eorder, n, vl, vu, il, iu, abstol,
                                           (T*)nullptr, (T*)nullptr, (rocblas_int*)nullptr,
                                           (rocblas_int*)nullptr, (T*)nullptr, (rocblas_int*)nullptr,
                                           (rocblas_int*)nullptr, (rocblas_int*)nullptr));
@@ -434,7 +434,7 @@ void testing_stebz(Arguments& argus)
     // check quick return
     if(n == 0)
     {
-        EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, range, order, n, vl, vu, il, iu, abstol,
+        EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, erange, eorder, n, vl, vu, il, iu, abstol,
                                               dD.data(), dE.data(), dnev.data(), dnsplit.data(),
                                               dW.data(), dIblock.data(), dIsplit.data(), dinfo.data()),
                               rocblas_status_success);
@@ -446,16 +446,16 @@ void testing_stebz(Arguments& argus)
 
     // check computations
     if(argus.unit_check || argus.norm_check)
-        stebz_getError<T>(handle, range, order, n, vl, vu, il, iu, abstol, dD, dE, dnev, dnsplit,
+        stebz_getError<T>(handle, erange, eorder, n, vl, vu, il, iu, abstol, dD, dE, dnev, dnsplit,
                           dW, dIblock, dIsplit, dinfo, hD, hE, hnev, hnevRes, hnsplit, hnsplitRes,
                           hW, hWRes, hIblock, hIblockRes, hIsplit, hIsplitRes, hinfo, hinfoRes,
                           &max_error);
 
     // collect performance data
     if(argus.timing)
-        stebz_getPerfData<T>(handle, range, order, n, vl, vu, il, iu, abstol, dD, dE, dnev, dnsplit,
-                             dW, dIblock, dIsplit, dinfo, hD, hE, hnev, hnsplit, hW, hIblock,
-                             hIsplit, hinfo, &gpu_time_used, &cpu_time_used, hot_calls,
+        stebz_getPerfData<T>(handle, erange, eorder, n, vl, vu, il, iu, abstol, dD, dE, dnev,
+                             dnsplit, dW, dIblock, dIsplit, dinfo, hD, hE, hnev, hnsplit, hW,
+                             hIblock, hIsplit, hinfo, &gpu_time_used, &cpu_time_used, hot_calls,
                              argus.profile, argus.profile_kernels, argus.perf);
 
     // validate results for rocsolver-test
@@ -469,8 +469,8 @@ void testing_stebz(Arguments& argus)
         if(!argus.perf)
         {
             rocsolver_bench_header("Arguments:");
-            rocsolver_bench_output("range", "order", "n", "vl", "vu", "il", "iu", "abstol");
-            rocsolver_bench_output(rangeC, orderC, n, vl, vu, il, iu, abstol);
+            rocsolver_bench_output("erange", "eorder", "n", "vl", "vu", "il", "iu", "abstol");
+            rocsolver_bench_output(erangeC, eorderC, n, vl, vu, il, iu, abstol);
 
             rocsolver_bench_header("Results:");
             if(argus.norm_check)

--- a/clients/include/testing_syevx_heevx.hpp
+++ b/clients/include/testing_syevx_heevx.hpp
@@ -492,7 +492,7 @@ void testing_syevx_heevx(Arguments& argus)
     // get arguments
     rocblas_local_handle handle;
     char evectC = argus.get<char>("evect");
-    char erangeC = argus.get<char>("range");
+    char erangeC = argus.get<char>("erange");
     char uploC = argus.get<char>("uplo");
     rocblas_int n = argus.get<rocblas_int>("n");
     rocblas_int lda = argus.get<rocblas_int>("lda", n);

--- a/clients/include/testing_sygvx_hegvx.hpp
+++ b/clients/include/testing_sygvx_hegvx.hpp
@@ -660,7 +660,7 @@ void testing_sygvx_hegvx(Arguments& argus)
     rocblas_local_handle handle;
     char itypeC = argus.get<char>("itype");
     char evectC = argus.get<char>("evect");
-    char erangeC = argus.get<char>("range");
+    char erangeC = argus.get<char>("erange");
     char uploC = argus.get<char>("uplo");
     rocblas_int n = argus.get<rocblas_int>("n");
     rocblas_int lda = argus.get<rocblas_int>("lda", n);

--- a/library/include/rocsolver-functions.h
+++ b/library/include/rocsolver-functions.h
@@ -3906,18 +3906,18 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zstedc(rocblas_handle handle,
 
     \details
     This function computes all the eigenvalues of T, all the eigenvalues in the half-open interval \f$(vl, vu]\f$,
-    or the il-th through iu-th eigenvalues, depending on the value of range.
+    or the il-th through iu-th eigenvalues, depending on the value of erange.
 
     The eigenvalues are returned in increasing order either for the entire matrix, or grouped by independent
-    diagonal blocks (if they exist), depending on the value of order.
+    diagonal blocks (if they exist), depending on the value of eorder.
 
     @param[in]
     handle      rocblas_handle.
     @param[in]
-    range       #rocblas_erange.\n
+    erange      #rocblas_erange.\n
                 Specifies the type of range or interval of the eigenvalues to be computed.
     @param[in]
-    order       #rocblas_eorder.\n
+    eorder      #rocblas_eorder.\n
                 Specifies whether the computed eigenvalues will be ordered by their position in the
                 entire spectrum, or grouped by independent diagonal (split off) blocks.
     @param[in]
@@ -3925,19 +3925,19 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zstedc(rocblas_handle handle,
                 The order of the tridiagonal matrix T.
     @param[in]
     vl          real type. vl < vu.\n
-                The lower bound of the search interval (vl, vu]. Ignored if range indicates to look
+                The lower bound of the search interval (vl, vu]. Ignored if erange indicates to look
                 for all the eigenvalues of T or the eigenvalues within a set of indices.
     @param[in]
     vu          real type. vl < vu.\n
-                The upper bound of the search interval (vl, vu]. Ignored if range indicates to look
+                The upper bound of the search interval (vl, vu]. Ignored if erange indicates to look
                 for all the eigenvalues of T or the eigenvalues within a set of indices.
     @param[in]
     il          rocblas_int. il = 1 if n = 0; 1 <= il <= iu otherwise.\n
-                The index of the smallest eigenvalue to be computed. Ignored if range indicates to look
+                The index of the smallest eigenvalue to be computed. Ignored if erange indicates to look
                 for all the eigenvalues of T or the eigenvalues in a half-open interval.
     @param[in]
     iu          rocblas_int. iu = 0 if n = 0; 1 <= il <= iu otherwise.\n
-                The index of the largest eigenvalue to be computed. Ignored if range indicates to look
+                The index of the largest eigenvalue to be computed. Ignored if erange indicates to look
                 for all the eigenvalues of T or the eigenvalues in a half-open interval.
     @param[in]
     abstol      real type.\n
@@ -3982,8 +3982,8 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zstedc(rocblas_handle handle,
     *****************************************************************************/
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_sstebz(rocblas_handle handle,
-                                                 const rocblas_erange range,
-                                                 const rocblas_eorder order,
+                                                 const rocblas_erange erange,
+                                                 const rocblas_eorder eorder,
                                                  const rocblas_int n,
                                                  const float vl,
                                                  const float vu,
@@ -4000,8 +4000,8 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_sstebz(rocblas_handle handle,
                                                  rocblas_int* info);
 
 ROCSOLVER_EXPORT rocblas_status rocsolver_dstebz(rocblas_handle handle,
-                                                 const rocblas_erange range,
-                                                 const rocblas_eorder order,
+                                                 const rocblas_erange erange,
+                                                 const rocblas_eorder eorder,
                                                  const rocblas_int n,
                                                  const double vl,
                                                  const double vu,

--- a/library/src/auxiliary/rocauxiliary_stebz.cpp
+++ b/library/src/auxiliary/rocauxiliary_stebz.cpp
@@ -6,8 +6,8 @@
 
 template <typename T>
 rocblas_status rocsolver_stebz_impl(rocblas_handle handle,
-                                    const rocblas_erange range,
-                                    const rocblas_eorder order,
+                                    const rocblas_erange erange,
+                                    const rocblas_eorder eorder,
                                     const rocblas_int n,
                                     const T vl,
                                     const T vu,
@@ -23,15 +23,15 @@ rocblas_status rocsolver_stebz_impl(rocblas_handle handle,
                                     rocblas_int* isplit,
                                     rocblas_int* info)
 {
-    ROCSOLVER_ENTER_TOP("stebz", "--range", range, "--order", order, "-n", n, "--vl", vl, "--vu",
-                        vu, "--il", il, "--iu", iu, "--abstol", abstol);
+    ROCSOLVER_ENTER_TOP("stebz", "--erange", erange, "--eorder", eorder, "-n", n, "--vl", vl,
+                        "--vu", vu, "--il", il, "--iu", iu, "--abstol", abstol);
 
     if(!handle)
         return rocblas_status_invalid_handle;
 
     // argument checking
-    rocblas_status st = rocsolver_stebz_argCheck(handle, range, order, n, vl, vu, il, iu, D, E, nev,
-                                                 nsplit, W, iblock, isplit, info);
+    rocblas_status st = rocsolver_stebz_argCheck(handle, erange, eorder, n, vl, vu, il, iu, D, E,
+                                                 nev, nsplit, W, iblock, isplit, info);
     if(st != rocblas_status_continue)
         return st;
 
@@ -72,7 +72,7 @@ rocblas_status rocsolver_stebz_impl(rocblas_handle handle,
 
     // execution
     return rocsolver_stebz_template<T>(
-        handle, range, order, n, vl, vu, il, iu, abstol, D, shiftD, strideD, E, shiftE, strideE,
+        handle, erange, eorder, n, vl, vu, il, iu, abstol, D, shiftD, strideD, E, shiftE, strideE,
         nev, nsplit, W, strideW, iblock, strideIblock, isplit, strideIsplit, info, batch_count,
         (rocblas_int*)work, (T*)pivmin, (T*)Esqr, (T*)bounds, (T*)inter, (rocblas_int*)ninter);
 }
@@ -86,8 +86,8 @@ rocblas_status rocsolver_stebz_impl(rocblas_handle handle,
 extern "C" {
 
 rocblas_status rocsolver_sstebz(rocblas_handle handle,
-                                const rocblas_erange range,
-                                const rocblas_eorder order,
+                                const rocblas_erange erange,
+                                const rocblas_eorder eorder,
                                 const rocblas_int n,
                                 const float vl,
                                 const float vu,
@@ -103,13 +103,13 @@ rocblas_status rocsolver_sstebz(rocblas_handle handle,
                                 rocblas_int* isplit,
                                 rocblas_int* info)
 {
-    return rocsolver_stebz_impl<float>(handle, range, order, n, vl, vu, il, iu, abstol, D, E, nev,
+    return rocsolver_stebz_impl<float>(handle, erange, eorder, n, vl, vu, il, iu, abstol, D, E, nev,
                                        nsplit, W, iblock, isplit, info);
 }
 
 rocblas_status rocsolver_dstebz(rocblas_handle handle,
-                                const rocblas_erange range,
-                                const rocblas_eorder order,
+                                const rocblas_erange erange,
+                                const rocblas_eorder eorder,
                                 const rocblas_int n,
                                 const double vl,
                                 const double vu,
@@ -125,8 +125,8 @@ rocblas_status rocsolver_dstebz(rocblas_handle handle,
                                 rocblas_int* isplit,
                                 rocblas_int* info)
 {
-    return rocsolver_stebz_impl<double>(handle, range, order, n, vl, vu, il, iu, abstol, D, E, nev,
-                                        nsplit, W, iblock, isplit, info);
+    return rocsolver_stebz_impl<double>(handle, erange, eorder, n, vl, vu, il, iu, abstol, D, E,
+                                        nev, nsplit, W, iblock, isplit, info);
 }
 
 } // extern C

--- a/library/src/auxiliary/rocauxiliary_stebz.hpp
+++ b/library/src/auxiliary/rocauxiliary_stebz.hpp
@@ -927,7 +927,7 @@ rocblas_status rocsolver_stebz_template(rocblas_handle handle,
                                         T* inter,
                                         rocblas_int* ninter)
 {
-    ROCSOLVER_ENTER("stebz", "range:", range, "order:", order, "n:", n, "vl:", vlow, "vu:", vup,
+    ROCSOLVER_ENTER("stebz", "erange:", range, "eorder:", order, "n:", n, "vl:", vlow, "vu:", vup,
                     "il:", ilow, "iu:", iup, "abstol:", abstol, "shiftD:", shiftD,
                     "shiftE:", shiftE, "bc:", batch_count);
 


### PR DESCRIPTION
For ease of use, the arguments to `rocsolver-bench` are designed to have the exact same names as the function arguments in `rocsolver-functions.h`. However, this is currently broken due to the existence of two different names for arguments of type `rocblas_erange`: "range" and "erange", only one of which is represented in client.cpp.

This PR adopts a consistent naming strategy for arguments of type `rocblas_erange`, and in order to be consistent with arguments of type `rocblas_evect`, I've adopted use of the "erange" name. For additional consistency I've also changed the name of arguments of type `rocblas_eorder` from "order" to "eorder".