### PR TITLE
Update include file path of rocblas fortran file

### DIFF
--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 if(BUILD_FORTRAN_SAMPLES)
   # the interface to rocblas for Fortran programs
   add_library(rocblas_module OBJECT
-    "${ROCBLAS_INCLUDE_DIR}/rocblas_module.f90"
+    "${ROCBLAS_INCLUDE_DIR}/rocblas/rocblas_module.f90"
   )
 endif()
 


### PR DESCRIPTION
Proposed Change:
- Update the cmake file of samples with path to rocblas fortran program according to latest structure <include/rocblas/rocblas_module.f90>