### PR TITLE
Fix reserved identifiers in include guards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,7 @@ The public interface must be:
 - Fully documented with Doxygen and Sphinx
 
 All identifiers in the public headers must be prefixed with `rocblas`, `ROCBLAS`, `rocsolver`,
-or `ROCSOLVER`. The prefixes `_ROCLAPACK` and `_ROCSOLVER` are deprecated and should not be used
-in new code.
+or `ROCSOLVER`.
 
 All user-visible symbols must be prefixed with `rocblas` or `rocsolver`.
 

--- a/library/include/rocsolver/internal/rocsolver-extra-types.h
+++ b/library/include/rocsolver/internal/rocsolver-extra-types.h
@@ -1,9 +1,9 @@
 /* ************************************************************************
- * Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2019-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
-#ifndef ROCSOLVER_EXTRAS_H_
-#define ROCSOLVER_EXTRAS_H_
+#ifndef ROCSOLVER_EXTRA_TYPES_H
+#define ROCSOLVER_EXTRA_TYPES_H
 
 #include <stdint.h>
 
@@ -121,4 +121,4 @@ typedef enum rocblas_srange_
     rocblas_srange_index = 263, /**< The \f$il\f$-th through \f$iu\f$-th singular values will be found.*/
 } rocblas_srange;
 
-#endif /* ROCSOLVER_EXTRAS_H_ */
+#endif /* ROCSOLVER_EXTRAS_H */

--- a/library/include/rocsolver/internal/rocsolver-extra-types.h
+++ b/library/include/rocsolver/internal/rocsolver-extra-types.h
@@ -121,4 +121,4 @@ typedef enum rocblas_srange_
     rocblas_srange_index = 263, /**< The \f$il\f$-th through \f$iu\f$-th singular values will be found.*/
 } rocblas_srange;
 
-#endif /* ROCSOLVER_EXTRAS_H */
+#endif /* ROCSOLVER_EXTRA_TYPES_H */

--- a/library/include/rocsolver/internal/rocsolver-functions.h
+++ b/library/include/rocsolver/internal/rocsolver-functions.h
@@ -1,9 +1,9 @@
 /* ************************************************************************
- * Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2019-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
-#ifndef _ROCLAPACK_FUNCTIONS_H
-#define _ROCLAPACK_FUNCTIONS_H
+#ifndef ROCSOLVER_FUNCTIONS_H
+#define ROCSOLVER_FUNCTIONS_H
 
 #include <rocblas/rocblas.h>
 
@@ -23729,4 +23729,4 @@ ROCSOLVER_EXPORT rocblas_status
 }
 #endif
 
-#endif /* _ROCLAPACK_FUNCTIONS_H */
+#endif /* ROCSOLVER_FUNCTIONS_H */

--- a/library/include/rocsolver/internal/rocsolver-version.h.in
+++ b/library/include/rocsolver/internal/rocsolver-version.h.in
@@ -1,11 +1,11 @@
 /* ************************************************************************
- * Copyright (c) 2019-2020 Advanced Micro Devices, Inc.
+ * Copyright (c) 2019-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 /* the configured version and settings
  */
-#ifndef ROCSOLVER_VERSION_H_
-#define ROCSOLVER_VERSION_H_
+#ifndef ROCSOLVER_VERSION_H
+#define ROCSOLVER_VERSION_H
 
 // clang-format off
 #define ROCSOLVER_VERSION_MAJOR @rocsolver_VERSION_MAJOR@
@@ -14,4 +14,4 @@
 #define ROCSOLVER_VERSION_TWEAK @rocsolver_VERSION_TWEAK@
 // clang-format on
 
-#endif
+#endif /* ROCSOLVER_VERSION_H */

--- a/library/include/rocsolver/rocsolver.h
+++ b/library/include/rocsolver/rocsolver.h
@@ -1,13 +1,13 @@
 /* ************************************************************************
- * Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2019-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 /*! \file
     \brief rocsolver.h includes other *.h and exposes a common interface
  ***************************************************************************/
 
-#ifndef _ROCSOLVER_H_
-#define _ROCSOLVER_H_
+#ifndef ROCSOLVER_H
+#define ROCSOLVER_H
 
 /* clang-format off */
 #include "internal/rocsolver-export.h"
@@ -17,4 +17,4 @@
 #include "internal/rocsolver-version.h"
 /* clang-format on */
 
-#endif /* _ROCSOLVER_H_ */
+#endif /* ROCSOLVER_H */


### PR DESCRIPTION
The include guards have been changed to the filename in uppercase letters, with all non-alphanumeric symbols replaced by underscore. This include guard pattern matches the guard that is used for the generated file `rocsolver-export.h`.

There are two reasons for this:
1. The C and C++ standards reserve all identifiers that begin with underscore followed by a capital letter [C99 §7.1.3] [C++11 §17.6.4.3.2].
2. In user-visible code, the rocSOLVER library should prevent name conflicts by only using identifiers that begin with `rocblas`, `ROCBLAS`, `rocsolver` or `ROCSOLVER`.

I ignored `rocsolver-aliases.h` to prevent conflicts with #511.

Ticket: SWDEV-343846