### PR TITLE
Add option to build rocblas to install.sh

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -39,10 +39,10 @@ def runCompileCommand(platform, project, jobName, boolean sameOrg=false)
         deps = '-b'
     }
     def command = """#!/usr/bin/env bash
+                ${centos}
                 set -ex
                 cd ${project.paths.project_build_prefix}
                 ${getRocBLAS}
-                ${centos}
                 ${project.paths.build_command} ${deps} ${debug} ${noOptimizations}
                 """
     platform.runCommand(this, command)

--- a/install.sh
+++ b/install.sh
@@ -157,7 +157,7 @@ install_zypper_packages( )
 
 install_rocblas_from_source( )
 {
-  rocblas_version=a70ac3d458f92ba90634c606b721fb8ca9e47a52
+  rocblas_version=2e659b6ce7b87ee30767ebbe34c6161b2922901c
   rocblas_srcdir=rocblas-src
   rocblas_blddir=rocblas-bld
   wget -nv -O rocblas-$rocblas_version.tar.gz \


### PR DESCRIPTION
This change adds an option to build and install a known good version of
rocBLAS when building rocSOLVER. The rocBLAS version hash should be
updated whenever changes are made to rocSOLVER that require a newer
version of rocBLAS. I expect it to require an update in any change that
fixes the rocSOLVER build after rocBLAS makes a change to its private
API.