### PR TITLE
invalid enum test use 0, rocblas invalid_data 255

### DIFF
--- a/clients/include/testing_gels.hpp
+++ b/clients/include/testing_gels.hpp
@@ -32,8 +32,8 @@ void gels_checkBadArgs(const rocblas_handle handle,
         rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_gels(STRIDED, handle, rocblas_operation(0), m, n, nrhs, dA,
-                                         lda, stA, dB, ldb, stB, info, bc),
+    EXPECT_ROCBLAS_STATUS(rocsolver_gels(STRIDED, handle, rocblas_operation(0), m, n, nrhs, dA, lda,
+                                         stA, dB, ldb, stB, info, bc),
                           rocblas_status_invalid_value)
         << "Must report error when operation is invalid";
 

--- a/clients/include/testing_gels.hpp
+++ b/clients/include/testing_gels.hpp
@@ -32,7 +32,7 @@ void gels_checkBadArgs(const rocblas_handle handle,
         rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_gels(STRIDED, handle, rocblas_operation(-1), m, n, nrhs, dA,
+    EXPECT_ROCBLAS_STATUS(rocsolver_gels(STRIDED, handle, rocblas_operation(0), m, n, nrhs, dA,
                                          lda, stA, dB, ldb, stB, info, bc),
                           rocblas_status_invalid_value)
         << "Must report error when operation is invalid";

--- a/clients/include/testing_gels_outofplace.hpp
+++ b/clients/include/testing_gels_outofplace.hpp
@@ -35,7 +35,7 @@ void gels_outofplace_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_gels_outofplace(STRIDED, handle, rocblas_operation(-1), m, n,
+    EXPECT_ROCBLAS_STATUS(rocsolver_gels_outofplace(STRIDED, handle, rocblas_operation(0), m, n,
                                                     nrhs, dA, lda, stA, dB, ldb, stB, dX, ldx, stX,
                                                     info, bc),
                           rocblas_status_invalid_value);

--- a/clients/include/testing_gesvd.hpp
+++ b/clients/include/testing_gesvd.hpp
@@ -41,11 +41,11 @@ void gesvd_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_gesvd(STRIDED, handle, rocblas_svect(-1), right_svect, m, n, dA,
+    EXPECT_ROCBLAS_STATUS(rocsolver_gesvd(STRIDED, handle, rocblas_svect(0), right_svect, m, n, dA,
                                           lda, stA, dS, stS, dU, ldu, stU, dV, ldv, stV, dE, stE,
                                           fa, dinfo, bc),
                           rocblas_status_invalid_value);
-    EXPECT_ROCBLAS_STATUS(rocsolver_gesvd(STRIDED, handle, left_svect, rocblas_svect(-1), m, n, dA,
+    EXPECT_ROCBLAS_STATUS(rocsolver_gesvd(STRIDED, handle, left_svect, rocblas_svect(0), m, n, dA,
                                           lda, stA, dS, stS, dU, ldu, stU, dV, ldv, stV, dE, stE,
                                           fa, dinfo, bc),
                           rocblas_status_invalid_value);

--- a/clients/include/testing_getrs.hpp
+++ b/clients/include/testing_getrs.hpp
@@ -32,7 +32,7 @@ void getrs_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_getrs(STRIDED, handle, rocblas_operation(-1), n, nrhs, dA, lda,
+    EXPECT_ROCBLAS_STATUS(rocsolver_getrs(STRIDED, handle, rocblas_operation(0), n, nrhs, dA, lda,
                                           stA, dIpiv, stP, dB, ldb, stB, bc),
                           rocblas_status_invalid_value);
 

--- a/clients/include/testing_larfb.hpp
+++ b/clients/include/testing_larfb.hpp
@@ -33,16 +33,16 @@ void larfb_checkBadArgs(const rocblas_handle handle,
         rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_larfb(handle, rocblas_side(-1), trans, direct, storev, m, n, k,
+    EXPECT_ROCBLAS_STATUS(rocsolver_larfb(handle, rocblas_side(0), trans, direct, storev, m, n, k,
                                           dV, ldv, dT, ldt, dA, lda),
                           rocblas_status_invalid_value);
-    EXPECT_ROCBLAS_STATUS(rocsolver_larfb(handle, side, rocblas_operation(-1), direct, storev, m, n,
+    EXPECT_ROCBLAS_STATUS(rocsolver_larfb(handle, side, rocblas_operation(0), direct, storev, m, n,
                                           k, dV, ldv, dT, ldt, dA, lda),
                           rocblas_status_invalid_value);
-    EXPECT_ROCBLAS_STATUS(rocsolver_larfb(handle, side, trans, rocblas_direct(-1), storev, m, n, k,
+    EXPECT_ROCBLAS_STATUS(rocsolver_larfb(handle, side, trans, rocblas_direct(0), storev, m, n, k,
                                           dV, ldv, dT, ldt, dA, lda),
                           rocblas_status_invalid_value);
-    EXPECT_ROCBLAS_STATUS(rocsolver_larfb(handle, side, trans, direct, rocblas_storev(-1), m, n, k,
+    EXPECT_ROCBLAS_STATUS(rocsolver_larfb(handle, side, trans, direct, rocblas_storev(0), m, n, k,
                                           dV, ldv, dT, ldt, dA, lda),
                           rocblas_status_invalid_value);
 

--- a/clients/include/testing_larft.hpp
+++ b/clients/include/testing_larft.hpp
@@ -29,10 +29,10 @@ void larft_checkBadArgs(const rocblas_handle handle,
 
     // values
     EXPECT_ROCBLAS_STATUS(
-        rocsolver_larft(handle, rocblas_direct(-1), storev, n, k, dV, ldv, dt, dT, ldt),
+        rocsolver_larft(handle, rocblas_direct(0), storev, n, k, dV, ldv, dt, dT, ldt),
         rocblas_status_invalid_value);
     EXPECT_ROCBLAS_STATUS(
-        rocsolver_larft(handle, direct, rocblas_storev(-1), n, k, dV, ldv, dt, dT, ldt),
+        rocsolver_larft(handle, direct, rocblas_storev(0), n, k, dV, ldv, dt, dT, ldt),
         rocblas_status_invalid_value);
 
     // pointers

--- a/clients/include/testing_orgbr_ungbr.hpp
+++ b/clients/include/testing_orgbr_ungbr.hpp
@@ -26,7 +26,7 @@ void orgbr_ungbr_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_orgbr_ungbr(handle, rocblas_storev(-1), m, n, k, dA, lda, dIpiv),
+    EXPECT_ROCBLAS_STATUS(rocsolver_orgbr_ungbr(handle, rocblas_storev(0), m, n, k, dA, lda, dIpiv),
                           rocblas_status_invalid_value);
 
     // pointers

--- a/clients/include/testing_orgtr_ungtr.hpp
+++ b/clients/include/testing_orgtr_ungtr.hpp
@@ -24,7 +24,7 @@ void orgtr_ungtr_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_orgtr_ungtr(handle, rocblas_fill(-1), n, dA, lda, dIpiv),
+    EXPECT_ROCBLAS_STATUS(rocsolver_orgtr_ungtr(handle, rocblas_fill(0), n, dA, lda, dIpiv),
                           rocblas_status_invalid_value);
 
     // pointers

--- a/clients/include/testing_ormbr_unmbr.hpp
+++ b/clients/include/testing_ormbr_unmbr.hpp
@@ -31,13 +31,13 @@ void ormbr_unmbr_checkBadArgs(const rocblas_handle handle,
         rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_ormbr_unmbr(handle, storev, rocblas_side(-1), trans, m, n, k,
+    EXPECT_ROCBLAS_STATUS(rocsolver_ormbr_unmbr(handle, storev, rocblas_side(0), trans, m, n, k,
                                                 dA, lda, dIpiv, dC, ldc),
                           rocblas_status_invalid_value);
-    EXPECT_ROCBLAS_STATUS(rocsolver_ormbr_unmbr(handle, rocblas_storev(-1), side, trans, m, n, k,
+    EXPECT_ROCBLAS_STATUS(rocsolver_ormbr_unmbr(handle, rocblas_storev(0), side, trans, m, n, k,
                                                 dA, lda, dIpiv, dC, ldc),
                           rocblas_status_invalid_value);
-    EXPECT_ROCBLAS_STATUS(rocsolver_ormbr_unmbr(handle, storev, side, rocblas_operation(-1), m, n,
+    EXPECT_ROCBLAS_STATUS(rocsolver_ormbr_unmbr(handle, storev, side, rocblas_operation(0), m, n,
                                                 k, dA, lda, dIpiv, dC, ldc),
                           rocblas_status_invalid_value);
     if(COMPLEX)

--- a/clients/include/testing_ormbr_unmbr.hpp
+++ b/clients/include/testing_ormbr_unmbr.hpp
@@ -31,14 +31,14 @@ void ormbr_unmbr_checkBadArgs(const rocblas_handle handle,
         rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_ormbr_unmbr(handle, storev, rocblas_side(0), trans, m, n, k,
-                                                dA, lda, dIpiv, dC, ldc),
+    EXPECT_ROCBLAS_STATUS(rocsolver_ormbr_unmbr(handle, storev, rocblas_side(0), trans, m, n, k, dA,
+                                                lda, dIpiv, dC, ldc),
                           rocblas_status_invalid_value);
-    EXPECT_ROCBLAS_STATUS(rocsolver_ormbr_unmbr(handle, rocblas_storev(0), side, trans, m, n, k,
-                                                dA, lda, dIpiv, dC, ldc),
+    EXPECT_ROCBLAS_STATUS(rocsolver_ormbr_unmbr(handle, rocblas_storev(0), side, trans, m, n, k, dA,
+                                                lda, dIpiv, dC, ldc),
                           rocblas_status_invalid_value);
-    EXPECT_ROCBLAS_STATUS(rocsolver_ormbr_unmbr(handle, storev, side, rocblas_operation(0), m, n,
-                                                k, dA, lda, dIpiv, dC, ldc),
+    EXPECT_ROCBLAS_STATUS(rocsolver_ormbr_unmbr(handle, storev, side, rocblas_operation(0), m, n, k,
+                                                dA, lda, dIpiv, dC, ldc),
                           rocblas_status_invalid_value);
     if(COMPLEX)
         EXPECT_ROCBLAS_STATUS(rocsolver_ormbr_unmbr(handle, storev, side, rocblas_operation_transpose,

--- a/clients/include/testing_ormlx_unmlx.hpp
+++ b/clients/include/testing_ormlx_unmlx.hpp
@@ -30,10 +30,10 @@ void ormlx_unmlx_checkBadArgs(const rocblas_handle handle,
         rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_ormlx_unmlx(MLQ, handle, rocblas_side(-1), trans, m, n, k, dA,
+    EXPECT_ROCBLAS_STATUS(rocsolver_ormlx_unmlx(MLQ, handle, rocblas_side(0), trans, m, n, k, dA,
                                                 lda, dIpiv, dC, ldc),
                           rocblas_status_invalid_value);
-    EXPECT_ROCBLAS_STATUS(rocsolver_ormlx_unmlx(MLQ, handle, side, rocblas_operation(-1), m, n, k,
+    EXPECT_ROCBLAS_STATUS(rocsolver_ormlx_unmlx(MLQ, handle, side, rocblas_operation(0), m, n, k,
                                                 dA, lda, dIpiv, dC, ldc),
                           rocblas_status_invalid_value);
     if(COMPLEX)

--- a/clients/include/testing_ormtr_unmtr.hpp
+++ b/clients/include/testing_ormtr_unmtr.hpp
@@ -31,12 +31,12 @@ void ormtr_unmtr_checkBadArgs(const rocblas_handle handle,
 
     // values
     EXPECT_ROCBLAS_STATUS(
-        rocsolver_ormtr_unmtr(handle, rocblas_side(-1), uplo, trans, m, n, dA, lda, dIpiv, dC, ldc),
+        rocsolver_ormtr_unmtr(handle, rocblas_side(0), uplo, trans, m, n, dA, lda, dIpiv, dC, ldc),
         rocblas_status_invalid_value);
     EXPECT_ROCBLAS_STATUS(
-        rocsolver_ormtr_unmtr(handle, side, rocblas_fill(-1), trans, m, n, dA, lda, dIpiv, dC, ldc),
+        rocsolver_ormtr_unmtr(handle, side, rocblas_fill(0), trans, m, n, dA, lda, dIpiv, dC, ldc),
         rocblas_status_invalid_value);
-    EXPECT_ROCBLAS_STATUS(rocsolver_ormtr_unmtr(handle, side, uplo, rocblas_operation(-1), m, n, dA,
+    EXPECT_ROCBLAS_STATUS(rocsolver_ormtr_unmtr(handle, side, uplo, rocblas_operation(0), m, n, dA,
                                                 lda, dIpiv, dC, ldc),
                           rocblas_status_invalid_value);
     if(COMPLEX)

--- a/clients/include/testing_ormxl_unmxl.hpp
+++ b/clients/include/testing_ormxl_unmxl.hpp
@@ -30,10 +30,10 @@ void ormxl_unmxl_checkBadArgs(const rocblas_handle handle,
         rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_ormxl_unmxl(MQL, handle, rocblas_side(-1), trans, m, n, k, dA,
+    EXPECT_ROCBLAS_STATUS(rocsolver_ormxl_unmxl(MQL, handle, rocblas_side(0), trans, m, n, k, dA,
                                                 lda, dIpiv, dC, ldc),
                           rocblas_status_invalid_value);
-    EXPECT_ROCBLAS_STATUS(rocsolver_ormxl_unmxl(MQL, handle, side, rocblas_operation(-1), m, n, k,
+    EXPECT_ROCBLAS_STATUS(rocsolver_ormxl_unmxl(MQL, handle, side, rocblas_operation(0), m, n, k,
                                                 dA, lda, dIpiv, dC, ldc),
                           rocblas_status_invalid_value);
     if(COMPLEX)

--- a/clients/include/testing_ormxr_unmxr.hpp
+++ b/clients/include/testing_ormxr_unmxr.hpp
@@ -30,10 +30,10 @@ void ormxr_unmxr_checkBadArgs(const rocblas_handle handle,
         rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_ormxr_unmxr(MQR, handle, rocblas_side(-1), trans, m, n, k, dA,
+    EXPECT_ROCBLAS_STATUS(rocsolver_ormxr_unmxr(MQR, handle, rocblas_side(0), trans, m, n, k, dA,
                                                 lda, dIpiv, dC, ldc),
                           rocblas_status_invalid_value);
-    EXPECT_ROCBLAS_STATUS(rocsolver_ormxr_unmxr(MQR, handle, side, rocblas_operation(-1), m, n, k,
+    EXPECT_ROCBLAS_STATUS(rocsolver_ormxr_unmxr(MQR, handle, side, rocblas_operation(0), m, n, k,
                                                 dA, lda, dIpiv, dC, ldc),
                           rocblas_status_invalid_value);
     if(COMPLEX)

--- a/clients/include/testing_stebz.hpp
+++ b/clients/include/testing_stebz.hpp
@@ -36,10 +36,10 @@ void stebz_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, rocblas_erange(-1), eorder, n, vl, vu, il, iu,
+    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, rocblas_erange(0), eorder, n, vl, vu, il, iu,
                                           abstol, dD, dE, dnev, dnsplit, dW, dIblock, dIsplit, dinfo),
                           rocblas_status_invalid_value);
-    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, erange, rocblas_eorder(-1), n, vl, vu, il, iu,
+    EXPECT_ROCBLAS_STATUS(rocsolver_stebz(handle, erange, rocblas_eorder(0), n, vl, vu, il, iu,
                                           abstol, dD, dE, dnev, dnsplit, dW, dIblock, dIsplit, dinfo),
                           rocblas_status_invalid_value);
 

--- a/clients/include/testing_stedc.hpp
+++ b/clients/include/testing_stedc.hpp
@@ -26,7 +26,7 @@ void stedc_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_stedc(handle, rocblas_evect(-1), n, dD, dE, dC, ldc, dInfo),
+    EXPECT_ROCBLAS_STATUS(rocsolver_stedc(handle, rocblas_evect(0), n, dD, dE, dC, ldc, dInfo),
                           rocblas_status_invalid_value);
 
     // pointers

--- a/clients/include/testing_steqr.hpp
+++ b/clients/include/testing_steqr.hpp
@@ -26,7 +26,7 @@ void steqr_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_steqr(handle, rocblas_evect(-1), n, dD, dE, dC, ldc, dInfo),
+    EXPECT_ROCBLAS_STATUS(rocsolver_steqr(handle, rocblas_evect(0), n, dD, dE, dC, ldc, dInfo),
                           rocblas_status_invalid_value);
 
     // pointers

--- a/clients/include/testing_syev_heev.hpp
+++ b/clients/include/testing_syev_heev.hpp
@@ -32,7 +32,7 @@ void syev_heev_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_syev_heev(STRIDED, handle, rocblas_evect(-1), uplo, n, dA, lda,
+    EXPECT_ROCBLAS_STATUS(rocsolver_syev_heev(STRIDED, handle, rocblas_evect(0), uplo, n, dA, lda,
                                               stA, dD, stD, dE, stE, dinfo, bc),
                           rocblas_status_invalid_value);
     EXPECT_ROCBLAS_STATUS(rocsolver_syev_heev(STRIDED, handle, evect, rocblas_fill_full, n, dA, lda,

--- a/clients/include/testing_syevd_heevd.hpp
+++ b/clients/include/testing_syevd_heevd.hpp
@@ -32,8 +32,8 @@ void syevd_heevd_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_syevd_heevd(STRIDED, handle, rocblas_evect(0), uplo, n, dA,
-                                                lda, stA, dD, stD, dE, stE, dinfo, bc),
+    EXPECT_ROCBLAS_STATUS(rocsolver_syevd_heevd(STRIDED, handle, rocblas_evect(0), uplo, n, dA, lda,
+                                                stA, dD, stD, dE, stE, dinfo, bc),
                           rocblas_status_invalid_value);
     EXPECT_ROCBLAS_STATUS(rocsolver_syevd_heevd(STRIDED, handle, evect, rocblas_fill_full, n, dA,
                                                 lda, stA, dD, stD, dE, stE, dinfo, bc),

--- a/clients/include/testing_syevd_heevd.hpp
+++ b/clients/include/testing_syevd_heevd.hpp
@@ -32,7 +32,7 @@ void syevd_heevd_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_syevd_heevd(STRIDED, handle, rocblas_evect(-1), uplo, n, dA,
+    EXPECT_ROCBLAS_STATUS(rocsolver_syevd_heevd(STRIDED, handle, rocblas_evect(0), uplo, n, dA,
                                                 lda, stA, dD, stD, dE, stE, dinfo, bc),
                           rocblas_status_invalid_value);
     EXPECT_ROCBLAS_STATUS(rocsolver_syevd_heevd(STRIDED, handle, evect, rocblas_fill_full, n, dA,

--- a/clients/include/testing_syevdx_heevdx_inplace.hpp
+++ b/clients/include/testing_syevdx_heevdx_inplace.hpp
@@ -38,9 +38,9 @@ void syevdx_heevdx_inplace_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_syevdx_heevdx_inplace(STRIDED, handle, rocblas_evect(0),
-                                                          erange, uplo, n, dA, lda, stA, vl, vu, il,
-                                                          iu, abstol, hNev, dW, stW, dinfo, bc),
+    EXPECT_ROCBLAS_STATUS(rocsolver_syevdx_heevdx_inplace(STRIDED, handle, rocblas_evect(0), erange,
+                                                          uplo, n, dA, lda, stA, vl, vu, il, iu,
+                                                          abstol, hNev, dW, stW, dinfo, bc),
                           rocblas_status_invalid_value);
     EXPECT_ROCBLAS_STATUS(rocsolver_syevdx_heevdx_inplace(STRIDED, handle, evect, rocblas_erange(0),
                                                           uplo, n, dA, lda, stA, vl, vu, il, iu,

--- a/clients/include/testing_syevdx_heevdx_inplace.hpp
+++ b/clients/include/testing_syevdx_heevdx_inplace.hpp
@@ -38,11 +38,11 @@ void syevdx_heevdx_inplace_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_syevdx_heevdx_inplace(STRIDED, handle, rocblas_evect(-1),
+    EXPECT_ROCBLAS_STATUS(rocsolver_syevdx_heevdx_inplace(STRIDED, handle, rocblas_evect(0),
                                                           erange, uplo, n, dA, lda, stA, vl, vu, il,
                                                           iu, abstol, hNev, dW, stW, dinfo, bc),
                           rocblas_status_invalid_value);
-    EXPECT_ROCBLAS_STATUS(rocsolver_syevdx_heevdx_inplace(STRIDED, handle, evect, rocblas_erange(-1),
+    EXPECT_ROCBLAS_STATUS(rocsolver_syevdx_heevdx_inplace(STRIDED, handle, evect, rocblas_erange(0),
                                                           uplo, n, dA, lda, stA, vl, vu, il, iu,
                                                           abstol, hNev, dW, stW, dinfo, bc),
                           rocblas_status_invalid_value);

--- a/clients/include/testing_syevj_heevj.hpp
+++ b/clients/include/testing_syevj_heevj.hpp
@@ -36,11 +36,11 @@ void syevj_heevj_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_syevj_heevj(STRIDED, handle, rocblas_esort(-1), evect, uplo, n,
+    EXPECT_ROCBLAS_STATUS(rocsolver_syevj_heevj(STRIDED, handle, rocblas_esort(0), evect, uplo, n,
                                                 dA, lda, stA, abstol, dResidual, max_sweeps,
                                                 dSweeps, dW, stW, dInfo, bc),
                           rocblas_status_invalid_value);
-    EXPECT_ROCBLAS_STATUS(rocsolver_syevj_heevj(STRIDED, handle, esort, rocblas_evect(-1), uplo, n,
+    EXPECT_ROCBLAS_STATUS(rocsolver_syevj_heevj(STRIDED, handle, esort, rocblas_evect(0), uplo, n,
                                                 dA, lda, stA, abstol, dResidual, max_sweeps,
                                                 dSweeps, dW, stW, dInfo, bc),
                           rocblas_status_invalid_value);

--- a/clients/include/testing_syevx_heevx.hpp
+++ b/clients/include/testing_syevx_heevx.hpp
@@ -43,11 +43,11 @@ void syevx_heevx_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx(STRIDED, handle, rocblas_evect(-1), erange, uplo, n,
+    EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx(STRIDED, handle, rocblas_evect(0), erange, uplo, n,
                                                 dA, lda, stA, vl, vu, il, iu, abstol, dNev, dW, stW,
                                                 dZ, ldz, stZ, dIfail, stF, dinfo, bc),
                           rocblas_status_invalid_value);
-    EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx(STRIDED, handle, evect, rocblas_erange(-1), uplo, n,
+    EXPECT_ROCBLAS_STATUS(rocsolver_syevx_heevx(STRIDED, handle, evect, rocblas_erange(0), uplo, n,
                                                 dA, lda, stA, vl, vu, il, iu, abstol, dNev, dW, stW,
                                                 dZ, ldz, stZ, dIfail, stF, dinfo, bc),
                           rocblas_status_invalid_value);

--- a/clients/include/testing_sygsx_hegsx.hpp
+++ b/clients/include/testing_sygsx_hegsx.hpp
@@ -30,7 +30,7 @@ void sygsx_hegsx_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_sygsx_hegsx(STRIDED, SYGST, handle, rocblas_eform(-1), uplo, n,
+    EXPECT_ROCBLAS_STATUS(rocsolver_sygsx_hegsx(STRIDED, SYGST, handle, rocblas_eform(0), uplo, n,
                                                 dA, lda, stA, dB, ldb, stB, bc),
                           rocblas_status_invalid_value);
     EXPECT_ROCBLAS_STATUS(rocsolver_sygsx_hegsx(STRIDED, SYGST, handle, itype, rocblas_fill_full, n,

--- a/clients/include/testing_sygv_hegv.hpp
+++ b/clients/include/testing_sygv_hegv.hpp
@@ -36,10 +36,10 @@ void sygv_hegv_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_sygv_hegv(STRIDED, handle, rocblas_eform(-1), evect, uplo, n, dA,
+    EXPECT_ROCBLAS_STATUS(rocsolver_sygv_hegv(STRIDED, handle, rocblas_eform(0), evect, uplo, n, dA,
                                               lda, stA, dB, ldb, stB, dD, stD, dE, stE, dInfo, bc),
                           rocblas_status_invalid_value);
-    EXPECT_ROCBLAS_STATUS(rocsolver_sygv_hegv(STRIDED, handle, itype, rocblas_evect(-1), uplo, n, dA,
+    EXPECT_ROCBLAS_STATUS(rocsolver_sygv_hegv(STRIDED, handle, itype, rocblas_evect(0), uplo, n, dA,
                                               lda, stA, dB, ldb, stB, dD, stD, dE, stE, dInfo, bc),
                           rocblas_status_invalid_value);
     EXPECT_ROCBLAS_STATUS(rocsolver_sygv_hegv(STRIDED, handle, itype, rocblas_evect_tridiagonal,

--- a/clients/include/testing_sygvd_hegvd.hpp
+++ b/clients/include/testing_sygvd_hegvd.hpp
@@ -36,10 +36,10 @@ void sygvd_hegvd_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_sygvd_hegvd(STRIDED, handle, rocblas_eform(-1), evect, uplo, n, dA,
+    EXPECT_ROCBLAS_STATUS(rocsolver_sygvd_hegvd(STRIDED, handle, rocblas_eform(0), evect, uplo, n, dA,
                                                 lda, stA, dB, ldb, stB, dD, stD, dE, stE, dInfo, bc),
                           rocblas_status_invalid_value);
-    EXPECT_ROCBLAS_STATUS(rocsolver_sygvd_hegvd(STRIDED, handle, itype, rocblas_evect(-1), uplo, n, dA,
+    EXPECT_ROCBLAS_STATUS(rocsolver_sygvd_hegvd(STRIDED, handle, itype, rocblas_evect(0), uplo, n, dA,
                                                 lda, stA, dB, ldb, stB, dD, stD, dE, stE, dInfo, bc),
                           rocblas_status_invalid_value);
     EXPECT_ROCBLAS_STATUS(rocsolver_sygvd_hegvd(STRIDED, handle, itype, rocblas_evect_tridiagonal,

--- a/clients/include/testing_sygvdx_hegvdx_inplace.hpp
+++ b/clients/include/testing_sygvdx_hegvdx_inplace.hpp
@@ -43,7 +43,7 @@ void sygvdx_hegvdx_inplace_checkBadArgs(const rocblas_handle handle,
 
     // values
     EXPECT_ROCBLAS_STATUS(rocsolver_sygvdx_hegvdx_inplace(
-                              STRIDED, handle, rocblas_eform(-1), evect, erange, uplo, n, dA, lda,
+                              STRIDED, handle, rocblas_eform(0), evect, erange, uplo, n, dA, lda,
                               stA, dB, ldb, stB, vl, vu, il, iu, abstol, hNev, dW, stW, dInfo, bc),
                           rocblas_status_invalid_value);
     EXPECT_ROCBLAS_STATUS(rocsolver_sygvdx_hegvdx_inplace(STRIDED, handle, itype,
@@ -52,7 +52,7 @@ void sygvdx_hegvdx_inplace_checkBadArgs(const rocblas_handle handle,
                                                           iu, abstol, hNev, dW, stW, dInfo, bc),
                           rocblas_status_invalid_value);
     EXPECT_ROCBLAS_STATUS(rocsolver_sygvdx_hegvdx_inplace(
-                              STRIDED, handle, itype, evect, rocblas_erange(-1), uplo, n, dA, lda,
+                              STRIDED, handle, itype, evect, rocblas_erange(0), uplo, n, dA, lda,
                               stA, dB, ldb, stB, vl, vu, il, iu, abstol, hNev, dW, stW, dInfo, bc),
                           rocblas_status_invalid_value);
     EXPECT_ROCBLAS_STATUS(rocsolver_sygvdx_hegvdx_inplace(

--- a/clients/include/testing_sygvj_hegvj.hpp
+++ b/clients/include/testing_sygvj_hegvj.hpp
@@ -39,11 +39,11 @@ void sygvj_hegvj_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_sygvj_hegvj(STRIDED, handle, rocblas_eform(-1), evect, uplo, n,
+    EXPECT_ROCBLAS_STATUS(rocsolver_sygvj_hegvj(STRIDED, handle, rocblas_eform(0), evect, uplo, n,
                                                 dA, lda, stA, dB, ldb, stB, abstol, dResidual,
                                                 max_sweeps, dSweeps, dW, stW, dInfo, bc),
                           rocblas_status_invalid_value);
-    EXPECT_ROCBLAS_STATUS(rocsolver_sygvj_hegvj(STRIDED, handle, itype, rocblas_evect(-1), uplo, n,
+    EXPECT_ROCBLAS_STATUS(rocsolver_sygvj_hegvj(STRIDED, handle, itype, rocblas_evect(0), uplo, n,
                                                 dA, lda, stA, dB, ldb, stB, abstol, dResidual,
                                                 max_sweeps, dSweeps, dW, stW, dInfo, bc),
                           rocblas_status_invalid_value);

--- a/clients/include/testing_sygvx_hegvx.hpp
+++ b/clients/include/testing_sygvx_hegvx.hpp
@@ -47,7 +47,7 @@ void sygvx_hegvx_checkBadArgs(const rocblas_handle handle,
                           rocblas_status_invalid_handle);
 
     // values
-    EXPECT_ROCBLAS_STATUS(rocsolver_sygvx_hegvx(STRIDED, handle, rocblas_eform(-1), evect, erange,
+    EXPECT_ROCBLAS_STATUS(rocsolver_sygvx_hegvx(STRIDED, handle, rocblas_eform(0), evect, erange,
                                                 uplo, n, dA, lda, stA, dB, ldb, stB, vl, vu, il, iu,
                                                 abstol, dNev, dW, stW, dZ, ldz, stZ, dIfail, stF,
                                                 dInfo, bc),
@@ -57,7 +57,7 @@ void sygvx_hegvx_checkBadArgs(const rocblas_handle handle,
                                                 il, iu, abstol, dNev, dW, stW, dZ, ldz, stZ, dIfail,
                                                 stF, dInfo, bc),
                           rocblas_status_invalid_value);
-    EXPECT_ROCBLAS_STATUS(rocsolver_sygvx_hegvx(STRIDED, handle, itype, evect, rocblas_erange(-1),
+    EXPECT_ROCBLAS_STATUS(rocsolver_sygvx_hegvx(STRIDED, handle, itype, evect, rocblas_erange(0),
                                                 uplo, n, dA, lda, stA, dB, ldb, stB, vl, vu, il, iu,
                                                 abstol, dNev, dW, stW, dZ, ldz, stZ, dIfail, stF,
                                                 dInfo, bc),

--- a/clients/include/testing_trtri.hpp
+++ b/clients/include/testing_trtri.hpp
@@ -31,7 +31,7 @@ void trtri_checkBadArgs(const rocblas_handle handle,
         rocsolver_trtri(STRIDED, handle, rocblas_fill_full, diag, n, dA, lda, stA, dInfo, bc),
         rocblas_status_invalid_value);
     EXPECT_ROCBLAS_STATUS(
-        rocsolver_trtri(STRIDED, handle, uplo, rocblas_diagonal(-1), n, dA, lda, stA, dInfo, bc),
+        rocsolver_trtri(STRIDED, handle, uplo, rocblas_diagonal(0), n, dA, lda, stA, dInfo, bc),
         rocblas_status_invalid_value);
 
     // sizes (only check batch_count if applicable)

--- a/common/include/rocsolver_datatype2string.hpp
+++ b/common/include/rocsolver_datatype2string.hpp
@@ -190,6 +190,7 @@ constexpr auto rocblas2string_datatype(rocblas_datatype type)
     case rocblas_datatype_u32_c: return "u32_c";
     case rocblas_datatype_bf16_r: return "bf16_r";
     case rocblas_datatype_bf16_c: return "bf16_c";
+    case rocblas_datatype_invalid: return "invalid";
     }
     return "invalid";
 }
@@ -219,7 +220,7 @@ constexpr rocblas_operation char2rocblas_operation(char value)
     case 't': return rocblas_operation_transpose;
     case 'C':
     case 'c': return rocblas_operation_conjugate_transpose;
-    default: return static_cast<rocblas_operation>(-1);
+    default: return static_cast<rocblas_operation>(0);
     }
 }
 
@@ -231,7 +232,7 @@ constexpr rocblas_fill char2rocblas_fill(char value)
     case 'u': return rocblas_fill_upper;
     case 'L':
     case 'l': return rocblas_fill_lower;
-    default: return static_cast<rocblas_fill>(-1);
+    default: return static_cast<rocblas_fill>(0);
     }
 }
 
@@ -243,7 +244,7 @@ constexpr rocblas_diagonal char2rocblas_diagonal(char value)
     case 'u': return rocblas_diagonal_unit;
     case 'N':
     case 'n': return rocblas_diagonal_non_unit;
-    default: return static_cast<rocblas_diagonal>(-1);
+    default: return static_cast<rocblas_diagonal>(0);
     }
 }
 
@@ -255,7 +256,7 @@ constexpr rocblas_side char2rocblas_side(char value)
     case 'l': return rocblas_side_left;
     case 'R':
     case 'r': return rocblas_side_right;
-    default: return static_cast<rocblas_side>(-1);
+    default: return static_cast<rocblas_side>(0);
     }
 }
 
@@ -265,7 +266,7 @@ constexpr rocblas_direct char2rocblas_direct(char value)
     {
     case 'F': return rocblas_forward_direction;
     case 'B': return rocblas_backward_direction;
-    default: return static_cast<rocblas_direct>(-1);
+    default: return static_cast<rocblas_direct>(0);
     }
 }
 
@@ -275,7 +276,7 @@ constexpr rocblas_storev char2rocblas_storev(char value)
     {
     case 'C': return rocblas_column_wise;
     case 'R': return rocblas_row_wise;
-    default: return static_cast<rocblas_storev>(-1);
+    default: return static_cast<rocblas_storev>(0);
     }
 }
 
@@ -285,7 +286,7 @@ constexpr rocblas_workmode char2rocblas_workmode(char value)
     {
     case 'O': return rocblas_outofplace;
     case 'I': return rocblas_inplace;
-    default: return static_cast<rocblas_workmode>(-1);
+    default: return static_cast<rocblas_workmode>(0);
     }
 }
 
@@ -297,7 +298,7 @@ constexpr rocblas_svect char2rocblas_svect(char value)
     case 'S': return rocblas_svect_singular;
     case 'O': return rocblas_svect_overwrite;
     case 'N': return rocblas_svect_none;
-    default: return static_cast<rocblas_svect>(-1);
+    default: return static_cast<rocblas_svect>(0);
     }
 }
 
@@ -308,7 +309,7 @@ constexpr rocblas_evect char2rocblas_evect(char value)
     case 'V': return rocblas_evect_original;
     case 'I': return rocblas_evect_tridiagonal;
     case 'N': return rocblas_evect_none;
-    default: return static_cast<rocblas_evect>(-1);
+    default: return static_cast<rocblas_evect>(0);
     }
 }
 
@@ -319,7 +320,7 @@ constexpr rocblas_eform char2rocblas_eform(char value)
     case '1': return rocblas_eform_ax;
     case '2': return rocblas_eform_abx;
     case '3': return rocblas_eform_bax;
-    default: return static_cast<rocblas_eform>(-1);
+    default: return static_cast<rocblas_eform>(0);
     }
 }
 
@@ -330,7 +331,7 @@ constexpr rocblas_erange char2rocblas_erange(char value)
     case 'A': return rocblas_erange_all;
     case 'V': return rocblas_erange_value;
     case 'I': return rocblas_erange_index;
-    default: return static_cast<rocblas_erange>(-1);
+    default: return static_cast<rocblas_erange>(0);
     }
 }
 
@@ -340,7 +341,7 @@ constexpr rocblas_eorder char2rocblas_eorder(char value)
     {
     case 'B': return rocblas_eorder_blocks;
     case 'E': return rocblas_eorder_entire;
-    default: return static_cast<rocblas_eorder>(-1);
+    default: return static_cast<rocblas_eorder>(0);
     }
 }
 
@@ -350,7 +351,7 @@ constexpr rocblas_esort char2rocblas_esort(char value)
     {
     case 'N': return rocblas_esort_none;
     case 'A': return rocblas_esort_ascending;
-    default: return static_cast<rocblas_esort>(-1);
+    default: return static_cast<rocblas_esort>(0);
     }
 }
 
@@ -361,7 +362,7 @@ inline rocblas_initialization string2rocblas_initialization(const std::string& v
         value == "rand_int"   ? rocblas_initialization_random_int :
         value == "trig_float" ? rocblas_initialization_trig_float :
         value == "hpl"        ? rocblas_initialization_hpl        :
-        static_cast<rocblas_initialization>(-1);
+        static_cast<rocblas_initialization>(0);
 }
 
 inline rocblas_datatype string2rocblas_datatype(const std::string& value)
@@ -383,6 +384,6 @@ inline rocblas_datatype string2rocblas_datatype(const std::string& value)
         value == "u32_r"                 ? rocblas_datatype_u32_r :
         value == "u8_c"                  ? rocblas_datatype_u8_c  :
         value == "u32_c"                 ? rocblas_datatype_u32_c :
-        static_cast<rocblas_datatype>(-1);
+        rocblas_datatype_invalid;
 }
 // clang-format on

--- a/library/src/rocblascommon/utility.hpp
+++ b/library/src/rocblascommon/utility.hpp
@@ -222,22 +222,23 @@ constexpr const char* rocblas_datatype_string(rocblas_datatype type)
 {
     switch(type)
     {
-    case rocblas_datatype_f16_r:  return "f16_r";
-    case rocblas_datatype_f32_r:  return "f32_r";
-    case rocblas_datatype_f64_r:  return "f64_r";
-    case rocblas_datatype_f16_c:  return "f16_c";
-    case rocblas_datatype_f32_c:  return "f32_c";
-    case rocblas_datatype_f64_c:  return "f64_c";
-    case rocblas_datatype_i8_r:   return "i8_r";
-    case rocblas_datatype_u8_r:   return "u8_r";
-    case rocblas_datatype_i32_r:  return "i32_r";
-    case rocblas_datatype_u32_r:  return "u32_r";
-    case rocblas_datatype_i8_c:   return "i8_c";
-    case rocblas_datatype_u8_c:   return "u8_c";
-    case rocblas_datatype_i32_c:  return "i32_c";
-    case rocblas_datatype_u32_c:  return "u32_c";
-    case rocblas_datatype_bf16_r: return "bf16_r";
-    case rocblas_datatype_bf16_c: return "bf16_c";
+    case rocblas_datatype_f16_r:   return "f16_r";
+    case rocblas_datatype_f32_r:   return "f32_r";
+    case rocblas_datatype_f64_r:   return "f64_r";
+    case rocblas_datatype_f16_c:   return "f16_c";
+    case rocblas_datatype_f32_c:   return "f32_c";
+    case rocblas_datatype_f64_c:   return "f64_c";
+    case rocblas_datatype_i8_r:    return "i8_r";
+    case rocblas_datatype_u8_r:    return "u8_r";
+    case rocblas_datatype_i32_r:   return "i32_r";
+    case rocblas_datatype_u32_r:   return "u32_r";
+    case rocblas_datatype_i8_c:    return "i8_c";
+    case rocblas_datatype_u8_c:    return "u8_c";
+    case rocblas_datatype_i32_c:   return "i32_c";
+    case rocblas_datatype_u32_c:   return "u32_c";
+    case rocblas_datatype_bf16_r:  return "bf16_r";
+    case rocblas_datatype_bf16_c:  return "bf16_c";
+    case rocblas_datatype_invalid: return "invalid";
     }
     return "invalid";
 }
@@ -247,28 +248,29 @@ constexpr size_t rocblas_sizeof_datatype(rocblas_datatype type)
 {
     switch(type)
     {
-    case rocblas_datatype_f16_r:  return 2;
-    case rocblas_datatype_f32_r:  return 4;
-    case rocblas_datatype_f64_r:  return 8;
-    case rocblas_datatype_f16_c:  return 4;
-    case rocblas_datatype_f32_c:  return 8;
-    case rocblas_datatype_f64_c:  return 16;
-    case rocblas_datatype_i8_r:   return 1;
-    case rocblas_datatype_u8_r:   return 1;
-    case rocblas_datatype_i32_r:  return 4;
-    case rocblas_datatype_u32_r:  return 4;
-    case rocblas_datatype_i8_c:   return 2;
-    case rocblas_datatype_u8_c:   return 2;
-    case rocblas_datatype_i32_c:  return 8;
-    case rocblas_datatype_u32_c:  return 8;
-    case rocblas_datatype_bf16_r: return 2;
-    case rocblas_datatype_bf16_c: return 4;
+    case rocblas_datatype_f16_r:   return 2;
+    case rocblas_datatype_f32_r:   return 4;
+    case rocblas_datatype_f64_r:   return 8;
+    case rocblas_datatype_f16_c:   return 4;
+    case rocblas_datatype_f32_c:   return 8;
+    case rocblas_datatype_f64_c:   return 16;
+    case rocblas_datatype_i8_r:    return 1;
+    case rocblas_datatype_u8_r:    return 1;
+    case rocblas_datatype_i32_r:   return 4;
+    case rocblas_datatype_u32_r:   return 4;
+    case rocblas_datatype_i8_c:    return 2;
+    case rocblas_datatype_u8_c:    return 2;
+    case rocblas_datatype_i32_c:   return 8;
+    case rocblas_datatype_u32_c:   return 8;
+    case rocblas_datatype_bf16_r:  return 2;
+    case rocblas_datatype_bf16_c:  return 4;
+    case rocblas_datatype_invalid: return 4;
     }
     return 0;
 }
 
 // return rocblas_datatype from type
-template <typename> static constexpr rocblas_datatype rocblas_datatype_from_type     = rocblas_datatype(-1);
+template <typename> static constexpr rocblas_datatype rocblas_datatype_from_type     = rocblas_datatype_invalid;
 template <> static constexpr auto rocblas_datatype_from_type<rocblas_half>           = rocblas_datatype_f16_r;
 template <> static constexpr auto rocblas_datatype_from_type<float>                  = rocblas_datatype_f32_r;
 template <> static constexpr auto rocblas_datatype_from_type<double>                 = rocblas_datatype_f64_r;


### PR DESCRIPTION
* fixes switch enum warnings
* matches fixes from rocblas for SWDEV-352481 for llvm16 use of -1 for invalid enum value