### PR TITLE
Fix package dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,7 +184,7 @@ if(BUILD_CLIENTS_TESTS OR BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_SAMPLES)
 endif()
 
 # Package-specific CPACK vars
-rocm_package_add_dependencies("rocblas >= 2.48" "rocblas < 2.49")
+rocm_package_add_dependencies(DEPENDS "rocblas >= 2.48" "rocblas < 2.49")
 
 if(OS_ID_sles)
   rocm_package_add_rpm_dependencies("libLLVM >= 7.0.1")


### PR DESCRIPTION
The rocsolver package was not depending on the rocblas package, because the keyword was missing in the specification. I noticed this while investigating https://github.com/RadeonOpenCompute/ROCm/issues/1879