### PR TITLE
HOTFIX: Remove backwards compatibility headers on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ option(WERROR "Treat warnings as errors" OFF)
 
 cmake_dependent_option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY
   "Build with file/folder reorg backward compatibility enabled" ON "NOT WIN32" OFF)
-if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
+if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
   rocm_wrap_header_dir(
     ${CMAKE_SOURCE_DIR}/library/include/rocsolver
     PATTERNS "*.h"

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -272,7 +272,7 @@ set_target_properties(rocsolver PROPERTIES
 )
 generate_export_header(rocsolver EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/rocsolver/rocsolver-export.h)
 
-if (BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
+if (BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
   rocm_wrap_header_file(
     rocsolver-version.h rocsolver-export.h
     GUARDS SYMLINK WRAPPER
@@ -342,7 +342,7 @@ rocm_export_targets(
   NAMESPACE roc::
 )
 
-if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
+if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
   rocm_install(
     DIRECTORY
        "${PROJECT_BINARY_DIR}/rocsolver"


### PR DESCRIPTION
The backwards compatibility headers should not be generated or installed on Windows.