### PR TITLE
Fix getf2_npvt/getrf_npvt singular value tests

### DIFF
--- a/clients/include/testing_getf2_getrf_npvt.hpp
+++ b/clients/include/testing_getf2_getrf_npvt.hpp
@@ -235,8 +235,8 @@ void getf2_getrf_npvt_getPerfData(const rocblas_handle handle,
 {
     if(!perf)
     {
-        getf2_getrf_npvt_initData<true, false, T>(handle, m, n, dA, lda, stA, dinfo, bc, hA,
-                                                  singular, hinfo);
+        getf2_getrf_npvt_initData<true, false, T>(handle, m, n, dA, lda, stA, dinfo, bc, hA, hinfo,
+                                                  singular);
 
         // cpu-lapack performance (only if no perf mode)
         *cpu_time_used = get_time_us_no_sync();
@@ -248,14 +248,14 @@ void getf2_getrf_npvt_getPerfData(const rocblas_handle handle,
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
-    getf2_getrf_npvt_initData<true, false, T>(handle, m, n, dA, lda, stA, dinfo, bc, hA, singular,
-                                              hinfo);
+    getf2_getrf_npvt_initData<true, false, T>(handle, m, n, dA, lda, stA, dinfo, bc, hA, hinfo,
+                                              singular);
 
     // cold calls
     for(int iter = 0; iter < 2; iter++)
     {
-        getf2_getrf_npvt_initData<false, true, T>(handle, m, n, dA, lda, stA, dinfo, bc, hA,
-                                                  singular, hinfo);
+        getf2_getrf_npvt_initData<false, true, T>(handle, m, n, dA, lda, stA, dinfo, bc, hA, hinfo,
+                                                  singular);
 
         CHECK_ROCBLAS_ERROR(rocsolver_getf2_getrf_npvt(STRIDED, GETRF, handle, m, n, dA.data(), lda,
                                                        stA, dinfo.data(), bc));
@@ -277,8 +277,8 @@ void getf2_getrf_npvt_getPerfData(const rocblas_handle handle,
     }
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
-        getf2_getrf_npvt_initData<false, true, T>(handle, m, n, dA, lda, stA, dinfo, bc, hA,
-                                                  singular, hinfo);
+        getf2_getrf_npvt_initData<false, true, T>(handle, m, n, dA, lda, stA, dinfo, bc, hA, hinfo,
+                                                  singular);
 
         start = get_time_us_sync(stream);
         rocsolver_getf2_getrf_npvt(STRIDED, GETRF, handle, m, n, dA.data(), lda, stA, dinfo.data(),


### PR DESCRIPTION
The getf2_getrf_npvt_initData function uses an unconstrained template argument for the type of hinfo and host_strided_batched<T> has an implicit conversion to bool, which allows these two variables to be passed in the wrong order without triggering any type errors.

I noticed this error in the process of rewriting host_strided_batched<T> because I removed the implicit conversion to bool.