### PR TITLE
Slim down the benchmark suite

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -107,6 +107,7 @@ if(BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
   set(common_source_files
     common/lapack_host_reference.cpp
     rocblascommon/clients_utility.cpp
+    rocblascommon/program_options.cpp
     ${explicit_inst_files}
   )
 

--- a/clients/rocblascommon/program_options.cpp
+++ b/clients/rocblascommon/program_options.cpp
@@ -1,0 +1,11 @@
+/* ************************************************************************
+ * Copyright (c) 2022 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include "rocblascommon/program_options.hpp"
+
+namespace roc
+{
+// Regular expression for token delimiters (whitespace and commas)
+const std::regex program_options_regex{"[, \\f\\n\\r\\t\\v]+", std::regex_constants::optimize};
+}

--- a/clients/rocblascommon/program_options.hpp
+++ b/clients/rocblascommon/program_options.hpp
@@ -19,7 +19,7 @@
 namespace roc
 {
 // Regular expression for token delimiters (whitespace and commas)
-static const std::regex program_options_regex{"[, \\f\\n\\r\\t\\v]+", std::regex_constants::optimize};
+extern const std::regex program_options_regex;
 
 // Polymorphic base class to use with dynamic_cast
 class value_base

--- a/scripts/perf/rocsolver-bench-suite.py
+++ b/scripts/perf/rocsolver-bench-suite.py
@@ -64,21 +64,21 @@ def parse_results(bench_output):
 
 def getrf_suite(*, precision):
     for fn in ['getrf', 'getrf_npvt']:
-        for m in chain(range(2, 59, 8),
-                       range(64, 257, 32),
-                       range(320, 2049, 64),
-                       range(2176, 4097, 128),
-                       range(4352, 8193, 256),
-                       range(8704, 12289, 512)):
+        for m in chain(range(2, 64, 8),
+                       range(64, 256, 32),
+                       range(256, 2048, 64),
+                       range(2048, 4096, 128),
+                       range(4096, 8193, 256)):
             yield (fn, f'-f {fn} -r {precision} -m {m} --iters 10')
 
 def getrf_strided_batched_suite(*, precision):
     for fn in ['getrf_strided_batched', 'getrf_npvt_strided_batched']:
-        for m, bc in chain(zip(range(2, 65, 1), repeat(5000)),
-                           zip(range(72, 257, 8), repeat(2500)),
-                           zip(range(272, 513, 16), repeat(1000)),
-                           zip(range(544, 1025, 32), repeat(500)),
-                           zip(range(1088, 2049, 64), repeat(50))):
+        for m, bc in chain(zip(range(2, 64, 1), repeat(5000)),
+                           zip(range(64, 256, 8), repeat(2500)),
+                           zip(range(256, 384, 16), repeat(1000)),
+                           zip(range(384, 512, 32), repeat(750)),
+                           zip(range(512, 640, 32), repeat(500)),
+                           zip(range(640, 1025, 64), repeat(50))):
             yield (fn, f'-f {fn} -r {precision} -m {m} --iters 10 --batch_count {bc}')
 
         yield (fn, f'-f {fn} -r {precision} -m 20 --iters 10 --batch_count 4096')
@@ -100,40 +100,43 @@ def getrf_strided_batched_suite(*, precision):
 
 def getri_suite(*, precision):
     for fn in ['getri', 'getri_npvt']:
-        for n in chain(range(2, 59, 8),
-                       range(64, 257, 32),
-                       range(320, 2049, 64),
-                       range(2176, 4097, 128),
-                       range(4352, 8193, 256),
-                       range(8704, 12289, 512)):
+        for n in chain(range(2, 64, 8),
+                       range(64, 256, 32),
+                       range(256, 1024, 64),
+                       range(1024, 2048, 128),
+                       range(2048, 4096, 256),
+                       range(4096, 8193, 512)):
             yield (fn, f'-f {fn} -r {precision} -n {n} --iters 10')
+
 
 def getri_strided_batched_suite(*, precision):
     for fn in ['getri_strided_batched', 'getri_npvt_strided_batched']:
-        for n, bc in chain(zip(range(2, 65, 1), repeat(5000)),
-                           zip(range(72, 257, 8), repeat(2500)),
-                           zip(range(272, 513, 16), repeat(1000)),
-                           zip(range(544, 1025, 32), repeat(500)),
-                           zip(range(1088, 2049, 64), repeat(50))):
+        for n, bc in chain(zip(range(2, 64, 1), repeat(5000)),
+                           zip(range(64, 256, 8), repeat(2500)),
+                           zip(range(256, 384, 16), repeat(1000)),
+                           zip(range(384, 512, 32), repeat(750)),
+                           zip(range(512, 640, 32), repeat(500)),
+                           zip(range(640, 1025, 64), repeat(50))):
             yield (fn, f'-f {fn} -r {precision} -n {n} --iters 10 --batch_count {bc}')
 
 def geqrf_suite(*, precision):
     for fn in ['geqrf']:
-        for m in chain(range(2, 59, 8),
-                       range(64, 257, 32),
-                       range(320, 2049, 64),
-                       range(2176, 4097, 128),
-                       range(4352, 8193, 256),
-                       range(8704, 12289, 512)):
+        for m in chain(range(2, 64, 8),
+                       range(64, 256, 32),
+                       range(256, 1024, 64),
+                       range(1024, 2048, 128),
+                       range(2048, 4096, 256),
+                       range(4096, 8193, 512)):
             yield (fn, f'-f {fn} -r {precision} -m {m} --iters 10')
 
 def geqrf_strided_batched_suite(*, precision):
     for fn in ['geqrf_strided_batched']:
-        for m, bc in chain(zip(range(2, 65, 1), repeat(5000)),
-                           zip(range(72, 257, 8), repeat(2500)),
-                           zip(range(272, 513, 16), repeat(1000)),
-                           zip(range(544, 1025, 32), repeat(500)),
-                           zip(range(1088, 2049, 64), repeat(50))):
+        for m, bc in chain(zip(range(2, 64, 1), repeat(5000)),
+                           zip(range(64, 256, 8), repeat(2500)),
+                           zip(range(256, 384, 16), repeat(1000)),
+                           zip(range(384, 512, 32), repeat(750)),
+                           zip(range(512, 640, 32), repeat(500)),
+                           zip(range(640, 1025, 64), repeat(50))):
             yield (fn, f'-f {fn} -r {precision} -m {m} --iters 10 --batch_count {bc}')
 
 suites = {

--- a/scripts/perf/rocsolver-bench-suite.py
+++ b/scripts/perf/rocsolver-bench-suite.py
@@ -117,6 +117,8 @@ def getri_strided_batched_suite(*, precision):
                            zip(range(384, 512, 32), repeat(750)),
                            zip(range(512, 640, 32), repeat(500)),
                            zip(range(640, 1025, 64), repeat(50))):
+            if precision == 'z' and 232 <= n:
+                continue # TODO: fix crash in rocsolver-bench at these sizes
             yield (fn, f'-f {fn} -r {precision} -n {n} --iters 10 --batch_count {bc}')
 
 def geqrf_suite(*, precision):


### PR DESCRIPTION
These changes are designed to reduce the runtime of our benchmark suite:

# Trim benchmark suite problems

- Reduce maximum problem sizes
  This will reduce overall runtime as well as the memory required to to run the suite. The largest getri_strided_batched benchmarks used >16 GiB of memory, which was too much for some GPUs.
- Reduce number of problems
  The getri benchmarks took significantly longer than the others, so the increment between matrix sizes was increased to reduce the  overall runtime of the benchmark suite. The geqrf tests and various strided_batched tests had smaller contributions to the overall runtime than getri, but were still significant and were reduced too.
- Simplify the use of chained ranges
  Python's range includes values in [min, max). This commit changes the usage from

      range(a, b+1, inc1), range(b+inc1, c, inc2)

  to  

      range(a, b, inc1), range(b, c, inc2)

  The only difference is that `b` has been moved from the first range to the second range. This is important for the strided_batched variants, as we use the same batch count for all elements in a range. For example, the first range may have a batch count of 5000 and the second may have a range of 2500. Since `b` has moved from the first range to the second range, it will have a lower batch count.

# Move regex initialization into an implementation file

Since the regex  object was marked static, each translation unit that included it got  its own copy. This resulted in dozens of copies of the regex being initialized (and optimized) during program initialization before calling into main.

For example, the first few lines of: 

    ltrace -cC rocsolver-bench -f geqrf_strided_batched -r s -m 48 --iters 10 --batch_count 5000

Before
------
```
% time     seconds  usecs/call     calls      function
------ ----------- ----------- --------- --------------------
 30.98    3.405386      283782        12 rocsolver_sgeqrf_strided_batched
 18.07    1.985818          48     40685 operator new(unsigned long)
 14.89    1.636944          61     26520 memcpy
 11.74    1.290850      107570        12 hipMemcpy
  8.32    0.914766          31     29441 std::ctype<char> const& std::use_facet<std::ctype<char> >(std::locale const&)
  5.48    0.602188          34     17665 operator delete(void*)
  4.15    0.455793          31     14691 std::__cxx11::collate<char> const& std::use_facet<std::__cxx11::collate<char> >(std::locale const&)
  1.66    0.182649          57      3201 memmove
```
After
-----
```
% time     seconds  usecs/call     calls      function
------ ----------- ----------- --------- --------------------
 39.55    3.257511      271459        12 rocsolver_sgeqrf_strided_batched
 19.06    1.570270          59     26522 memcpy
 17.56    1.446569          57     25258 operator new(unsigned long)
 14.34    1.181109       98425        12 hipMemcpy
  2.03    0.167594          62      2679 memmove
  1.67    0.137848        6892        20 hipStreamSynchronize
  1.62    0.133081      133081         1 hipGetDeviceCount
  1.46    0.119986          53      2238 operator delete(void*)
```

I kind of want to further trim that. While I managed to eliminate 38% of the allocations with that change, I suspect the complexity of the option parsing still hides a few (smaller) needless inefficiencies. I'm tempted to refactor it towards something simpler.