### PR TITLE
Revert "Remove rpath/runpath from ROCm binaries and libraries (#483)"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -59,7 +59,7 @@ Options:
   -s | --static               Pass this flag to build rocsolver as a static library.
                               (rocsolver must be built statically when the used companion rocblas is also static).
 
-  -r | --relocatable          Pass this flag to disable creation of ldconfig files in generated packages.
+  -r | --relocatable          Pass this to add RUNPATH(based on ROCM_RPATH) and remove ldconf entry.
 
   -n | --no-optimizations     Pass this flag to disable optimizations for small sizes.
 
@@ -538,7 +538,6 @@ fi
 cmake_common_options+=(
   "-DROCM_PATH=${rocm_path}"
   '-DCPACK_SET_DESTDIR=OFF'
-  "-DCMAKE_SKIP_INSTALL_RPATH=TRUE"
   "-DCMAKE_INSTALL_PREFIX=${lib_dir}"
   "-DCPACK_PACKAGING_INSTALL_PREFIX=${install_dir}"
   "-DCMAKE_BUILD_TYPE=${build_type}"
@@ -583,7 +582,12 @@ else
   cmake_common_options+=('-DBUILD_FILE_REORG_BACKWARD_COMPATIBILITY=OFF')
 fi
 
+rocm_rpath=""
 if [[ "${build_relocatable}" == true ]]; then
+    rocm_rpath=" -Wl,--enable-new-dtags -Wl,--rpath,/opt/rocm/lib:/opt/rocm/lib64"
+    if ! [ -z ${ROCM_RPATH+x} ]; then
+        rocm_rpath=" -Wl,--enable-new-dtags -Wl,--rpath,${ROCM_RPATH}"
+    fi
     cmake_common_options+=('-DROCM_DISABLE_LDCONFIG=ON')
 fi
 
@@ -598,7 +602,7 @@ fi
 # check exit codes for everything from here onwards
 set -eu
 
-${cmake_executable} "${cmake_common_options[@]}" "${cmake_client_options[@]}" "${main}"
+${cmake_executable} "${cmake_common_options[@]}" "${cmake_client_options[@]}" -DCMAKE_SHARED_LINKER_FLAGS="${rocm_rpath}" "${main}"
 
 if [[ "${build_library}" == true ]]; then
   ${cmake_executable} --build . -j$(nproc) --target install


### PR DESCRIPTION
SWDEV-310152 has been deferred to a later release. It would be worse to have only some of the libraries changed in ROCm 5.5 than to have them all configured one way or the other, so we will undo the changes made to rocSOLVER for this release.

This reverts commit f62bb7f76a0c671f8c6b7463f41831353eafffa5.