### PR TITLE
Fix compatibility with older versions of LAPACK

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -20,9 +20,16 @@ endif()
 
 if(BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
   if(ROCSOLVER_FIND_PACKAGE_LAPACK_CONFIG)
-    find_package(LAPACK 3.9.1 REQUIRED CONFIG)
+    find_package(LAPACK REQUIRED CONFIG)
   else()
-    find_package(LAPACK 3.9.1 REQUIRED)
+    find_package(LAPACK REQUIRED)
+  endif()
+
+  if(NOT LAPACK_LIBRARIES)
+    set(LAPACK_LIBRARIES
+      ${LAPACK_blas_LIBRARIES}
+      ${LAPACK_lapack_LIBRARIES}
+    )
   endif()
 
   add_library(clients-common INTERFACE)

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -20,9 +20,9 @@ endif()
 
 if(BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
   if(ROCSOLVER_FIND_PACKAGE_LAPACK_CONFIG)
-    find_package(LAPACK REQUIRED CONFIG)
+    find_package(LAPACK 3.9.1 REQUIRED CONFIG)
   else()
-    find_package(LAPACK REQUIRED)
+    find_package(LAPACK 3.9.1 REQUIRED)
   endif()
 
   add_library(clients-common INTERFACE)

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -20,9 +20,9 @@ endif()
 
 if(BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
   if(ROCSOLVER_FIND_PACKAGE_LAPACK_CONFIG)
-    find_package(LAPACK REQUIRED CONFIG)
+    find_package(LAPACK 3.7 REQUIRED CONFIG)
   else()
-    find_package(LAPACK REQUIRED)
+    find_package(LAPACK 3.7 REQUIRED)
   endif()
 
   if(NOT LAPACK_LIBRARIES)


### PR DESCRIPTION
After #445 was merged, the rocSOLVER build fails when both LAPACK 3.7.1 (previously required by rocSOLVER) and 3.9.1 are present on a system. This is because rocSOLVER's cmake system picks up 3.7.1, in which LAPACK_LIBRARIES is undefined. This PR ensures <strike>3.9.1 will be picked up instead</strike> LAPACK_LIBRARIES will be defined.