### PR TITLE
Fix stebz bug for range = index, and failing tests in Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 - Fixed incorrect SYGS2/HEGS2, SYGST/HEGST, SYGV/HEGV, and SYGVD/HEGVD results for batch counts
   larger than 32.
 - Fixed STEIN memory access fault when nev is 0.
+- Fixed incorrect STEBZ results for close eigenvalues when range = index.
 
 ### Known Issues
 ### Security

--- a/clients/gtest/stebz_gtest.cpp
+++ b/clients/gtest/stebz_gtest.cpp
@@ -22,8 +22,8 @@ typedef std::tuple<vector<int>, vector<int>> stebz_tuple;
 // if rng = 2, then find the il-th to the iu-th eigenvalue
 
 // Note: all tests are prepared with diagonally dominant matrices that have random diagonal
-// elements in [-20, -11] U [11, 20], and off-diagonal elements in [-4, 5].
-// Thus, all eigenvalues should be in [-30, 30]
+// elements in [-20, -11] U [11, 20], and off-diagonal elements in [-0.4, 0.5].
+// Thus, all eigenvalues should be in [-20, 20]
 
 // case when n == 0, ord == 0, and rng == 0 will also execute the bad arguments test
 // (null handle, null pointers and invalid values)

--- a/clients/gtest/stebz_gtest.cpp
+++ b/clients/gtest/stebz_gtest.cpp
@@ -23,7 +23,7 @@ typedef std::tuple<vector<int>, vector<int>> stebz_tuple;
 
 // Note: all tests are prepared with diagonally dominant matrices that have random diagonal
 // elements in [-20, -11] U [11, 20], and off-diagonal elements in [-0.4, 0.5].
-// Thus, all eigenvalues should be in [-20, 20]
+// Thus, all the eigenvalues are guaranteed to be in [-20, 20]
 
 // case when n == 0, ord == 0, and rng == 0 will also execute the bad arguments test
 // (null handle, null pointers and invalid values)

--- a/clients/include/testing_stebz.hpp
+++ b/clients/include/testing_stebz.hpp
@@ -127,7 +127,7 @@ void stebz_initData(const rocblas_handle handle, const rocblas_int n, Td& dD, Td
         for(rocblas_int i = 0; i < n; i++)
         {
             hD[0][i] += 10;
-            hE[0][i] = (hE[0][i] - 5) / 1;
+            hE[0][i] = (hE[0][i] - 5) / 10;
             if(i == n / 4 || i == n / 2 || i == n - 1)
                 hE[0][i] = 0;
             if(i == n / 7 || i == n / 5 || i == n / 3)
@@ -229,7 +229,7 @@ void stebz_getError(const rocblas_handle handle,
         for(int k = 0; k < nn; ++k)
         {
             int difb = std::abs(hIblock[0][k] - hIblockRes[0][k]);
-            T difv = std::abs(hW[0][k] - hWRes[0][k]) / hW[0][k]; 
+            T difv = std::abs(hW[0][k] - hWRes[0][k]) / hW[0][k];
             if(difb > 0 && difv > n * get_epsilon<T>())
                 *max_err += difb;
         }

--- a/library/src/auxiliary/rocauxiliary_stebz.hpp
+++ b/library/src/auxiliary/rocauxiliary_stebz.hpp
@@ -93,27 +93,21 @@ __device__ rocblas_int sturm_count(const rocblas_int n, T* D, T* E, T pmin, T c)
 
     ev = 0;
     t = D[0] - c;
-//printf("en 0: %2.15f ",double(t));
     if(t <= pmin)
     {
-//printf("ssuma");
         ev++;
         t = std::min(t, -pmin);
     }
-//printf("\n");
 
     // main loop
     for(rocblas_int i = 1; i < n; ++i)
     {
         t = D[i] - c - E[i - 1] / t;
-//printf("en %d: %2.15f ",i,double(t));
         if(t <= pmin)
         {
-//printf("ssuma");
             ev++;
             t = std::min(t, -pmin);
         }
-//printf("\n");
     }
 
     return ev;
@@ -788,27 +782,18 @@ ROCSOLVER_KERNEL void stebz_synthesis_kernel(const rocblas_erange range,
         {
             for(int b = 0; b < nofb; ++b)
             {
-//int b = 0;
                 bin = (b == 0) ? 0 : IS[b - 1];
                 for(int bb = 0; bb < tmpnev[b]; ++bb)
                 {
                     tmp = W[bin + bb];
                     ntmp = IB[bin + bb];
-//tmp2 = tmp;// + pmin + std::abs(tmp) * eps *n;// + bnorm * eps * n;
-//                ntmp = index ? sturm_count(n, D, Esqr, pmin, tmp2) : 0;
-
-//printf("in block %d: %d less than %2.15f\n",b+1,ntmp,double(tmp2));
-
-//                if(!index || (ntmp >= ilow && ntmp <= iup))
-//printf("--> yes\n");
                     inter[nnt] = tmp;
                     ninter[nnt] = ntmp;
                     inter[nnt + n] = tmp;
-//                    ninter[nnt + n] = ntmp;
                     nnt++;
                 }
             }
-            
+
             // discard extra values
             increasing_order(nnt, inter + n, ninter + n);
             for(int i = 0; i < nnt; ++i)
@@ -819,7 +804,8 @@ ROCSOLVER_KERNEL void stebz_synthesis_kernel(const rocblas_erange range,
                     tmp2 = inter[n + j];
                     if(tmp == tmp2)
                     {
-                        tmp2 = (j == nnt - 1) ? (bounds[1] - tmp2) / 2 : (inter[n + j + 1] - tmp2) / 2;
+                        tmp2 = (j == nnt - 1) ? (bounds[1] - tmp2) / 2
+                                              : (inter[n + j + 1] - tmp2) / 2;
                         tmp2 += tmp;
                         ntmp = sturm_count(n, D, Esqr, pmin, tmp2);
                         if(ntmp >= ilow && ntmp <= iup)
@@ -987,11 +973,6 @@ rocblas_status rocsolver_stebz_template(rocblas_handle handle,
                                         T* inter,
                                         rocblas_int* ninter)
 {
-//print_device_matrix(std::cout,"D",1,n,D,1);
-//print_device_matrix(std::cout,"E",1,n,E,1);
-
-
-
     ROCSOLVER_ENTER("stebz", "erange:", range, "eorder:", order, "n:", n, "vl:", vlow, "vu:", vup,
                     "il:", ilow, "iu:", iup, "abstol:", abstol, "shiftD:", shiftD,
                     "shiftE:", shiftE, "bc:", batch_count);
@@ -1052,39 +1033,15 @@ rocblas_status rocsolver_stebz_template(rocblas_handle handle,
         split-off blocks- into the host, to launch exactly that amount of thread-blocks,
         could give better performance) **/
 
-
-//print_device_matrix(std::cout,"Work before",1,n,work,1);
-//print_device_matrix(std::cout,"bounds before",1,2,bounds,1);
-
     ROCSOLVER_LAUNCH_KERNEL(stebz_bisection_kernel<T>, dim3(IBISEC_BLKS, batch_count),
                             dim3(IBISEC_THDS), 0, stream, range, n, atol, D, shiftD, strideD, E,
                             shiftE, strideE, nev, nsplit, W, strideW, IB, strideIB, IS, strideIS,
                             info, work, pivmin, Esqr, bounds, inter, ninter, eps, sfmin);
 
-//print_device_matrix(std::cout,"nev before",1,1,nev,1);
-//print_device_matrix(std::cout,"W before",1,n,W,1);
-//print_device_matrix(std::cout,"iblock before",1,n,IB,1);
-//print_device_matrix(std::cout,"Work before",1,n,work,1);
-//print_device_matrix(std::cout,"bounds before",1,2,bounds,1);
-
     // Finally, synthetize the results from all the split blocks
-    ROCSOLVER_LAUNCH_KERNEL(stebz_synthesis_kernel<T>, gridReset, threads, 0, stream, range, order,
-                            n, ilow, iup, D, shiftD, strideD, nev, nsplit, W, strideW, IB, strideIB,
-                            IS, strideIS, batch_count, work, pivmin, Esqr, bounds, inter, ninter, eps);
-
-
-//print_device_matrix(std::cout,"info",1,1,info,1);
-//print_device_matrix(std::cout,"nsplit",1,1,nsplit,1);
-//print_device_matrix(std::cout,"isplit",1,n,IS,1);
-//print_device_matrix(std::cout,"nev after",1,1,nev,1);
-//print_device_matrix(std::cout,"W after",1,n,W,1);
-//print_device_matrix(std::cout,"iblock after",1,n,IB,1);
-//print_device_matrix(std::cout,"Work after",1,n,work,1);
-//print_device_matrix(std::cout,"bounds after",1,2,bounds,1);
-
-
-
-
+    ROCSOLVER_LAUNCH_KERNEL(stebz_synthesis_kernel<T>, gridReset, threads, 0, stream, range, order, n,
+                            ilow, iup, D, shiftD, strideD, nev, nsplit, W, strideW, IB, strideIB, IS,
+                            strideIS, batch_count, work, pivmin, Esqr, bounds, inter, ninter, eps);
 
     return rocblas_status_success;
 }


### PR DESCRIPTION
This PR fixes failing tests on Windows CI (https://ontrack-internal.amd.com/browse/SWDEV-330297).
Also, it standardizes the tests matrices as in other partial-eigenproblem routines.  This revealed further bugs in the actual algorithm for range = index. This PR also includes the fix. 
