### PR TITLE
Add gfx1101 to default compilation targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ if(NOT DEFINED AMDGPU_TARGETS)
       gfx90a:xnack-
       gfx90a:xnack+
       gfx1100
+      gfx1101
       gfx1102
   )
 endif()


### PR DESCRIPTION
Build kernels for gfx1101 if the compiler supports it.