### PR TITLE
rocblas_is_complex instead of is_complex

### DIFF
--- a/clients/include/norm.hpp
+++ b/clients/include/norm.hpp
@@ -64,7 +64,7 @@ inline void xaxpy(int* n,
 
 /* Norm of error functions */
 
-template <typename T, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 double norm_error(char norm_type,
                   rocblas_int M,
                   rocblas_int N,
@@ -106,7 +106,7 @@ double norm_error(char norm_type,
     return error;
 }
 
-template <typename T, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 double norm_error(char norm_type,
                   rocblas_int M,
                   rocblas_int N,

--- a/clients/include/rocsolver_dispatcher.hpp
+++ b/clients/include/rocsolver_dispatcher.hpp
@@ -220,7 +220,7 @@ class rocsolver_dispatcher
             return rocblas_status_invalid_value;
     }
 
-    template <typename T, std::enable_if_t<!is_complex<T>, int> = 0>
+    template <typename T, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
     static rocblas_status run_function_limited_precision(const char* name, Arguments& argus)
     {
         // Map for functions that support only single and double precisions
@@ -296,7 +296,7 @@ class rocsolver_dispatcher
             return rocblas_status_invalid_value;
     }
 
-    template <typename T, std::enable_if_t<is_complex<T>, int> = 0>
+    template <typename T, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
     static rocblas_status run_function_limited_precision(const char* name, Arguments& argus)
     {
         // Map for functions that support only single-complex and double-complex precisions

--- a/clients/include/rocsolver_test.hpp
+++ b/clients/include/rocsolver_test.hpp
@@ -78,13 +78,13 @@ inline void rocsolver_bench_endl()
     std::fflush(stdout);
 }
 
-template <typename T, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 inline T sconj(T scalar)
 {
     return scalar;
 }
 
-template <typename T, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 inline T sconj(T scalar)
 {
     return std::conj(scalar);

--- a/clients/include/testing_gebd2_gebrd.hpp
+++ b/clients/include/testing_gebd2_gebrd.hpp
@@ -206,7 +206,7 @@ void gebd2_gebrd_getError(const rocblas_handle handle,
                           Uh& hTaup,
                           double* max_err)
 {
-    constexpr bool COMPLEX = is_complex<T>;
+    constexpr bool COMPLEX = rocblas_is_complex<T>;
     constexpr bool VERIFY_IMPLICIT_TEST = false;
 
     std::vector<T> hW(max(m, n));

--- a/clients/include/testing_gels.hpp
+++ b/clients/include/testing_gels.hpp
@@ -348,7 +348,7 @@ void gels_getPerfData(const rocblas_handle handle,
     *gpu_time_used /= hot_calls;
 }
 
-template <bool BATCHED, bool STRIDED, typename T, bool COMPLEX = is_complex<T>>
+template <bool BATCHED, bool STRIDED, typename T, bool COMPLEX = rocblas_is_complex<T>>
 void testing_gels(Arguments& argus)
 {
     // get arguments

--- a/clients/include/testing_gels_outofplace.hpp
+++ b/clients/include/testing_gels_outofplace.hpp
@@ -113,7 +113,7 @@ void testing_gels_outofplace_bad_arg()
     rocblas_stride stX = 1;
     rocblas_int bc = 1;
     rocblas_operation trans
-        = (!is_complex<T> ? rocblas_operation_transpose : rocblas_operation_conjugate_transpose);
+        = (!rocblas_is_complex<T> ? rocblas_operation_transpose : rocblas_operation_conjugate_transpose);
     if(BATCHED)
     {
         // memory allocations
@@ -400,7 +400,7 @@ void gels_outofplace_getPerfData(const rocblas_handle handle,
     *gpu_time_used /= hot_calls;
 }
 
-template <bool BATCHED, bool STRIDED, typename T, bool COMPLEX = is_complex<T>>
+template <bool BATCHED, bool STRIDED, typename T, bool COMPLEX = rocblas_is_complex<T>>
 void testing_gels_outofplace(Arguments& argus)
 {
     // get arguments

--- a/clients/include/testing_latrd.hpp
+++ b/clients/include/testing_latrd.hpp
@@ -76,7 +76,7 @@ void testing_latrd_bad_arg()
     latrd_checkBadArgs(handle, uplo, n, k, dA.data(), lda, dE.data(), dTau.data(), dW.data(), ldw);
 }
 
-template <bool CPU, bool GPU, typename T, typename Td, typename Th, std::enable_if_t<!is_complex<T>, int> = 0>
+template <bool CPU, bool GPU, typename T, typename Td, typename Th, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 void latrd_initData(const rocblas_handle handle,
                     const rocblas_int n,
                     Td& dA,
@@ -107,7 +107,7 @@ void latrd_initData(const rocblas_handle handle,
     }
 }
 
-template <bool CPU, bool GPU, typename T, typename Td, typename Th, std::enable_if_t<is_complex<T>, int> = 0>
+template <bool CPU, bool GPU, typename T, typename Td, typename Th, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 void latrd_initData(const rocblas_handle handle,
                     const rocblas_int n,
                     Td& dA,

--- a/clients/include/testing_ormbr_unmbr.hpp
+++ b/clients/include/testing_ormbr_unmbr.hpp
@@ -73,7 +73,7 @@ void ormbr_unmbr_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_success);
 }
 
-template <typename T, bool COMPLEX = is_complex<T>>
+template <typename T, bool COMPLEX = rocblas_is_complex<T>>
 void testing_ormbr_unmbr_bad_arg()
 {
     // safe arguments
@@ -297,7 +297,7 @@ void ormbr_unmbr_getPerfData(const rocblas_handle handle,
     *gpu_time_used /= hot_calls;
 }
 
-template <typename T, bool COMPLEX = is_complex<T>>
+template <typename T, bool COMPLEX = rocblas_is_complex<T>>
 void testing_ormbr_unmbr(Arguments& argus)
 {
     // get arguments

--- a/clients/include/testing_ormlx_unmlx.hpp
+++ b/clients/include/testing_ormlx_unmlx.hpp
@@ -69,7 +69,7 @@ void ormlx_unmlx_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_success);
 }
 
-template <typename T, bool MLQ, bool COMPLEX = is_complex<T>>
+template <typename T, bool MLQ, bool COMPLEX = rocblas_is_complex<T>>
 void testing_ormlx_unmlx_bad_arg()
 {
     // safe arguments
@@ -268,7 +268,7 @@ void ormlx_unmlx_getPerfData(const rocblas_handle handle,
     *gpu_time_used /= hot_calls;
 }
 
-template <typename T, bool MLQ, bool COMPLEX = is_complex<T>>
+template <typename T, bool MLQ, bool COMPLEX = rocblas_is_complex<T>>
 void testing_ormlx_unmlx(Arguments& argus)
 {
     // get arguments

--- a/clients/include/testing_ormtr_unmtr.hpp
+++ b/clients/include/testing_ormtr_unmtr.hpp
@@ -69,7 +69,7 @@ void ormtr_unmtr_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_success);
 }
 
-template <typename T, bool COMPLEX = is_complex<T>>
+template <typename T, bool COMPLEX = rocblas_is_complex<T>>
 void testing_ormtr_unmtr_bad_arg()
 {
     // safe arguments
@@ -269,7 +269,7 @@ void ormtr_unmtr_getPerfData(const rocblas_handle handle,
     *gpu_time_used /= hot_calls;
 }
 
-template <typename T, bool COMPLEX = is_complex<T>>
+template <typename T, bool COMPLEX = rocblas_is_complex<T>>
 void testing_ormtr_unmtr(Arguments& argus)
 {
     // get arguments

--- a/clients/include/testing_ormxl_unmxl.hpp
+++ b/clients/include/testing_ormxl_unmxl.hpp
@@ -69,7 +69,7 @@ void ormxl_unmxl_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_success);
 }
 
-template <typename T, bool MQL, bool COMPLEX = is_complex<T>>
+template <typename T, bool MQL, bool COMPLEX = rocblas_is_complex<T>>
 void testing_ormxl_unmxl_bad_arg()
 {
     // safe arguments
@@ -268,7 +268,7 @@ void ormxl_unmxl_getPerfData(const rocblas_handle handle,
     *gpu_time_used /= hot_calls;
 }
 
-template <typename T, bool MQL, bool COMPLEX = is_complex<T>>
+template <typename T, bool MQL, bool COMPLEX = rocblas_is_complex<T>>
 void testing_ormxl_unmxl(Arguments& argus)
 {
     // get arguments

--- a/clients/include/testing_ormxr_unmxr.hpp
+++ b/clients/include/testing_ormxr_unmxr.hpp
@@ -69,7 +69,7 @@ void ormxr_unmxr_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_success);
 }
 
-template <typename T, bool MQR, bool COMPLEX = is_complex<T>>
+template <typename T, bool MQR, bool COMPLEX = rocblas_is_complex<T>>
 void testing_ormxr_unmxr_bad_arg()
 {
     // safe arguments
@@ -268,7 +268,7 @@ void ormxr_unmxr_getPerfData(const rocblas_handle handle,
     *gpu_time_used /= hot_calls;
 }
 
-template <typename T, bool MQR, bool COMPLEX = is_complex<T>>
+template <typename T, bool MQR, bool COMPLEX = rocblas_is_complex<T>>
 void testing_ormxr_unmxr(Arguments& argus)
 {
     // get arguments

--- a/clients/include/testing_stedc.hpp
+++ b/clients/include/testing_stedc.hpp
@@ -148,7 +148,7 @@ void stedc_getError(const rocblas_handle handle,
                     Uh& hInfoRes,
                     double* max_err)
 {
-    constexpr bool COMPLEX = is_complex<T>;
+    constexpr bool COMPLEX = rocblas_is_complex<T>;
     using S = decltype(std::real(T{}));
 
     int lgn = floor(log(n - 1) / log(2)) + 1;
@@ -257,7 +257,7 @@ void stedc_getPerfData(const rocblas_handle handle,
                        const bool profile_kernels,
                        const bool perf)
 {
-    constexpr bool COMPLEX = is_complex<T>;
+    constexpr bool COMPLEX = rocblas_is_complex<T>;
     using S = decltype(std::real(T{}));
 
     int lgn = floor(log(n - 1) / log(2)) + 1;

--- a/clients/include/testing_syev_heev.hpp
+++ b/clients/include/testing_syev_heev.hpp
@@ -191,7 +191,7 @@ void syev_heev_getError(const rocblas_handle handle,
                         Ih& hinfoRes,
                         double* max_err)
 {
-    constexpr bool COMPLEX = is_complex<T>;
+    constexpr bool COMPLEX = rocblas_is_complex<T>;
     using S = decltype(std::real(T{}));
 
     int sizeE = 3 * n - 1;
@@ -292,7 +292,7 @@ void syev_heev_getPerfData(const rocblas_handle handle,
                            const bool profile_kernels,
                            const bool perf)
 {
-    constexpr bool COMPLEX = is_complex<T>;
+    constexpr bool COMPLEX = rocblas_is_complex<T>;
     using S = decltype(std::real(T{}));
 
     int sizeE = 3 * n - 1;

--- a/clients/include/testing_syevd_heevd.hpp
+++ b/clients/include/testing_syevd_heevd.hpp
@@ -191,7 +191,7 @@ void syevd_heevd_getError(const rocblas_handle handle,
                           Ih& hinfoRes,
                           double* max_err)
 {
-    constexpr bool COMPLEX = is_complex<T>;
+    constexpr bool COMPLEX = rocblas_is_complex<T>;
     using S = decltype(std::real(T{}));
 
     int sizeE, lwork;
@@ -304,7 +304,7 @@ void syevd_heevd_getPerfData(const rocblas_handle handle,
                              const bool profile_kernels,
                              const bool perf)
 {
-    constexpr bool COMPLEX = is_complex<T>;
+    constexpr bool COMPLEX = rocblas_is_complex<T>;
     using S = decltype(std::real(T{}));
 
     int sizeE, lwork;

--- a/clients/include/testing_syevdx_heevdx_inplace.hpp
+++ b/clients/include/testing_syevdx_heevdx_inplace.hpp
@@ -232,7 +232,7 @@ void syevdx_heevdx_inplace_getError(const rocblas_handle handle,
                                     Ih& hinfoRes,
                                     double* max_err)
 {
-    constexpr bool COMPLEX = is_complex<T>;
+    constexpr bool COMPLEX = rocblas_is_complex<T>;
 
     int lwork = !COMPLEX ? 35 * n : 33 * n;
     int lrwork = !COMPLEX ? 0 : 7 * n;
@@ -353,7 +353,7 @@ void syevdx_heevdx_inplace_getPerfData(const rocblas_handle handle,
                                        const bool profile_kernels,
                                        const bool perf)
 {
-    constexpr bool COMPLEX = is_complex<T>;
+    constexpr bool COMPLEX = rocblas_is_complex<T>;
 
     int lwork = !COMPLEX ? 35 * n : 33 * n;
     int lrwork = !COMPLEX ? 0 : 7 * n;

--- a/clients/include/testing_syevx_heevx.hpp
+++ b/clients/include/testing_syevx_heevx.hpp
@@ -268,7 +268,7 @@ void syevx_heevx_getError(const rocblas_handle handle,
                           Ih& hinfoRes,
                           double* max_err)
 {
-    constexpr bool COMPLEX = is_complex<T>;
+    constexpr bool COMPLEX = rocblas_is_complex<T>;
 
     int lwork = !COMPLEX ? 35 * n : 33 * n;
     int lrwork = !COMPLEX ? 0 : 7 * n;
@@ -417,7 +417,7 @@ void syevx_heevx_getPerfData(const rocblas_handle handle,
                              const bool profile_kernels,
                              const bool perf)
 {
-    constexpr bool COMPLEX = is_complex<T>;
+    constexpr bool COMPLEX = rocblas_is_complex<T>;
 
     int lwork = !COMPLEX ? 35 * n : 33 * n;
     int lrwork = !COMPLEX ? 0 : 7 * n;

--- a/clients/include/testing_sygv_hegv.hpp
+++ b/clients/include/testing_sygv_hegv.hpp
@@ -263,7 +263,7 @@ void sygv_hegv_getError(const rocblas_handle handle,
                         double* max_err,
                         const bool singular)
 {
-    constexpr bool COMPLEX = is_complex<T>;
+    constexpr bool COMPLEX = rocblas_is_complex<T>;
     using S = decltype(std::real(T{}));
 
     rocblas_int lwork = (COMPLEX ? 2 * n - 1 : 3 * n - 1);
@@ -405,7 +405,7 @@ void sygv_hegv_getPerfData(const rocblas_handle handle,
                            const bool perf,
                            const bool singular)
 {
-    constexpr bool COMPLEX = is_complex<T>;
+    constexpr bool COMPLEX = rocblas_is_complex<T>;
     using S = decltype(std::real(T{}));
 
     rocblas_int lwork = (COMPLEX ? 2 * n - 1 : 3 * n - 1);

--- a/clients/include/testing_sygvd_hegvd.hpp
+++ b/clients/include/testing_sygvd_hegvd.hpp
@@ -267,7 +267,7 @@ void sygvd_hegvd_getError(const rocblas_handle handle,
                           double* max_err,
                           const bool singular)
 {
-    constexpr bool COMPLEX = is_complex<T>;
+    constexpr bool COMPLEX = rocblas_is_complex<T>;
     using S = decltype(std::real(T{}));
 
     int lrwork, lwork;
@@ -421,7 +421,7 @@ void sygvd_hegvd_getPerfData(const rocblas_handle handle,
                              const bool perf,
                              const bool singular)
 {
-    constexpr bool COMPLEX = is_complex<T>;
+    constexpr bool COMPLEX = rocblas_is_complex<T>;
     using S = decltype(std::real(T{}));
 
     int lrwork, lwork;

--- a/clients/include/testing_sygvx_hegvx.hpp
+++ b/clients/include/testing_sygvx_hegvx.hpp
@@ -386,7 +386,7 @@ void sygvx_hegvx_getError(const rocblas_handle handle,
                           double* max_err,
                           const bool singular)
 {
-    constexpr bool COMPLEX = is_complex<T>;
+    constexpr bool COMPLEX = rocblas_is_complex<T>;
 
     int lwork = (COMPLEX ? 2 * n : 8 * n);
     int lrwork = (COMPLEX ? 7 * n : 0);
@@ -576,7 +576,7 @@ void sygvx_hegvx_getPerfData(const rocblas_handle handle,
                              const bool perf,
                              const bool singular)
 {
-    constexpr bool COMPLEX = is_complex<T>;
+    constexpr bool COMPLEX = rocblas_is_complex<T>;
 
     int lwork = (COMPLEX ? 2 * n : 8 * n);
     int lrwork = (COMPLEX ? 7 * n : 0);

--- a/clients/include/testing_sytxx_hetxx.hpp
+++ b/clients/include/testing_sytxx_hetxx.hpp
@@ -119,7 +119,7 @@ void testing_sytxx_hetxx_bad_arg()
     }
 }
 
-template <bool CPU, bool GPU, typename T, typename Td, typename Th, std::enable_if_t<!is_complex<T>, int> = 0>
+template <bool CPU, bool GPU, typename T, typename Td, typename Th, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 void sytxx_hetxx_initData(const rocblas_handle handle,
                           const rocblas_int n,
                           Td& dA,
@@ -154,7 +154,7 @@ void sytxx_hetxx_initData(const rocblas_handle handle,
     }
 }
 
-template <bool CPU, bool GPU, typename T, typename Td, typename Th, std::enable_if_t<is_complex<T>, int> = 0>
+template <bool CPU, bool GPU, typename T, typename Td, typename Th, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 void sytxx_hetxx_initData(const rocblas_handle handle,
                           const rocblas_int n,
                           Td& dA,
@@ -212,7 +212,7 @@ void sytxx_hetxx_getError(const rocblas_handle handle,
                           Uh& hTau,
                           double* max_err)
 {
-    constexpr bool COMPLEX = is_complex<T>;
+    constexpr bool COMPLEX = rocblas_is_complex<T>;
 
     std::vector<T> hW(32 * n);
 

--- a/clients/rocblascommon/rocblas_math.hpp
+++ b/clients/rocblascommon/rocblas_math.hpp
@@ -38,13 +38,13 @@ inline bool rocblas_isnan(T)
     return false;
 }
 
-template <typename T, std::enable_if_t<!std::is_integral<T>{} && !is_complex<T>, int> = 0>
+template <typename T, std::enable_if_t<!std::is_integral<T>{} && !rocblas_is_complex<T>, int> = 0>
 inline bool rocblas_isnan(T arg)
 {
     return std::isnan(arg);
 }
 
-template <typename T, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 inline bool rocblas_isnan(const T& arg)
 {
     return rocblas_isnan(std::real(arg)) || rocblas_isnan(std::imag(arg));

--- a/common/include/common_host_helpers.hpp
+++ b/common/include/common_host_helpers.hpp
@@ -82,7 +82,7 @@ void pairs_to_string(std::string& str, const char* sep, T1 arg1, T2 arg2, Ts... 
 /***********************************************************************/
 
 /*! \brief Print provided data into specified stream (real case)*/
-template <typename T, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 void print_to_stream(std::ostream& os,
                      const std::string name,
                      const rocblas_int m,
@@ -149,7 +149,7 @@ void print_to_stream(std::ostream& os,
 }
 
 /*! \brief Print provided data into specified stream (complex cases)*/
-template <typename T, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 void print_to_stream(std::ostream& os,
                      const std::string name,
                      const rocblas_int m,
@@ -380,7 +380,7 @@ void print_host_matrix(std::ostream& os,
     os.flush();
 }
 
-template <typename T, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 void print_host_matrix(std::ostream& os,
                        const std::string name,
                        const rocblas_int m,
@@ -410,7 +410,7 @@ void print_host_matrix(std::ostream& os,
     os.flush();
 }
 
-template <typename T, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 void print_host_matrix(std::ostream& os,
                        const std::string name,
                        const rocblas_int m,

--- a/library/src/auxiliary/rocauxiliary_labrd.hpp
+++ b/library/src/auxiliary/rocauxiliary_labrd.hpp
@@ -88,7 +88,7 @@ rocblas_status rocsolver_labrd_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename T, typename S, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename S, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_labrd_template(rocblas_handle handle,
                                         const rocblas_int m,
                                         const rocblas_int n,

--- a/library/src/auxiliary/rocauxiliary_lacgv.hpp
+++ b/library/src/auxiliary/rocauxiliary_lacgv.hpp
@@ -12,7 +12,7 @@
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
 
-template <typename T, typename U, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, typename U, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 ROCSOLVER_KERNEL void conj_in_place(const rocblas_int m,
                                     const rocblas_int n,
                                     U A,
@@ -23,7 +23,7 @@ ROCSOLVER_KERNEL void conj_in_place(const rocblas_int m,
     // do nothing
 }
 
-template <typename T, typename U, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, typename U, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 ROCSOLVER_KERNEL void conj_in_place(const rocblas_int m,
                                     const rocblas_int n,
                                     U A,
@@ -65,7 +65,7 @@ rocblas_status
     return rocblas_status_continue;
 }
 
-template <typename T, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_lacgv_template(rocblas_handle handle,
                                         const rocblas_int n,
                                         U x,

--- a/library/src/auxiliary/rocauxiliary_larf.hpp
+++ b/library/src/auxiliary/rocauxiliary_larf.hpp
@@ -82,7 +82,7 @@ rocblas_status rocsolver_larf_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename T, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_larf_template(rocblas_handle handle,
                                        const rocblas_side side,
                                        const rocblas_int m,

--- a/library/src/auxiliary/rocauxiliary_larfg.hpp
+++ b/library/src/auxiliary/rocauxiliary_larfg.hpp
@@ -12,7 +12,7 @@
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
 
-template <typename T, typename U, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, typename U, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 ROCSOLVER_KERNEL void set_taubeta(T* tau,
                                   const rocblas_stride strideP,
                                   T* norms,
@@ -46,7 +46,7 @@ ROCSOLVER_KERNEL void set_taubeta(T* tau,
     }
 }
 
-template <typename T, typename U, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, typename U, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 ROCSOLVER_KERNEL void set_taubeta(T* tau,
                                   const rocblas_stride strideP,
                                   T* norms,
@@ -144,7 +144,7 @@ rocblas_status rocsolver_larfg_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename T, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_larfg_template(rocblas_handle handle,
                                         const rocblas_int n,
                                         U alpha,

--- a/library/src/auxiliary/rocauxiliary_larft.hpp
+++ b/library/src/auxiliary/rocauxiliary_larft.hpp
@@ -13,7 +13,7 @@
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
 
-template <typename T, typename U, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, typename U, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 ROCSOLVER_KERNEL void set_triangular(const rocblas_int n,
                                      const rocblas_int k,
                                      U V,
@@ -68,7 +68,7 @@ ROCSOLVER_KERNEL void set_triangular(const rocblas_int n,
     }
 }
 
-template <typename T, typename U, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, typename U, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 ROCSOLVER_KERNEL void set_triangular(const rocblas_int n,
                                      const rocblas_int k,
                                      U V,
@@ -204,7 +204,7 @@ rocblas_status rocsolver_larft_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename T, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_larft_template(rocblas_handle handle,
                                         const rocblas_direct direct,
                                         const rocblas_storev storev,

--- a/library/src/auxiliary/rocauxiliary_latrd.hpp
+++ b/library/src/auxiliary/rocauxiliary_latrd.hpp
@@ -86,7 +86,7 @@ rocblas_status rocsolver_latrd_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename T, typename S, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename S, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_latrd_template(rocblas_handle handle,
                                         const rocblas_fill uplo,
                                         const rocblas_int n,

--- a/library/src/auxiliary/rocauxiliary_org2l_ung2l.cpp
+++ b/library/src/auxiliary/rocauxiliary_org2l_ung2l.cpp
@@ -13,7 +13,7 @@ rocblas_status rocsolver_org2l_ung2l_impl(rocblas_handle handle,
                                           const rocblas_int lda,
                                           T* ipiv)
 {
-    const char* name = (!is_complex<T> ? "org2l" : "ung2l");
+    const char* name = (!rocblas_is_complex<T> ? "org2l" : "ung2l");
     ROCSOLVER_ENTER_TOP(name, "-m", m, "-n", n, "-k", k, "--lda", lda);
 
     if(!handle)

--- a/library/src/auxiliary/rocauxiliary_org2l_ung2l.hpp
+++ b/library/src/auxiliary/rocauxiliary_org2l_ung2l.hpp
@@ -94,7 +94,7 @@ rocblas_status rocsolver_org2l_orgql_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename T, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_org2l_ung2l_template(rocblas_handle handle,
                                               const rocblas_int m,
                                               const rocblas_int n,

--- a/library/src/auxiliary/rocauxiliary_org2r_ung2r.cpp
+++ b/library/src/auxiliary/rocauxiliary_org2r_ung2r.cpp
@@ -13,7 +13,7 @@ rocblas_status rocsolver_org2r_ung2r_impl(rocblas_handle handle,
                                           const rocblas_int lda,
                                           T* ipiv)
 {
-    const char* name = (!is_complex<T> ? "org2r" : "ung2r");
+    const char* name = (!rocblas_is_complex<T> ? "org2r" : "ung2r");
     ROCSOLVER_ENTER_TOP(name, "-m", m, "-n", n, "-k", k, "--lda", lda);
 
     if(!handle)

--- a/library/src/auxiliary/rocauxiliary_orgbr_ungbr.cpp
+++ b/library/src/auxiliary/rocauxiliary_orgbr_ungbr.cpp
@@ -14,7 +14,7 @@ rocblas_status rocsolver_orgbr_ungbr_impl(rocblas_handle handle,
                                           const rocblas_int lda,
                                           T* ipiv)
 {
-    const char* name = (!is_complex<T> ? "orgbr" : "ungbr");
+    const char* name = (!rocblas_is_complex<T> ? "orgbr" : "ungbr");
     ROCSOLVER_ENTER_TOP(name, "--storev", storev, "-m", m, "-n", n, "-k", k, "--lda", lda);
 
     if(!handle)

--- a/library/src/auxiliary/rocauxiliary_orgl2_ungl2.cpp
+++ b/library/src/auxiliary/rocauxiliary_orgl2_ungl2.cpp
@@ -13,7 +13,7 @@ rocblas_status rocsolver_orgl2_ungl2_impl(rocblas_handle handle,
                                           const rocblas_int lda,
                                           T* ipiv)
 {
-    const char* name = (!is_complex<T> ? "orgl2" : "ungl2");
+    const char* name = (!rocblas_is_complex<T> ? "orgl2" : "ungl2");
     ROCSOLVER_ENTER_TOP(name, "-m", m, "-n", n, "-k", k, "--lda", lda);
 
     if(!handle)

--- a/library/src/auxiliary/rocauxiliary_orgl2_ungl2.hpp
+++ b/library/src/auxiliary/rocauxiliary_orgl2_ungl2.hpp
@@ -96,7 +96,7 @@ rocblas_status rocsolver_orgl2_orglq_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename T, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_orgl2_ungl2_template(rocblas_handle handle,
                                               const rocblas_int m,
                                               const rocblas_int n,

--- a/library/src/auxiliary/rocauxiliary_orglq_unglq.cpp
+++ b/library/src/auxiliary/rocauxiliary_orglq_unglq.cpp
@@ -13,7 +13,7 @@ rocblas_status rocsolver_orglq_unglq_impl(rocblas_handle handle,
                                           const rocblas_int lda,
                                           T* ipiv)
 {
-    const char* name = (!is_complex<T> ? "orglq" : "unglq");
+    const char* name = (!rocblas_is_complex<T> ? "orglq" : "unglq");
     ROCSOLVER_ENTER_TOP(name, "-m", m, "-n", n, "-k", k, "--lda", lda);
 
     if(!handle)

--- a/library/src/auxiliary/rocauxiliary_orgql_ungql.cpp
+++ b/library/src/auxiliary/rocauxiliary_orgql_ungql.cpp
@@ -13,7 +13,7 @@ rocblas_status rocsolver_orgql_ungql_impl(rocblas_handle handle,
                                           const rocblas_int lda,
                                           T* ipiv)
 {
-    const char* name = (!is_complex<T> ? "orgql" : "ungql");
+    const char* name = (!rocblas_is_complex<T> ? "orgql" : "ungql");
     ROCSOLVER_ENTER_TOP(name, "-m", m, "-n", n, "-k", k, "--lda", lda);
 
     if(!handle)

--- a/library/src/auxiliary/rocauxiliary_orgqr_ungqr.cpp
+++ b/library/src/auxiliary/rocauxiliary_orgqr_ungqr.cpp
@@ -13,7 +13,7 @@ rocblas_status rocsolver_orgqr_ungqr_impl(rocblas_handle handle,
                                           const rocblas_int lda,
                                           T* ipiv)
 {
-    const char* name = (!is_complex<T> ? "orgqr" : "ungqr");
+    const char* name = (!rocblas_is_complex<T> ? "orgqr" : "ungqr");
     ROCSOLVER_ENTER_TOP(name, "-m", m, "-n", n, "-k", k, "--lda", lda);
 
     if(!handle)

--- a/library/src/auxiliary/rocauxiliary_orgtr_ungtr.cpp
+++ b/library/src/auxiliary/rocauxiliary_orgtr_ungtr.cpp
@@ -12,7 +12,7 @@ rocblas_status rocsolver_orgtr_ungtr_impl(rocblas_handle handle,
                                           const rocblas_int lda,
                                           T* ipiv)
 {
-    const char* name = (!is_complex<T> ? "orgtr" : "ungtr");
+    const char* name = (!rocblas_is_complex<T> ? "orgtr" : "ungtr");
     ROCSOLVER_ENTER_TOP(name, "--uplo", uplo, "-n", n, "--lda", lda);
 
     if(!handle)

--- a/library/src/auxiliary/rocauxiliary_orm2l_unm2l.cpp
+++ b/library/src/auxiliary/rocauxiliary_orm2l_unm2l.cpp
@@ -4,7 +4,7 @@
 
 #include "rocauxiliary_orm2l_unm2l.hpp"
 
-template <typename T, bool COMPLEX = is_complex<T>>
+template <typename T, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_orm2l_unm2l_impl(rocblas_handle handle,
                                           const rocblas_side side,
                                           const rocblas_operation trans,
@@ -17,7 +17,7 @@ rocblas_status rocsolver_orm2l_unm2l_impl(rocblas_handle handle,
                                           T* C,
                                           const rocblas_int ldc)
 {
-    const char* name = (!is_complex<T> ? "orm2l" : "unm2l");
+    const char* name = (!rocblas_is_complex<T> ? "orm2l" : "unm2l");
     ROCSOLVER_ENTER_TOP(name, "--side", side, "--trans", trans, "-m", m, "-n", n, "-k", k, "--lda",
                         lda, "--ldc", ldc);
 

--- a/library/src/auxiliary/rocauxiliary_orm2l_unm2l.hpp
+++ b/library/src/auxiliary/rocauxiliary_orm2l_unm2l.hpp
@@ -88,7 +88,7 @@ rocblas_status rocsolver_orm2l_ormql_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename T, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_orm2l_unm2l_template(rocblas_handle handle,
                                               const rocblas_side side,
                                               const rocblas_operation trans,

--- a/library/src/auxiliary/rocauxiliary_orm2r_unm2r.cpp
+++ b/library/src/auxiliary/rocauxiliary_orm2r_unm2r.cpp
@@ -4,7 +4,7 @@
 
 #include "rocauxiliary_orm2r_unm2r.hpp"
 
-template <typename T, bool COMPLEX = is_complex<T>>
+template <typename T, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_orm2r_unm2r_impl(rocblas_handle handle,
                                           const rocblas_side side,
                                           const rocblas_operation trans,
@@ -17,7 +17,7 @@ rocblas_status rocsolver_orm2r_unm2r_impl(rocblas_handle handle,
                                           T* C,
                                           const rocblas_int ldc)
 {
-    const char* name = (!is_complex<T> ? "orm2r" : "unm2r");
+    const char* name = (!rocblas_is_complex<T> ? "orm2r" : "unm2r");
     ROCSOLVER_ENTER_TOP(name, "--side", side, "--trans", trans, "-m", m, "-n", n, "-k", k, "--lda",
                         lda, "--ldc", ldc);
 

--- a/library/src/auxiliary/rocauxiliary_orm2r_unm2r.hpp
+++ b/library/src/auxiliary/rocauxiliary_orm2r_unm2r.hpp
@@ -88,7 +88,7 @@ rocblas_status rocsolver_orm2r_ormqr_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename T, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_orm2r_unm2r_template(rocblas_handle handle,
                                               const rocblas_side side,
                                               const rocblas_operation trans,

--- a/library/src/auxiliary/rocauxiliary_ormbr_unmbr.cpp
+++ b/library/src/auxiliary/rocauxiliary_ormbr_unmbr.cpp
@@ -4,7 +4,7 @@
 
 #include "rocauxiliary_ormbr_unmbr.hpp"
 
-template <typename T, bool COMPLEX = is_complex<T>>
+template <typename T, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_ormbr_unmbr_impl(rocblas_handle handle,
                                           const rocblas_storev storev,
                                           const rocblas_side side,
@@ -18,7 +18,7 @@ rocblas_status rocsolver_ormbr_unmbr_impl(rocblas_handle handle,
                                           T* C,
                                           const rocblas_int ldc)
 {
-    const char* name = (!is_complex<T> ? "ormbr" : "unmbr");
+    const char* name = (!rocblas_is_complex<T> ? "ormbr" : "unmbr");
     ROCSOLVER_ENTER_TOP(name, "--storev", storev, "--side", side, "--trans", trans, "-m", m, "-n",
                         n, "-k", k, "--lda", lda, "--ldc", ldc);
 

--- a/library/src/auxiliary/rocauxiliary_ormbr_unmbr.hpp
+++ b/library/src/auxiliary/rocauxiliary_ormbr_unmbr.hpp
@@ -102,7 +102,7 @@ rocblas_status rocsolver_ormbr_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <bool BATCHED, bool STRIDED, typename T, typename U, bool COMPLEX = is_complex<T>>
+template <bool BATCHED, bool STRIDED, typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_ormbr_unmbr_template(rocblas_handle handle,
                                               const rocblas_storev storev,
                                               const rocblas_side side,

--- a/library/src/auxiliary/rocauxiliary_orml2_unml2.cpp
+++ b/library/src/auxiliary/rocauxiliary_orml2_unml2.cpp
@@ -4,7 +4,7 @@
 
 #include "rocauxiliary_orml2_unml2.hpp"
 
-template <typename T, bool COMPLEX = is_complex<T>>
+template <typename T, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_orml2_unml2_impl(rocblas_handle handle,
                                           const rocblas_side side,
                                           const rocblas_operation trans,
@@ -17,7 +17,7 @@ rocblas_status rocsolver_orml2_unml2_impl(rocblas_handle handle,
                                           T* C,
                                           const rocblas_int ldc)
 {
-    const char* name = (!is_complex<T> ? "orml2" : "unml2");
+    const char* name = (!rocblas_is_complex<T> ? "orml2" : "unml2");
     ROCSOLVER_ENTER_TOP(name, "--side", side, "--trans", trans, "-m", m, "-n", n, "-k", k, "--lda",
                         lda, "--ldc", ldc);
 

--- a/library/src/auxiliary/rocauxiliary_orml2_unml2.hpp
+++ b/library/src/auxiliary/rocauxiliary_orml2_unml2.hpp
@@ -88,7 +88,7 @@ rocblas_status rocsolver_orml2_ormlq_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename T, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_orml2_unml2_template(rocblas_handle handle,
                                               const rocblas_side side,
                                               const rocblas_operation trans,

--- a/library/src/auxiliary/rocauxiliary_ormlq_unmlq.cpp
+++ b/library/src/auxiliary/rocauxiliary_ormlq_unmlq.cpp
@@ -4,7 +4,7 @@
 
 #include "rocauxiliary_ormlq_unmlq.hpp"
 
-template <typename T, bool COMPLEX = is_complex<T>>
+template <typename T, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_ormlq_unmlq_impl(rocblas_handle handle,
                                           const rocblas_side side,
                                           const rocblas_operation trans,
@@ -17,7 +17,7 @@ rocblas_status rocsolver_ormlq_unmlq_impl(rocblas_handle handle,
                                           T* C,
                                           const rocblas_int ldc)
 {
-    const char* name = (!is_complex<T> ? "ormlq" : "unmlq");
+    const char* name = (!rocblas_is_complex<T> ? "ormlq" : "unmlq");
     ROCSOLVER_ENTER_TOP(name, "--side", side, "--trans", trans, "-m", m, "-n", n, "-k", k, "--lda",
                         lda, "--ldc", ldc);
 

--- a/library/src/auxiliary/rocauxiliary_ormlq_unmlq.hpp
+++ b/library/src/auxiliary/rocauxiliary_ormlq_unmlq.hpp
@@ -61,7 +61,7 @@ void rocsolver_ormlq_unmlq_getMemorySize(const rocblas_side side,
         *size_trfact = 0;
 }
 
-template <bool BATCHED, bool STRIDED, typename T, typename U, bool COMPLEX = is_complex<T>>
+template <bool BATCHED, bool STRIDED, typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_ormlq_unmlq_template(rocblas_handle handle,
                                               const rocblas_side side,
                                               const rocblas_operation trans,

--- a/library/src/auxiliary/rocauxiliary_ormql_unmql.cpp
+++ b/library/src/auxiliary/rocauxiliary_ormql_unmql.cpp
@@ -4,7 +4,7 @@
 
 #include "rocauxiliary_ormql_unmql.hpp"
 
-template <typename T, bool COMPLEX = is_complex<T>>
+template <typename T, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_ormql_unmql_impl(rocblas_handle handle,
                                           const rocblas_side side,
                                           const rocblas_operation trans,
@@ -17,7 +17,7 @@ rocblas_status rocsolver_ormql_unmql_impl(rocblas_handle handle,
                                           T* C,
                                           const rocblas_int ldc)
 {
-    const char* name = (!is_complex<T> ? "ormql" : "unmql");
+    const char* name = (!rocblas_is_complex<T> ? "ormql" : "unmql");
     ROCSOLVER_ENTER_TOP(name, "--side", side, "--trans", trans, "-m", m, "-n", n, "-k", k, "--lda",
                         lda, "--ldc", ldc);
 

--- a/library/src/auxiliary/rocauxiliary_ormqr_unmqr.cpp
+++ b/library/src/auxiliary/rocauxiliary_ormqr_unmqr.cpp
@@ -4,7 +4,7 @@
 
 #include "rocauxiliary_ormqr_unmqr.hpp"
 
-template <typename T, bool COMPLEX = is_complex<T>>
+template <typename T, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_ormqr_unmqr_impl(rocblas_handle handle,
                                           const rocblas_side side,
                                           const rocblas_operation trans,
@@ -17,7 +17,7 @@ rocblas_status rocsolver_ormqr_unmqr_impl(rocblas_handle handle,
                                           T* C,
                                           const rocblas_int ldc)
 {
-    const char* name = (!is_complex<T> ? "ormqr" : "unmqr");
+    const char* name = (!rocblas_is_complex<T> ? "ormqr" : "unmqr");
     ROCSOLVER_ENTER_TOP(name, "--side", side, "--trans", trans, "-m", m, "-n", n, "-k", k, "--lda",
                         lda, "--ldc", ldc);
 

--- a/library/src/auxiliary/rocauxiliary_ormtr_unmtr.cpp
+++ b/library/src/auxiliary/rocauxiliary_ormtr_unmtr.cpp
@@ -4,7 +4,7 @@
 
 #include "rocauxiliary_ormtr_unmtr.hpp"
 
-template <typename T, bool COMPLEX = is_complex<T>>
+template <typename T, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_ormtr_unmtr_impl(rocblas_handle handle,
                                           const rocblas_side side,
                                           const rocblas_fill uplo,
@@ -17,7 +17,7 @@ rocblas_status rocsolver_ormtr_unmtr_impl(rocblas_handle handle,
                                           T* C,
                                           const rocblas_int ldc)
 {
-    const char* name = (!is_complex<T> ? "ormtr" : "unmtr");
+    const char* name = (!rocblas_is_complex<T> ? "ormtr" : "unmtr");
     ROCSOLVER_ENTER_TOP(name, "--side", side, "--uplo", uplo, "--trans", trans, "-m", m, "-n", n,
                         "--lda", lda, "--ldc", ldc);
 

--- a/library/src/auxiliary/rocauxiliary_ormtr_unmtr.hpp
+++ b/library/src/auxiliary/rocauxiliary_ormtr_unmtr.hpp
@@ -95,7 +95,7 @@ rocblas_status rocsolver_ormtr_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <bool BATCHED, bool STRIDED, typename T, typename U, bool COMPLEX = is_complex<T>>
+template <bool BATCHED, bool STRIDED, typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_ormtr_unmtr_template(rocblas_handle handle,
                                               const rocblas_side side,
                                               const rocblas_fill uplo,

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -117,7 +117,7 @@ ROCSOLVER_KERNEL void stedc_kernel(const rocblas_int n,
 
 /** This local gemm adapts rocblas_gemm to multiply complex*real, and
     overwrite result: A = A*B **/
-template <bool BATCHED, bool STRIDED, typename T, typename S, typename U, std::enable_if_t<!is_complex<T>, int> = 0>
+template <bool BATCHED, bool STRIDED, typename T, typename S, typename U, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 void local_gemm(rocblas_handle handle,
                 const rocblas_int n,
                 U A,
@@ -157,7 +157,7 @@ void local_gemm(rocblas_handle handle,
     rocblas_set_pointer_mode(handle, old_mode);
 }
 
-template <bool BATCHED, bool STRIDED, typename T, typename S, typename U, std::enable_if_t<is_complex<T>, int> = 0>
+template <bool BATCHED, bool STRIDED, typename T, typename S, typename U, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 void local_gemm(rocblas_handle handle,
                 const rocblas_int n,
                 U A,
@@ -227,7 +227,7 @@ void rocsolver_stedc_getMemorySize(const rocblas_evect evect,
                                    size_t* size_tempgemm,
                                    size_t* size_workArr)
 {
-    constexpr bool COMPLEX = is_complex<T>;
+    constexpr bool COMPLEX = rocblas_is_complex<T>;
 
     // if quick return no workspace needed
     if(n <= 1 || !batch_count)

--- a/library/src/auxiliary/rocauxiliary_stein.hpp
+++ b/library/src/auxiliary/rocauxiliary_stein.hpp
@@ -21,7 +21,7 @@
 
 #define STEIN_MAX_NRMCHK 2
 
-template <typename T, typename S, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, typename S, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 __device__ void stein_reorthogonalize(rocblas_int i,
                                       const rocblas_int j,
                                       const rocblas_int n,
@@ -43,7 +43,7 @@ __device__ void stein_reorthogonalize(rocblas_int i,
     }
 }
 
-template <typename T, typename S, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, typename S, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 __device__ void stein_reorthogonalize(rocblas_int i,
                                       const rocblas_int j,
                                       const rocblas_int n,

--- a/library/src/include/lapack_device_functions.hpp
+++ b/library/src/include/lapack_device_functions.hpp
@@ -299,7 +299,7 @@ __device__ void gemm_btrans(const rocblas_int tid,
     to create a givens rotation such that:
     [  c s ]' * [ f ] = [ r ]
     [ -s c ]    [ g ]   [ 0 ] **/
-template <typename T, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 __device__ void lartg(T& f, T& g, T& c, T& s, T& r)
 {
     if(g == 0)
@@ -418,7 +418,7 @@ __device__ void lasr(const rocblas_side side,
 /** LAE2 computes the eigenvalues of a 2x2 symmetric matrix
     [ a b ]
     [ b c ] **/
-template <typename T, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 __device__ void lae2(T& a, T& b, T& c, T& rt1, T& rt2)
 {
     T sm = a + c;
@@ -470,7 +470,7 @@ __device__ void lae2(T& a, T& b, T& c, T& rt1, T& rt2)
 /** LAEV2 computes the eigenvalues and eigenvectors of a 2x2 symmetric matrix
     [ a b ]
     [ b c ] **/
-template <typename T, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 __device__ void laev2(T& a, T& b, T& c, T& rt1, T& rt2, T& cs1, T& sn1)
 {
     int sgn1, sgn2;

--- a/library/src/include/lapack_host_functions.hpp
+++ b/library/src/include/lapack_host_functions.hpp
@@ -96,7 +96,7 @@
 
 /** This function returns the block size for the internal
     (blocked) trsm implementation **/
-template <bool ISBATCHED, typename T, std::enable_if_t<!is_complex<T>, int> = 0>
+template <bool ISBATCHED, typename T, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 rocblas_int rocsolver_trsm_blksize(const rocblas_int m, const rocblas_int n)
 {
     rocblas_int blk;
@@ -127,7 +127,7 @@ rocblas_int rocsolver_trsm_blksize(const rocblas_int m, const rocblas_int n)
 }
 
 /** complex type version **/
-template <bool ISBATCHED, typename T, std::enable_if_t<is_complex<T>, int> = 0>
+template <bool ISBATCHED, typename T, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 rocblas_int rocsolver_trsm_blksize(const rocblas_int m, const rocblas_int n)
 {
     rocblas_int blk;

--- a/library/src/include/lib_device_helpers.hpp
+++ b/library/src/include/lib_device_helpers.hpp
@@ -25,13 +25,13 @@
 // device functions that are used by many kernels
 // **********************************************************
 
-template <typename S, typename T, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename S, typename T, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 __device__ S aabs(T val)
 {
     return std::abs(val);
 }
 
-template <typename S, typename T, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename S, typename T, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 __device__ S aabs(T val)
 {
     return asum(val);
@@ -223,7 +223,7 @@ ROCSOLVER_KERNEL void copy_mat(const rocblas_int m,
     If uplo = rocblas_fill_lower, only the lower triangular part is copied
     Only valid when A is complex and buffer real. If REAL, only works with real part of A;
     if !REAL only works with imaginary part of A**/
-template <typename T, typename S, bool REAL, typename U, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, typename S, bool REAL, typename U, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 ROCSOLVER_KERNEL void copy_mat(copymat_direction direction,
                                const rocblas_int m,
                                const rocblas_int n,
@@ -356,7 +356,7 @@ ROCSOLVER_KERNEL void restau(const rocblas_int k, T* ipiv, const rocblas_stride 
         tau[i] = -tau[i];
 }
 
-template <typename T, typename S, typename U, std::enable_if_t<!is_complex<T> || is_complex<S>, int> = 0>
+template <typename T, typename S, typename U, std::enable_if_t<!rocblas_is_complex<T> || rocblas_is_complex<S>, int> = 0>
 ROCSOLVER_KERNEL void set_diag(S* D,
                                const rocblas_int shiftd,
                                const rocblas_stride strided,
@@ -381,7 +381,7 @@ ROCSOLVER_KERNEL void set_diag(S* D,
     }
 }
 
-template <typename T, typename S, typename U, std::enable_if_t<is_complex<T> && !is_complex<S>, int> = 0>
+template <typename T, typename S, typename U, std::enable_if_t<rocblas_is_complex<T> && !rocblas_is_complex<S>, int> = 0>
 ROCSOLVER_KERNEL void set_diag(S* D,
                                const rocblas_int shiftd,
                                const rocblas_stride strided,
@@ -591,7 +591,7 @@ ROCSOLVER_KERNEL void copyshift_down(const bool copy,
 /** set_offdiag kernel copies the off-diagonal element of A, which is the non-zero element
     resulting by applying the Householder reflector to the working column, to E. Then set it
     to 1 to prepare for the application of the Householder reflector to the rest of the matrix **/
-template <typename T, typename S, typename U, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, typename S, typename U, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 ROCSOLVER_KERNEL void set_offdiag(const rocblas_int batch_count,
                                   U A,
                                   const rocblas_int shiftA,
@@ -611,7 +611,7 @@ ROCSOLVER_KERNEL void set_offdiag(const rocblas_int batch_count,
     }
 }
 
-template <typename T, typename S, typename U, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, typename S, typename U, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 ROCSOLVER_KERNEL void set_offdiag(const rocblas_int batch_count,
                                   U A,
                                   const rocblas_int shiftA,

--- a/library/src/include/rocblas.hpp
+++ b/library/src/include/rocblas.hpp
@@ -865,7 +865,7 @@ rocblas_status rocblasCall_trmm(rocblas_handle handle,
                   "n:", n, "shiftA:", offsetA, "lda:", lda, "shiftB:", offsetB, "ldb:", ldb,
                   "bc:", batch_count);
 
-    constexpr rocblas_int nb = (!is_complex<T> ? ROCBLAS_TRMM_REAL_NB : ROCBLAS_TRMM_COMPLEX_NB);
+    constexpr rocblas_int nb = (!rocblas_is_complex<T> ? ROCBLAS_TRMM_REAL_NB : ROCBLAS_TRMM_COMPLEX_NB);
 
     return rocblas_internal_trmm_template<nb, BATCHED, T>(
         handle, side, uplo, transA, diag, m, n, cast2constType<T>(alpha), stride_alpha,
@@ -900,7 +900,7 @@ rocblas_status rocblasCall_trmm(rocblas_handle handle,
                   "n:", n, "shiftA:", offsetA, "lda:", lda, "shiftB:", offsetB, "ldb:", ldb,
                   "bc:", batch_count);
 
-    constexpr rocblas_int nb = (!is_complex<T> ? ROCBLAS_TRMM_REAL_NB : ROCBLAS_TRMM_COMPLEX_NB);
+    constexpr rocblas_int nb = (!rocblas_is_complex<T> ? ROCBLAS_TRMM_REAL_NB : ROCBLAS_TRMM_COMPLEX_NB);
 
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
@@ -916,7 +916,7 @@ rocblas_status rocblasCall_trmm(rocblas_handle handle,
 }
 
 // syr2
-template <typename T, typename U, typename V, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, typename U, typename V, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 rocblas_status rocblasCall_syr2_her2(rocblas_handle handle,
                                      rocblas_fill uplo,
                                      rocblas_int n,
@@ -947,7 +947,7 @@ rocblas_status rocblasCall_syr2_her2(rocblas_handle handle,
 }
 
 // syr2 overload
-template <typename T, typename U, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, typename U, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 rocblas_status rocblasCall_syr2_her2(rocblas_handle handle,
                                      rocblas_fill uplo,
                                      rocblas_int n,
@@ -985,7 +985,7 @@ rocblas_status rocblasCall_syr2_her2(rocblas_handle handle,
 }
 
 // her2
-template <typename T, typename U, typename V, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, typename U, typename V, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 rocblas_status rocblasCall_syr2_her2(rocblas_handle handle,
                                      rocblas_fill uplo,
                                      rocblas_int n,
@@ -1016,7 +1016,7 @@ rocblas_status rocblasCall_syr2_her2(rocblas_handle handle,
 }
 
 // her2 overload
-template <typename T, typename U, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, typename U, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 rocblas_status rocblasCall_syr2_her2(rocblas_handle handle,
                                      rocblas_fill uplo,
                                      rocblas_int n,
@@ -1054,7 +1054,7 @@ rocblas_status rocblasCall_syr2_her2(rocblas_handle handle,
 }
 
 // syrk
-template <typename T, typename U, typename V, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, typename U, typename V, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 rocblas_status rocblasCall_syrk_herk(rocblas_handle handle,
                                      rocblas_fill uplo,
                                      rocblas_operation transA,
@@ -1084,7 +1084,7 @@ rocblas_status rocblasCall_syrk_herk(rocblas_handle handle,
 }
 
 // herk
-template <typename T, typename U, typename V, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, typename U, typename V, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 rocblas_status rocblasCall_syrk_herk(rocblas_handle handle,
                                      rocblas_fill uplo,
                                      rocblas_operation transA,
@@ -1114,7 +1114,7 @@ rocblas_status rocblasCall_syrk_herk(rocblas_handle handle,
 }
 
 // syr2k
-template <bool BATCHED, typename T, typename Ua, typename Ub, typename V, std::enable_if_t<!is_complex<T>, int> = 0>
+template <bool BATCHED, typename T, typename Ua, typename Ub, typename V, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 rocblas_status rocblasCall_syr2k_her2k(rocblas_handle handle,
                                        rocblas_fill uplo,
                                        rocblas_operation trans,
@@ -1149,7 +1149,7 @@ rocblas_status rocblasCall_syr2k_her2k(rocblas_handle handle,
 }
 
 // syr2k overload
-template <bool BATCHED, typename T, typename Ua, typename Ub, std::enable_if_t<!is_complex<T>, int> = 0>
+template <bool BATCHED, typename T, typename Ua, typename Ub, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 rocblas_status rocblasCall_syr2k_her2k(rocblas_handle handle,
                                        rocblas_fill uplo,
                                        rocblas_operation trans,
@@ -1191,7 +1191,7 @@ rocblas_status rocblasCall_syr2k_her2k(rocblas_handle handle,
 }
 
 // her2k
-template <bool BATCHED, typename T, typename Ua, typename Ub, typename V, std::enable_if_t<is_complex<T>, int> = 0>
+template <bool BATCHED, typename T, typename Ua, typename Ub, typename V, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 rocblas_status rocblasCall_syr2k_her2k(rocblas_handle handle,
                                        rocblas_fill uplo,
                                        rocblas_operation trans,
@@ -1228,7 +1228,7 @@ rocblas_status rocblasCall_syr2k_her2k(rocblas_handle handle,
 }
 
 // her2k overload
-template <bool BATCHED, typename T, typename Ua, typename Ub, std::enable_if_t<is_complex<T>, int> = 0>
+template <bool BATCHED, typename T, typename Ua, typename Ub, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 rocblas_status rocblasCall_syr2k_her2k(rocblas_handle handle,
                                        rocblas_fill uplo,
                                        rocblas_operation trans,
@@ -1279,7 +1279,7 @@ void rocblasCall_symv_hemv_mem(rocblas_int n, rocblas_int batch_count, size_t* w
 }
 
 // symv
-template <typename T, typename U, typename V, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, typename U, typename V, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 rocblas_status rocblasCall_symv_hemv(rocblas_handle handle,
                                      rocblas_fill uplo,
                                      rocblas_int n,
@@ -1314,7 +1314,7 @@ rocblas_status rocblasCall_symv_hemv(rocblas_handle handle,
 }
 
 // symv overload
-template <typename T, typename U, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, typename U, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 rocblas_status rocblasCall_symv_hemv(rocblas_handle handle,
                                      rocblas_fill uplo,
                                      rocblas_int n,
@@ -1356,7 +1356,7 @@ rocblas_status rocblasCall_symv_hemv(rocblas_handle handle,
 }
 
 // hemv
-template <typename T, typename U, typename V, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, typename U, typename V, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 rocblas_status rocblasCall_symv_hemv(rocblas_handle handle,
                                      rocblas_fill uplo,
                                      rocblas_int n,
@@ -1391,7 +1391,7 @@ rocblas_status rocblasCall_symv_hemv(rocblas_handle handle,
 }
 
 // hemv overload
-template <typename T, typename U, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, typename U, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 rocblas_status rocblasCall_symv_hemv(rocblas_handle handle,
                                      rocblas_fill uplo,
                                      rocblas_int n,
@@ -1433,7 +1433,7 @@ rocblas_status rocblasCall_symv_hemv(rocblas_handle handle,
 }
 
 // symm
-template <typename T, typename U, typename V, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, typename U, typename V, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 rocblas_status rocblasCall_symm_hemm(rocblas_handle handle,
                                      rocblas_side side,
                                      rocblas_fill uplo,
@@ -1467,7 +1467,7 @@ rocblas_status rocblasCall_symm_hemm(rocblas_handle handle,
 }
 
 // hemm
-template <typename T, typename U, typename V, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, typename U, typename V, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 rocblas_status rocblasCall_symm_hemm(rocblas_handle handle,
                                      rocblas_side side,
                                      rocblas_fill uplo,

--- a/library/src/lapack/roclapack_gebd2.hpp
+++ b/library/src/lapack/roclapack_gebd2.hpp
@@ -74,7 +74,7 @@ rocblas_status rocsolver_gebd2_gebrd_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename T, typename S, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename S, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_gebd2_template(rocblas_handle handle,
                                         const rocblas_int m,
                                         const rocblas_int n,

--- a/library/src/lapack/roclapack_gebrd.hpp
+++ b/library/src/lapack/roclapack_gebrd.hpp
@@ -67,7 +67,7 @@ void rocsolver_gebrd_getMemorySize(const rocblas_int m,
     }
 }
 
-template <bool BATCHED, bool STRIDED, typename T, typename S, typename U, bool COMPLEX = is_complex<T>>
+template <bool BATCHED, bool STRIDED, typename T, typename S, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_gebrd_template(rocblas_handle handle,
                                         const rocblas_int m,
                                         const rocblas_int n,

--- a/library/src/lapack/roclapack_gelq2.hpp
+++ b/library/src/lapack/roclapack_gelq2.hpp
@@ -76,7 +76,7 @@ rocblas_status rocsolver_gelq2_gelqf_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename T, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_gelq2_template(rocblas_handle handle,
                                         const rocblas_int m,
                                         const rocblas_int n,

--- a/library/src/lapack/roclapack_gels.cpp
+++ b/library/src/lapack/roclapack_gels.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_gels.hpp"
 
-template <typename T, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_gels_impl(rocblas_handle handle,
                                    rocblas_operation trans,
                                    const rocblas_int m,

--- a/library/src/lapack/roclapack_gels_batched.cpp
+++ b/library/src/lapack/roclapack_gels_batched.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_gels.hpp"
 
-template <typename T, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_gels_batched_impl(rocblas_handle handle,
                                            rocblas_operation trans,
                                            const rocblas_int m,

--- a/library/src/lapack/roclapack_gels_outofplace.cpp
+++ b/library/src/lapack/roclapack_gels_outofplace.cpp
@@ -12,7 +12,7 @@
  * ===========================================================================
  */
 
-template <typename T, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_gels_outofplace_impl(rocblas_handle handle,
                                               rocblas_operation trans,
                                               const rocblas_int m,

--- a/library/src/lapack/roclapack_gels_strided_batched.cpp
+++ b/library/src/lapack/roclapack_gels_strided_batched.cpp
@@ -4,7 +4,7 @@
 
 #include "roclapack_gels.hpp"
 
-template <typename T, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_gels_strided_batched_impl(rocblas_handle handle,
                                                    rocblas_operation trans,
                                                    const rocblas_int m,

--- a/library/src/lapack/roclapack_geql2.hpp
+++ b/library/src/lapack/roclapack_geql2.hpp
@@ -76,7 +76,7 @@ rocblas_status rocsolver_geql2_geqlf_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename T, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_geql2_template(rocblas_handle handle,
                                         const rocblas_int m,
                                         const rocblas_int n,

--- a/library/src/lapack/roclapack_geqr2.hpp
+++ b/library/src/lapack/roclapack_geqr2.hpp
@@ -76,7 +76,7 @@ rocblas_status rocsolver_geqr2_geqrf_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename T, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_geqr2_template(rocblas_handle handle,
                                         const rocblas_int m,
                                         const rocblas_int n,

--- a/library/src/lapack/roclapack_gerq2.hpp
+++ b/library/src/lapack/roclapack_gerq2.hpp
@@ -76,7 +76,7 @@ rocblas_status rocsolver_gerq2_gerqf_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename T, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_gerq2_template(rocblas_handle handle,
                                         const rocblas_int m,
                                         const rocblas_int n,

--- a/library/src/lapack/roclapack_gesvd.hpp
+++ b/library/src/lapack/roclapack_gesvd.hpp
@@ -340,7 +340,7 @@ rocblas_status rocsolver_gesvd_template(rocblas_handle handle,
                     "shiftA:", shiftA, "lda:", lda, "ldu:", ldu, "ldv:", ldv, "mode:", fast_alg,
                     "bc:", batch_count);
 
-    constexpr bool COMPLEX = is_complex<T>;
+    constexpr bool COMPLEX = rocblas_is_complex<T>;
 
     // quick return
     if(n == 0 || m == 0 || batch_count == 0)

--- a/library/src/lapack/roclapack_getf2.hpp
+++ b/library/src/lapack/roclapack_getf2.hpp
@@ -178,7 +178,7 @@ inline rocblas_int getf2_get_checksingularity_blksize(const rocblas_int n)
     Returns 1 when the use of the small kernel will give better performance,
     Returns 2 when the use of the panel kernel will give better performance,
     Returns 0 when it would be better to use the normal code. **/
-template <bool ISBATCHED, typename T, std::enable_if_t<!is_complex<T>, int> = 0>
+template <bool ISBATCHED, typename T, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 int select_spkernel(const rocblas_int m, const rocblas_int n, const bool pivot)
 {
     int ker = 0;
@@ -276,7 +276,7 @@ int select_spkernel(const rocblas_int m, const rocblas_int n, const bool pivot)
 }
 
 /** Complex type version **/
-template <bool ISBATCHED, typename T, std::enable_if_t<is_complex<T>, int> = 0>
+template <bool ISBATCHED, typename T, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 int select_spkernel(const rocblas_int m, const rocblas_int n, const bool pivot)
 {
     int ker = 0;

--- a/library/src/lapack/roclapack_getrf.hpp
+++ b/library/src/lapack/roclapack_getrf.hpp
@@ -211,7 +211,7 @@ ROCSOLVER_KERNEL void getrf_row_permutate(const rocblas_int n,
 
 /** This function returns the outer block size based on defined variables
     tunable by the user (defined in ideal_sizes.hpp) **/
-template <bool ISBATCHED, typename T, std::enable_if_t<!is_complex<T>, int> = 0>
+template <bool ISBATCHED, typename T, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 rocblas_int getrf_get_blksize(rocblas_int dim, const bool pivot)
 {
     rocblas_int blk;
@@ -258,7 +258,7 @@ rocblas_int getrf_get_blksize(rocblas_int dim, const bool pivot)
 }
 
 /** Complex type version **/
-template <bool ISBATCHED, typename T, std::enable_if_t<is_complex<T>, int> = 0>
+template <bool ISBATCHED, typename T, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 rocblas_int getrf_get_blksize(rocblas_int dim, const bool pivot)
 {
     rocblas_int blk;
@@ -307,7 +307,7 @@ rocblas_int getrf_get_blksize(rocblas_int dim, const bool pivot)
 /** This function returns the inner block size. This has been tuned based on
     experiments with panel matrices; it is not expected to change a lot.
     (not tunable by the user for now) **/
-template <bool ISBATCHED, typename T, std::enable_if_t<!is_complex<T>, int> = 0>
+template <bool ISBATCHED, typename T, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 rocblas_int getrf_get_innerBlkSize(rocblas_int m, rocblas_int n, const bool pivot)
 {
     rocblas_int blk;
@@ -362,7 +362,7 @@ rocblas_int getrf_get_innerBlkSize(rocblas_int m, rocblas_int n, const bool pivo
 }
 
 /** complex type version **/
-template <bool ISBATCHED, typename T, std::enable_if_t<is_complex<T>, int> = 0>
+template <bool ISBATCHED, typename T, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 rocblas_int getrf_get_innerBlkSize(rocblas_int m, rocblas_int n, const bool pivot)
 {
     rocblas_int blk;

--- a/library/src/lapack/roclapack_potf2.hpp
+++ b/library/src/lapack/roclapack_potf2.hpp
@@ -13,7 +13,7 @@
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
 
-template <typename T, typename U, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, typename U, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 ROCSOLVER_KERNEL void sqrtDiagOnward(U A,
                                      const rocblas_int shiftA,
                                      const rocblas_int strideA,
@@ -44,7 +44,7 @@ ROCSOLVER_KERNEL void sqrtDiagOnward(U A,
     }
 }
 
-template <typename T, typename U, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, typename U, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 ROCSOLVER_KERNEL void sqrtDiagOnward(U A,
                                      const rocblas_int shiftA,
                                      const rocblas_int strideA,
@@ -131,7 +131,7 @@ rocblas_status rocsolver_potf2_potrf_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename T, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_potf2_template(rocblas_handle handle,
                                         const rocblas_fill uplo,
                                         const rocblas_int n,

--- a/library/src/lapack/roclapack_potrf.hpp
+++ b/library/src/lapack/roclapack_potrf.hpp
@@ -88,7 +88,7 @@ void rocsolver_potrf_getMemorySize(const rocblas_int n,
     }
 }
 
-template <bool BATCHED, typename T, typename S, typename U, bool COMPLEX = is_complex<T>>
+template <bool BATCHED, typename T, typename S, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_potrf_template(rocblas_handle handle,
                                         const rocblas_fill uplo,
                                         const rocblas_int n,

--- a/library/src/lapack/roclapack_syev_heev.cpp
+++ b/library/src/lapack/roclapack_syev_heev.cpp
@@ -15,7 +15,7 @@ rocblas_status rocsolver_syev_heev_impl(rocblas_handle handle,
                                         S* E,
                                         rocblas_int* info)
 {
-    const char* name = (!is_complex<T> ? "syev" : "heev");
+    const char* name = (!rocblas_is_complex<T> ? "syev" : "heev");
     ROCSOLVER_ENTER_TOP(name, "--evect", evect, "--uplo", uplo, "-n", n, "--lda", lda);
 
     if(!handle)

--- a/library/src/lapack/roclapack_syev_heev.hpp
+++ b/library/src/lapack/roclapack_syev_heev.hpp
@@ -17,7 +17,7 @@
 #include "rocsolver/rocsolver.h"
 
 /** Set results for the scalar case (n=1) **/
-template <typename T, typename U, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, typename U, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 ROCSOLVER_KERNEL void scalar_case(const rocblas_evect evect,
                                   U AA,
                                   const rocblas_stride strideA,
@@ -38,7 +38,7 @@ ROCSOLVER_KERNEL void scalar_case(const rocblas_evect evect,
     }
 }
 
-template <typename T, typename S, typename U, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, typename S, typename U, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 ROCSOLVER_KERNEL void scalar_case(const rocblas_evect evect,
                                   U AA,
                                   const rocblas_stride strideA,

--- a/library/src/lapack/roclapack_syev_heev_batched.cpp
+++ b/library/src/lapack/roclapack_syev_heev_batched.cpp
@@ -18,7 +18,7 @@ rocblas_status rocsolver_syev_heev_batched_impl(rocblas_handle handle,
                                                 rocblas_int* info,
                                                 const rocblas_int batch_count)
 {
-    const char* name = (!is_complex<T> ? "syev_batched" : "heev_batched");
+    const char* name = (!rocblas_is_complex<T> ? "syev_batched" : "heev_batched");
     ROCSOLVER_ENTER_TOP(name, "--evect", evect, "--uplo", uplo, "-n", n, "--lda", lda, "--strideD",
                         strideD, "--strideE", strideE, "--batch_count", batch_count);
 

--- a/library/src/lapack/roclapack_syev_heev_strided_batched.cpp
+++ b/library/src/lapack/roclapack_syev_heev_strided_batched.cpp
@@ -19,7 +19,7 @@ rocblas_status rocsolver_syev_heev_strided_batched_impl(rocblas_handle handle,
                                                         rocblas_int* info,
                                                         const rocblas_int batch_count)
 {
-    const char* name = (!is_complex<T> ? "syev_strided_batched" : "heev_strided_batched");
+    const char* name = (!rocblas_is_complex<T> ? "syev_strided_batched" : "heev_strided_batched");
     ROCSOLVER_ENTER_TOP(name, "--evect", evect, "--uplo", uplo, "-n", n, "--lda", lda, "--strideA",
                         strideA, "--strideD", strideD, "--strideE", strideE, "--batch_count",
                         batch_count);

--- a/library/src/lapack/roclapack_syevd_heevd.cpp
+++ b/library/src/lapack/roclapack_syevd_heevd.cpp
@@ -15,7 +15,7 @@ rocblas_status rocsolver_syevd_heevd_impl(rocblas_handle handle,
                                           S* E,
                                           rocblas_int* info)
 {
-    const char* name = (!is_complex<T> ? "syevd" : "heevd");
+    const char* name = (!rocblas_is_complex<T> ? "syevd" : "heevd");
     ROCSOLVER_ENTER_TOP(name, "--evect", evect, "--uplo", uplo, "-n", n, "--lda", lda);
 
     if(!handle)

--- a/library/src/lapack/roclapack_syevd_heevd_batched.cpp
+++ b/library/src/lapack/roclapack_syevd_heevd_batched.cpp
@@ -18,7 +18,7 @@ rocblas_status rocsolver_syevd_heevd_batched_impl(rocblas_handle handle,
                                                   rocblas_int* info,
                                                   const rocblas_int batch_count)
 {
-    const char* name = (!is_complex<T> ? "syevd_batched" : "heevd_batched");
+    const char* name = (!rocblas_is_complex<T> ? "syevd_batched" : "heevd_batched");
     ROCSOLVER_ENTER_TOP(name, "--evect", evect, "--uplo", uplo, "-n", n, "--lda", lda, "--strideD",
                         strideD, "--strideE", strideE, "--batch_count", batch_count);
 

--- a/library/src/lapack/roclapack_syevd_heevd_strided_batched.cpp
+++ b/library/src/lapack/roclapack_syevd_heevd_strided_batched.cpp
@@ -19,7 +19,7 @@ rocblas_status rocsolver_syevd_heevd_strided_batched_impl(rocblas_handle handle,
                                                           rocblas_int* info,
                                                           const rocblas_int batch_count)
 {
-    const char* name = (!is_complex<T> ? "syevd_strided_batched" : "heevd_strided_batched");
+    const char* name = (!rocblas_is_complex<T> ? "syevd_strided_batched" : "heevd_strided_batched");
     ROCSOLVER_ENTER_TOP(name, "--evect", evect, "--uplo", uplo, "-n", n, "--lda", lda, "--strideA",
                         strideA, "--strideD", strideD, "--strideE", strideE, "--batch_count",
                         batch_count);

--- a/library/src/lapack/roclapack_syevdx_heevdx_inplace.cpp
+++ b/library/src/lapack/roclapack_syevdx_heevdx_inplace.cpp
@@ -32,7 +32,7 @@ rocblas_status rocsolver_syevdx_heevdx_inplace_impl(rocblas_handle handle,
                                                     S* W,
                                                     rocblas_int* info)
 {
-    const char* name = (!is_complex<T> ? "syevdx_inplace" : "heevdx_inplace");
+    const char* name = (!rocblas_is_complex<T> ? "syevdx_inplace" : "heevdx_inplace");
     ROCSOLVER_ENTER_TOP(name, "--evect", evect, "--erange", erange, "--uplo", uplo, "-n", n, "--lda",
                         lda, "--vl", vl, "--vu", vu, "--il", il, "--iu", iu, "--abstol", abstol);
 

--- a/library/src/lapack/roclapack_syevx_heevx.cpp
+++ b/library/src/lapack/roclapack_syevx_heevx.cpp
@@ -24,7 +24,7 @@ rocblas_status rocsolver_syevx_heevx_impl(rocblas_handle handle,
                                           rocblas_int* ifail,
                                           rocblas_int* info)
 {
-    const char* name = (!is_complex<T> ? "syevx" : "heevx");
+    const char* name = (!rocblas_is_complex<T> ? "syevx" : "heevx");
     ROCSOLVER_ENTER_TOP(name, "--evect", evect, "--erange", erange, "--uplo", uplo, "-n", n,
                         "--lda", lda, "--vl", vl, "--vu", vu, "--il", il, "--iu", iu, "--abstol",
                         abstol, "--ldz", ldz);

--- a/library/src/lapack/roclapack_syevx_heevx_batched.cpp
+++ b/library/src/lapack/roclapack_syevx_heevx_batched.cpp
@@ -27,7 +27,7 @@ rocblas_status rocsolver_syevx_heevx_batched_impl(rocblas_handle handle,
                                                   rocblas_int* info,
                                                   const rocblas_int batch_count)
 {
-    const char* name = (!is_complex<T> ? "syevx_batched" : "heevx_batched");
+    const char* name = (!rocblas_is_complex<T> ? "syevx_batched" : "heevx_batched");
     ROCSOLVER_ENTER_TOP(name, "--evect", evect, "--erange", erange, "--uplo", uplo, "-n", n,
                         "--lda", lda, "--vl", vl, "--vu", vu, "--il", il, "--iu", iu, "--abstol",
                         abstol, "--strideW", strideW, "--ldz", ldz, "--strideF", strideF,

--- a/library/src/lapack/roclapack_syevx_heevx_strided_batched.cpp
+++ b/library/src/lapack/roclapack_syevx_heevx_strided_batched.cpp
@@ -29,7 +29,7 @@ rocblas_status rocsolver_syevx_heevx_strided_batched_impl(rocblas_handle handle,
                                                           rocblas_int* info,
                                                           const rocblas_int batch_count)
 {
-    const char* name = (!is_complex<T> ? "syevx_strided_batched" : "heevx_strided_batched");
+    const char* name = (!rocblas_is_complex<T> ? "syevx_strided_batched" : "heevx_strided_batched");
     ROCSOLVER_ENTER_TOP(name, "--evect", evect, "--erange", erange, "--uplo", uplo, "-n", n,
                         "--lda", lda, "--strideA", strideA, "--vl", vl, "--vu", vu, "--il", il,
                         "--iu", iu, "--abstol", abstol, "--strideW", strideW, "--ldz", ldz,

--- a/library/src/lapack/roclapack_sygs2_hegs2.cpp
+++ b/library/src/lapack/roclapack_sygs2_hegs2.cpp
@@ -14,7 +14,7 @@ rocblas_status rocsolver_sygs2_hegs2_impl(rocblas_handle handle,
                                           U B,
                                           const rocblas_int ldb)
 {
-    const char* name = (!is_complex<T> ? "sygs2" : "hegs2");
+    const char* name = (!rocblas_is_complex<T> ? "sygs2" : "hegs2");
     ROCSOLVER_ENTER_TOP(name, "--itype", itype, "--uplo", uplo, "-n", n, "--lda", lda, "--ldb", ldb);
 
     if(!handle)

--- a/library/src/lapack/roclapack_sygs2_hegs2.hpp
+++ b/library/src/lapack/roclapack_sygs2_hegs2.hpp
@@ -177,7 +177,7 @@ rocblas_status rocsolver_sygs2_hegs2_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <bool BATCHED, typename T, typename U, bool COMPLEX = is_complex<T>>
+template <bool BATCHED, typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_sygs2_hegs2_template(rocblas_handle handle,
                                               const rocblas_eform itype,
                                               const rocblas_fill uplo,

--- a/library/src/lapack/roclapack_sygs2_hegs2_batched.cpp
+++ b/library/src/lapack/roclapack_sygs2_hegs2_batched.cpp
@@ -15,7 +15,7 @@ rocblas_status rocsolver_sygs2_hegs2_batched_impl(rocblas_handle handle,
                                                   const rocblas_int ldb,
                                                   const rocblas_int batch_count)
 {
-    const char* name = (!is_complex<T> ? "sygs2_batched" : "hegs2_batched");
+    const char* name = (!rocblas_is_complex<T> ? "sygs2_batched" : "hegs2_batched");
     ROCSOLVER_ENTER_TOP(name, "--itype", itype, "--uplo", uplo, "-n", n, "--lda", lda, "--ldb", ldb,
                         "--batch_count", batch_count);
 

--- a/library/src/lapack/roclapack_sygs2_hegs2_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sygs2_hegs2_strided_batched.cpp
@@ -17,7 +17,7 @@ rocblas_status rocsolver_sygs2_hegs2_strided_batched_impl(rocblas_handle handle,
                                                           const rocblas_stride strideB,
                                                           const rocblas_int batch_count)
 {
-    const char* name = (!is_complex<T> ? "sygs2_strided_batched" : "hegs2_strided_batched");
+    const char* name = (!rocblas_is_complex<T> ? "sygs2_strided_batched" : "hegs2_strided_batched");
     ROCSOLVER_ENTER_TOP(name, "--itype", itype, "--uplo", uplo, "-n", n, "--lda", lda, "--strideA",
                         strideA, "--ldb", ldb, "--strideB", strideB, "--batch_count", batch_count);
 

--- a/library/src/lapack/roclapack_sygst_hegst.cpp
+++ b/library/src/lapack/roclapack_sygst_hegst.cpp
@@ -14,7 +14,7 @@ rocblas_status rocsolver_sygst_hegst_impl(rocblas_handle handle,
                                           U B,
                                           const rocblas_int ldb)
 {
-    const char* name = (!is_complex<T> ? "sygst" : "hegst");
+    const char* name = (!rocblas_is_complex<T> ? "sygst" : "hegst");
     ROCSOLVER_ENTER_TOP(name, "--itype", itype, "--uplo", uplo, "-n", n, "--lda", lda, "--ldb", ldb);
 
     using S = decltype(std::real(T{}));

--- a/library/src/lapack/roclapack_sygst_hegst.hpp
+++ b/library/src/lapack/roclapack_sygst_hegst.hpp
@@ -90,7 +90,7 @@ void rocsolver_sygst_hegst_getMemorySize(const rocblas_fill uplo,
     }
 }
 
-template <bool BATCHED, bool STRIDED, typename T, typename S, typename U, bool COMPLEX = is_complex<T>>
+template <bool BATCHED, bool STRIDED, typename T, typename S, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                                               const rocblas_eform itype,
                                               const rocblas_fill uplo,

--- a/library/src/lapack/roclapack_sygst_hegst_batched.cpp
+++ b/library/src/lapack/roclapack_sygst_hegst_batched.cpp
@@ -15,7 +15,7 @@ rocblas_status rocsolver_sygst_hegst_batched_impl(rocblas_handle handle,
                                                   const rocblas_int ldb,
                                                   const rocblas_int batch_count)
 {
-    const char* name = (!is_complex<T> ? "sygst_batched" : "hegst_batched");
+    const char* name = (!rocblas_is_complex<T> ? "sygst_batched" : "hegst_batched");
     ROCSOLVER_ENTER_TOP(name, "--itype", itype, "--uplo", uplo, "-n", n, "--lda", lda, "--ldb", ldb,
                         "--batch_count", batch_count);
 

--- a/library/src/lapack/roclapack_sygst_hegst_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sygst_hegst_strided_batched.cpp
@@ -17,7 +17,7 @@ rocblas_status rocsolver_sygst_hegst_strided_batched_impl(rocblas_handle handle,
                                                           const rocblas_stride strideB,
                                                           const rocblas_int batch_count)
 {
-    const char* name = (!is_complex<T> ? "sygst_strided_batched" : "hegst_strided_batched");
+    const char* name = (!rocblas_is_complex<T> ? "sygst_strided_batched" : "hegst_strided_batched");
     ROCSOLVER_ENTER_TOP(name, "--itype", itype, "--uplo", uplo, "-n", n, "--lda", lda, "--strideA",
                         strideA, "--ldb", ldb, "--strideB", strideB, "--batch_count", batch_count);
 

--- a/library/src/lapack/roclapack_sygv_hegv.cpp
+++ b/library/src/lapack/roclapack_sygv_hegv.cpp
@@ -18,7 +18,7 @@ rocblas_status rocsolver_sygv_hegv_impl(rocblas_handle handle,
                                         S* E,
                                         rocblas_int* info)
 {
-    const char* name = (!is_complex<T> ? "sygv" : "hegv");
+    const char* name = (!rocblas_is_complex<T> ? "sygv" : "hegv");
     ROCSOLVER_ENTER_TOP(name, "--itype", itype, "--evect", evect, "--uplo", uplo, "-n", n, "--lda",
                         lda, "--ldb", ldb);
 

--- a/library/src/lapack/roclapack_sygv_hegv.hpp
+++ b/library/src/lapack/roclapack_sygv_hegv.hpp
@@ -147,7 +147,7 @@ rocblas_status rocsolver_sygv_hegv_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <bool BATCHED, bool STRIDED, typename T, typename S, typename U, bool COMPLEX = is_complex<T>>
+template <bool BATCHED, bool STRIDED, typename T, typename S, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_sygv_hegv_template(rocblas_handle handle,
                                             const rocblas_eform itype,
                                             const rocblas_evect evect,

--- a/library/src/lapack/roclapack_sygv_hegv_batched.cpp
+++ b/library/src/lapack/roclapack_sygv_hegv_batched.cpp
@@ -21,7 +21,7 @@ rocblas_status rocsolver_sygv_hegv_batched_impl(rocblas_handle handle,
                                                 rocblas_int* info,
                                                 const rocblas_int batch_count)
 {
-    const char* name = (!is_complex<T> ? "sygv_batched" : "hegv_batched");
+    const char* name = (!rocblas_is_complex<T> ? "sygv_batched" : "hegv_batched");
     ROCSOLVER_ENTER_TOP(name, "--itype", itype, "--evect", evect, "--uplo", uplo, "-n", n, "--lda",
                         lda, "--ldb", ldb, "--strideD", strideD, "--strideE", strideE,
                         "--batch_count", batch_count);

--- a/library/src/lapack/roclapack_sygv_hegv_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sygv_hegv_strided_batched.cpp
@@ -23,7 +23,7 @@ rocblas_status rocsolver_sygv_hegv_strided_batched_impl(rocblas_handle handle,
                                                         rocblas_int* info,
                                                         const rocblas_int batch_count)
 {
-    const char* name = (!is_complex<T> ? "sygv_strided_batched" : "hegv_strided_batched");
+    const char* name = (!rocblas_is_complex<T> ? "sygv_strided_batched" : "hegv_strided_batched");
     ROCSOLVER_ENTER_TOP(name, "--itype", itype, "--evect", evect, "--uplo", uplo, "-n", n, "--lda",
                         lda, "--strideA", strideA, "--ldb", ldb, "--strideB", strideB, "--strideD",
                         strideD, "--strideE", strideE, "--batch_count", batch_count);

--- a/library/src/lapack/roclapack_sygvd_hegvd.cpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd.cpp
@@ -18,7 +18,7 @@ rocblas_status rocsolver_sygvd_hegvd_impl(rocblas_handle handle,
                                           S* E,
                                           rocblas_int* info)
 {
-    const char* name = (!is_complex<T> ? "sygvd" : "hegvd");
+    const char* name = (!rocblas_is_complex<T> ? "sygvd" : "hegvd");
     ROCSOLVER_ENTER_TOP(name, "--itype", itype, "--evect", evect, "--uplo", uplo, "-n", n, "--lda",
                         lda, "--ldb", ldb);
 

--- a/library/src/lapack/roclapack_sygvd_hegvd.hpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd.hpp
@@ -96,7 +96,7 @@ void rocsolver_sygvd_hegvd_getMemorySize(const rocblas_eform itype,
     *optim_mem = opt1 && opt2 && opt3;
 }
 
-template <bool BATCHED, bool STRIDED, typename T, typename S, typename U, bool COMPLEX = is_complex<T>>
+template <bool BATCHED, bool STRIDED, typename T, typename S, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_sygvd_hegvd_template(rocblas_handle handle,
                                               const rocblas_eform itype,
                                               const rocblas_evect evect,

--- a/library/src/lapack/roclapack_sygvd_hegvd_batched.cpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd_batched.cpp
@@ -21,7 +21,7 @@ rocblas_status rocsolver_sygvd_hegvd_batched_impl(rocblas_handle handle,
                                                   rocblas_int* info,
                                                   const rocblas_int batch_count)
 {
-    const char* name = (!is_complex<T> ? "sygvd_batched" : "hegvd_batched");
+    const char* name = (!rocblas_is_complex<T> ? "sygvd_batched" : "hegvd_batched");
     ROCSOLVER_ENTER_TOP(name, "--itype", itype, "--evect", evect, "--uplo", uplo, "-n", n, "--lda",
                         lda, "--ldb", ldb, "--strideD", strideD, "--strideE", strideE,
                         "--batch_count", batch_count);

--- a/library/src/lapack/roclapack_sygvd_hegvd_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd_strided_batched.cpp
@@ -23,7 +23,7 @@ rocblas_status rocsolver_sygvd_hegvd_strided_batched_impl(rocblas_handle handle,
                                                           rocblas_int* info,
                                                           const rocblas_int batch_count)
 {
-    const char* name = (!is_complex<T> ? "sygvd_strided_batched" : "hegvd_strided_batched");
+    const char* name = (!rocblas_is_complex<T> ? "sygvd_strided_batched" : "hegvd_strided_batched");
     ROCSOLVER_ENTER_TOP(name, "--itype", itype, "--evect", evect, "--uplo", uplo, "-n", n, "--lda",
                         lda, "--strideA", strideA, "--ldb", ldb, "--strideB", strideB, "--strideD",
                         strideD, "--strideE", strideE, "--batch_count", batch_count);

--- a/library/src/lapack/roclapack_sygvx_hegvx.cpp
+++ b/library/src/lapack/roclapack_sygvx_hegvx.cpp
@@ -27,7 +27,7 @@ rocblas_status rocsolver_sygvx_hegvx_impl(rocblas_handle handle,
                                           rocblas_int* ifail,
                                           rocblas_int* info)
 {
-    const char* name = (!is_complex<T> ? "sygvx" : "hegvx");
+    const char* name = (!rocblas_is_complex<T> ? "sygvx" : "hegvx");
     ROCSOLVER_ENTER_TOP(name, "--itype", itype, "--evect", evect, "--erange", erange, "--uplo",
                         uplo, "-n", n, "--lda", lda, "--ldb", ldb, "--vl", vl, "--vu", vu, "--il",
                         il, "--iu", iu, "--abstol", abstol, "--ldz", ldz);

--- a/library/src/lapack/roclapack_sygvx_hegvx.hpp
+++ b/library/src/lapack/roclapack_sygvx_hegvx.hpp
@@ -185,7 +185,7 @@ void rocsolver_sygvx_hegvx_getMemorySize(const rocblas_eform itype,
     *optim_mem = opt1 && opt2 && opt3;
 }
 
-template <bool BATCHED, bool STRIDED, typename T, typename S, typename U, bool COMPLEX = is_complex<T>>
+template <bool BATCHED, bool STRIDED, typename T, typename S, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_sygvx_hegvx_template(rocblas_handle handle,
                                               const rocblas_eform itype,
                                               const rocblas_evect evect,

--- a/library/src/lapack/roclapack_sygvx_hegvx_batched.cpp
+++ b/library/src/lapack/roclapack_sygvx_hegvx_batched.cpp
@@ -30,7 +30,7 @@ rocblas_status rocsolver_sygvx_hegvx_batched_impl(rocblas_handle handle,
                                                   rocblas_int* info,
                                                   const rocblas_int batch_count)
 {
-    const char* name = (!is_complex<T> ? "sygvx_batched" : "hegvx_batched");
+    const char* name = (!rocblas_is_complex<T> ? "sygvx_batched" : "hegvx_batched");
     ROCSOLVER_ENTER_TOP(name, "--itype", itype, "--evect", evect, "--erange", erange, "--uplo",
                         uplo, "-n", n, "--lda", lda, "--ldb", ldb, "--vl", vl, "--vu", vu, "--il",
                         il, "--iu", iu, "--abstol", abstol, "--strideW", strideW, "--ldz", ldz,

--- a/library/src/lapack/roclapack_sygvx_hegvx_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sygvx_hegvx_strided_batched.cpp
@@ -33,7 +33,7 @@ rocblas_status rocsolver_sygvx_hegvx_strided_batched_impl(rocblas_handle handle,
                                                           rocblas_int* info,
                                                           const rocblas_int batch_count)
 {
-    const char* name = (!is_complex<T> ? "sygvx_strided_batched" : "hegvx_strided_batched");
+    const char* name = (!rocblas_is_complex<T> ? "sygvx_strided_batched" : "hegvx_strided_batched");
     ROCSOLVER_ENTER_TOP(name, "--itype", itype, "--evect", evect, "--erange", erange, "--uplo",
                         uplo, "-n", n, "--lda", lda, "--strideA", strideA, "--ldb", ldb,
                         "--strideB", strideB, "--vl", vl, "--vu", vu, "--il", il, "--iu", iu,

--- a/library/src/lapack/roclapack_sytd2_hetd2.cpp
+++ b/library/src/lapack/roclapack_sytd2_hetd2.cpp
@@ -14,7 +14,7 @@ rocblas_status rocsolver_sytd2_hetd2_impl(rocblas_handle handle,
                                           S* E,
                                           T* tau)
 {
-    const char* name = (!is_complex<T> ? "sytd2" : "hetd2");
+    const char* name = (!rocblas_is_complex<T> ? "sytd2" : "hetd2");
     ROCSOLVER_ENTER_TOP(name, "--uplo", uplo, "-n", n, "--lda", lda);
 
     if(!handle)

--- a/library/src/lapack/roclapack_sytd2_hetd2.hpp
+++ b/library/src/lapack/roclapack_sytd2_hetd2.hpp
@@ -30,7 +30,7 @@ ROCSOLVER_KERNEL void
 
 /** set_tridiag kernel copies results to set tridiagonal form in A, diagonal elements in D
     and off-diagonal elements in E **/
-template <typename T, typename S, typename U, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, typename S, typename U, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 ROCSOLVER_KERNEL void set_tridiag(const rocblas_fill uplo,
                                   const rocblas_int n,
                                   U A,
@@ -66,7 +66,7 @@ ROCSOLVER_KERNEL void set_tridiag(const rocblas_fill uplo,
     }
 }
 
-template <typename T, typename S, typename U, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, typename S, typename U, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 ROCSOLVER_KERNEL void set_tridiag(const rocblas_fill uplo,
                                   const rocblas_int n,
                                   U A,
@@ -176,7 +176,7 @@ rocblas_status rocsolver_sytd2_hetd2_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename T, typename S, typename U, bool COMPLEX = is_complex<T>>
+template <typename T, typename S, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_sytd2_hetd2_template(rocblas_handle handle,
                                               const rocblas_fill uplo,
                                               const rocblas_int n,

--- a/library/src/lapack/roclapack_sytd2_hetd2_batched.cpp
+++ b/library/src/lapack/roclapack_sytd2_hetd2_batched.cpp
@@ -18,7 +18,7 @@ rocblas_status rocsolver_sytd2_hetd2_batched_impl(rocblas_handle handle,
                                                   const rocblas_stride strideP,
                                                   const rocblas_int batch_count)
 {
-    const char* name = (!is_complex<T> ? "sytd2_batched" : "hetd2_batched");
+    const char* name = (!rocblas_is_complex<T> ? "sytd2_batched" : "hetd2_batched");
     ROCSOLVER_ENTER_TOP(name, "--uplo", uplo, "-n", n, "--lda", lda, "--strideD", strideD,
                         "--strideE", strideE, "--strideP", strideP, "--batch_count", batch_count);
 

--- a/library/src/lapack/roclapack_sytd2_hetd2_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sytd2_hetd2_strided_batched.cpp
@@ -19,7 +19,7 @@ rocblas_status rocsolver_sytd2_hetd2_strided_batched_impl(rocblas_handle handle,
                                                           const rocblas_stride strideP,
                                                           const rocblas_int batch_count)
 {
-    const char* name = (!is_complex<T> ? "sytd2_strided_batched" : "hetd2_strided_batched");
+    const char* name = (!rocblas_is_complex<T> ? "sytd2_strided_batched" : "hetd2_strided_batched");
     ROCSOLVER_ENTER_TOP(name, "--uplo", uplo, "-n", n, "--lda", lda, "--strideA", strideA,
                         "--strideD", strideD, "--strideE", strideE, "--strideP", strideP,
                         "--batch_count", batch_count);

--- a/library/src/lapack/roclapack_sytrd_hetrd.cpp
+++ b/library/src/lapack/roclapack_sytrd_hetrd.cpp
@@ -14,7 +14,7 @@ rocblas_status rocsolver_sytrd_hetrd_impl(rocblas_handle handle,
                                           S* E,
                                           T* tau)
 {
-    const char* name = (!is_complex<T> ? "sytrd" : "hetrd");
+    const char* name = (!rocblas_is_complex<T> ? "sytrd" : "hetrd");
     ROCSOLVER_ENTER_TOP(name, "--uplo", uplo, "-n", n, "--lda", lda);
 
     if(!handle)

--- a/library/src/lapack/roclapack_sytrd_hetrd.hpp
+++ b/library/src/lapack/roclapack_sytrd_hetrd.hpp
@@ -82,7 +82,7 @@ rocblas_status rocsolver_sytrd_hetrd_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <bool BATCHED, typename T, typename S, typename U, bool COMPLEX = is_complex<T>>
+template <bool BATCHED, typename T, typename S, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_sytrd_hetrd_template(rocblas_handle handle,
                                               const rocblas_fill uplo,
                                               const rocblas_int n,

--- a/library/src/lapack/roclapack_sytrd_hetrd_batched.cpp
+++ b/library/src/lapack/roclapack_sytrd_hetrd_batched.cpp
@@ -18,7 +18,7 @@ rocblas_status rocsolver_sytrd_hetrd_batched_impl(rocblas_handle handle,
                                                   const rocblas_stride strideP,
                                                   const rocblas_int batch_count)
 {
-    const char* name = (!is_complex<T> ? "sytrd_batched" : "hetrd_batched");
+    const char* name = (!rocblas_is_complex<T> ? "sytrd_batched" : "hetrd_batched");
     ROCSOLVER_ENTER_TOP(name, "--uplo", uplo, "-n", n, "--lda", lda, "--strideD", strideD,
                         "--strideE", strideE, "--strideP", strideP, "--batch_count", batch_count);
 

--- a/library/src/lapack/roclapack_sytrd_hetrd_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sytrd_hetrd_strided_batched.cpp
@@ -19,7 +19,7 @@ rocblas_status rocsolver_sytrd_hetrd_strided_batched_impl(rocblas_handle handle,
                                                           const rocblas_stride strideP,
                                                           const rocblas_int batch_count)
 {
-    const char* name = (!is_complex<T> ? "sytrd_strided_batched" : "hetrd_strided_batched");
+    const char* name = (!rocblas_is_complex<T> ? "sytrd_strided_batched" : "hetrd_strided_batched");
     ROCSOLVER_ENTER_TOP(name, "--uplo", uplo, "-n", n, "--lda", lda, "--strideA", strideA,
                         "--strideD", strideD, "--strideE", strideE, "--strideP", strideP,
                         "--batch_count", batch_count);

--- a/library/src/rocblascommon/utility.hpp
+++ b/library/src/rocblascommon/utility.hpp
@@ -33,13 +33,13 @@ __device__ inline rocblas_half2
 
 // Conjugate a value. For most types, simply return argument; for
 // rocblas_float_complex and rocblas_double_complex, return std::conj(z)
-template <typename T, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 __device__ __host__ inline T conj(const T& z)
 {
     return z;
 }
 
-template <typename T, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 __device__ __host__ inline T conj(const T& z)
 {
     return std::conj(z);
@@ -337,14 +337,14 @@ constexpr rocblas_status get_rocblas_status_for_hip_status(hipError_t status)
 }
 
 // Absolute value
-template <typename T, std::enable_if_t<!is_complex<T>, int> = 0>
+template <typename T, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
 __device__ __host__ inline T rocblas_abs(T x)
 {
     return x < 0 ? -x : x;
 }
 
 // For complex, we have defined a __device__ __host__ compatible std::abs
-template <typename T, std::enable_if_t<is_complex<T>, int> = 0>
+template <typename T, std::enable_if_t<rocblas_is_complex<T>, int> = 0>
 __device__ __host__ inline auto rocblas_abs(T x)
 {
     return std::abs(x);
@@ -377,7 +377,7 @@ struct rocblas_real_t_impl
 };
 
 template <typename T>
-struct rocblas_real_t_impl<T, std::enable_if_t<is_complex<T>>>
+struct rocblas_real_t_impl<T, std::enable_if_t<rocblas_is_complex<T>>>
 {
     using type = decltype(std::real(T{}));
 };


### PR DESCRIPTION
Search-and-replace of `is_complex` to `rocblas_is_complex` (see https://github.com/ROCmSoftwarePlatform/rocBLAS-internal/pull/1216).

Don't mean to step on any toes, just noticed an abundance of warnings when trying to build rocSOLVER against some rocBLAS changes, feel free to disregard/close if you have other plans.