### PR TITLE
Fix use of fmt 9.0 and later in logging test

### DIFF
--- a/clients/gtest/logging_gtest.cpp
+++ b/clients/gtest/logging_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include <cstdlib>
@@ -49,7 +49,7 @@ protected:
         {
             if(HasFailure() && std::getenv("ROCSOLVER_TEST_DEBUG"))
                 fmt::print(stderr, "ROCSOLVER_TEST_DEBUG is set so {} was not removed.\n",
-                           log_filepath);
+                           log_filepath.string());
             else
                 EXPECT_TRUE(fs::remove(log_filepath));
         }


### PR DESCRIPTION
The implicitly defined formatter that rocsolver was using for `std::filesystem::path` has been removed from fmt 9.0 and later.

This change doesn't actually fix compatibility with the official fmt 9.0 or 9.1 releases, because those releases are still incompatible with HIP. However, it is sufficient for using rocsolver with fmt@9 from spack (because the fix for the HIP incompatibility has been backported into fmt@9 by the Spack package maintainer).