### PR TITLE
Hotfix call to set_zero kernel in lauum

### DIFF
--- a/library/src/auxiliary/rocauxiliary_lauum.hpp
+++ b/library/src/auxiliary/rocauxiliary_lauum.hpp
@@ -69,6 +69,11 @@ rocblas_status rocsolver_lauum_template(rocblas_handle handle,
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
 
+    // everything must be executed with scalars on the host
+    rocblas_pointer_mode old_mode;
+    rocblas_get_pointer_mode(handle, &old_mode);
+    rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
+
     rocblas_int strideW = n * n;
     rocblas_int blocks = (n - 1) / BS2 + 1;
     dim3 grid(blocks, blocks, batch_count);
@@ -92,5 +97,6 @@ rocblas_status rocsolver_lauum_template(rocblas_handle handle,
     ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, grid, threads, 0, stream, n, n, work, 0, n, strideW, A,
                             shiftA, lda, strideA, no_mask{}, uplo);
 
+    rocblas_set_pointer_mode(handle, old_mode);
     return rocblas_status_success;
 }

--- a/library/src/auxiliary/rocauxiliary_lauum.hpp
+++ b/library/src/auxiliary/rocauxiliary_lauum.hpp
@@ -1,5 +1,5 @@
 /************************************************************************
- * Copyright (c) 2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2023 Advanced Micro Devices, Inc.
  * ***********************************************************************/
 
 #pragma once
@@ -76,10 +76,8 @@ rocblas_status rocsolver_lauum_template(rocblas_handle handle,
     T one = 1;
     T zero = 0;
 
-    rocblas_fill uploC = (uplo == rocblas_fill_upper) ? rocblas_fill_lower : rocblas_fill_upper;
-
     // put the triangular factor of interest in work
-    ROCSOLVER_LAUNCH_KERNEL(set_zero<T>, grid, threads, 0, stream, n, n, work, 0, n, strideW, uploC);
+    ROCSOLVER_LAUNCH_KERNEL(set_zero<T>, grid, threads, 0, stream, n, n, work, 0, n, strideW, uplo);
     ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, grid, threads, 0, stream, n, n, A, shiftA, lda, strideA,
                             work, 0, n, strideW, no_mask{}, uplo);
 


### PR DESCRIPTION
Testing on new hardware has revealed a bug in LAUUM where the part of the workspace matrix that is supposed to be zero is instead filled with uninitialized garbage values. This is because the `set_zero` kernel, confusingly, will zero out the part of the matrix that is NOT specified by `uplo` (the part specified by `uplo` will remain unchanged). This could be the culprit for why the complex versions of the function failed their tests.

I'm opening this PR as a hotfix for 5.5. Because of https://github.com/ROCmSoftwarePlatform/rocSOLVER/pull/508 and https://github.com/ROCmSoftwarePlatform/rocSOLVER/pull/510, I'm not sure if this will get merged back into develop, so I haven't altered the `set_zero` kernel. I suggest we do so on the develop branch for the sake of clarity and to avoid this kind of bug in the future.