### PR TITLE
Move gfx11 to the optional targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,16 +128,20 @@ message(STATUS "Tests: ${BUILD_CLIENTS_TESTS}")
 message(STATUS "Benchmarks: ${BUILD_CLIENTS_BENCHMARKS}")
 message(STATUS "Samples: ${BUILD_CLIENTS_SAMPLES}")
 
-# Query for compiler support of GPU archs
-rocm_check_target_ids(OPTIONAL_AMDGPU_TARGETS
-  TARGETS
-    gfx90a:xnack-
-    gfx90a:xnack+
-)
+if(NOT DEFINED AMDGPU_TARGETS)
+  # Query for compiler support of GPU archs
+  rocm_check_target_ids(OPTIONAL_AMDGPU_TARGETS
+    TARGETS
+      gfx90a:xnack-
+      gfx90a:xnack+
+      gfx1100
+      gfx1102
+  )
+endif()
 
 # Set this before finding hip so that hip::device has the required arch flags
 # added as usage requirements on its interface
-set(AMDGPU_TARGETS "gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx1010;gfx1030;gfx1102;gfx1100;${OPTIONAL_AMDGPU_TARGETS}"
+set(AMDGPU_TARGETS "gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx1010;gfx1030;${OPTIONAL_AMDGPU_TARGETS}"
   CACHE STRING "List of specific machine types for library to target")
 
 # Find HIP dependencies


### PR DESCRIPTION
This changes rocSOLVER to only add gfx11 to the default build targets when rocm_check_target_ids reports that they are supported by the compiler. It enables rocSOLVER to be built more easily on older compilers. Additionally, the check for compiler support is skipped when an AMDGPU_TARGET has been explicitly specified (since its only purpose is for setting the default value, which is not used in that case).