### PR TITLE
Using rocblas header file for block sizes

### DIFF
--- a/library/src/include/rocblas.hpp
+++ b/library/src/include/rocblas.hpp
@@ -12,7 +12,7 @@
 #include "lib_host_helpers.hpp"
 #include "rocblas/internal/rocblas-exported-proto.hpp"
 #include "rocblas/internal/rocblas_device_malloc.hpp"
-#include "rocblas/internal/rocblas_block_sizes.hpp"
+#include "rocblas/internal/rocblas_block_sizes.h"
 #include "rocsolver_logger.hpp"
 
 template <typename T>

--- a/library/src/include/rocblas.hpp
+++ b/library/src/include/rocblas.hpp
@@ -1100,7 +1100,7 @@ rocblas_status rocblasCall_syrk_herk(rocblas_handle handle,
 
     using S = decltype(std::real(T{}));
 
-    constexpr rocblas_int NB = BATCHED ? ROCBLAS_XHERK_BATCHED_NB : ROCBLAS_XHERK_NB;
+    constexpr rocblas_int NB = BATCHED ? ROCBLAS_HERK_BATCHED_NB : ROCBLAS_HERK_NB;
     return rocblas_internal_herk_template<NB, BATCHED, T>(
         handle, uplo, transA, n, k, cast2constType<S>(alpha), cast2constType<T>(A), offsetA, lda,
         strideA, cast2constType<S>(beta), C, offsetC, ldc, strideC, batch_count);
@@ -1583,7 +1583,7 @@ void rocblasCall_trsm_mem(rocblas_side side,
         no_opt_size could be used in the future if we generalize the use of
         rocblas_workmode parameter **/
 
-    rocblas_internal_trsm_workspace_size<ROCBLAS_XTRSM_NB, BATCHED, T>(
+    rocblas_internal_trsm_workspace_size<ROCBLAS_TRSM_NB, BATCHED, T>(
         side, transA, m, n, batch_count, 0, x_temp, x_temp_arr, invA, invA_arr, &no_opt_size);
 }
 
@@ -1622,7 +1622,7 @@ rocblas_status rocblasCall_trsm(rocblas_handle handle,
                   "bc:", batch_count);
 
     U supplied_invA = nullptr;
-    return rocblas_internal_trsm_template<ROCBLAS_XTRSM_NB, ROCBLAS_SDCTRSV_NB, BATCHED, T>(
+    return rocblas_internal_trsm_template<ROCBLAS_TRSM_NB, ROCBLAS_SDCTRSV_NB, BATCHED, T>(
         handle, side, uplo, transA, diag, m, n, alpha, cast2constType(A), offset_A, lda, stride_A,
         B, offset_B, ldb, stride_B, batch_count, optimal_mem, x_temp, x_temp_arr, invA, invA_arr,
         cast2constType(supplied_invA), 0);
@@ -1662,7 +1662,7 @@ rocblas_status rocblasCall_trsm(rocblas_handle handle,
                   "bc:", batch_count);
 
     U supplied_invA = nullptr;
-    return rocblas_internal_trsm_template<ROCBLAS_XTRSM_NB, ROCBLAS_ZTRSV_NB, BATCHED, T>(
+    return rocblas_internal_trsm_template<ROCBLAS_TRSM_NB, ROCBLAS_ZTRSV_NB, BATCHED, T>(
         handle, side, uplo, transA, diag, m, n, alpha, cast2constType(A), offset_A, lda, stride_A,
         B, offset_B, ldb, stride_B, batch_count, optimal_mem, x_temp, x_temp_arr, invA, invA_arr,
         cast2constType(supplied_invA), 0);
@@ -1709,7 +1709,7 @@ rocblas_status rocblasCall_trsm(rocblas_handle handle,
                             batch_count);
 
     U supplied_invA = nullptr;
-    return rocblas_internal_trsm_template<ROCBLAS_XTRSM_NB, ROCBLAS_SDCTRSV_NB, BATCHED, T>(
+    return rocblas_internal_trsm_template<ROCBLAS_TRSM_NB, ROCBLAS_SDCTRSV_NB, BATCHED, T>(
         handle, side, uplo, transA, diag, m, n, alpha, cast2constType((U)workArr), offset_A, lda,
         stride_A, B, offset_B, ldb, stride_B, batch_count, optimal_mem, x_temp, x_temp_arr, invA,
         invA_arr, cast2constType(supplied_invA), 0);
@@ -1755,7 +1755,7 @@ rocblas_status rocblasCall_trsm(rocblas_handle handle,
                             batch_count);
 
     U supplied_invA = nullptr;
-    return rocblas_internal_trsm_template<ROCBLAS_XTRSM_NB, ROCBLAS_ZTRSV_NB, BATCHED, T>(
+    return rocblas_internal_trsm_template<ROCBLAS_TRSM_NB, ROCBLAS_ZTRSV_NB, BATCHED, T>(
         handle, side, uplo, transA, diag, m, n, alpha, cast2constType((U)workArr), offset_A, lda,
         stride_A, B, offset_B, ldb, stride_B, batch_count, optimal_mem, x_temp, x_temp_arr, invA,
         invA_arr, cast2constType(supplied_invA), 0);
@@ -1765,7 +1765,7 @@ rocblas_status rocblasCall_trsm(rocblas_handle handle,
 template <bool BATCHED, typename T>
 void rocblasCall_trtri_mem(rocblas_int n, rocblas_int batch_count, size_t* c_temp, size_t* c_temp_arr)
 {
-    size_t c_temp_els = rocblas_internal_trtri_temp_size<ROCBLAS_XTRTRI_NB>(n, batch_count);
+    size_t c_temp_els = rocblas_internal_trtri_temp_size<ROCBLAS_TRTRI_NB>(n, batch_count);
     *c_temp = c_temp_els * sizeof(T);
 
     *c_temp_arr = BATCHED ? sizeof(T*) * batch_count : 0;
@@ -1793,7 +1793,7 @@ rocblas_status rocblasCall_trtri(rocblas_handle handle,
     ROCBLAS_ENTER("trtri", "uplo:", uplo, "diag:", diag, "n:", n, "shiftA:", offset_A, "lda:", lda,
                   "shiftC:", offset_invA, "ldc:", ldinvA, "bc:", batch_count);
 
-    return rocblas_internal_trtri_template<ROCBLAS_XTRTRI_NB, BATCHED, STRIDED, T>(
+    return rocblas_internal_trtri_template<ROCBLAS_TRTRI_NB, BATCHED, STRIDED, T>(
         handle, uplo, diag, n, cast2constType(A), offset_A, lda, stride_A, 0, invA, offset_invA,
         ldinvA, stride_invA, 0, batch_count, 1, c_temp);
 }
@@ -1820,7 +1820,7 @@ rocblas_status rocblasCall_trtri(rocblas_handle handle,
     ROCBLAS_ENTER("trtri", "uplo:", uplo, "diag:", diag, "n:", n, "shiftA:", offset_A, "lda:", lda,
                   "shiftC:", offset_invA, "ldc:", ldinvA, "bc:", batch_count);
 
-    size_t c_temp_els = rocblas_internal_trtri_temp_size<ROCBLAS_XTRTRI_NB>(n, 1);
+    size_t c_temp_els = rocblas_internal_trtri_temp_size<ROCBLAS_TRTRI_NB>(n, 1);
 
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
@@ -1829,7 +1829,7 @@ rocblas_status rocblasCall_trtri(rocblas_handle handle,
     ROCSOLVER_LAUNCH_KERNEL(get_array, dim3(blocks), dim3(256), 0, stream, c_temp_arr, c_temp,
                             c_temp_els, batch_count);
 
-    return rocblas_internal_trtri_template<ROCBLAS_XTRTRI_NB, BATCHED, STRIDED, T>(
+    return rocblas_internal_trtri_template<ROCBLAS_TRTRI_NB, BATCHED, STRIDED, T>(
         handle, uplo, diag, n, cast2constType(A), offset_A, lda, stride_A, 0, invA, offset_invA,
         ldinvA, stride_invA, 0, batch_count, 1, cast2constPointer(c_temp_arr));
 }
@@ -1856,7 +1856,7 @@ rocblas_status rocblasCall_trtri(rocblas_handle handle,
     ROCBLAS_ENTER("trtri", "uplo:", uplo, "diag:", diag, "n:", n, "shiftA:", offset_A, "lda:", lda,
                   "shiftC:", offset_invA, "ldc:", ldinvA, "bc:", batch_count);
 
-    size_t c_temp_els = rocblas_internal_trtri_temp_size<ROCBLAS_XTRTRI_NB>(n, 1);
+    size_t c_temp_els = rocblas_internal_trtri_temp_size<ROCBLAS_TRTRI_NB>(n, 1);
 
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
@@ -1867,7 +1867,7 @@ rocblas_status rocblasCall_trtri(rocblas_handle handle,
     ROCSOLVER_LAUNCH_KERNEL(get_array, dim3(blocks), dim3(256), 0, stream, c_temp_arr, c_temp,
                             c_temp_els, batch_count);
 
-    return rocblas_internal_trtri_template<ROCBLAS_XTRTRI_NB, BATCHED, STRIDED, T>(
+    return rocblas_internal_trtri_template<ROCBLAS_TRTRI_NB, BATCHED, STRIDED, T>(
         handle, uplo, diag, n, cast2constType(A), offset_A, lda, stride_A, 0,
         cast2constPointer(workArr), offset_invA, ldinvA, stride_invA, 0, batch_count, 1,
         cast2constPointer(c_temp_arr));

--- a/library/src/include/rocblas.hpp
+++ b/library/src/include/rocblas.hpp
@@ -11,8 +11,8 @@
 #include "lib_device_helpers.hpp"
 #include "lib_host_helpers.hpp"
 #include "rocblas/internal/rocblas-exported-proto.hpp"
-#include "rocblas/internal/rocblas_device_malloc.hpp"
 #include "rocblas/internal/rocblas_block_sizes.h"
+#include "rocblas/internal/rocblas_device_malloc.hpp"
 #include "rocsolver_logger.hpp"
 
 template <typename T>
@@ -852,8 +852,7 @@ rocblas_status rocblasCall_trmm(rocblas_handle handle,
                   "n:", n, "shiftA:", offsetA, "lda:", lda, "shiftB:", offsetB, "ldb:", ldb,
                   "bc:", batch_count);
 
-    constexpr rocblas_int nb
-        = (!rocblas_is_complex<T> ? ROCBLAS_SDTRMM_NB : ROCBLAS_CZTRMM_NB);
+    constexpr rocblas_int nb = (!rocblas_is_complex<T> ? ROCBLAS_SDTRMM_NB : ROCBLAS_CZTRMM_NB);
 
     return rocblas_internal_trmm_template<nb, BATCHED, T>(
         handle, side, uplo, transA, diag, m, n, cast2constType<T>(alpha), stride_alpha,
@@ -888,8 +887,7 @@ rocblas_status rocblasCall_trmm(rocblas_handle handle,
                   "n:", n, "shiftA:", offsetA, "lda:", lda, "shiftB:", offsetB, "ldb:", ldb,
                   "bc:", batch_count);
 
-    constexpr rocblas_int nb
-        = (!rocblas_is_complex<T> ? ROCBLAS_SDTRMM_NB : ROCBLAS_CZTRMM_NB);
+    constexpr rocblas_int nb = (!rocblas_is_complex<T> ? ROCBLAS_SDTRMM_NB : ROCBLAS_CZTRMM_NB);
 
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);

--- a/library/src/include/rocblas.hpp
+++ b/library/src/include/rocblas.hpp
@@ -12,26 +12,8 @@
 #include "lib_host_helpers.hpp"
 #include "rocblas/internal/rocblas-exported-proto.hpp"
 #include "rocblas/internal/rocblas_device_malloc.hpp"
+#include "rocblas/internal/rocblas_block_sizes.hpp"
 #include "rocsolver_logger.hpp"
-
-// THESE FOLLOWING VALUES ARE TO MATCH ROCBLAS C++ INTERFACE
-// THEY ARE DEFINED/TUNED IN ROCBLAS
-#define ROCBLAS_AXPY_NB 256
-#define ROCBLAS_SCAL_NB 256
-#define ROCBLAS_DOT_NB 512
-#define ROCBLAS_TRMV_NB 512
-#define ROCBLAS_TRMM_REAL_NB 32
-#define ROCBLAS_TRMM_COMPLEX_NB 16
-#define ROCBLAS_IAMAX_NB 1024
-#define ROCBLAS_TRSV_BLOCK 64
-#define ROCBLAS_TRSV_Z_BLOCK 32
-#define ROCBLAS_TRSM_BLOCK 128
-#define ROCBLAS_TRTRI_NB 16
-#define ROCBLAS_SYRK_NB 32
-#define ROCBLAS_SYRK_S_NB 16
-#define ROCBLAS_SYRK_BATCHED_NB 16
-#define ROCBLAS_HERK_NB 32
-#define ROCBLAS_HERK_BATCHED_NB 8
 
 template <typename T>
 struct rocblas_index_value_t;
@@ -871,7 +853,7 @@ rocblas_status rocblasCall_trmm(rocblas_handle handle,
                   "bc:", batch_count);
 
     constexpr rocblas_int nb
-        = (!rocblas_is_complex<T> ? ROCBLAS_TRMM_REAL_NB : ROCBLAS_TRMM_COMPLEX_NB);
+        = (!rocblas_is_complex<T> ? ROCBLAS_SDTRMM_NB : ROCBLAS_CZTRMM_NB);
 
     return rocblas_internal_trmm_template<nb, BATCHED, T>(
         handle, side, uplo, transA, diag, m, n, cast2constType<T>(alpha), stride_alpha,
@@ -907,7 +889,7 @@ rocblas_status rocblasCall_trmm(rocblas_handle handle,
                   "bc:", batch_count);
 
     constexpr rocblas_int nb
-        = (!rocblas_is_complex<T> ? ROCBLAS_TRMM_REAL_NB : ROCBLAS_TRMM_COMPLEX_NB);
+        = (!rocblas_is_complex<T> ? ROCBLAS_SDTRMM_NB : ROCBLAS_CZTRMM_NB);
 
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
@@ -1085,9 +1067,9 @@ rocblas_status rocblasCall_syrk_herk(rocblas_handle handle,
 
     using S = decltype(std::real(T{}));
 
-    constexpr rocblas_int NB = BATCHED  ? ROCBLAS_SYRK_BATCHED_NB
-        : std::is_same<T, float>::value ? ROCBLAS_SYRK_S_NB
-                                        : ROCBLAS_SYRK_NB;
+    constexpr rocblas_int NB = BATCHED  ? ROCBLAS_SDSYRK_BATCHED_NB
+        : std::is_same<T, float>::value ? ROCBLAS_SSYRK_NB
+                                        : ROCBLAS_DCZSYRK_NB;
     return rocblas_internal_syrk_template<NB, BATCHED, T>(
         handle, uplo, transA, n, k, cast2constType<S>(alpha), cast2constType<T>(A), offsetA, lda,
         strideA, cast2constType<S>(beta), C, offsetC, ldc, strideC, batch_count);
@@ -1118,7 +1100,7 @@ rocblas_status rocblasCall_syrk_herk(rocblas_handle handle,
 
     using S = decltype(std::real(T{}));
 
-    constexpr rocblas_int NB = BATCHED ? ROCBLAS_HERK_BATCHED_NB : ROCBLAS_HERK_NB;
+    constexpr rocblas_int NB = BATCHED ? ROCBLAS_XHERK_BATCHED_NB : ROCBLAS_XHERK_NB;
     return rocblas_internal_herk_template<NB, BATCHED, T>(
         handle, uplo, transA, n, k, cast2constType<S>(alpha), cast2constType<T>(A), offsetA, lda,
         strideA, cast2constType<S>(beta), C, offsetC, ldc, strideC, batch_count);
@@ -1548,7 +1530,7 @@ rocblas_status rocblasCall_trsv(rocblas_handle handle,
                   "bc:", batch_count);
 
     // nullptr for optional alpha
-    return rocblas_internal_trsv_substitution_template<ROCBLAS_TRSV_BLOCK, T>(
+    return rocblas_internal_trsv_substitution_template<ROCBLAS_SDCTRSV_NB, T>(
         handle, uplo, transA, diag, m, cast2constType(A), offset_A, lda, stride_A, nullptr, x,
         offset_x, incx, stride_x, batch_count, w_completed_sec);
 }
@@ -1579,7 +1561,7 @@ rocblas_status rocblasCall_trsv(rocblas_handle handle,
                   "bc:", batch_count);
 
     // nullptr for optional alpha
-    return rocblas_internal_trsv_substitution_template<ROCBLAS_TRSV_Z_BLOCK, T>(
+    return rocblas_internal_trsv_substitution_template<ROCBLAS_ZTRSV_NB, T>(
         handle, uplo, transA, diag, m, cast2constType(A), offset_A, lda, stride_A, nullptr, x,
         offset_x, incx, stride_x, batch_count, w_completed_sec);
 }
@@ -1601,7 +1583,7 @@ void rocblasCall_trsm_mem(rocblas_side side,
         no_opt_size could be used in the future if we generalize the use of
         rocblas_workmode parameter **/
 
-    rocblas_internal_trsm_workspace_size<ROCBLAS_TRSM_BLOCK, BATCHED, T>(
+    rocblas_internal_trsm_workspace_size<ROCBLAS_XTRSM_NB, BATCHED, T>(
         side, transA, m, n, batch_count, 0, x_temp, x_temp_arr, invA, invA_arr, &no_opt_size);
 }
 
@@ -1640,7 +1622,7 @@ rocblas_status rocblasCall_trsm(rocblas_handle handle,
                   "bc:", batch_count);
 
     U supplied_invA = nullptr;
-    return rocblas_internal_trsm_template<ROCBLAS_TRSM_BLOCK, ROCBLAS_TRSV_BLOCK, BATCHED, T>(
+    return rocblas_internal_trsm_template<ROCBLAS_XTRSM_NB, ROCBLAS_SDCTRSV_NB, BATCHED, T>(
         handle, side, uplo, transA, diag, m, n, alpha, cast2constType(A), offset_A, lda, stride_A,
         B, offset_B, ldb, stride_B, batch_count, optimal_mem, x_temp, x_temp_arr, invA, invA_arr,
         cast2constType(supplied_invA), 0);
@@ -1680,7 +1662,7 @@ rocblas_status rocblasCall_trsm(rocblas_handle handle,
                   "bc:", batch_count);
 
     U supplied_invA = nullptr;
-    return rocblas_internal_trsm_template<ROCBLAS_TRSM_BLOCK, ROCBLAS_TRSV_Z_BLOCK, BATCHED, T>(
+    return rocblas_internal_trsm_template<ROCBLAS_XTRSM_NB, ROCBLAS_ZTRSV_NB, BATCHED, T>(
         handle, side, uplo, transA, diag, m, n, alpha, cast2constType(A), offset_A, lda, stride_A,
         B, offset_B, ldb, stride_B, batch_count, optimal_mem, x_temp, x_temp_arr, invA, invA_arr,
         cast2constType(supplied_invA), 0);
@@ -1727,7 +1709,7 @@ rocblas_status rocblasCall_trsm(rocblas_handle handle,
                             batch_count);
 
     U supplied_invA = nullptr;
-    return rocblas_internal_trsm_template<ROCBLAS_TRSM_BLOCK, ROCBLAS_TRSV_BLOCK, BATCHED, T>(
+    return rocblas_internal_trsm_template<ROCBLAS_XTRSM_NB, ROCBLAS_SDCTRSV_NB, BATCHED, T>(
         handle, side, uplo, transA, diag, m, n, alpha, cast2constType((U)workArr), offset_A, lda,
         stride_A, B, offset_B, ldb, stride_B, batch_count, optimal_mem, x_temp, x_temp_arr, invA,
         invA_arr, cast2constType(supplied_invA), 0);
@@ -1773,7 +1755,7 @@ rocblas_status rocblasCall_trsm(rocblas_handle handle,
                             batch_count);
 
     U supplied_invA = nullptr;
-    return rocblas_internal_trsm_template<ROCBLAS_TRSM_BLOCK, ROCBLAS_TRSV_Z_BLOCK, BATCHED, T>(
+    return rocblas_internal_trsm_template<ROCBLAS_XTRSM_NB, ROCBLAS_ZTRSV_NB, BATCHED, T>(
         handle, side, uplo, transA, diag, m, n, alpha, cast2constType((U)workArr), offset_A, lda,
         stride_A, B, offset_B, ldb, stride_B, batch_count, optimal_mem, x_temp, x_temp_arr, invA,
         invA_arr, cast2constType(supplied_invA), 0);
@@ -1783,7 +1765,7 @@ rocblas_status rocblasCall_trsm(rocblas_handle handle,
 template <bool BATCHED, typename T>
 void rocblasCall_trtri_mem(rocblas_int n, rocblas_int batch_count, size_t* c_temp, size_t* c_temp_arr)
 {
-    size_t c_temp_els = rocblas_internal_trtri_temp_size<ROCBLAS_TRTRI_NB>(n, batch_count);
+    size_t c_temp_els = rocblas_internal_trtri_temp_size<ROCBLAS_XTRTRI_NB>(n, batch_count);
     *c_temp = c_temp_els * sizeof(T);
 
     *c_temp_arr = BATCHED ? sizeof(T*) * batch_count : 0;
@@ -1811,7 +1793,7 @@ rocblas_status rocblasCall_trtri(rocblas_handle handle,
     ROCBLAS_ENTER("trtri", "uplo:", uplo, "diag:", diag, "n:", n, "shiftA:", offset_A, "lda:", lda,
                   "shiftC:", offset_invA, "ldc:", ldinvA, "bc:", batch_count);
 
-    return rocblas_internal_trtri_template<ROCBLAS_TRTRI_NB, BATCHED, STRIDED, T>(
+    return rocblas_internal_trtri_template<ROCBLAS_XTRTRI_NB, BATCHED, STRIDED, T>(
         handle, uplo, diag, n, cast2constType(A), offset_A, lda, stride_A, 0, invA, offset_invA,
         ldinvA, stride_invA, 0, batch_count, 1, c_temp);
 }
@@ -1838,7 +1820,7 @@ rocblas_status rocblasCall_trtri(rocblas_handle handle,
     ROCBLAS_ENTER("trtri", "uplo:", uplo, "diag:", diag, "n:", n, "shiftA:", offset_A, "lda:", lda,
                   "shiftC:", offset_invA, "ldc:", ldinvA, "bc:", batch_count);
 
-    size_t c_temp_els = rocblas_internal_trtri_temp_size<ROCBLAS_TRTRI_NB>(n, 1);
+    size_t c_temp_els = rocblas_internal_trtri_temp_size<ROCBLAS_XTRTRI_NB>(n, 1);
 
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
@@ -1847,7 +1829,7 @@ rocblas_status rocblasCall_trtri(rocblas_handle handle,
     ROCSOLVER_LAUNCH_KERNEL(get_array, dim3(blocks), dim3(256), 0, stream, c_temp_arr, c_temp,
                             c_temp_els, batch_count);
 
-    return rocblas_internal_trtri_template<ROCBLAS_TRTRI_NB, BATCHED, STRIDED, T>(
+    return rocblas_internal_trtri_template<ROCBLAS_XTRTRI_NB, BATCHED, STRIDED, T>(
         handle, uplo, diag, n, cast2constType(A), offset_A, lda, stride_A, 0, invA, offset_invA,
         ldinvA, stride_invA, 0, batch_count, 1, cast2constPointer(c_temp_arr));
 }
@@ -1874,7 +1856,7 @@ rocblas_status rocblasCall_trtri(rocblas_handle handle,
     ROCBLAS_ENTER("trtri", "uplo:", uplo, "diag:", diag, "n:", n, "shiftA:", offset_A, "lda:", lda,
                   "shiftC:", offset_invA, "ldc:", ldinvA, "bc:", batch_count);
 
-    size_t c_temp_els = rocblas_internal_trtri_temp_size<ROCBLAS_TRTRI_NB>(n, 1);
+    size_t c_temp_els = rocblas_internal_trtri_temp_size<ROCBLAS_XTRTRI_NB>(n, 1);
 
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
@@ -1885,7 +1867,7 @@ rocblas_status rocblasCall_trtri(rocblas_handle handle,
     ROCSOLVER_LAUNCH_KERNEL(get_array, dim3(blocks), dim3(256), 0, stream, c_temp_arr, c_temp,
                             c_temp_els, batch_count);
 
-    return rocblas_internal_trtri_template<ROCBLAS_TRTRI_NB, BATCHED, STRIDED, T>(
+    return rocblas_internal_trtri_template<ROCBLAS_XTRTRI_NB, BATCHED, STRIDED, T>(
         handle, uplo, diag, n, cast2constType(A), offset_A, lda, stride_A, 0,
         cast2constPointer(workArr), offset_invA, ldinvA, stride_invA, 0, batch_count, 1,
         cast2constPointer(c_temp_arr));


### PR DESCRIPTION
Companion to [rocBLAS #1289](https://github.com/ROCmSoftwarePlatform/rocBLAS-internal/pull/1289). Moving rocBLAS block sizes to a header file.