### PR TITLE
Enable Origin header file dump option for wrapper

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -255,6 +255,7 @@ if (BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
     rocsolver-version.h rocsolver-export.h
     GUARDS SYMLINK WRAPPER
     WRAPPER_LOCATIONS include rocsolver/include
+    ORIGINAL_FILES ${PROJECT_BINARY_DIR}/include/rocsolver/rocsolver-version.h
   )
 endif( )
 


### PR DESCRIPTION
Summary of proposed changes:

- Original Header File Dump enabled for version header wrapper to support backward Compatibility for PT/TF
- ROCM-CMAKE Version required https://github.com/RadeonOpenCompute/rocm-cmake/commit/d108dbf05e029996d5d7bcbe258abb1166547a30