### PR TITLE
Extended use of internal trsm 

### DIFF
--- a/library/src/include/lapack_device_functions.hpp
+++ b/library/src/include/lapack_device_functions.hpp
@@ -1098,6 +1098,27 @@ ROCSOLVER_KERNEL void gemm_kernel(const rocblas_int m,
 
 // **************** forward substitution kernels ************************//
 ///////////////////////////////////////////////////////////////////////////
+/** The following kernels implement forward substitution for lower triangular L
+    or upper triangular U matrices in the form
+    LX = B
+    U'X = B
+    B = XU
+    B = XL'
+
+    nx is the number of variables and ny the number of right/left-hand-sides.
+    Whether B is accessed by rows (left-hand-sides) or columns (right-hand-sides) is
+    determined by the values of ldb1 and ldb2. Whether L/U is transposed or not is
+    determined by the values of lda1 and lda2.
+
+    Call this kernel with 'batch_count' groups in z, and enough
+    groups in y to cover all the 'ny' right/left-hand-sides (columns/rows of B).
+    There should be only one group in x with hipBlockDim_x = nx.
+    Size of shared memory per group should be:
+    lmemsize = hipBlockDim_y * sizeof(T);
+
+    There are 4 different forward substitution kernels; each one deals with
+    a combination of unit and conjugate. In the non-unit case, the kernles DO NOT
+    verify whether the diagonal element of L/U is non-zero.**/
 template <typename T, typename U>
 ROCSOLVER_KERNEL void unit_forward_substitution_kernel(const rocblas_int nx,
                                                        const rocblas_int ny,
@@ -1318,6 +1339,27 @@ ROCSOLVER_KERNEL void conj_nonunit_forward_substitution_kernel(const rocblas_int
 
 // **************** backward substitution kernels ************************//
 ////////////////////////////////////////////////////////////////////////////
+/** The following kernels implement backward substitution for lower triangular L
+    or upper triangular U matrices in the form
+    L'X = B
+    UX = B
+    B = XU'
+    B = XL
+
+    nx is the number of variables and ny the number of right/left-hand-sides.
+    Whether B is accessed by rows (left-hand-sides) or columns (right-hand-sides) is
+    determined by the values of ldb1 and ldb2. Whether L/U is transposed or not is
+    determined by the values of lda1 and lda2.
+
+    Call this kernel with 'batch_count' groups in z, and enough
+    groups in y to cover all the 'ny' right/left-hand-sides (columns/rows of B).
+    There should be only one group in x with hipBlockDim_x = nx.
+    Size of shared memory per group should be:
+    lmemsize = hipBlockDim_y * sizeof(T);
+
+    There are 4 different backward substitution kernels; each one deals with
+    a combination of unit and conjugate. In the non-unit case, the kernles DO NOT
+    verify whether the diagonal element of L/U is non-zero.**/
 template <typename T, typename U>
 ROCSOLVER_KERNEL void unit_backward_substitution_kernel(const rocblas_int nx,
                                                         const rocblas_int ny,

--- a/library/src/include/lapack_device_functions.hpp
+++ b/library/src/include/lapack_device_functions.hpp
@@ -1117,7 +1117,7 @@ ROCSOLVER_KERNEL void gemm_kernel(const rocblas_int m,
     lmemsize = hipBlockDim_y * sizeof(T);
 
     There are 4 different forward substitution kernels; each one deals with
-    a combination of unit and conjugate. In the non-unit case, the kernles DO NOT
+    a combination of unit and conjugate. In the non-unit case, the kernels DO NOT
     verify whether the diagonal element of L/U is non-zero.**/
 template <typename T, typename U>
 ROCSOLVER_KERNEL void unit_forward_substitution_kernel(const rocblas_int nx,
@@ -1358,7 +1358,7 @@ ROCSOLVER_KERNEL void conj_nonunit_forward_substitution_kernel(const rocblas_int
     lmemsize = hipBlockDim_y * sizeof(T);
 
     There are 4 different backward substitution kernels; each one deals with
-    a combination of unit and conjugate. In the non-unit case, the kernles DO NOT
+    a combination of unit and conjugate. In the non-unit case, the kernels DO NOT
     verify whether the diagonal element of L/U is non-zero.**/
 template <typename T, typename U>
 ROCSOLVER_KERNEL void unit_backward_substitution_kernel(const rocblas_int nx,

--- a/library/src/include/lapack_device_functions.hpp
+++ b/library/src/include/lapack_device_functions.hpp
@@ -1244,8 +1244,7 @@ ROCSOLVER_KERNEL void nonunit_forward_substitution_kernel(const rocblas_int nx,
             __syncthreads();
             if(x == k)
             {
-                d = A[x * (lda1 + lda2)];
-                c = d != 0 ? c / d : c;
+                c = c / A[x * (lda1 + lda2)];
                 b[ty] = c;
             }
             __syncthreads();
@@ -1253,10 +1252,7 @@ ROCSOLVER_KERNEL void nonunit_forward_substitution_kernel(const rocblas_int nx,
             c -= (x > k) ? A[ida + k * lda2] * b[ty] : 0;
         }
         if(x == nx - 1)
-        {
-            d = A[x * (lda1 + lda2)];
-            c = d != 0 ? c / d : c;
-        }
+            c = c / A[x * (lda1 + lda2)];
 
         // move results back to global
         B[idb] = c;
@@ -1305,8 +1301,7 @@ ROCSOLVER_KERNEL void conj_nonunit_forward_substitution_kernel(const rocblas_int
             __syncthreads();
             if(x == k)
             {
-                d = conj(A[x * (lda1 + lda2)]);
-                c = d != 0 ? c / d : c;
+                c = c / conj(A[x * (lda1 + lda2)]);
                 b[ty] = c;
             }
             __syncthreads();
@@ -1314,10 +1309,7 @@ ROCSOLVER_KERNEL void conj_nonunit_forward_substitution_kernel(const rocblas_int
             c -= (x > k) ? conj(A[ida + k * lda2]) * b[ty] : 0;
         }
         if(x == nx - 1)
-        {
-            d = conj(A[x * (lda1 + lda2)]);
-            c = d != 0 ? c / d : c;
-        }
+            c = c / conj(A[x * (lda1 + lda2)]);
 
         // move results back to global
         B[idb] = c;
@@ -1472,8 +1464,7 @@ ROCSOLVER_KERNEL void nonunit_backward_substitution_kernel(const rocblas_int nx,
             __syncthreads();
             if(x == k)
             {
-                d = A[x * (lda1 + lda2)];
-                c = d != 0 ? c / d : c;
+                c = c / A[x * (lda1 + lda2)];
                 b[ty] = c;
             }
             __syncthreads();
@@ -1481,10 +1472,7 @@ ROCSOLVER_KERNEL void nonunit_backward_substitution_kernel(const rocblas_int nx,
             c -= (x < k) ? A[ida + k * lda2] * b[ty] : 0;
         }
         if(x == 0)
-        {
-            d = A[x * (lda1 + lda2)];
-            c = d != 0 ? c / d : c;
-        }
+            c = c / A[x * (lda1 + lda2)];
 
         // move results back to global
         B[idb] = c;
@@ -1533,8 +1521,7 @@ ROCSOLVER_KERNEL void conj_nonunit_backward_substitution_kernel(const rocblas_in
             __syncthreads();
             if(x == k)
             {
-                d = conj(A[x * (lda1 + lda2)]);
-                c = d != 0 ? c / d : c;
+                c = c / conj(A[x * (lda1 + lda2)]);
                 b[ty] = c;
             }
             __syncthreads();
@@ -1542,10 +1529,7 @@ ROCSOLVER_KERNEL void conj_nonunit_backward_substitution_kernel(const rocblas_in
             c -= (x < k) ? conj(A[ida + k * lda2]) * b[ty] : 0;
         }
         if(x == 0)
-        {
-            d = conj(A[x * (lda1 + lda2)]);
-            c = d != 0 ? c / d : c;
-        }
+            c = c / conj(A[x * (lda1 + lda2)]);
 
         // move results back to global
         B[idb] = c;

--- a/library/src/include/lapack_device_functions.hpp
+++ b/library/src/include/lapack_device_functions.hpp
@@ -1222,7 +1222,7 @@ ROCSOLVER_KERNEL void trsm2_upper_kernel(const rocblas_int m,
 }*/
 
 // forward substitution kernel for unit case
-template <typename T, typename U>
+/*template <typename T, typename U>
 ROCSOLVER_KERNEL void unit_forward_substitution_kernel(const bool isleft,
                                                        const bool islower,
                                                        const rocblas_int nx,
@@ -1273,22 +1273,23 @@ ROCSOLVER_KERNEL void unit_forward_substitution_kernel(const bool isleft,
         else
             B[y + x * ldb] = c;
     }
-}
+}*/
 
-// forward substitution kernel for non-unit case
+// forward substitution kernel
 template <typename T, typename U>
-ROCSOLVER_KERNEL void nonunit_forward_substitution_kernel(const bool isleft,
-                                                          const bool islower,
-                                                          const rocblas_int nx,
-                                                          const rocblas_int ny,
-                                                          U AA,
-                                                          const rocblas_int shiftA,
-                                                          const rocblas_int lda,
-                                                          const rocblas_stride strideA,
-                                                          U BB,
-                                                          const rocblas_int shiftB,
-                                                          const rocblas_int ldb,
-                                                          const rocblas_stride strideB)
+ROCSOLVER_KERNEL void forward_substitution_kernel(const bool isleft,
+                                                  const bool islower,
+                                                  const bool isunit,
+                                                  const rocblas_int nx,
+                                                  const rocblas_int ny,
+                                                  U AA,
+                                                  const rocblas_int shiftA,
+                                                  const rocblas_int lda,
+                                                  const rocblas_stride strideA,
+                                                  U BB,
+                                                  const rocblas_int shiftB,
+                                                  const rocblas_int ldb,
+                                                  const rocblas_stride strideB)
 {
     int bid = hipBlockIdx_z;
     int x = hipThreadIdx_x;
@@ -1315,7 +1316,7 @@ ROCSOLVER_KERNEL void nonunit_forward_substitution_kernel(const bool isleft,
             __syncthreads();
             if(x == k)
             {
-                d = A[x + x * lda];
+                d = isunit ? 0 : A[x + x * lda];
                 c = d != 0 ? c / d : c;
                 b[ty] = c;
             }
@@ -1326,7 +1327,7 @@ ROCSOLVER_KERNEL void nonunit_forward_substitution_kernel(const bool isleft,
         }
         if(x == nx - 1)
         {
-            d = A[x + x * lda];
+            d = isunit ? 0 : A[x + x * lda];
             c = d != 0 ? c / d : c;
         }
 
@@ -1339,7 +1340,7 @@ ROCSOLVER_KERNEL void nonunit_forward_substitution_kernel(const bool isleft,
 }
 
 // backward substitution kernel for unit case
-template <typename T, typename U>
+/*template <typename T, typename U>
 ROCSOLVER_KERNEL void unit_backward_substitution_kernel(const bool isleft,
                                                         const bool islower,
                                                         const rocblas_int nx,
@@ -1390,22 +1391,23 @@ ROCSOLVER_KERNEL void unit_backward_substitution_kernel(const bool isleft,
         else
             B[y + x * ldb] = c;
     }
-}
+}*/
 
-// backward substitution kernel for non-unit case
+// backward substitution kernel
 template <typename T, typename U>
-ROCSOLVER_KERNEL void nonunit_backward_substitution_kernel(const bool isleft,
-                                                           const bool islower,
-                                                           const rocblas_int nx,
-                                                           const rocblas_int ny,
-                                                           U AA,
-                                                           const rocblas_int shiftA,
-                                                           const rocblas_int lda,
-                                                           const rocblas_stride strideA,
-                                                           U BB,
-                                                           const rocblas_int shiftB,
-                                                           const rocblas_int ldb,
-                                                           const rocblas_stride strideB)
+ROCSOLVER_KERNEL void backward_substitution_kernel(const bool isleft,
+                                                   const bool islower,
+                                                   const bool isunit,
+                                                   const rocblas_int nx,
+                                                   const rocblas_int ny,
+                                                   U AA,
+                                                   const rocblas_int shiftA,
+                                                   const rocblas_int lda,
+                                                   const rocblas_stride strideA,
+                                                   U BB,
+                                                   const rocblas_int shiftB,
+                                                   const rocblas_int ldb,
+                                                   const rocblas_stride strideB)
 {
     int bid = hipBlockIdx_z;
     int x = hipThreadIdx_x;
@@ -1432,7 +1434,7 @@ ROCSOLVER_KERNEL void nonunit_backward_substitution_kernel(const bool isleft,
             __syncthreads();
             if(x == k)
             {
-                d = A[x + x * lda];
+                d = isunit ? 0 : A[x + x * lda];
                 c = d != 0 ? c / d : c;
                 b[ty] = c;
             }
@@ -1443,7 +1445,7 @@ ROCSOLVER_KERNEL void nonunit_backward_substitution_kernel(const bool isleft,
         }
         if(x == 0)
         {
-            d = A[x + x * lda];
+            d = isunit ? 0 : A[x + x * lda];
             c = d != 0 ? c / d : c;
         }
 

--- a/library/src/include/lapack_host_functions.hpp
+++ b/library/src/include/lapack_host_functions.hpp
@@ -170,7 +170,7 @@ rocblas_int rocsolver_trsm_blksize(const rocblas_int m, const rocblas_int n)
     }
 
     if(blk == 1)
-        blk = m;
+        blk = std::min(m, 512);
 
     return blk;
 }
@@ -201,7 +201,7 @@ rocblas_int rocsolver_trsm_blksize(const rocblas_int m, const rocblas_int n)
     }
 
     if(blk == 1)
-        blk = m;
+        blk = std::min(m, 512);
 
     return blk;
 }
@@ -338,7 +338,7 @@ void rocsolver_trsm_lower(rocblas_handle handle,
         threads = dim3(dimx, dimy, 1);
         lmemsize = dimy * sizeof(T);
 
-        if(notrans) // >>>>>> case: LX = B
+        if(notrans) // forward case: LX = B
         {
             lda1 = 1;
             lda2 = lda;
@@ -378,7 +378,7 @@ void rocsolver_trsm_lower(rocblas_handle handle,
             FORWARD_SUBSTITUTIONS;
         }
 
-        else // >>>>>> case: L'X = B
+        else // backward case: L'X = B
         {
             lda1 = lda;
             lda2 = 1;
@@ -431,7 +431,7 @@ void rocsolver_trsm_lower(rocblas_handle handle,
         threads = dim3(dimx, dimy, 1);
         lmemsize = dimy * sizeof(T);
 
-        if(notrans) // >>>>>> case: B = XL
+        if(notrans) // backward case: B = XL
         {
             lda1 = lda;
             lda2 = 1;
@@ -471,7 +471,7 @@ void rocsolver_trsm_lower(rocblas_handle handle,
             BACKWARD_SUBSTITUTIONS;
         }
 
-        else // >>>>>> case: B = XL'
+        else // forward case: B = XL'
         {
             lda1 = 1;
             lda2 = lda;
@@ -590,7 +590,7 @@ void rocsolver_trsm_upper(rocblas_handle handle,
         threads = dim3(dimx, dimy, 1);
         lmemsize = dimy * sizeof(T);
 
-        if(!notrans) // >>>>>> case: U'X = B
+        if(!notrans) // forward case: U'X = B
         {
             lda1 = lda;
             lda2 = 1;
@@ -630,7 +630,7 @@ void rocsolver_trsm_upper(rocblas_handle handle,
             FORWARD_SUBSTITUTIONS;
         }
 
-        else // >>>>>> case: UX = B
+        else // backward case: UX = B
         {
             lda1 = 1;
             lda2 = lda;
@@ -683,7 +683,7 @@ void rocsolver_trsm_upper(rocblas_handle handle,
         threads = dim3(dimx, dimy, 1);
         lmemsize = dimy * sizeof(T);
 
-        if(!notrans) // >>>>>> case: B = XU'
+        if(!notrans) // backward case: B = XU'
         {
             lda1 = 1;
             lda2 = lda;
@@ -723,7 +723,7 @@ void rocsolver_trsm_upper(rocblas_handle handle,
             BACKWARD_SUBSTITUTIONS;
         }
 
-        else // >>>>>> case: B = XU
+        else // forward case: B = XU
         {
             lda1 = lda;
             lda2 = 1;

--- a/library/src/include/lapack_host_functions.hpp
+++ b/library/src/include/lapack_host_functions.hpp
@@ -276,15 +276,16 @@ void rocsolver_trsm_lower(rocblas_handle handle,
         threads = dim3(dimx, dimy, 1);
         lmemsize = dimy * sizeof(T);
         ROCSOLVER_LAUNCH_KERNEL(trsm2_lower_kernel<T>, grid, threads, lmemsize, stream, jb, n, A,
-                                shiftA + idx2D(j, j, lda), lda, strideA, B, shiftB + idx2D(j, 0, ldb), ldb, strideB);
+                                shiftA + idx2D(j, j, lda), lda, strideA, B,
+                                shiftB + idx2D(j, 0, ldb), ldb, strideB);
 
         // update right hand sides
         if(nextpiv < m)
         {
             rocblasCall_gemm<BATCHED, STRIDED, T>(
                 handle, rocblas_operation_none, rocblas_operation_none, m - nextpiv, n, jb, &minone,
-                A, shiftA + idx2D(nextpiv, j, lda), lda, strideA, B, shiftB + idx2D(j, 0, ldb),
-                ldb, strideB, &one, B, shiftB + idx2D(nextpiv, 0, ldb), ldb, strideB, batch_count,
+                A, shiftA + idx2D(nextpiv, j, lda), lda, strideA, B, shiftB + idx2D(j, 0, ldb), ldb,
+                strideB, &one, B, shiftB + idx2D(nextpiv, 0, ldb), ldb, strideB, batch_count,
                 nullptr);
         }
     }
@@ -339,8 +340,8 @@ void rocsolver_trsm_upper(rocblas_handle handle,
     {
         rocblasCall_trsm<BATCHED, T>(handle, rocblas_side_right, rocblas_fill_upper,
                                      rocblas_operation_none, rocblas_diagonal_non_unit, m, n, &one,
-                                     A, shiftA, lda, strideA, B, shiftB, ldb, strideB,
-                                     batch_count, optim_mem, work1, work2, work3, work4);
+                                     A, shiftA, lda, strideA, B, shiftB, ldb, strideB, batch_count,
+                                     optim_mem, work1, work2, work3, work4);
         return;
     }
 
@@ -358,15 +359,16 @@ void rocsolver_trsm_upper(rocblas_handle handle,
         threads = dim3(dimx, dimy, 1);
         lmemsize = dimx * sizeof(T);
         ROCSOLVER_LAUNCH_KERNEL(trsm2_upper_kernel<T>, grid, threads, lmemsize, stream, m, jb, A,
-                                shiftA + idx2D(j, j, lda), lda, strideA, B, shiftB + idx2D(0, j, ldb), ldb, strideB);
+                                shiftA + idx2D(j, j, lda), lda, strideA, B,
+                                shiftB + idx2D(0, j, ldb), ldb, strideB);
 
         // update right hand sides
         if(nextpiv < n)
         {
             rocblasCall_gemm<BATCHED, STRIDED, T>(
                 handle, rocblas_operation_none, rocblas_operation_none, m, n - nextpiv, jb, &minone,
-                B, shiftB + idx2D(0, j, ldb), ldb, strideB, A, shiftA + idx2D(j, nextpiv, lda),
-                lda, strideA, &one, B, shiftB + idx2D(0, nextpiv, ldb), ldb, strideB, batch_count,
+                B, shiftB + idx2D(0, j, ldb), ldb, strideB, A, shiftA + idx2D(j, nextpiv, lda), lda,
+                strideA, &one, B, shiftB + idx2D(0, nextpiv, ldb), ldb, strideB, batch_count,
                 nullptr);
         }
     }

--- a/library/src/include/lapack_host_functions.hpp
+++ b/library/src/include/lapack_host_functions.hpp
@@ -160,6 +160,7 @@ rocblas_int rocsolver_trsm_blksize(const rocblas_int m, const rocblas_int n)
 /** This function determine workspace size for the internal trsm **/
 template <bool BATCHED, bool STRIDED, typename T>
 void rocsolver_trsm_mem(const rocblas_side side,
+                        const rocblas_operation trans,
                         const rocblas_int m,
                         const rocblas_int n,
                         const rocblas_int batch_count,
@@ -206,8 +207,8 @@ void rocsolver_trsm_mem(const rocblas_side side,
         mm = (m % 128 != 0) ? m : m + 1;
     }
 
-    rocblasCall_trsm_mem<BATCHED, T>(side, rocblas_operation_none, mm, n, batch_count, size_work1,
-                                     size_work2, size_work3, size_work4);
+    rocblasCall_trsm_mem<BATCHED, T>(side, trans, mm, n, batch_count, size_work1, size_work2,
+                                     size_work3, size_work4);
 }
 
 /** Internal TRSM (lower case):

--- a/library/src/lapack/roclapack_gels.hpp
+++ b/library/src/lapack/roclapack_gels.hpp
@@ -4,13 +4,14 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ***********************************************************************/
 
 #pragma once
 
 #include "auxiliary/rocauxiliary_ormlq_unmlq.hpp"
 #include "auxiliary/rocauxiliary_ormqr_unmqr.hpp"
+#include "lapack_host_functions.hpp"
 #include "rocblas.hpp"
 #include "roclapack_gelqf.hpp"
 #include "roclapack_geqrf.hpp"
@@ -92,8 +93,9 @@ void rocsolver_gels_getMemorySize(const rocblas_operation trans,
         ROCSOLVER_ASSUME_X(gexxf_scalars == ormxx_scalars, "GELQF and ORMLQ use the same scalars");
     }
 
-    rocblasCall_trsm_mem<BATCHED, T>(rocblas_side_left, trans, std::min(m, n), nrhs, batch_count,
-                                     &trsm_x_temp, &trsm_x_temp_arr, &trsm_invA, &trsm_invA_arr);
+    rocsolver_trsm_mem<BATCHED, STRIDED, T>(rocblas_side_left, trans, std::min(m, n), nrhs,
+                                            batch_count, &trsm_x_temp, &trsm_x_temp_arr, &trsm_invA,
+                                            &trsm_invA_arr, optim_mem);
 
     // TODO: rearrange to minimize total size
     *size_scalars = gexxf_scalars;
@@ -107,9 +109,6 @@ void rocsolver_gels_getMemorySize(const rocblas_operation trans,
         *size_ipiv_savedB = sizeof(T) * std::min(m, n) * nrhs * batch_count;
     else
         *size_ipiv_savedB = sizeof(T) * std::max(m, n) * nrhs * batch_count;
-
-    // always allocate all required memory for TRSM optimal performance
-    *optim_mem = true;
 }
 
 template <bool COMPLEX, typename T>
@@ -218,7 +217,6 @@ rocblas_status rocsolver_gels_template(rocblas_handle handle,
     const rocblas_int copyblocksmin = (std::min(m, n) - 1) / 32 + 1;
     const rocblas_int copyblocksmax = (std::max(m, n) - 1) / 32 + 1;
     const rocblas_int copyblocksy = (nrhs - 1) / 32 + 1;
-    const T one = 1;
 
     // TODO: apply scaling to improve accuracy over a larger range of values
 
@@ -248,11 +246,10 @@ rocblas_status rocsolver_gels_template(rocblas_handle handle,
                                     ldb, strideB, ipiv_savedB, info_mask(info));
 
             // solve RX = Q'B, overwriting B with X
-            rocblasCall_trsm<BATCHED, T>(handle, rocblas_side_left, rocblas_fill_upper,
-                                         rocblas_operation_none, rocblas_diagonal_non_unit, n, nrhs,
-                                         &one, A, shiftA, lda, strideA, B, shiftB, ldb, strideB,
-                                         batch_count, optim_mem, work_x_temp, workArr_temp_arr,
-                                         diag_trfac_invA, trfact_workTrmm_invA_arr);
+            rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit, n,
+                nrhs, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, batch_count, optim_mem,
+                work_x_temp, workArr_temp_arr, diag_trfac_invA, trfact_workTrmm_invA_arr);
 
             // restore elements of B that were overwritten in cases where info is nonzero
             ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, U>), dim3(copyblocksmin, copyblocksy, batch_count),
@@ -272,11 +269,11 @@ rocblas_status rocsolver_gels_template(rocblas_handle handle,
                                     ldb, strideB, ipiv_savedB, info_mask(info));
 
             // solve R'Y = B overwriting B with Y (here Y = Q'X)
-            rocblasCall_trsm<BATCHED, T>(
-                handle, rocblas_side_left, rocblas_fill_upper,
-                rocblas_operation_conjugate_transpose, rocblas_diagonal_non_unit, n, nrhs, &one, A,
-                shiftA, lda, strideA, B, shiftB, ldb, strideB, batch_count, optim_mem, work_x_temp,
-                workArr_temp_arr, diag_trfac_invA, trfact_workTrmm_invA_arr);
+            rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                rocblas_diagonal_non_unit, n, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb,
+                strideB, batch_count, optim_mem, work_x_temp, workArr_temp_arr, diag_trfac_invA,
+                trfact_workTrmm_invA_arr);
 
             // zero row n to m-1 of B in cases where info is zero
             const rocblas_int zeroblocksx = (m - n - 1) / 32 + 1;
@@ -316,11 +313,10 @@ rocblas_status rocsolver_gels_template(rocblas_handle handle,
                                     ldb, strideB, ipiv_savedB, info_mask(info));
 
             // solve LY = B overwriting B with Y (here Y = QX)
-            rocblasCall_trsm<BATCHED, T>(handle, rocblas_side_left, rocblas_fill_lower,
-                                         rocblas_operation_none, rocblas_diagonal_non_unit, m, nrhs,
-                                         &one, A, shiftA, lda, strideA, B, shiftB, ldb, strideB,
-                                         batch_count, optim_mem, work_x_temp, workArr_temp_arr,
-                                         diag_trfac_invA, trfact_workTrmm_invA_arr);
+            rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit, m,
+                nrhs, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, batch_count, optim_mem,
+                work_x_temp, workArr_temp_arr, diag_trfac_invA, trfact_workTrmm_invA_arr);
 
             // zero row m to n-1 of B in cases where info is zero
             const rocblas_int zeroblocksx = (n - m - 1) / 32 + 1;
@@ -358,11 +354,11 @@ rocblas_status rocsolver_gels_template(rocblas_handle handle,
                                     ldb, strideB, ipiv_savedB, info_mask(info));
 
             // solve L'X = QB, overwriting B with X
-            rocblasCall_trsm<BATCHED, T>(
-                handle, rocblas_side_left, rocblas_fill_lower,
-                rocblas_operation_conjugate_transpose, rocblas_diagonal_non_unit, m, nrhs, &one, A,
-                shiftA, lda, strideA, B, shiftB, ldb, strideB, batch_count, optim_mem, work_x_temp,
-                workArr_temp_arr, diag_trfac_invA, trfact_workTrmm_invA_arr);
+            rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                rocblas_diagonal_non_unit, m, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb,
+                strideB, batch_count, optim_mem, work_x_temp, workArr_temp_arr, diag_trfac_invA,
+                trfact_workTrmm_invA_arr);
 
             // restore elements of B that were overwritten in cases where info is nonzero
             ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, U>), dim3(copyblocksmin, copyblocksy, batch_count),

--- a/library/src/lapack/roclapack_gels_outofplace.hpp
+++ b/library/src/lapack/roclapack_gels_outofplace.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (c) 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
  * ***********************************************************************/
 
 #pragma once
@@ -180,7 +180,6 @@ rocblas_status rocsolver_gels_outofplace_template(rocblas_handle handle,
     const rocblas_int copyblocksmin = (std::min(m, n) - 1) / 32 + 1;
     const rocblas_int copyblocksmax = (std::max(m, n) - 1) / 32 + 1;
     const rocblas_int copyblocksy = (nrhs - 1) / 32 + 1;
-    const T one = 1;
 
     // TODO: apply scaling to improve accuracy over a larger range of values
 
@@ -211,11 +210,10 @@ rocblas_status rocsolver_gels_outofplace_template(rocblas_handle handle,
                                     strideA, info);
 
             // solve RX = Q'B
-            rocblasCall_trsm<BATCHED, T>(handle, rocblas_side_left, rocblas_fill_upper,
-                                         rocblas_operation_none, rocblas_diagonal_non_unit, n, nrhs,
-                                         &one, A, shiftA, lda, strideA, B, shiftB, ldb, strideB,
-                                         batch_count, optim_mem, work_x_temp, workArr_temp_arr,
-                                         diag_trfac_invA, trfact_workTrmm_invA_arr);
+            rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit, n,
+                nrhs, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, batch_count, optim_mem,
+                work_x_temp, workArr_temp_arr, diag_trfac_invA, trfact_workTrmm_invA_arr);
 
             // copy result to X
             ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, U>), dim3(copyblocksmin, copyblocksy, batch_count),
@@ -239,11 +237,11 @@ rocblas_status rocsolver_gels_outofplace_template(rocblas_handle handle,
                                     shiftX, ldx, strideX);
 
             // solve R'Y = B (here Y = Q'X)
-            rocblasCall_trsm<BATCHED, T>(
-                handle, rocblas_side_left, rocblas_fill_upper,
-                rocblas_operation_conjugate_transpose, rocblas_diagonal_non_unit, n, nrhs, &one, A,
-                shiftA, lda, strideA, X, shiftX, ldx, strideX, batch_count, optim_mem, work_x_temp,
-                workArr_temp_arr, diag_trfac_invA, trfact_workTrmm_invA_arr);
+            rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                rocblas_diagonal_non_unit, n, nrhs, A, shiftA, lda, strideA, X, shiftX, ldx,
+                strideX, batch_count, optim_mem, work_x_temp, workArr_temp_arr, diag_trfac_invA,
+                trfact_workTrmm_invA_arr);
 
             // zero row n to m-1 of X in cases where info is zero
             const rocblas_int zeroblocksx = (m - n - 1) / 32 + 1;
@@ -276,11 +274,10 @@ rocblas_status rocsolver_gels_outofplace_template(rocblas_handle handle,
                                     shiftX, ldx, strideX);
 
             // solve LY = B (here Y = QX)
-            rocblasCall_trsm<BATCHED, T>(handle, rocblas_side_left, rocblas_fill_lower,
-                                         rocblas_operation_none, rocblas_diagonal_non_unit, m, nrhs,
-                                         &one, A, shiftA, lda, strideA, X, shiftX, ldx, strideX,
-                                         batch_count, optim_mem, work_x_temp, workArr_temp_arr,
-                                         diag_trfac_invA, trfact_workTrmm_invA_arr);
+            rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit, m,
+                nrhs, A, shiftA, lda, strideA, X, shiftX, ldx, strideX, batch_count, optim_mem,
+                work_x_temp, workArr_temp_arr, diag_trfac_invA, trfact_workTrmm_invA_arr);
 
             // zero row m to n-1 of X in cases where info is zero
             const rocblas_int zeroblocksx = (n - m - 1) / 32 + 1;
@@ -310,11 +307,11 @@ rocblas_status rocsolver_gels_outofplace_template(rocblas_handle handle,
                                     strideA, info);
 
             // solve L'X = QB
-            rocblasCall_trsm<BATCHED, T>(
-                handle, rocblas_side_left, rocblas_fill_lower,
-                rocblas_operation_conjugate_transpose, rocblas_diagonal_non_unit, m, nrhs, &one, A,
-                shiftA, lda, strideA, B, shiftB, ldb, strideB, batch_count, optim_mem, work_x_temp,
-                workArr_temp_arr, diag_trfac_invA, trfact_workTrmm_invA_arr);
+            rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                rocblas_diagonal_non_unit, m, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb,
+                strideB, batch_count, optim_mem, work_x_temp, workArr_temp_arr, diag_trfac_invA,
+                trfact_workTrmm_invA_arr);
 
             // copy result to X
             ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, U>), dim3(copyblocksmin, copyblocksy, batch_count),

--- a/library/src/lapack/roclapack_gesv.hpp
+++ b/library/src/lapack/roclapack_gesv.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
  * ***********************************************************************/
 
 #pragma once
@@ -88,8 +88,8 @@ void rocsolver_gesv_getMemorySize(const rocblas_int n,
         size_pivotval, size_pivotidx, size_iipiv, size_iinfo, &opt1);
 
     // workspace required for calling GETRS
-    rocsolver_getrs_getMemorySize<BATCHED, T>(rocblas_operation_none, n, nrhs, batch_count, &w1,
-                                              &w2, &w3, &w4, &opt2);
+    rocsolver_getrs_getMemorySize<BATCHED, STRIDED, T>(rocblas_operation_none, n, nrhs, batch_count,
+                                                       &w1, &w2, &w3, &w4, &opt2);
 
     *size_work1 = std::max(*size_work1, w1);
     *size_work2 = std::max(*size_work2, w2);
@@ -165,9 +165,9 @@ rocblas_status rocsolver_gesv_template(rocblas_handle handle,
                             (T*)work, info_mask(info));
 
     // solve AX = B, overwriting B with X
-    rocsolver_getrs_template<BATCHED, T>(handle, rocblas_operation_none, n, nrhs, A, shiftA, lda,
-                                         strideA, ipiv, strideP, B, shiftB, ldb, strideB,
-                                         batch_count, work1, work2, work3, work4, optim_mem, true);
+    rocsolver_getrs_template<BATCHED, STRIDED, T>(
+        handle, rocblas_operation_none, n, nrhs, A, shiftA, lda, strideA, ipiv, strideP, B, shiftB,
+        ldb, strideB, batch_count, work1, work2, work3, work4, optim_mem, true);
 
     // restore elements of B that were overwritten by GETRS in cases where info is nonzero
     ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(copyblocksx, copyblocksy, batch_count), dim3(32, 32),

--- a/library/src/lapack/roclapack_gesv_outofplace.hpp
+++ b/library/src/lapack/roclapack_gesv_outofplace.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
  * ***********************************************************************/
 
 #pragma once
@@ -88,8 +88,8 @@ void rocsolver_gesv_outofplace_getMemorySize(const rocblas_int n,
         size_pivotval, size_pivotidx, size_iipiv, size_iinfo, &opt1);
 
     // workspace required for calling GETRS
-    rocsolver_getrs_getMemorySize<BATCHED, T>(rocblas_operation_none, n, nrhs, batch_count, &w1,
-                                              &w2, &w3, &w4, &opt2);
+    rocsolver_getrs_getMemorySize<BATCHED, STRIDED, T>(rocblas_operation_none, n, nrhs, batch_count,
+                                                       &w1, &w2, &w3, &w4, &opt2);
 
     *size_work1 = std::max(*size_work1, w1);
     *size_work2 = std::max(*size_work2, w2);
@@ -164,9 +164,9 @@ rocblas_status rocsolver_gesv_outofplace_template(rocblas_handle handle,
                             0, stream, n, nrhs, B, shiftB, ldb, strideB, X, shiftX, ldx, strideX);
 
     // solve AX = B
-    rocsolver_getrs_template<BATCHED, T>(handle, rocblas_operation_none, n, nrhs, A, shiftA, lda,
-                                         strideA, ipiv, strideP, X, shiftX, ldx, strideX,
-                                         batch_count, work1, work2, work3, work4, optim_mem, true);
+    rocsolver_getrs_template<BATCHED, STRIDED, T>(
+        handle, rocblas_operation_none, n, nrhs, A, shiftA, lda, strideA, ipiv, strideP, X, shiftX,
+        ldx, strideX, batch_count, work1, work2, work3, work4, optim_mem, true);
 
     return rocblas_status_success;
 }

--- a/library/src/lapack/roclapack_getrf.hpp
+++ b/library/src/lapack/roclapack_getrf.hpp
@@ -588,14 +588,15 @@ void rocsolver_getrf_getMemorySize(const rocblas_int m,
         *size_iipiv = pivot ? m * sizeof(rocblas_int) * batch_count : 0;
 
         // extra workspace for calling largest possible TRSM
-        rocsolver_trsm_mem<BATCHED, STRIDED, T>(rocblas_side_left, min(dim, 512), n, batch_count,
-                                                size_work1, size_work2, size_work3, size_work4,
-                                                optim_mem, true);
+        rocsolver_trsm_mem<BATCHED, STRIDED, T>(rocblas_side_left, rocblas_operation_none,
+                                                min(dim, 512), n, batch_count, size_work1,
+                                                size_work2, size_work3, size_work4, optim_mem, true);
         if(!pivot)
         {
             size_t w1, w2, w3, w4;
-            rocsolver_trsm_mem<BATCHED, STRIDED, T>(rocblas_side_right, m, min(dim, 512),
-                                                    batch_count, &w1, &w2, &w3, &w4, optim_mem, true);
+            rocsolver_trsm_mem<BATCHED, STRIDED, T>(rocblas_side_right, rocblas_operation_none, m,
+                                                    min(dim, 512), batch_count, &w1, &w2, &w3, &w4,
+                                                    optim_mem, true);
             *size_work1 = std::max(*size_work1, w1);
             *size_work2 = std::max(*size_work2, w2);
             *size_work3 = std::max(*size_work3, w3);

--- a/library/src/lapack/roclapack_getrf.hpp
+++ b/library/src/lapack/roclapack_getrf.hpp
@@ -494,8 +494,9 @@ rocblas_status getrf_panelLU(rocblas_handle handle,
         if(k + jb < nn)
         {
             rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-                handle, jb, nn - k - jb, A, shiftA + idx2D(k, k, lda), lda, strideA, A, shiftA + idx2D(k, k + jb, lda),
-                lda, strideA, batch_count, optim_mem, work1, work2, work3, work4);
+                handle, jb, nn - k - jb, A, shiftA + idx2D(k, k, lda), lda, strideA, A,
+                shiftA + idx2D(k, k + jb, lda), lda, strideA, batch_count, optim_mem, work1, work2,
+                work3, work4);
 
             if(k + jb < mm)
                 rocblasCall_gemm<BATCHED, STRIDED, T>(
@@ -703,8 +704,9 @@ rocblas_status rocsolver_getrf_template(rocblas_handle handle,
 
             // update remaining rows in outer panel
             rocsolver_trsm_upper<BATCHED, STRIDED, T>(
-                handle, m - j - jb, jb, A, shiftA + idx2D(j, j, lda), lda, strideA, A, shiftA + idx2D(jb + j, j, lda),
-                lda, strideA, batch_count, optim_mem, work1, work2, work3, work4);
+                handle, m - j - jb, jb, A, shiftA + idx2D(j, j, lda), lda, strideA, A,
+                shiftA + idx2D(jb + j, j, lda), lda, strideA, batch_count, optim_mem, work1, work2,
+                work3, work4);
         }
 
         // update trailing matrix
@@ -714,8 +716,9 @@ rocblas_status rocsolver_getrf_template(rocblas_handle handle,
         if(nextpiv < n)
         {
             rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-                handle, jb, nn, A, shiftA + idx2D(j, j, lda), lda, strideA, A, shiftA + idx2D(j, nextpiv, lda), lda,
-                strideA, batch_count, optim_mem, work1, work2, work3, work4);
+                handle, jb, nn, A, shiftA + idx2D(j, j, lda), lda, strideA, A,
+                shiftA + idx2D(j, nextpiv, lda), lda, strideA, batch_count, optim_mem, work1, work2,
+                work3, work4);
 
             if(nextpiv < m)
             {

--- a/library/src/lapack/roclapack_getrf.hpp
+++ b/library/src/lapack/roclapack_getrf.hpp
@@ -494,7 +494,7 @@ rocblas_status getrf_panelLU(rocblas_handle handle,
         if(k + jb < nn)
         {
             rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-                handle, jb, nn - k - jb, A, shiftA + idx2D(k, k, lda), shiftA + idx2D(k, k + jb, lda),
+                handle, jb, nn - k - jb, A, shiftA + idx2D(k, k, lda), lda, strideA, A, shiftA + idx2D(k, k + jb, lda),
                 lda, strideA, batch_count, optim_mem, work1, work2, work3, work4);
 
             if(k + jb < mm)
@@ -703,7 +703,7 @@ rocblas_status rocsolver_getrf_template(rocblas_handle handle,
 
             // update remaining rows in outer panel
             rocsolver_trsm_upper<BATCHED, STRIDED, T>(
-                handle, m - j - jb, jb, A, shiftA + idx2D(j, j, lda), shiftA + idx2D(jb + j, j, lda),
+                handle, m - j - jb, jb, A, shiftA + idx2D(j, j, lda), lda, strideA, A, shiftA + idx2D(jb + j, j, lda),
                 lda, strideA, batch_count, optim_mem, work1, work2, work3, work4);
         }
 
@@ -714,7 +714,7 @@ rocblas_status rocsolver_getrf_template(rocblas_handle handle,
         if(nextpiv < n)
         {
             rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-                handle, jb, nn, A, shiftA + idx2D(j, j, lda), shiftA + idx2D(j, nextpiv, lda), lda,
+                handle, jb, nn, A, shiftA + idx2D(j, j, lda), lda, strideA, A, shiftA + idx2D(j, nextpiv, lda), lda,
                 strideA, batch_count, optim_mem, work1, work2, work3, work4);
 
             if(nextpiv < m)

--- a/library/src/lapack/roclapack_getrf.hpp
+++ b/library/src/lapack/roclapack_getrf.hpp
@@ -494,7 +494,8 @@ rocblas_status getrf_panelLU(rocblas_handle handle,
         if(k + jb < nn)
         {
             rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-                handle, jb, nn - k - jb, A, shiftA + idx2D(k, k, lda), lda, strideA, A,
+                handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_unit, jb,
+                nn - k - jb, A, shiftA + idx2D(k, k, lda), lda, strideA, A,
                 shiftA + idx2D(k, k + jb, lda), lda, strideA, batch_count, optim_mem, work1, work2,
                 work3, work4);
 
@@ -704,7 +705,8 @@ rocblas_status rocsolver_getrf_template(rocblas_handle handle,
 
             // update remaining rows in outer panel
             rocsolver_trsm_upper<BATCHED, STRIDED, T>(
-                handle, m - j - jb, jb, A, shiftA + idx2D(j, j, lda), lda, strideA, A,
+                handle, rocblas_side_right, rocblas_operation_none, rocblas_diagonal_non_unit,
+                m - j - jb, jb, A, shiftA + idx2D(j, j, lda), lda, strideA, A,
                 shiftA + idx2D(jb + j, j, lda), lda, strideA, batch_count, optim_mem, work1, work2,
                 work3, work4);
         }
@@ -716,9 +718,9 @@ rocblas_status rocsolver_getrf_template(rocblas_handle handle,
         if(nextpiv < n)
         {
             rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-                handle, jb, nn, A, shiftA + idx2D(j, j, lda), lda, strideA, A,
-                shiftA + idx2D(j, nextpiv, lda), lda, strideA, batch_count, optim_mem, work1, work2,
-                work3, work4);
+                handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_unit, jb, nn, A,
+                shiftA + idx2D(j, j, lda), lda, strideA, A, shiftA + idx2D(j, nextpiv, lda), lda,
+                strideA, batch_count, optim_mem, work1, work2, work3, work4);
 
             if(nextpiv < m)
             {

--- a/library/src/lapack/roclapack_getri_outofplace.cpp
+++ b/library/src/lapack/roclapack_getri_outofplace.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "roclapack_getri_outofplace.hpp"
@@ -43,8 +43,8 @@ rocblas_status rocsolver_getri_outofplace_impl(rocblas_handle handle,
     bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
 
-    rocsolver_getri_outofplace_getMemorySize<false, T>(n, batch_count, &size_work1, &size_work2,
-                                                       &size_work3, &size_work4, &optim_mem);
+    rocsolver_getri_outofplace_getMemorySize<false, false, T>(
+        n, batch_count, &size_work1, &size_work2, &size_work3, &size_work4, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
@@ -62,7 +62,7 @@ rocblas_status rocsolver_getri_outofplace_impl(rocblas_handle handle,
     work4 = mem[3];
 
     // Execution
-    return rocsolver_getri_outofplace_template<false, T>(
+    return rocsolver_getri_outofplace_template<false, false, T>(
         handle, n, A, shiftA, lda, strideA, ipiv, shiftP, strideP, C, shiftC, ldc, strideC, info,
         batch_count, work1, work2, work3, work4, optim_mem, pivot);
 }

--- a/library/src/lapack/roclapack_getri_outofplace.hpp
+++ b/library/src/lapack/roclapack_getri_outofplace.hpp
@@ -1,5 +1,5 @@
 /************************************************************************
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
  * ***********************************************************************/
 
 #pragma once
@@ -9,7 +9,7 @@
 #include "roclapack_getrs.hpp"
 #include "rocsolver/rocsolver.h"
 
-template <bool BATCHED, typename T>
+template <bool BATCHED, bool STRIDED, typename T>
 void rocsolver_getri_outofplace_getMemorySize(const rocblas_int n,
                                               const rocblas_int batch_count,
                                               size_t* size_work1,
@@ -30,8 +30,9 @@ void rocsolver_getri_outofplace_getMemorySize(const rocblas_int n,
     }
 
     // requirements for calling GETRS
-    rocsolver_getrs_getMemorySize<BATCHED, T>(rocblas_operation_none, n, n, batch_count, size_work1,
-                                              size_work2, size_work3, size_work4, optim_mem);
+    rocsolver_getrs_getMemorySize<BATCHED, STRIDED, T>(rocblas_operation_none, n, n, batch_count,
+                                                       size_work1, size_work2, size_work3,
+                                                       size_work4, optim_mem);
 }
 
 template <typename T>
@@ -66,7 +67,7 @@ rocblas_status rocsolver_getri_outofplace_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <bool BATCHED, typename T, typename U>
+template <bool BATCHED, bool STRIDED, typename T, typename U>
 rocblas_status rocsolver_getri_outofplace_template(rocblas_handle handle,
                                                    const rocblas_int n,
                                                    U A,
@@ -118,9 +119,9 @@ rocblas_status rocsolver_getri_outofplace_template(rocblas_handle handle,
                             stream, n, n, C, shiftC, ldc, strideC);
 
     // compute inverse
-    rocsolver_getrs_template<BATCHED, T>(handle, rocblas_operation_none, n, n, A, shiftA, lda,
-                                         strideA, ipiv, strideP, C, shiftC, ldc, strideC,
-                                         batch_count, work1, work2, work3, work4, optim_mem, pivot);
+    rocsolver_getrs_template<BATCHED, STRIDED, T>(
+        handle, rocblas_operation_none, n, n, A, shiftA, lda, strideA, ipiv, strideP, C, shiftC,
+        ldc, strideC, batch_count, work1, work2, work3, work4, optim_mem, pivot);
 
     return rocblas_status_success;
 }

--- a/library/src/lapack/roclapack_getri_outofplace_batched.cpp
+++ b/library/src/lapack/roclapack_getri_outofplace_batched.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "roclapack_getri_outofplace.hpp"
@@ -44,8 +44,8 @@ rocblas_status rocsolver_getri_outofplace_batched_impl(rocblas_handle handle,
     bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
 
-    rocsolver_getri_outofplace_getMemorySize<true, T>(n, batch_count, &size_work1, &size_work2,
-                                                      &size_work3, &size_work4, &optim_mem);
+    rocsolver_getri_outofplace_getMemorySize<true, false, T>(
+        n, batch_count, &size_work1, &size_work2, &size_work3, &size_work4, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
@@ -63,7 +63,7 @@ rocblas_status rocsolver_getri_outofplace_batched_impl(rocblas_handle handle,
     work4 = mem[3];
 
     // Execution
-    return rocsolver_getri_outofplace_template<true, T>(
+    return rocsolver_getri_outofplace_template<true, false, T>(
         handle, n, A, shiftA, lda, strideA, ipiv, shiftP, strideP, C, shiftC, ldc, strideC, info,
         batch_count, work1, work2, work3, work4, optim_mem, pivot);
 }

--- a/library/src/lapack/roclapack_getri_outofplace_strided_batched.cpp
+++ b/library/src/lapack/roclapack_getri_outofplace_strided_batched.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "roclapack_getri_outofplace.hpp"
@@ -43,8 +43,8 @@ rocblas_status rocsolver_getri_outofplace_strided_batched_impl(rocblas_handle ha
     bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
 
-    rocsolver_getri_outofplace_getMemorySize<false, T>(n, batch_count, &size_work1, &size_work2,
-                                                       &size_work3, &size_work4, &optim_mem);
+    rocsolver_getri_outofplace_getMemorySize<false, true, T>(
+        n, batch_count, &size_work1, &size_work2, &size_work3, &size_work4, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
@@ -62,7 +62,7 @@ rocblas_status rocsolver_getri_outofplace_strided_batched_impl(rocblas_handle ha
     work4 = mem[3];
 
     // Execution
-    return rocsolver_getri_outofplace_template<false, T>(
+    return rocsolver_getri_outofplace_template<false, true, T>(
         handle, n, A, shiftA, lda, strideA, ipiv, shiftP, strideP, C, shiftC, ldc, strideC, info,
         batch_count, work1, work2, work3, work4, optim_mem, pivot);
 }

--- a/library/src/lapack/roclapack_getrs.cpp
+++ b/library/src/lapack/roclapack_getrs.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "roclapack_getrs.hpp"
@@ -40,8 +40,8 @@ rocblas_status rocsolver_getrs_impl(rocblas_handle handle,
     // size of workspace (for calling TRSM)
     bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
-    rocsolver_getrs_getMemorySize<false, T>(trans, n, nrhs, batch_count, &size_work1, &size_work2,
-                                            &size_work3, &size_work4, &optim_mem);
+    rocsolver_getrs_getMemorySize<false, false, T>(
+        trans, n, nrhs, batch_count, &size_work1, &size_work2, &size_work3, &size_work4, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
@@ -60,9 +60,9 @@ rocblas_status rocsolver_getrs_impl(rocblas_handle handle,
     work4 = mem[3];
 
     // execution
-    return rocsolver_getrs_template<false, T>(handle, trans, n, nrhs, A, shiftA, lda, strideA, ipiv,
-                                              strideP, B, shiftB, ldb, strideB, batch_count, work1,
-                                              work2, work3, work4, optim_mem, true);
+    return rocsolver_getrs_template<false, false, T>(
+        handle, trans, n, nrhs, A, shiftA, lda, strideA, ipiv, strideP, B, shiftB, ldb, strideB,
+        batch_count, work1, work2, work3, work4, optim_mem, true);
 }
 
 /*

--- a/library/src/lapack/roclapack_getrs.hpp
+++ b/library/src/lapack/roclapack_getrs.hpp
@@ -127,9 +127,9 @@ rocblas_status rocsolver_getrs_template(rocblas_handle handle,
                                         strideP, 1, batch_count);
 
         // solve L*X = B, overwriting B with X
-        rocsolver_trsm_lower<BATCHED, STRIDED, T>(handle, n, nrhs, A, shiftA, lda, strideA, B,
-                                                  shiftB, ldb, strideB, batch_count, optim_mem,
-                                                  work1, work2, work3, work4);
+        rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+            handle, rocblas_side_left, trans, rocblas_diagonal_unit, n, nrhs, A, shiftA, lda,
+            strideA, B, shiftB, ldb, strideB, batch_count, optim_mem, work1, work2, work3, work4);
         //        rocblasCall_trsm<BATCHED, T>(handle, rocblas_side_left, rocblas_fill_lower, trans,
         //                                     rocblas_diagonal_unit, n, nrhs, &one, A, shiftA, lda, strideA,
         //                                     B, shiftB, ldb, strideB, batch_count, optim_mem, work1, work2,

--- a/library/src/lapack/roclapack_getrs.hpp
+++ b/library/src/lapack/roclapack_getrs.hpp
@@ -109,14 +109,6 @@ rocblas_status rocsolver_getrs_template(rocblas_handle handle,
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
 
-    // everything must be executed with scalars on the host
-    rocblas_pointer_mode old_mode;
-    rocblas_get_pointer_mode(handle, &old_mode);
-    rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
-
-    // constants to use when calling rocblas functions
-    T one = 1; // constant 1 in host
-
     if(trans == rocblas_operation_none)
     {
         // first apply row interchanges to the right hand sides
@@ -152,6 +144,5 @@ rocblas_status rocsolver_getrs_template(rocblas_handle handle,
                                         strideP, -1, batch_count);
     }
 
-    rocblas_set_pointer_mode(handle, old_mode);
     return rocblas_status_success;
 }

--- a/library/src/lapack/roclapack_getrs.hpp
+++ b/library/src/lapack/roclapack_getrs.hpp
@@ -109,6 +109,11 @@ rocblas_status rocsolver_getrs_template(rocblas_handle handle,
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
 
+    // everything must be executed with scalars on the host
+    rocblas_pointer_mode old_mode;
+    rocblas_get_pointer_mode(handle, &old_mode);
+    rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
+
     if(trans == rocblas_operation_none)
     {
         // first apply row interchanges to the right hand sides
@@ -144,5 +149,6 @@ rocblas_status rocsolver_getrs_template(rocblas_handle handle,
                                         strideP, -1, batch_count);
     }
 
+    rocblas_set_pointer_mode(handle, old_mode);
     return rocblas_status_success;
 }

--- a/library/src/lapack/roclapack_getrs_batched.cpp
+++ b/library/src/lapack/roclapack_getrs_batched.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "roclapack_getrs.hpp"
@@ -41,8 +41,8 @@ rocblas_status rocsolver_getrs_batched_impl(rocblas_handle handle,
     // size of workspace (for calling TRSM)
     bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
-    rocsolver_getrs_getMemorySize<true, T>(trans, n, nrhs, batch_count, &size_work1, &size_work2,
-                                           &size_work3, &size_work4, &optim_mem);
+    rocsolver_getrs_getMemorySize<true, false, T>(trans, n, nrhs, batch_count, &size_work1,
+                                                  &size_work2, &size_work3, &size_work4, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
@@ -61,9 +61,9 @@ rocblas_status rocsolver_getrs_batched_impl(rocblas_handle handle,
     work4 = mem[3];
 
     // execution
-    return rocsolver_getrs_template<true, T>(handle, trans, n, nrhs, A, shiftA, lda, strideA, ipiv,
-                                             strideP, B, shiftB, ldb, strideB, batch_count, work1,
-                                             work2, work3, work4, optim_mem, true);
+    return rocsolver_getrs_template<true, false, T>(
+        handle, trans, n, nrhs, A, shiftA, lda, strideA, ipiv, strideP, B, shiftB, ldb, strideB,
+        batch_count, work1, work2, work3, work4, optim_mem, true);
 }
 
 /*

--- a/library/src/lapack/roclapack_getrs_strided_batched.cpp
+++ b/library/src/lapack/roclapack_getrs_strided_batched.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "roclapack_getrs.hpp"
@@ -40,8 +40,8 @@ rocblas_status rocsolver_getrs_strided_batched_impl(rocblas_handle handle,
     // size of workspace (for calling TRSM)
     bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
-    rocsolver_getrs_getMemorySize<false, T>(trans, n, nrhs, batch_count, &size_work1, &size_work2,
-                                            &size_work3, &size_work4, &optim_mem);
+    rocsolver_getrs_getMemorySize<false, true, T>(trans, n, nrhs, batch_count, &size_work1,
+                                                  &size_work2, &size_work3, &size_work4, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
@@ -60,9 +60,9 @@ rocblas_status rocsolver_getrs_strided_batched_impl(rocblas_handle handle,
     work4 = mem[3];
 
     // execution
-    return rocsolver_getrs_template<false, T>(handle, trans, n, nrhs, A, shiftA, lda, strideA, ipiv,
-                                              strideP, B, shiftB, ldb, strideB, batch_count, work1,
-                                              work2, work3, work4, optim_mem, true);
+    return rocsolver_getrs_template<false, true, T>(
+        handle, trans, n, nrhs, A, shiftA, lda, strideA, ipiv, strideP, B, shiftB, ldb, strideB,
+        batch_count, work1, work2, work3, work4, optim_mem, true);
 }
 
 /*

--- a/library/src/lapack/roclapack_posv.cpp
+++ b/library/src/lapack/roclapack_posv.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "roclapack_posv.hpp"
@@ -44,9 +44,9 @@ rocblas_status rocsolver_posv_impl(rocblas_handle handle,
     size_t size_work1, size_work2, size_work3, size_work4;
     // extra requirements for calling POTRF and to copy B
     size_t size_pivots_savedB, size_iinfo;
-    rocsolver_posv_getMemorySize<false, T>(n, nrhs, uplo, batch_count, &size_scalars, &size_work1,
-                                           &size_work2, &size_work3, &size_work4,
-                                           &size_pivots_savedB, &size_iinfo, &optim_mem);
+    rocsolver_posv_getMemorySize<false, false, T>(n, nrhs, uplo, batch_count, &size_scalars,
+                                                  &size_work1, &size_work2, &size_work3, &size_work4,
+                                                  &size_pivots_savedB, &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
@@ -72,7 +72,7 @@ rocblas_status rocsolver_posv_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_posv_template<false, T, S>(
+    return rocsolver_posv_template<false, false, T, S>(
         handle, uplo, n, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, info, batch_count,
         (T*)scalars, work1, work2, work3, work4, (T*)pivots_savedB, (rocblas_int*)iinfo, optim_mem);
 }

--- a/library/src/lapack/roclapack_posv.hpp
+++ b/library/src/lapack/roclapack_posv.hpp
@@ -79,9 +79,9 @@ void rocsolver_posv_getMemorySize(const rocblas_int n,
     size_t w1, w2, w3, w4;
 
     // workspace required for potrf
-    rocsolver_potrf_getMemorySize<BATCHED, T>(n, uplo, batch_count, size_scalars, size_work1,
-                                              size_work2, size_work3, size_work4,
-                                              size_pivots_savedB, size_iinfo, &opt1);
+    rocsolver_potrf_getMemorySize<BATCHED, STRIDED, T>(n, uplo, batch_count, size_scalars,
+                                                       size_work1, size_work2, size_work3, size_work4,
+                                                       size_pivots_savedB, size_iinfo, &opt1);
 
     // workspace required for potrs
     rocsolver_potrs_getMemorySize<BATCHED, STRIDED, T>(n, nrhs, batch_count, &w1, &w2, &w3, &w4,
@@ -147,9 +147,9 @@ rocblas_status rocsolver_posv_template(rocblas_handle handle,
     const rocblas_int copyblocksy = (nrhs - 1) / 32 + 1;
 
     // compute Cholesky factorization of A
-    rocsolver_potrf_template<BATCHED, T, S>(handle, uplo, n, A, shiftA, lda, strideA, info,
-                                            batch_count, scalars, work1, work2, work3, work4,
-                                            pivots_savedB, iinfo, optim_mem);
+    rocsolver_potrf_template<BATCHED, STRIDED, T, S>(handle, uplo, n, A, shiftA, lda, strideA, info,
+                                                     batch_count, scalars, work1, work2, work3,
+                                                     work4, pivots_savedB, iinfo, optim_mem);
 
     // save elements of B that will be overwritten by POTRS for cases where info is nonzero
     ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, U>), dim3(copyblocksx, copyblocksy, batch_count),

--- a/library/src/lapack/roclapack_posv.hpp
+++ b/library/src/lapack/roclapack_posv.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
  * ***********************************************************************/
 
 #pragma once
@@ -47,7 +47,7 @@ rocblas_status rocsolver_posv_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <bool BATCHED, typename T>
+template <bool BATCHED, bool STRIDED, typename T>
 void rocsolver_posv_getMemorySize(const rocblas_int n,
                                   const rocblas_int nrhs,
                                   const rocblas_fill uplo,
@@ -84,7 +84,8 @@ void rocsolver_posv_getMemorySize(const rocblas_int n,
                                               size_pivots_savedB, size_iinfo, &opt1);
 
     // workspace required for potrs
-    rocsolver_potrs_getMemorySize<BATCHED, T>(n, nrhs, batch_count, &w1, &w2, &w3, &w4, &opt2);
+    rocsolver_potrs_getMemorySize<BATCHED, STRIDED, T>(n, nrhs, batch_count, &w1, &w2, &w3, &w4,
+                                                       &opt2);
 
     *size_work1 = std::max(*size_work1, w1);
     *size_work2 = std::max(*size_work2, w2);
@@ -96,7 +97,7 @@ void rocsolver_posv_getMemorySize(const rocblas_int n,
     *size_pivots_savedB = std::max(*size_pivots_savedB, sizeof(T) * n * nrhs * batch_count);
 }
 
-template <bool BATCHED, typename T, typename S, typename U>
+template <bool BATCHED, bool STRIDED, typename T, typename S, typename U>
 rocblas_status rocsolver_posv_template(rocblas_handle handle,
                                        const rocblas_fill uplo,
                                        const rocblas_int n,
@@ -156,9 +157,9 @@ rocblas_status rocsolver_posv_template(rocblas_handle handle,
                             strideB, pivots_savedB, info_mask(info));
 
     // solve AX = B, overwriting B with X
-    rocsolver_potrs_template<BATCHED, T>(handle, uplo, n, nrhs, A, shiftA, lda, strideA, B, shiftB,
-                                         ldb, strideB, batch_count, work1, work2, work3, work4,
-                                         optim_mem);
+    rocsolver_potrs_template<BATCHED, STRIDED, T>(handle, uplo, n, nrhs, A, shiftA, lda, strideA, B,
+                                                  shiftB, ldb, strideB, batch_count, work1, work2,
+                                                  work3, work4, optim_mem);
 
     // restore elements of B that were overwritten by POTRS in cases where info is nonzero
     ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, U>), dim3(copyblocksx, copyblocksy, batch_count),

--- a/library/src/lapack/roclapack_posv_batched.cpp
+++ b/library/src/lapack/roclapack_posv_batched.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "roclapack_posv.hpp"
@@ -46,9 +46,9 @@ rocblas_status rocsolver_posv_batched_impl(rocblas_handle handle,
     size_t size_work1, size_work2, size_work3, size_work4;
     // extra requirements for calling POTRF and to copy B
     size_t size_pivots_savedB, size_iinfo;
-    rocsolver_posv_getMemorySize<true, T>(n, nrhs, uplo, batch_count, &size_scalars, &size_work1,
-                                          &size_work2, &size_work3, &size_work4,
-                                          &size_pivots_savedB, &size_iinfo, &optim_mem);
+    rocsolver_posv_getMemorySize<true, false, T>(n, nrhs, uplo, batch_count, &size_scalars,
+                                                 &size_work1, &size_work2, &size_work3, &size_work4,
+                                                 &size_pivots_savedB, &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
@@ -74,7 +74,7 @@ rocblas_status rocsolver_posv_batched_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_posv_template<true, T, S>(
+    return rocsolver_posv_template<true, false, T, S>(
         handle, uplo, n, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, info, batch_count,
         (T*)scalars, work1, work2, work3, work4, (T*)pivots_savedB, (rocblas_int*)iinfo, optim_mem);
 }

--- a/library/src/lapack/roclapack_posv_strided_batched.cpp
+++ b/library/src/lapack/roclapack_posv_strided_batched.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "roclapack_posv.hpp"
@@ -45,9 +45,9 @@ rocblas_status rocsolver_posv_strided_batched_impl(rocblas_handle handle,
     size_t size_work1, size_work2, size_work3, size_work4;
     // extra requirements for calling POTRF and to copy B
     size_t size_pivots_savedB, size_iinfo;
-    rocsolver_posv_getMemorySize<false, T>(n, nrhs, uplo, batch_count, &size_scalars, &size_work1,
-                                           &size_work2, &size_work3, &size_work4,
-                                           &size_pivots_savedB, &size_iinfo, &optim_mem);
+    rocsolver_posv_getMemorySize<false, true, T>(n, nrhs, uplo, batch_count, &size_scalars,
+                                                 &size_work1, &size_work2, &size_work3, &size_work4,
+                                                 &size_pivots_savedB, &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
@@ -73,7 +73,7 @@ rocblas_status rocsolver_posv_strided_batched_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_posv_template<false, T, S>(
+    return rocsolver_posv_template<false, true, T, S>(
         handle, uplo, n, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, info, batch_count,
         (T*)scalars, work1, work2, work3, work4, (T*)pivots_savedB, (rocblas_int*)iinfo, optim_mem);
 }

--- a/library/src/lapack/roclapack_potrf.cpp
+++ b/library/src/lapack/roclapack_potrf.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "roclapack_potrf.hpp"
@@ -41,9 +41,9 @@ rocblas_status rocsolver_potrf_impl(rocblas_handle handle,
     size_t size_pivots;
     // size to store info about positiveness of each subblock
     size_t size_iinfo;
-    rocsolver_potrf_getMemorySize<false, T>(n, uplo, batch_count, &size_scalars, &size_work1,
-                                            &size_work2, &size_work3, &size_work4, &size_pivots,
-                                            &size_iinfo, &optim_mem);
+    rocsolver_potrf_getMemorySize<false, false, T>(n, uplo, batch_count, &size_scalars, &size_work1,
+                                                   &size_work2, &size_work3, &size_work4,
+                                                   &size_pivots, &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
@@ -69,9 +69,9 @@ rocblas_status rocsolver_potrf_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_potrf_template<false, T, S>(handle, uplo, n, A, shiftA, lda, strideA, info,
-                                                 batch_count, (T*)scalars, work1, work2, work3,
-                                                 work4, (T*)pivots, (rocblas_int*)iinfo, optim_mem);
+    return rocsolver_potrf_template<false, false, T, S>(
+        handle, uplo, n, A, shiftA, lda, strideA, info, batch_count, (T*)scalars, work1, work2,
+        work3, work4, (T*)pivots, (rocblas_int*)iinfo, optim_mem);
 }
 
 /*

--- a/library/src/lapack/roclapack_potrf.hpp
+++ b/library/src/lapack/roclapack_potrf.hpp
@@ -86,7 +86,7 @@ void rocsolver_potrf_getMemorySize(const rocblas_int n,
     }
 }
 
-template <bool BATCHED, bool STRIDED, typename T, typename S, typename U, bool COMPLEX = is_complex<T>>
+template <bool BATCHED, bool STRIDED, typename T, typename S, typename U>
 rocblas_status rocsolver_potrf_template(rocblas_handle handle,
                                         const rocblas_fill uplo,
                                         const rocblas_int n,

--- a/library/src/lapack/roclapack_potrf_batched.cpp
+++ b/library/src/lapack/roclapack_potrf_batched.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "roclapack_potrf.hpp"
@@ -42,9 +42,9 @@ rocblas_status rocsolver_potrf_batched_impl(rocblas_handle handle,
     size_t size_pivots;
     // size to store info about positiveness of each subblock
     size_t size_iinfo;
-    rocsolver_potrf_getMemorySize<true, T>(n, uplo, batch_count, &size_scalars, &size_work1,
-                                           &size_work2, &size_work3, &size_work4, &size_pivots,
-                                           &size_iinfo, &optim_mem);
+    rocsolver_potrf_getMemorySize<true, false, T>(n, uplo, batch_count, &size_scalars, &size_work1,
+                                                  &size_work2, &size_work3, &size_work4,
+                                                  &size_pivots, &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
@@ -70,9 +70,9 @@ rocblas_status rocsolver_potrf_batched_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_potrf_template<true, T, S>(handle, uplo, n, A, shiftA, lda, strideA, info,
-                                                batch_count, (T*)scalars, work1, work2, work3,
-                                                work4, (T*)pivots, (rocblas_int*)iinfo, optim_mem);
+    return rocsolver_potrf_template<true, false, T, S>(
+        handle, uplo, n, A, shiftA, lda, strideA, info, batch_count, (T*)scalars, work1, work2,
+        work3, work4, (T*)pivots, (rocblas_int*)iinfo, optim_mem);
 }
 
 /*

--- a/library/src/lapack/roclapack_potrf_strided_batched.cpp
+++ b/library/src/lapack/roclapack_potrf_strided_batched.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "roclapack_potrf.hpp"
@@ -40,9 +40,9 @@ rocblas_status rocsolver_potrf_strided_batched_impl(rocblas_handle handle,
     size_t size_pivots;
     // size to store info about positiveness of each subblock
     size_t size_iinfo;
-    rocsolver_potrf_getMemorySize<false, T>(n, uplo, batch_count, &size_scalars, &size_work1,
-                                            &size_work2, &size_work3, &size_work4, &size_pivots,
-                                            &size_iinfo, &optim_mem);
+    rocsolver_potrf_getMemorySize<false, true, T>(n, uplo, batch_count, &size_scalars, &size_work1,
+                                                  &size_work2, &size_work3, &size_work4,
+                                                  &size_pivots, &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
@@ -68,9 +68,9 @@ rocblas_status rocsolver_potrf_strided_batched_impl(rocblas_handle handle,
         init_scalars(handle, (T*)scalars);
 
     // execution
-    return rocsolver_potrf_template<false, T, S>(handle, uplo, n, A, shiftA, lda, strideA, info,
-                                                 batch_count, (T*)scalars, work1, work2, work3,
-                                                 work4, (T*)pivots, (rocblas_int*)iinfo, optim_mem);
+    return rocsolver_potrf_template<false, true, T, S>(
+        handle, uplo, n, A, shiftA, lda, strideA, info, batch_count, (T*)scalars, work1, work2,
+        work3, work4, (T*)pivots, (rocblas_int*)iinfo, optim_mem);
 }
 
 /*

--- a/library/src/lapack/roclapack_potrs.cpp
+++ b/library/src/lapack/roclapack_potrs.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "roclapack_potrs.hpp"
@@ -37,8 +37,8 @@ rocblas_status rocsolver_potrs_impl(rocblas_handle handle,
     // size of workspace (for calling TRSM)
     bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
-    rocsolver_potrs_getMemorySize<false, T>(n, nrhs, batch_count, &size_work1, &size_work2,
-                                            &size_work3, &size_work4, &optim_mem);
+    rocsolver_potrs_getMemorySize<false, false, T>(n, nrhs, batch_count, &size_work1, &size_work2,
+                                                   &size_work3, &size_work4, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
@@ -57,9 +57,9 @@ rocblas_status rocsolver_potrs_impl(rocblas_handle handle,
     work4 = mem[3];
 
     // execution
-    return rocsolver_potrs_template<false, T>(handle, uplo, n, nrhs, A, shiftA, lda, strideA, B,
-                                              shiftB, ldb, strideB, batch_count, work1, work2,
-                                              work3, work4, optim_mem);
+    return rocsolver_potrs_template<false, false, T>(handle, uplo, n, nrhs, A, shiftA, lda, strideA,
+                                                     B, shiftB, ldb, strideB, batch_count, work1,
+                                                     work2, work3, work4, optim_mem);
 }
 
 /*

--- a/library/src/lapack/roclapack_potrs.hpp
+++ b/library/src/lapack/roclapack_potrs.hpp
@@ -113,6 +113,11 @@ rocblas_status rocsolver_potrs_template(rocblas_handle handle,
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
 
+    // everything must be executed with scalars on the host
+    rocblas_pointer_mode old_mode;
+    rocblas_get_pointer_mode(handle, &old_mode);
+    rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
+
     if(uplo == rocblas_fill_upper)
     {
         // solve U'*X = B, overwriting B with X
@@ -142,5 +147,6 @@ rocblas_status rocsolver_potrs_template(rocblas_handle handle,
             batch_count, optim_mem, work1, work2, work3, work4);
     }
 
+    rocblas_set_pointer_mode(handle, old_mode);
     return rocblas_status_success;
 }

--- a/library/src/lapack/roclapack_potrs.hpp
+++ b/library/src/lapack/roclapack_potrs.hpp
@@ -4,11 +4,12 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
  * ***********************************************************************/
 
 #pragma once
 
+#include "lapack_host_functions.hpp"
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
 
@@ -44,7 +45,7 @@ rocblas_status rocsolver_potrs_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <bool BATCHED, typename T>
+template <bool BATCHED, bool STRIDED, typename T>
 void rocsolver_potrs_getMemorySize(const rocblas_int n,
                                    const rocblas_int nrhs,
                                    const rocblas_int batch_count,
@@ -69,23 +70,20 @@ void rocsolver_potrs_getMemorySize(const rocblas_int n,
     // call with both rocblas_operation_none and rocblas_operation_conjugate_transpose and take maximum memory
     size_t size_work1_temp1, size_work1_temp2, size_work2_temp1, size_work2_temp2, size_work3_temp1,
         size_work3_temp2, size_work4_temp1, size_work4_temp2;
-    rocblasCall_trsm_mem<BATCHED, T>(rocblas_side_left, rocblas_operation_none, n, nrhs,
-                                     batch_count, &size_work1_temp1, &size_work2_temp1,
-                                     &size_work3_temp1, &size_work4_temp1);
-    rocblasCall_trsm_mem<BATCHED, T>(rocblas_side_left, rocblas_operation_conjugate_transpose, n,
-                                     nrhs, batch_count, &size_work1_temp2, &size_work2_temp2,
-                                     &size_work3_temp2, &size_work4_temp2);
+    rocsolver_trsm_mem<BATCHED, STRIDED, T>(rocblas_side_left, rocblas_operation_none, n, nrhs,
+                                            batch_count, &size_work1_temp1, &size_work2_temp1,
+                                            &size_work3_temp1, &size_work4_temp1, optim_mem);
+    rocsolver_trsm_mem<BATCHED, STRIDED, T>(
+        rocblas_side_left, rocblas_operation_conjugate_transpose, n, nrhs, batch_count,
+        &size_work1_temp2, &size_work2_temp2, &size_work3_temp2, &size_work4_temp2, optim_mem);
 
     *size_work1 = std::max(size_work1_temp1, size_work1_temp2);
     *size_work2 = std::max(size_work2_temp1, size_work2_temp2);
     *size_work3 = std::max(size_work3_temp1, size_work3_temp2);
     *size_work4 = std::max(size_work4_temp1, size_work4_temp2);
-
-    // always allocate all required memory for TRSM optimal performance
-    *optim_mem = true;
 }
 
-template <bool BATCHED, typename T, typename U>
+template <bool BATCHED, bool STRIDED, typename T, typename U>
 rocblas_status rocsolver_potrs_template(rocblas_handle handle,
                                         const rocblas_fill uplo,
                                         const rocblas_int n,
@@ -115,43 +113,34 @@ rocblas_status rocsolver_potrs_template(rocblas_handle handle,
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
 
-    // everything must be executed with scalars on the host
-    rocblas_pointer_mode old_mode;
-    rocblas_get_pointer_mode(handle, &old_mode);
-    rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
-
-    // constants to use when calling rocblas functions
-    T one = 1; // constant 1 in host
-
     if(uplo == rocblas_fill_upper)
     {
         // solve U'*X = B, overwriting B with X
-        rocblasCall_trsm<BATCHED, T>(handle, rocblas_side_left, uplo,
-                                     rocblas_operation_conjugate_transpose, rocblas_diagonal_non_unit,
-                                     n, nrhs, &one, A, shiftA, lda, strideA, B, shiftB, ldb,
-                                     strideB, batch_count, optim_mem, work1, work2, work3, work4);
+        rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+            handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+            rocblas_diagonal_non_unit, n, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb, strideB,
+            batch_count, optim_mem, work1, work2, work3, work4);
 
         // solve U*X = B, overwriting B with X
-        rocblasCall_trsm<BATCHED, T>(handle, rocblas_side_left, uplo, rocblas_operation_none,
-                                     rocblas_diagonal_non_unit, n, nrhs, &one, A, shiftA, lda,
-                                     strideA, B, shiftB, ldb, strideB, batch_count, optim_mem,
-                                     work1, work2, work3, work4);
+        rocsolver_trsm_upper<BATCHED, STRIDED, T>(handle, rocblas_side_left, rocblas_operation_none,
+                                                  rocblas_diagonal_non_unit, n, nrhs, A, shiftA,
+                                                  lda, strideA, B, shiftB, ldb, strideB, batch_count,
+                                                  optim_mem, work1, work2, work3, work4);
     }
     else
     {
         // solve L*X = B, overwriting B with X
-        rocblasCall_trsm<BATCHED, T>(handle, rocblas_side_left, uplo, rocblas_operation_none,
-                                     rocblas_diagonal_non_unit, n, nrhs, &one, A, shiftA, lda,
-                                     strideA, B, shiftB, ldb, strideB, batch_count, optim_mem,
-                                     work1, work2, work3, work4);
+        rocsolver_trsm_lower<BATCHED, STRIDED, T>(handle, rocblas_side_left, rocblas_operation_none,
+                                                  rocblas_diagonal_non_unit, n, nrhs, A, shiftA,
+                                                  lda, strideA, B, shiftB, ldb, strideB, batch_count,
+                                                  optim_mem, work1, work2, work3, work4);
 
         // solve L'*X = B, overwriting B with X
-        rocblasCall_trsm<BATCHED, T>(handle, rocblas_side_left, uplo,
-                                     rocblas_operation_conjugate_transpose, rocblas_diagonal_non_unit,
-                                     n, nrhs, &one, A, shiftA, lda, strideA, B, shiftB, ldb,
-                                     strideB, batch_count, optim_mem, work1, work2, work3, work4);
+        rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+            handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+            rocblas_diagonal_non_unit, n, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb, strideB,
+            batch_count, optim_mem, work1, work2, work3, work4);
     }
 
-    rocblas_set_pointer_mode(handle, old_mode);
     return rocblas_status_success;
 }

--- a/library/src/lapack/roclapack_potrs_batched.cpp
+++ b/library/src/lapack/roclapack_potrs_batched.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "roclapack_potrs.hpp"
@@ -38,8 +38,8 @@ rocblas_status rocsolver_potrs_batched_impl(rocblas_handle handle,
     // size of workspace (for calling TRSM)
     bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
-    rocsolver_potrs_getMemorySize<true, T>(n, nrhs, batch_count, &size_work1, &size_work2,
-                                           &size_work3, &size_work4, &optim_mem);
+    rocsolver_potrs_getMemorySize<true, false, T>(n, nrhs, batch_count, &size_work1, &size_work2,
+                                                  &size_work3, &size_work4, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
@@ -58,9 +58,9 @@ rocblas_status rocsolver_potrs_batched_impl(rocblas_handle handle,
     work4 = mem[3];
 
     // execution
-    return rocsolver_potrs_template<true, T>(handle, uplo, n, nrhs, A, shiftA, lda, strideA, B,
-                                             shiftB, ldb, strideB, batch_count, work1, work2, work3,
-                                             work4, optim_mem);
+    return rocsolver_potrs_template<true, false, T>(handle, uplo, n, nrhs, A, shiftA, lda, strideA,
+                                                    B, shiftB, ldb, strideB, batch_count, work1,
+                                                    work2, work3, work4, optim_mem);
 }
 
 /*

--- a/library/src/lapack/roclapack_potrs_strided_batched.cpp
+++ b/library/src/lapack/roclapack_potrs_strided_batched.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "roclapack_potrs.hpp"
@@ -37,8 +37,8 @@ rocblas_status rocsolver_potrs_strided_batched_impl(rocblas_handle handle,
     // size of workspace (for calling TRSM)
     bool optim_mem;
     size_t size_work1, size_work2, size_work3, size_work4;
-    rocsolver_potrs_getMemorySize<false, T>(n, nrhs, batch_count, &size_work1, &size_work2,
-                                            &size_work3, &size_work4, &optim_mem);
+    rocsolver_potrs_getMemorySize<false, true, T>(n, nrhs, batch_count, &size_work1, &size_work2,
+                                                  &size_work3, &size_work4, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_work1, size_work2, size_work3,
@@ -57,9 +57,9 @@ rocblas_status rocsolver_potrs_strided_batched_impl(rocblas_handle handle,
     work4 = mem[3];
 
     // execution
-    return rocsolver_potrs_template<false, T>(handle, uplo, n, nrhs, A, shiftA, lda, strideA, B,
-                                              shiftB, ldb, strideB, batch_count, work1, work2,
-                                              work3, work4, optim_mem);
+    return rocsolver_potrs_template<false, true, T>(handle, uplo, n, nrhs, A, shiftA, lda, strideA,
+                                                    B, shiftB, ldb, strideB, batch_count, work1,
+                                                    work2, work3, work4, optim_mem);
 }
 
 /*

--- a/library/src/lapack/roclapack_sygst_hegst.cpp
+++ b/library/src/lapack/roclapack_sygst_hegst.cpp
@@ -42,9 +42,9 @@ rocblas_status rocsolver_sygst_hegst_impl(rocblas_handle handle,
     // size of reusable workspace (and for calling SYGS2/HEGS2 and TRSM)
     bool optim_mem;
     size_t size_work_x_temp, size_workArr_temp_arr, size_store_wcs_invA, size_invA_arr;
-    rocsolver_sygst_hegst_getMemorySize<false, T>(uplo, itype, n, batch_count, &size_scalars,
-                                                  &size_work_x_temp, &size_workArr_temp_arr,
-                                                  &size_store_wcs_invA, &size_invA_arr, &optim_mem);
+    rocsolver_sygst_hegst_getMemorySize<false, false, T>(
+        uplo, itype, n, batch_count, &size_scalars, &size_work_x_temp, &size_workArr_temp_arr,
+        &size_store_wcs_invA, &size_invA_arr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_x_temp,

--- a/library/src/lapack/roclapack_sygst_hegst.hpp
+++ b/library/src/lapack/roclapack_sygst_hegst.hpp
@@ -9,11 +9,12 @@
 
 #pragma once
 
+#include "lapack_host_functions.hpp"
 #include "rocblas.hpp"
 #include "roclapack_sygs2_hegs2.hpp"
 #include "rocsolver/rocsolver.h"
 
-template <bool BATCHED, typename T>
+template <bool BATCHED, bool STRIDED, typename T>
 void rocsolver_sygst_hegst_getMemorySize(const rocblas_fill uplo,
                                          const rocblas_eform itype,
                                          const rocblas_int n,
@@ -62,28 +63,27 @@ void rocsolver_sygst_hegst_getMemorySize(const rocblas_fill uplo,
             // extra requirements for calling TRSM
             if(uplo == rocblas_fill_upper)
             {
-                rocblasCall_trsm_mem<BATCHED, T>(rocblas_side_left,
-                                                 rocblas_operation_conjugate_transpose, n - kb, kb,
-                                                 batch_count, &temp1, &temp2, &temp3, &temp4);
-                rocblasCall_trsm_mem<BATCHED, T>(rocblas_side_right, rocblas_operation_none, n - kb,
-                                                 kb, batch_count, &temp5, &temp6, &temp7, &temp8);
+                rocsolver_trsm_mem<BATCHED, STRIDED, T>(
+                    rocblas_side_left, rocblas_operation_conjugate_transpose, n - kb, kb,
+                    batch_count, &temp1, &temp2, &temp3, &temp4, optim_mem);
+                rocsolver_trsm_mem<BATCHED, STRIDED, T>(rocblas_side_right, rocblas_operation_none,
+                                                        n - kb, kb, batch_count, &temp5, &temp6,
+                                                        &temp7, &temp8, optim_mem);
             }
             else
             {
-                rocblasCall_trsm_mem<BATCHED, T>(rocblas_side_left, rocblas_operation_none, n - kb,
-                                                 kb, batch_count, &temp1, &temp2, &temp3, &temp4);
-                rocblasCall_trsm_mem<BATCHED, T>(rocblas_side_right,
-                                                 rocblas_operation_conjugate_transpose, n - kb, kb,
-                                                 batch_count, &temp5, &temp6, &temp7, &temp8);
+                rocsolver_trsm_mem<BATCHED, STRIDED, T>(rocblas_side_left, rocblas_operation_none,
+                                                        n - kb, kb, batch_count, &temp1, &temp2,
+                                                        &temp3, &temp4, optim_mem);
+                rocsolver_trsm_mem<BATCHED, STRIDED, T>(
+                    rocblas_side_right, rocblas_operation_conjugate_transpose, n - kb, kb,
+                    batch_count, &temp5, &temp6, &temp7, &temp8, optim_mem);
             }
 
             *size_work_x_temp = max(*size_work_x_temp, max(temp1, temp5));
             *size_workArr_temp_arr = max(*size_workArr_temp_arr, max(temp2, temp6));
             *size_store_wcs_invA = max(*size_store_wcs_invA, max(temp3, temp7));
             *size_invA_arr = max(*size_invA_arr, max(temp4, temp8));
-
-            // always allocate all required memory for TRSM optimal performance
-            *optim_mem = true;
         }
         else
             *optim_mem = true;
@@ -156,12 +156,11 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
 
                 if(k + kb < n)
                 {
-                    rocblasCall_trsm<BATCHED, T>(
-                        handle, rocblas_side_left, uplo, rocblas_operation_conjugate_transpose,
-                        rocblas_diagonal_non_unit, kb, n - k - kb, &t_one, B,
-                        shiftB + idx2D(k, k, ldb), ldb, strideB, A, shiftA + idx2D(k, k + kb, lda),
-                        lda, strideA, batch_count, optim_mem, work_x_temp, workArr_temp_arr,
-                        store_wcs_invA, invA_arr);
+                    rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                        handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                        rocblas_diagonal_non_unit, kb, n - k - kb, B, shiftB + idx2D(k, k, ldb),
+                        ldb, strideB, A, shiftA + idx2D(k, k + kb, lda), lda, strideA, batch_count,
+                        optim_mem, work_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr);
 
                     rocblasCall_symm_hemm<T>(handle, rocblas_side_left, uplo, kb, n - k - kb,
                                              &t_minhalf, A, shiftA + idx2D(k, k, lda), lda, strideA,
@@ -181,10 +180,9 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                                              &t_one, A, shiftA + idx2D(k, k + kb, lda), lda,
                                              strideA, batch_count);
 
-                    rocblasCall_trsm<BATCHED, T>(
-                        handle, rocblas_side_right, uplo, rocblas_operation_none,
-                        rocblas_diagonal_non_unit, kb, n - k - kb, &t_one, B,
-                        shiftB + idx2D(k + kb, k + kb, ldb), ldb, strideB, A,
+                    rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                        handle, rocblas_side_right, rocblas_operation_none, rocblas_diagonal_non_unit,
+                        kb, n - k - kb, B, shiftB + idx2D(k + kb, k + kb, ldb), ldb, strideB, A,
                         shiftA + idx2D(k, k + kb, lda), lda, strideA, batch_count, optim_mem,
                         work_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr);
                 }
@@ -204,12 +202,11 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
 
                 if(k + kb < n)
                 {
-                    rocblasCall_trsm<BATCHED, T>(
-                        handle, rocblas_side_right, uplo, rocblas_operation_conjugate_transpose,
-                        rocblas_diagonal_non_unit, n - k - kb, kb, &t_one, B,
-                        shiftB + idx2D(k, k, ldb), ldb, strideB, A, shiftA + idx2D(k + kb, k, lda),
-                        lda, strideA, batch_count, optim_mem, work_x_temp, workArr_temp_arr,
-                        store_wcs_invA, invA_arr);
+                    rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                        handle, rocblas_side_right, rocblas_operation_conjugate_transpose,
+                        rocblas_diagonal_non_unit, n - k - kb, kb, B, shiftB + idx2D(k, k, ldb),
+                        ldb, strideB, A, shiftA + idx2D(k + kb, k, lda), lda, strideA, batch_count,
+                        optim_mem, work_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr);
 
                     rocblasCall_symm_hemm<T>(handle, rocblas_side_right, uplo, n - k - kb, kb,
                                              &t_minhalf, A, shiftA + idx2D(k, k, lda), lda, strideA,
@@ -229,10 +226,9 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                                              &t_one, A, shiftA + idx2D(k + kb, k, lda), lda,
                                              strideA, batch_count);
 
-                    rocblasCall_trsm<BATCHED, T>(
-                        handle, rocblas_side_left, uplo, rocblas_operation_none,
-                        rocblas_diagonal_non_unit, n - k - kb, kb, &t_one, B,
-                        shiftB + idx2D(k + kb, k + kb, ldb), ldb, strideB, A,
+                    rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                        handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit,
+                        n - k - kb, kb, B, shiftB + idx2D(k + kb, k + kb, ldb), ldb, strideB, A,
                         shiftA + idx2D(k + kb, k, lda), lda, strideA, batch_count, optim_mem,
                         work_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr);
                 }

--- a/library/src/lapack/roclapack_sygst_hegst_batched.cpp
+++ b/library/src/lapack/roclapack_sygst_hegst_batched.cpp
@@ -44,9 +44,9 @@ rocblas_status rocsolver_sygst_hegst_batched_impl(rocblas_handle handle,
     // size of reusable workspace (and for calling SYGS2/HEGS2 and TRSM)
     bool optim_mem;
     size_t size_work_x_temp, size_workArr_temp_arr, size_store_wcs_invA, size_invA_arr;
-    rocsolver_sygst_hegst_getMemorySize<true, T>(uplo, itype, n, batch_count, &size_scalars,
-                                                 &size_work_x_temp, &size_workArr_temp_arr,
-                                                 &size_store_wcs_invA, &size_invA_arr, &optim_mem);
+    rocsolver_sygst_hegst_getMemorySize<true, false, T>(
+        uplo, itype, n, batch_count, &size_scalars, &size_work_x_temp, &size_workArr_temp_arr,
+        &size_store_wcs_invA, &size_invA_arr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_x_temp,

--- a/library/src/lapack/roclapack_sygst_hegst_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sygst_hegst_strided_batched.cpp
@@ -42,9 +42,9 @@ rocblas_status rocsolver_sygst_hegst_strided_batched_impl(rocblas_handle handle,
     // size of reusable workspace (and for calling SYGS2/HEGS2 and TRSM)
     bool optim_mem;
     size_t size_work_x_temp, size_workArr_temp_arr, size_store_wcs_invA, size_invA_arr;
-    rocsolver_sygst_hegst_getMemorySize<false, T>(uplo, itype, n, batch_count, &size_scalars,
-                                                  &size_work_x_temp, &size_workArr_temp_arr,
-                                                  &size_store_wcs_invA, &size_invA_arr, &optim_mem);
+    rocsolver_sygst_hegst_getMemorySize<false, true, T>(
+        uplo, itype, n, batch_count, &size_scalars, &size_work_x_temp, &size_workArr_temp_arr,
+        &size_store_wcs_invA, &size_invA_arr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_x_temp,

--- a/library/src/lapack/roclapack_sygv_hegv.cpp
+++ b/library/src/lapack/roclapack_sygv_hegv.cpp
@@ -52,7 +52,7 @@ rocblas_status rocsolver_sygv_hegv_impl(rocblas_handle handle,
     size_t size_pivots_workArr;
     // size of temporary info array
     size_t size_iinfo;
-    rocsolver_sygv_hegv_getMemorySize<false, T, S>(
+    rocsolver_sygv_hegv_getMemorySize<false, false, T, S>(
         itype, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
         &size_work4, &size_pivots_workArr, &size_iinfo, &optim_mem);
 

--- a/library/src/lapack/roclapack_sygv_hegv.hpp
+++ b/library/src/lapack/roclapack_sygv_hegv.hpp
@@ -29,7 +29,7 @@ ROCSOLVER_KERNEL void sygv_update_info(T* info, T* iinfo, const rocblas_int n, c
     }
 }
 
-template <bool BATCHED, typename T, typename S>
+template <bool BATCHED, bool STRIDED, typename T, typename S>
 void rocsolver_sygv_hegv_getMemorySize(const rocblas_eform itype,
                                        const rocblas_evect evect,
                                        const rocblas_fill uplo,
@@ -68,8 +68,8 @@ void rocsolver_sygv_hegv_getMemorySize(const rocblas_eform itype,
     *size_iinfo = max(*size_iinfo, sizeof(rocblas_int) * batch_count);
 
     // requirements for calling SYGST/HEGST
-    rocsolver_sygst_hegst_getMemorySize<BATCHED, T>(uplo, itype, n, batch_count, &unused, &temp1,
-                                                    &temp2, &temp3, &temp4, &opt2);
+    rocsolver_sygst_hegst_getMemorySize<BATCHED, STRIDED, T>(uplo, itype, n, batch_count, &unused,
+                                                             &temp1, &temp2, &temp3, &temp4, &opt2);
     *size_work1 = max(*size_work1, temp1);
     *size_work2 = max(*size_work2, temp2);
     *size_work3 = max(*size_work3, temp3);
@@ -92,15 +92,12 @@ void rocsolver_sygv_hegv_getMemorySize(const rocblas_eform itype,
                 = (uplo == rocblas_fill_upper ? rocblas_operation_none
                                               : rocblas_operation_conjugate_transpose);
             // requirements for calling TRSM
-            rocblasCall_trsm_mem<BATCHED, T>(rocblas_side_left, trans, n, n, batch_count, &temp1,
-                                             &temp2, &temp3, &temp4);
+            rocsolver_trsm_mem<BATCHED, STRIDED, T>(rocblas_side_left, trans, n, n, batch_count,
+                                                    &temp1, &temp2, &temp3, &temp4, &opt3);
             *size_work1 = max(*size_work1, temp1);
             *size_work2 = max(*size_work2, temp2);
             *size_work3 = max(*size_work3, temp3);
             *size_work4 = max(*size_work4, temp4);
-
-            // always allocate all required memory for TRSM optimal performance
-            opt3 = true;
         }
     }
 
@@ -240,13 +237,16 @@ rocblas_status rocsolver_sygv_hegv_template(rocblas_handle handle,
     {
         if(itype == rocblas_eform_ax || itype == rocblas_eform_abx)
         {
-            rocblas_operation trans
-                = (uplo == rocblas_fill_upper ? rocblas_operation_none
-                                              : rocblas_operation_conjugate_transpose);
-            rocblasCall_trsm<BATCHED, T>(handle, rocblas_side_left, uplo, trans,
-                                         rocblas_diagonal_non_unit, n, neig, &one, B, shiftB, ldb,
-                                         strideB, A, shiftA, lda, strideA, batch_count, optim_mem,
-                                         work1, work2, work3, work4);
+            if(uplo == rocblas_fill_upper)
+                rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                    handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit, n,
+                    neig, B, shiftB, ldb, strideB, A, shiftA, lda, strideA, batch_count, optim_mem,
+                    work1, work2, work3, work4);
+            else
+                rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                    handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                    rocblas_diagonal_non_unit, n, neig, B, shiftB, ldb, strideB, A, shiftA, lda,
+                    strideA, batch_count, optim_mem, work1, work2, work3, work4);
         }
         else
         {

--- a/library/src/lapack/roclapack_sygv_hegv.hpp
+++ b/library/src/lapack/roclapack_sygv_hegv.hpp
@@ -62,9 +62,9 @@ void rocsolver_sygv_hegv_getMemorySize(const rocblas_eform itype,
     size_t unused, temp1, temp2, temp3, temp4, temp5;
 
     // requirements for calling POTRF
-    rocsolver_potrf_getMemorySize<BATCHED, T>(n, uplo, batch_count, size_scalars, size_work1,
-                                              size_work2, size_work3, size_work4,
-                                              size_pivots_workArr, size_iinfo, &opt1);
+    rocsolver_potrf_getMemorySize<BATCHED, STRIDED, T>(n, uplo, batch_count, size_scalars,
+                                                       size_work1, size_work2, size_work3, size_work4,
+                                                       size_pivots_workArr, size_iinfo, &opt1);
     *size_iinfo = max(*size_iinfo, sizeof(rocblas_int) * batch_count);
 
     // requirements for calling SYGST/HEGST
@@ -204,9 +204,9 @@ rocblas_status rocsolver_sygv_hegv_template(rocblas_handle handle,
     T one = 1;
 
     // perform Cholesky factorization of B
-    rocsolver_potrf_template<BATCHED, T, S>(handle, uplo, n, B, shiftB, ldb, strideB, info,
-                                            batch_count, scalars, work1, work2, work3, work4,
-                                            (T*)pivots_workArr, iinfo, optim_mem);
+    rocsolver_potrf_template<BATCHED, STRIDED, T, S>(handle, uplo, n, B, shiftB, ldb, strideB, info,
+                                                     batch_count, scalars, work1, work2, work3,
+                                                     work4, (T*)pivots_workArr, iinfo, optim_mem);
 
     /** (TODO: Strictly speaking, computations should stop here is B is not positive definite.
         A should not be modified in this case as no eigenvalues or eigenvectors can be computed.

--- a/library/src/lapack/roclapack_sygv_hegv_batched.cpp
+++ b/library/src/lapack/roclapack_sygv_hegv_batched.cpp
@@ -53,9 +53,9 @@ rocblas_status rocsolver_sygv_hegv_batched_impl(rocblas_handle handle,
     size_t size_pivots_workArr;
     // size of temporary info array
     size_t size_iinfo;
-    rocsolver_sygv_hegv_getMemorySize<true, T, S>(itype, evect, uplo, n, batch_count, &size_scalars,
-                                                  &size_work1, &size_work2, &size_work3, &size_work4,
-                                                  &size_pivots_workArr, &size_iinfo, &optim_mem);
+    rocsolver_sygv_hegv_getMemorySize<true, false, T, S>(
+        itype, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
+        &size_work4, &size_pivots_workArr, &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,

--- a/library/src/lapack/roclapack_sygv_hegv_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sygv_hegv_strided_batched.cpp
@@ -51,7 +51,7 @@ rocblas_status rocsolver_sygv_hegv_strided_batched_impl(rocblas_handle handle,
     size_t size_pivots_workArr;
     // size of temporary info array
     size_t size_iinfo;
-    rocsolver_sygv_hegv_getMemorySize<false, T, S>(
+    rocsolver_sygv_hegv_getMemorySize<false, true, T, S>(
         itype, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
         &size_work4, &size_pivots_workArr, &size_iinfo, &optim_mem);
 

--- a/library/src/lapack/roclapack_sygvd_hegvd.cpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd.cpp
@@ -53,7 +53,7 @@ rocblas_status rocsolver_sygvd_hegvd_impl(rocblas_handle handle,
     size_t size_pivots_workArr;
     // size of temporary info array
     size_t size_iinfo;
-    rocsolver_sygvd_hegvd_getMemorySize<false, T, S>(
+    rocsolver_sygvd_hegvd_getMemorySize<false, false, T, S>(
         itype, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
         &size_work4, &size_tau, &size_pivots_workArr, &size_iinfo, &optim_mem);
 

--- a/library/src/lapack/roclapack_sygvd_hegvd.hpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd.hpp
@@ -16,7 +16,7 @@
 #include "roclapack_sygv_hegv.hpp"
 #include "rocsolver/rocsolver.h"
 
-template <bool BATCHED, typename T, typename S>
+template <bool BATCHED, bool STRIDED, typename T, typename S>
 void rocsolver_sygvd_hegvd_getMemorySize(const rocblas_eform itype,
                                          const rocblas_evect evect,
                                          const rocblas_fill uplo,
@@ -57,8 +57,8 @@ void rocsolver_sygvd_hegvd_getMemorySize(const rocblas_eform itype,
     *size_iinfo = max(*size_iinfo, sizeof(rocblas_int) * batch_count);
 
     // requirements for calling SYGST/HEGST
-    rocsolver_sygst_hegst_getMemorySize<BATCHED, T>(uplo, itype, n, batch_count, &unused, &temp1,
-                                                    &temp2, &temp3, &temp4, &opt2);
+    rocsolver_sygst_hegst_getMemorySize<BATCHED, STRIDED, T>(uplo, itype, n, batch_count, &unused,
+                                                             &temp1, &temp2, &temp3, &temp4, &opt2);
     *size_work1 = max(*size_work1, temp1);
     *size_work2 = max(*size_work2, temp2);
     *size_work3 = max(*size_work3, temp3);
@@ -81,15 +81,12 @@ void rocsolver_sygvd_hegvd_getMemorySize(const rocblas_eform itype,
             rocblas_operation trans
                 = (uplo == rocblas_fill_upper ? rocblas_operation_none
                                               : rocblas_operation_conjugate_transpose);
-            rocblasCall_trsm_mem<BATCHED, T>(rocblas_side_left, trans, n, n, batch_count, &temp1,
-                                             &temp2, &temp3, &temp4);
+            rocsolver_trsm_mem<BATCHED, STRIDED, T>(rocblas_side_left, trans, n, n, batch_count,
+                                                    &temp1, &temp2, &temp3, &temp4, &opt3);
             *size_work1 = max(*size_work1, temp1);
             *size_work2 = max(*size_work2, temp2);
             *size_work3 = max(*size_work3, temp3);
             *size_work4 = max(*size_work4, temp4);
-
-            // always allocate all required memory for TRSM optimal performance
-            opt3 = true;
         }
     }
 
@@ -184,13 +181,16 @@ rocblas_status rocsolver_sygvd_hegvd_template(rocblas_handle handle,
     {
         if(itype == rocblas_eform_ax || itype == rocblas_eform_abx)
         {
-            rocblas_operation trans
-                = (uplo == rocblas_fill_upper ? rocblas_operation_none
-                                              : rocblas_operation_conjugate_transpose);
-            rocblasCall_trsm<BATCHED, T>(handle, rocblas_side_left, uplo, trans,
-                                         rocblas_diagonal_non_unit, n, n, &one, B, shiftB, ldb,
-                                         strideB, A, shiftA, lda, strideA, batch_count, optim_mem,
-                                         work1, work2, work3, work4);
+            if(uplo == rocblas_fill_upper)
+                rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                    handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit, n,
+                    n, B, shiftB, ldb, strideB, A, shiftA, lda, strideA, batch_count, optim_mem,
+                    work1, work2, work3, work4);
+            else
+                rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                    handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                    rocblas_diagonal_non_unit, n, n, B, shiftB, ldb, strideB, A, shiftA, lda,
+                    strideA, batch_count, optim_mem, work1, work2, work3, work4);
         }
         else
         {

--- a/library/src/lapack/roclapack_sygvd_hegvd.hpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd.hpp
@@ -51,9 +51,9 @@ void rocsolver_sygvd_hegvd_getMemorySize(const rocblas_eform itype,
     size_t unused, temp1, temp2, temp3, temp4, temp5;
 
     // requirements for calling POTRF
-    rocsolver_potrf_getMemorySize<BATCHED, T>(n, uplo, batch_count, size_scalars, size_work1,
-                                              size_work2, size_work3, size_work4,
-                                              size_pivots_workArr, size_iinfo, &opt1);
+    rocsolver_potrf_getMemorySize<BATCHED, STRIDED, T>(n, uplo, batch_count, size_scalars,
+                                                       size_work1, size_work2, size_work3, size_work4,
+                                                       size_pivots_workArr, size_iinfo, &opt1);
     *size_iinfo = max(*size_iinfo, sizeof(rocblas_int) * batch_count);
 
     // requirements for calling SYGST/HEGST
@@ -154,9 +154,9 @@ rocblas_status rocsolver_sygvd_hegvd_template(rocblas_handle handle,
     T one = 1;
 
     // perform Cholesky factorization of B
-    rocsolver_potrf_template<BATCHED, T, S>(handle, uplo, n, B, shiftB, ldb, strideB, info,
-                                            batch_count, scalars, work1, work2, work3, work4,
-                                            (T*)pivots_workArr, iinfo, optim_mem);
+    rocsolver_potrf_template<BATCHED, STRIDED, T, S>(handle, uplo, n, B, shiftB, ldb, strideB, info,
+                                                     batch_count, scalars, work1, work2, work3,
+                                                     work4, (T*)pivots_workArr, iinfo, optim_mem);
 
     /** (TODO: Strictly speaking, computations should stop here is B is not positive definite.
         A should not be modified in this case as no eigenvalues or eigenvectors can be computed.

--- a/library/src/lapack/roclapack_sygvd_hegvd_batched.cpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd_batched.cpp
@@ -54,7 +54,7 @@ rocblas_status rocsolver_sygvd_hegvd_batched_impl(rocblas_handle handle,
     size_t size_pivots_workArr;
     // size of temporary info array
     size_t size_iinfo;
-    rocsolver_sygvd_hegvd_getMemorySize<true, T, S>(
+    rocsolver_sygvd_hegvd_getMemorySize<true, false, T, S>(
         itype, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
         &size_work4, &size_tau, &size_pivots_workArr, &size_iinfo, &optim_mem);
 

--- a/library/src/lapack/roclapack_sygvd_hegvd_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd_strided_batched.cpp
@@ -52,7 +52,7 @@ rocblas_status rocsolver_sygvd_hegvd_strided_batched_impl(rocblas_handle handle,
     size_t size_pivots_workArr;
     // size of temporary info array
     size_t size_iinfo;
-    rocsolver_sygvd_hegvd_getMemorySize<false, T, S>(
+    rocsolver_sygvd_hegvd_getMemorySize<false, true, T, S>(
         itype, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
         &size_work4, &size_tau, &size_pivots_workArr, &size_iinfo, &optim_mem);
 

--- a/library/src/lapack/roclapack_sygvx_hegvx.cpp
+++ b/library/src/lapack/roclapack_sygvx_hegvx.cpp
@@ -67,7 +67,7 @@ rocblas_status rocsolver_sygvx_hegvx_impl(rocblas_handle handle,
     size_t size_work7_workArr;
     // size of temporary info array
     size_t size_iinfo;
-    rocsolver_sygvx_hegvx_getMemorySize<false, T, S>(
+    rocsolver_sygvx_hegvx_getMemorySize<false, false, T, S>(
         itype, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
         &size_work4, &size_work5, &size_work6, &size_D, &size_E, &size_iblock, &size_isplit,
         &size_tau, &size_work7_workArr, &size_iinfo, &optim_mem);

--- a/library/src/lapack/roclapack_sygvx_hegvx.hpp
+++ b/library/src/lapack/roclapack_sygvx_hegvx.hpp
@@ -139,9 +139,9 @@ void rocsolver_sygvx_hegvx_getMemorySize(const rocblas_eform itype,
     size_t unused, temp1, temp2, temp3, temp4, temp5;
 
     // requirements for calling POTRF
-    rocsolver_potrf_getMemorySize<BATCHED, T>(n, uplo, batch_count, size_scalars, size_work1,
-                                              size_work2, size_work3, size_work4,
-                                              size_work7_workArr, size_iinfo, &opt1);
+    rocsolver_potrf_getMemorySize<BATCHED, STRIDED, T>(n, uplo, batch_count, size_scalars,
+                                                       size_work1, size_work2, size_work3, size_work4,
+                                                       size_work7_workArr, size_iinfo, &opt1);
     *size_iinfo = max(*size_iinfo, sizeof(rocblas_int) * batch_count);
 
     // requirements for calling SYGST/HEGST
@@ -264,9 +264,9 @@ rocblas_status rocsolver_sygvx_hegvx_template(rocblas_handle handle,
     T one = 1;
 
     // perform Cholesky factorization of B
-    rocsolver_potrf_template<BATCHED, T, S>(handle, uplo, n, B, shiftB, ldb, strideB, info,
-                                            batch_count, scalars, work1, work2, work3, work4,
-                                            (T*)work7_workArr, iinfo, optim_mem);
+    rocsolver_potrf_template<BATCHED, STRIDED, T, S>(handle, uplo, n, B, shiftB, ldb, strideB, info,
+                                                     batch_count, scalars, work1, work2, work3,
+                                                     work4, (T*)work7_workArr, iinfo, optim_mem);
 
     /** (TODO: Strictly speaking, computations should stop here if B is not positive definite.
         A should not be modified in this case as no eigenvalues or eigenvectors can be computed.

--- a/library/src/lapack/roclapack_sygvx_hegvx_batched.cpp
+++ b/library/src/lapack/roclapack_sygvx_hegvx_batched.cpp
@@ -68,7 +68,7 @@ rocblas_status rocsolver_sygvx_hegvx_batched_impl(rocblas_handle handle,
     size_t size_work7_workArr;
     // size of temporary info array
     size_t size_iinfo;
-    rocsolver_sygvx_hegvx_getMemorySize<true, T, S>(
+    rocsolver_sygvx_hegvx_getMemorySize<true, false, T, S>(
         itype, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
         &size_work4, &size_work5, &size_work6, &size_D, &size_E, &size_iblock, &size_isplit,
         &size_tau, &size_work7_workArr, &size_iinfo, &optim_mem);

--- a/library/src/lapack/roclapack_sygvx_hegvx_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sygvx_hegvx_strided_batched.cpp
@@ -67,7 +67,7 @@ rocblas_status rocsolver_sygvx_hegvx_strided_batched_impl(rocblas_handle handle,
     size_t size_work7_workArr;
     // size of temporary info array
     size_t size_iinfo;
-    rocsolver_sygvx_hegvx_getMemorySize<false, T, S>(
+    rocsolver_sygvx_hegvx_getMemorySize<false, true, T, S>(
         itype, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
         &size_work4, &size_work5, &size_work6, &size_D, &size_E, &size_iblock, &size_isplit,
         &size_tau, &size_work7_workArr, &size_iinfo, &optim_mem);


### PR DESCRIPTION
These PR generalizes the optimized internal rocsolver_trsm routines and use them in all functions that require triangular system solvers: 
gels, getrf, getrs, potrf, potrs, sygst/hegst, sygv/hegv, sygvd/hegvd, and sygvx/hegvx
and indirectly in:
gesv, posv, and getri_outofplace,