### PR TITLE
5.5 hotfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,6 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 - SYEVJ/HEEVJ should now properly output the eigenvalues when no sweeps are executed.
 - Fixed GETF2\_NPVT and GETRF\_NPVT input data initialization in tests and benchmarks.
 
-### Known Issues
-- The Divide and Conquer approach currently fails under some circumstances.
-
 
 ## rocSOLVER 3.20.0 for ROCm 5.4.0
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 - SYEVJ/HEEVJ should now be invariant under matrix scaling.
 - SYEVJ/HEEVJ should now properly output the eigenvalues when no sweeps are executed.
 - Fixed GETF2\_NPVT and GETRF\_NPVT input data initialization in tests and benchmarks.
+- Fixed rocblas missing from the dependency list of the rocsolver deb and rpm packages.
 
 
 ## rocSOLVER 3.20.0 for ROCm 5.4.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,7 +184,7 @@ if(BUILD_CLIENTS_TESTS OR BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_SAMPLES)
 endif()
 
 # Package-specific CPACK vars
-rocm_package_add_dependencies("rocblas >= 2.47" "rocblas < 2.48")
+rocm_package_add_dependencies(DEPENDS "rocblas >= 2.47" "rocblas < 2.48")
 
 if(OS_ID_sles)
   rocm_package_add_rpm_dependencies("libLLVM >= 7.0.1")

--- a/clients/gtest/stedc_gtest.cpp
+++ b/clients/gtest/stedc_gtest.cpp
@@ -36,11 +36,7 @@ const vector<vector<int>> matrix_size_range = {
     {35, 40}};
 
 // for daily_lapack tests
-// const vector<vector<int>> large_matrix_size_range = {{192, 192}, {256, 270}, {300, 300}};
-// (TODO: the instance {256, 270} failed on CI and was removed.
-//  The cause is unknown at the moment. We should reproduce, troubleshoot, and
-//  add a hotfix in the future if needed)
-const vector<vector<int>> large_matrix_size_range = {{192, 192}, {250, 250}, {300, 300}};
+const vector<vector<int>> large_matrix_size_range = {{192, 192}, {250, 250}, {256, 270}, {300, 300}};
 
 Arguments stedc_setup_arguments(stedc_tuple tup)
 {
@@ -100,8 +96,10 @@ TEST_P(STEDC, __double_complex)
     run_tests<rocblas_double_complex>();
 }
 
-// INSTANTIATE_TEST_SUITE_P(daily_lapack,
-//                          STEDC,
-//                          Combine(ValuesIn(large_matrix_size_range), ValuesIn(op_range)));
+INSTANTIATE_TEST_SUITE_P(daily_lapack,
+                         STEDC,
+                         Combine(ValuesIn(large_matrix_size_range), ValuesIn(op_range)));
 
-INSTANTIATE_TEST_SUITE_P(known_bug, STEDC, Combine(ValuesIn(matrix_size_range), ValuesIn(op_range)));
+INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+                         STEDC,
+                         Combine(ValuesIn(matrix_size_range), ValuesIn(op_range)));

--- a/clients/gtest/syevd_heevd_gtest.cpp
+++ b/clients/gtest/syevd_heevd_gtest.cpp
@@ -155,12 +155,12 @@ TEST_P(HEEVD, strided_batched__double_complex)
 }
 
 // daily_lapack tests normal execution with medium to large sizes
-// INSTANTIATE_TEST_SUITE_P(daily_lapack, SYEVD, Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
+INSTANTIATE_TEST_SUITE_P(daily_lapack, SYEVD, Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
 
-// INSTANTIATE_TEST_SUITE_P(daily_lapack, HEEVD, Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
+INSTANTIATE_TEST_SUITE_P(daily_lapack, HEEVD, Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
 
 // checkin_lapack tests normal execution with small sizes, invalid sizes,
 // quick returns, and corner cases
-INSTANTIATE_TEST_SUITE_P(known_bug, SYEVD, Combine(ValuesIn(size_range), ValuesIn(op_range)));
+INSTANTIATE_TEST_SUITE_P(checkin_lapack, SYEVD, Combine(ValuesIn(size_range), ValuesIn(op_range)));
 
-INSTANTIATE_TEST_SUITE_P(known_bug, HEEVD, Combine(ValuesIn(size_range), ValuesIn(op_range)));
+INSTANTIATE_TEST_SUITE_P(checkin_lapack, HEEVD, Combine(ValuesIn(size_range), ValuesIn(op_range)));

--- a/clients/gtest/sygvd_hegvd_gtest.cpp
+++ b/clients/gtest/sygvd_hegvd_gtest.cpp
@@ -35,11 +35,8 @@ const vector<vector<int>> matrix_size_range = {
     // normal (valid) samples
     {20, 30, 20, 1},
     {35, 35, 35, 0},
-    {52, 52, 52, 1}};
-//{50, 50, 60, 1}};
-// (TODO: the instance {50, 50, 60, 1} failed on CI and was removed.
-//  The cause is unknown at the moment. We should reproduce, troubleshoot, and
-//  add a hotfix in the future if needed)
+    {52, 52, 52, 1},
+    {50, 50, 60, 1}};
 
 // for daily_lapack tests
 const vector<vector<int>> large_matrix_size_range = {
@@ -170,14 +167,18 @@ TEST_P(HEGVD, strided_batched__double_complex)
     run_tests<false, true, rocblas_double_complex>();
 }
 
-// INSTANTIATE_TEST_SUITE_P(daily_lapack,
-//                          SYGVD,
-//                          Combine(ValuesIn(large_matrix_size_range), ValuesIn(type_range)));
+INSTANTIATE_TEST_SUITE_P(daily_lapack,
+                         SYGVD,
+                         Combine(ValuesIn(large_matrix_size_range), ValuesIn(type_range)));
 
-INSTANTIATE_TEST_SUITE_P(known_bug, SYGVD, Combine(ValuesIn(matrix_size_range), ValuesIn(type_range)));
+INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+                         SYGVD,
+                         Combine(ValuesIn(matrix_size_range), ValuesIn(type_range)));
 
-// INSTANTIATE_TEST_SUITE_P(daily_lapack,
-//                          HEGVD,
-//                          Combine(ValuesIn(large_matrix_size_range), ValuesIn(type_range)));
+INSTANTIATE_TEST_SUITE_P(daily_lapack,
+                         HEGVD,
+                         Combine(ValuesIn(large_matrix_size_range), ValuesIn(type_range)));
 
-INSTANTIATE_TEST_SUITE_P(known_bug, HEGVD, Combine(ValuesIn(matrix_size_range), ValuesIn(type_range)));
+INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+                         HEGVD,
+                         Combine(ValuesIn(matrix_size_range), ValuesIn(type_range)));

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -777,6 +777,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(BDIM) stedc_kernel(const rocblas_int n,
             // find initial positions of each sub-blocks)
             if(tidb == 0)
                 ns[tid] = 0;
+            __syncthreads();
 
             // find sub-block sizes
             if(id == 0)
@@ -1495,7 +1496,7 @@ void rocsolver_stedc_getMemorySize(const rocblas_evect evect,
     }
 
     // if size is too small, use steqr
-    else if(n <= STEDC_MIN_DC_SIZE)
+    else if(n < STEDC_MIN_DC_SIZE)
     {
         rocsolver_steqr_getMemorySize<T, S>(evect, n, batch_count, size_work_stack);
         *size_tempvect = 0;

--- a/library/src/lapack/roclapack_syevj_heevj.hpp
+++ b/library/src/lapack/roclapack_syevj_heevj.hpp
@@ -1166,6 +1166,7 @@ ROCSOLVER_KERNEL void syevj_finalize(const rocblas_esort esort,
                 p = W[i];
             }
         }
+        __syncthreads();
 
         if(m != j)
         {


### PR DESCRIPTION
This PR addresses all the issues observed in the last staging test for 5.5 FC.
It removes the known-bug tags and restores the normal test suite. 