### PR TITLE
Improve error reporting for zero-tolerance test failures

### DIFF
--- a/clients/include/testing_bdsqr.hpp
+++ b/clients/include/testing_bdsqr.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -247,6 +247,7 @@ void bdsqr_getError(const rocblas_handle handle,
 
     // Check info for non-covergence
     *max_err = 0;
+    EXPECT_EQ(hInfo[0][0], hInfoRes[0][0]);
     if(hInfo[0][0] != hInfoRes[0][0])
         *max_err = 1;
 

--- a/clients/include/testing_bdsqr.hpp
+++ b/clients/include/testing_bdsqr.hpp
@@ -245,14 +245,14 @@ void bdsqr_getError(const rocblas_handle handle,
     if(nc > 0)
         CHECK_HIP_ERROR(hC.transfer_from(dC));
 
-    // Check info for non-covergence
+    // Check info for non-convergence
     *max_err = 0;
     EXPECT_EQ(hInfo[0][0], hInfoRes[0][0]);
     if(hInfo[0][0] != hInfoRes[0][0])
         *max_err = 1;
 
     // (We expect the used input matrices to always converge. Testing
-    // implicitely the equivalent non-converged matrix is very complicated and it boils
+    // implicitly the equivalent non-converged matrix is very complicated and it boils
     // down to essentially run the algorithm again and until convergence is achieved).
 
     // error is ||hD - hDRes||
@@ -271,7 +271,7 @@ void bdsqr_getError(const rocblas_handle handle,
 
         if(uplo == rocblas_fill_upper)
         {
-            // check singular vectors implicitely (A'*u_i = s_i*v_i)
+            // check singular vectors implicitly (A'*u_i = s_i*v_i)
             for(rocblas_int i = 0; i < nv; ++i)
             {
                 for(rocblas_int j = 0; j < n; ++j)
@@ -287,7 +287,7 @@ void bdsqr_getError(const rocblas_handle handle,
         }
         else
         {
-            // check singular vectors implicitely (A*v_i = s_i*u_i)
+            // check singular vectors implicitly (A*v_i = s_i*u_i)
             for(rocblas_int i = 0; i < nv; ++i)
             {
                 for(rocblas_int j = 0; j < n; ++j)

--- a/clients/include/testing_bdsvdx.hpp
+++ b/clients/include/testing_bdsvdx.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -209,6 +209,7 @@ void bdsvdx_getError(const rocblas_handle handle,
     }
 
     // check info
+    EXPECT_EQ(hInfo[0][0], hInfoRes[0][0]);
     if(hInfo[0][0] != hInfoRes[0][0])
         *max_err = 1;
     else
@@ -263,6 +264,7 @@ void bdsvdx_getError(const rocblas_handle handle,
             err = 0;
             for(int j = 0; j < nn; j++)
             {
+                EXPECT_EQ(hIfailRes[0][j], 0) << "where j = " << j;
                 if(hIfailRes[0][j] != 0)
                     err++;
             }
@@ -277,6 +279,7 @@ void bdsvdx_getError(const rocblas_handle handle,
             err = 0;
             for(int j = 0; j < hInfoRes[0][0]; j++)
             {
+                EXPECT_EQ(hIfailRes[0][j], 0) << "where j = " << j;
                 if(hIfailRes[0][j] == 0)
                     err++;
             }

--- a/clients/include/testing_bdsvdx.hpp
+++ b/clients/include/testing_bdsvdx.hpp
@@ -280,7 +280,7 @@ void bdsvdx_getError(const rocblas_handle handle,
             err = 0;
             for(int j = 0; j < hInfoRes[0][0]; j++)
             {
-                EXPECT_EQ(hIfailRes[0][j], 0) << "where j = " << j;
+                EXPECT_NE(hIfailRes[0][j], 0) << "where j = " << j;
                 if(hIfailRes[0][j] == 0)
                     err++;
             }

--- a/clients/include/testing_bdsvdx.hpp
+++ b/clients/include/testing_bdsvdx.hpp
@@ -215,13 +215,14 @@ void bdsvdx_getError(const rocblas_handle handle,
     else
         *max_err = 0;
 
-    // if finding singular values succeded, check values
+    // if finding singular values succeeded, check values
     double err;
     if(hInfoRes[0][0] == 0)
     {
         // check number of computed singular values
         rocblas_int nn = hNsvRes[0][0];
         *max_err += std::abs(nn - hNsv[0][0]);
+        EXPECT_EQ(hNsv[0][0], hNsvRes[0][0]);
 
         // error is ||hS - hSRes|| / ||hS||
         // using frobenius norm

--- a/clients/include/testing_geblttrf_npvt.hpp
+++ b/clients/include/testing_geblttrf_npvt.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -280,11 +280,13 @@ void geblttrf_npvt_getError(const rocblas_handle handle,
     {
         if(singular && (b == bc / 4 || b == bc / 2 || b == bc - 1))
         {
+            EXPECT_GT(hInfoRes[b][0], 0) << "where b = " << b;
             if(hInfoRes[b][0] <= 0)
                 err++;
         }
         else
         {
+            EXPECT_EQ(hInfoRes[b][0], 0) << "where b = " << b;
             if(hInfoRes[b][0] != 0)
                 err++;
         }

--- a/clients/include/testing_gels.hpp
+++ b/clients/include/testing_gels.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -265,8 +265,11 @@ void gels_getError(const rocblas_handle handle,
     // also check info for singularities
     err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             err++;
+    }
     *max_err += err;
 }
 

--- a/clients/include/testing_gels_outofplace.hpp
+++ b/clients/include/testing_gels_outofplace.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -306,8 +306,11 @@ void gels_outofplace_getError(const rocblas_handle handle,
     // also check info for singularities
     err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             err++;
+    }
     *max_err += err;
 }
 

--- a/clients/include/testing_gesv.hpp
+++ b/clients/include/testing_gesv.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -241,8 +241,11 @@ void gesv_getError(const rocblas_handle handle,
     // also check info for singularities
     err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             err++;
+    }
     *max_err += err;
 }
 

--- a/clients/include/testing_gesv_outofplace.hpp
+++ b/clients/include/testing_gesv_outofplace.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -264,8 +264,11 @@ void gesv_outofplace_getError(const rocblas_handle handle,
     // also check info for singularities
     err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             err++;
+    }
     *max_err += err;
 }
 

--- a/clients/include/testing_gesvd.hpp
+++ b/clients/include/testing_gesvd.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -340,8 +340,11 @@ void gesvd_getError(const rocblas_handle handle,
     // Check info for non-convergence
     *max_err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
             *max_err += 1;
+    }
 
     // (We expect the used input matrices to always converge. Testing
     // implicitly the equivalent non-converged matrix is very complicated and it boils

--- a/clients/include/testing_gesvdj.hpp
+++ b/clients/include/testing_gesvdj.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -336,18 +336,28 @@ void gesvdj_getError(const rocblas_handle handle,
     // Check info for non-convergence
     *max_err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
             *max_err += 1;
+    }
 
     // Also check validity of residual
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_GE(hResidualRes[b][0], 0) << "where b = " << b;
         if(hResidualRes[b][0] < 0)
             *max_err += 1;
+    }
 
     // Also check validity of sweeps
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_GE(hResidualRes[b][0], 0) << "where b = " << b;
+        EXPECT_LE(hSweepsRes[b][0], max_sweeps) << "where b = " << b;
         if(hSweepsRes[b][0] < 0 || hSweepsRes[b][0] > max_sweeps)
             *max_err += 1;
+    }
 
     // (We expect the used input matrices to always converge. Testing
     // implicitly the equivalent non-converged matrix is very complicated and it boils

--- a/clients/include/testing_gesvdj_notransv.hpp
+++ b/clients/include/testing_gesvdj_notransv.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -352,18 +352,28 @@ void gesvdj_notransv_getError(const rocblas_handle handle,
     // Check info for non-convergence
     *max_err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
             *max_err += 1;
+    }
 
     // Also check validity of residual
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_GE(hResidualRes[b][0], 0) << "where b = " << b;
         if(hResidualRes[b][0] < 0)
             *max_err += 1;
+    }
 
     // Also check validity of sweeps
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_GE(hResidualRes[b][0], 0) << "where b = " << b;
+        EXPECT_LE(hSweepsRes[b][0], max_sweeps) << "where b = " << b;
         if(hSweepsRes[b][0] < 0 || hSweepsRes[b][0] > max_sweeps)
             *max_err += 1;
+    }
 
     // (We expect the used input matrices to always converge. Testing
     // implicitly the equivalent non-converged matrix is very complicated and it boils

--- a/clients/include/testing_gesvdx.hpp
+++ b/clients/include/testing_gesvdx.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -447,6 +447,7 @@ void gesvdx_getError(const rocblas_handle handle,
     double err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
     {
+        EXPECT_EQ(hNsv[b][0], hNsvRes[b][0]) << "where b = " << b;
         if(hNsv[b][0] != hNsvRes[b][0])
             err++;
     }

--- a/clients/include/testing_gesvdx.hpp
+++ b/clients/include/testing_gesvdx.hpp
@@ -434,10 +434,12 @@ void gesvdx_getError(const rocblas_handle handle,
     //  meaning in gesvd_, however, We expect the used input matrices to always converge)
     /*for(rocblas_int b = 0; b < bc; ++b)
     {
+        EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
             *max_err += 1;
         for(int j = 0; j < hNsv[b][0]; ++j)
         {
+            EXPECT_EQ(hifail[b][j], hifailRes[b][j]) << "where b = " << b << ", j = " << j;
             if(hifail[b][j] != hifailRes[b][j])
                 *max_err += 1;
         }

--- a/clients/include/testing_getf2_getrf.hpp
+++ b/clients/include/testing_getf2_getrf.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -240,16 +240,22 @@ void getf2_getrf_getError(const rocblas_handle handle,
         // also check pivoting (count the number of incorrect pivots)
         err = 0;
         for(rocblas_int i = 0; i < min(m, n); ++i)
+        {
+            EXPECT_EQ(hIpiv[b][i], hIpivRes[b][i]) << "where b = " << b << ", i = " << i;
             if(hIpiv[b][i] != hIpivRes[b][i])
                 err++;
+        }
         *max_err = err > *max_err ? err : *max_err;
     }
 
     // also check info for singularities
     err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             err++;
+    }
     *max_err += err;
 }
 

--- a/clients/include/testing_getf2_getrf_npvt.hpp
+++ b/clients/include/testing_getf2_getrf_npvt.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -208,8 +208,11 @@ void getf2_getrf_npvt_getError(const rocblas_handle handle,
     // also check info for singularities
     err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hinfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hInfoRes[b][0])
             err++;
+    }
     *max_err += err;
 }
 

--- a/clients/include/testing_getri.hpp
+++ b/clients/include/testing_getri.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -215,6 +215,7 @@ void getri_getError(const rocblas_handle handle,
     *max_err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
     {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             err++;
     }

--- a/clients/include/testing_getri_npvt.hpp
+++ b/clients/include/testing_getri_npvt.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -184,6 +184,7 @@ void getri_npvt_getError(const rocblas_handle handle,
     *max_err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
     {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             err++;
     }

--- a/clients/include/testing_getri_npvt_outofplace.hpp
+++ b/clients/include/testing_getri_npvt_outofplace.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -206,6 +206,7 @@ void getri_npvt_outofplace_getError(const rocblas_handle handle,
     *max_err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
     {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             err++;
     }

--- a/clients/include/testing_getri_outofplace.hpp
+++ b/clients/include/testing_getri_outofplace.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -234,6 +234,7 @@ void getri_outofplace_getError(const rocblas_handle handle,
     *max_err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
     {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             err++;
     }

--- a/clients/include/testing_lasyf.hpp
+++ b/clients/include/testing_lasyf.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -201,25 +201,33 @@ void lasyf_getError(const rocblas_handle handle,
     if(uplo == rocblas_fill_upper)
     {
         for(rocblas_int i = n - hKBRes[0][0]; i < n; ++i)
+        {
+            EXPECT_EQ(hIpiv[0][i], hIpivRes[0][i]) << "where i = " << i;
             if(hIpiv[0][i] != hIpivRes[0][i])
                 err++;
+        }
     }
     else
     {
         for(rocblas_int i = 0; i < hKBRes[0][0]; ++i)
+        {
+            EXPECT_EQ(hIpiv[0][i], hIpivRes[0][i]) << "where i = " << i;
             if(hIpiv[0][i] != hIpivRes[0][i])
                 err++;
+        }
     }
     *max_err = err > *max_err ? err : *max_err;
 
     // also check kb
     err = 0;
+    EXPECT_EQ(hKB[0][0], hKBRes[0][0]);
     if(hKB[0][0] != hKBRes[0][0])
         err++;
     *max_err += err;
 
     // also check info
     err = 0;
+    EXPECT_EQ(hInfo[0][0], hInfoRes[0][0]);
     if(hInfo[0][0] != hInfoRes[0][0])
         err++;
     *max_err += err;

--- a/clients/include/testing_posv.hpp
+++ b/clients/include/testing_posv.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -219,8 +219,11 @@ void posv_getError(const rocblas_handle handle,
     // also check info for non positive definite cases
     err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             err++;
+    }
     *max_err += err;
 }
 

--- a/clients/include/testing_potf2_potrf.hpp
+++ b/clients/include/testing_potf2_potrf.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -202,8 +202,11 @@ void potf2_potrf_getError(const rocblas_handle handle,
     // also check info for non positive definite cases
     err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             err++;
+    }
     *max_err += err;
 }
 

--- a/clients/include/testing_potri.hpp
+++ b/clients/include/testing_potri.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -179,6 +179,7 @@ void potri_getError(const rocblas_handle handle,
     *max_err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
     {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             err++;
     }

--- a/clients/include/testing_stebz.hpp
+++ b/clients/include/testing_stebz.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -203,6 +203,7 @@ void stebz_getError(const rocblas_handle handle,
               hIblock[0], hIsplit[0], work.data(), iwork.data(), hinfo[0]);
 
     // check info
+    EXPECT_EQ(hinfo[0][0], hinfoRes[0][0]);
     if(hinfo[0][0] != hinfoRes[0][0])
         *max_err = 1;
     else

--- a/clients/include/testing_stebz.hpp
+++ b/clients/include/testing_stebz.hpp
@@ -212,10 +212,14 @@ void stebz_getError(const rocblas_handle handle,
     // check number of split blocks
     rocblas_int ns = hnsplit[0][0];
     *max_err += std::abs(ns - hnsplitRes[0][0]);
+    EXPECT_EQ(hnsplit[0][0], hnsplitRes[0][0]);
 
     // check split blocks limits
     for(int k = 0; k < ns; ++k)
+    {
         *max_err += std::abs(hIsplit[0][k] - hIsplitRes[0][k]);
+        EXPECT_EQ(hIsplit[0][k], hIsplitRes[0][k]) << "where k = " << k;
+    }
 
     // if finding eigenvalues succeded, check values
     if(hinfo[0][0] == 0)
@@ -223,6 +227,7 @@ void stebz_getError(const rocblas_handle handle,
         // check number of computed eigenvalues
         rocblas_int nn = hnev[0][0];
         *max_err += std::abs(nn - hnevRes[0][0]);
+        EXPECT_EQ(hnev[0][0], hnevRes[0][0]);
 
         // check block indices
         // (note: as very close eigenvalues could be considered to belong to different
@@ -232,8 +237,12 @@ void stebz_getError(const rocblas_handle handle,
         {
             int difb = std::abs(hIblock[0][k] - hIblockRes[0][k]);
             T difv = std::abs(hW[0][k] - hWRes[0][k]) / hW[0][k];
-            if(difb > 0 && difv > n * get_epsilon<T>())
-                *max_err += difb;
+            if(difv > n * get_epsilon<T>())
+            {
+                EXPECT_EQ(hIblock[0][k], hIblockRes[0][k]) << "where k = " << k;
+                if(difb > 0)
+                    *max_err += difb;
+            }
         }
 
         // error is ||hW - hWRes|| / ||hW||

--- a/clients/include/testing_stedc.hpp
+++ b/clients/include/testing_stedc.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -286,6 +286,7 @@ void stedc_getError(const rocblas_handle handle,
               iwork.data(), liwork, hInfo[0]);
 
     // check info
+    EXPECT_EQ(hInfo[0][0], hInfoRes[0][0]);
     if(hInfo[0][0] != hInfoRes[0][0])
         *max_err = 1;
     else

--- a/clients/include/testing_stein.hpp
+++ b/clients/include/testing_stein.hpp
@@ -274,7 +274,7 @@ void stein_getError(const rocblas_handle handle,
         err = 0;
         for(int j = 0; j < hInfo[0][0]; j++)
         {
-            EXPECT_EQ(hIfailRes[0][j], 0) << "j = " << j;
+            EXPECT_NE(hIfailRes[0][j], 0) << "j = " << j;
             if(hIfailRes[0][j] == 0)
                 err++;
         }

--- a/clients/include/testing_stein.hpp
+++ b/clients/include/testing_stein.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -220,6 +220,7 @@ void stein_getError(const rocblas_handle handle,
               iwork.data(), hIfail[0], hInfo[0]);
 
     // check info
+    EXPECT_EQ(hInfo[0][0], hInfoRes[0][0]);
     if(hInfo[0][0] != hInfoRes[0][0])
         *max_err = 1;
     else
@@ -233,6 +234,7 @@ void stein_getError(const rocblas_handle handle,
         err = 0;
         for(int j = 0; j < hNev[0][0]; j++)
         {
+            EXPECT_EQ(hIfailRes[0][j], 0) << "j = " << j;
             if(hIfailRes[0][j] != 0)
                 err++;
         }
@@ -272,6 +274,7 @@ void stein_getError(const rocblas_handle handle,
         err = 0;
         for(int j = 0; j < hInfo[0][0]; j++)
         {
+            EXPECT_EQ(hIfailRes[0][j], 0) << "j = " << j;
             if(hIfailRes[0][j] == 0)
                 err++;
         }

--- a/clients/include/testing_steqr.hpp
+++ b/clients/include/testing_steqr.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -191,6 +191,7 @@ void steqr_getError(const rocblas_handle handle,
     cpu_steqr(evect, n, hD[0], hE[0], hC[0], ldc, work.data(), hInfo[0]);
 
     // check info
+    EXPECT_EQ(hInfo[0][0], hInfoRes[0][0]);
     if(hInfo[0][0] != hInfoRes[0][0])
         *max_err = 1;
     else

--- a/clients/include/testing_syev_heev.hpp
+++ b/clients/include/testing_syev_heev.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -222,8 +222,11 @@ void syev_heev_getError(const rocblas_handle handle,
     // Check info for non-convergence
     *max_err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
             *max_err += 1;
+    }
 
     // (We expect the used input matrices to always converge. Testing
     // implicitly the equivalent non-converged matrix is very complicated and it boils

--- a/clients/include/testing_syevd_heevd.hpp
+++ b/clients/include/testing_syevd_heevd.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -234,8 +234,11 @@ void syevd_heevd_getError(const rocblas_handle handle,
     // Check info for non-convergence
     *max_err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
             *max_err += 1;
+    }
 
     // (We expect the used input matrices to always converge. Testing
     // implicitly the equivalent non-converged matrix is very complicated and it boils

--- a/clients/include/testing_syevdx_heevdx_inplace.hpp
+++ b/clients/include/testing_syevdx_heevdx_inplace.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -271,14 +271,20 @@ void syevdx_heevdx_inplace_getError(const rocblas_handle handle,
     // Check info for non-convergence
     *max_err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
             *max_err += 1;
+    }
 
     // Check number of returned eigenvalues
     double err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hNev[b][0], hNevRes[b][0]) << "where b = " << b;
         if(hNev[b][0] != hNevRes[b][0])
             err++;
+    }
     *max_err = err > *max_err ? err : *max_err;
 
     // (We expect the used input matrices to always converge. Testing

--- a/clients/include/testing_syevx_heevx.hpp
+++ b/clients/include/testing_syevx_heevx.hpp
@@ -351,6 +351,7 @@ void syevx_heevx_getError(const rocblas_handle handle,
                 err = 0;
                 for(int j = 0; j < hNev[b][0]; j++)
                 {
+                    EXPECT_EQ(hIfailRes[b][j], 0) << "where b = " << b << ", j = " << j;
                     if(hIfailRes[b][j] != 0)
                         err++;
                 }
@@ -378,6 +379,7 @@ void syevx_heevx_getError(const rocblas_handle handle,
                 err = 0;
                 for(int j = 0; j < hinfo[b][0]; j++)
                 {
+                    EXPECT_NE(hIfailRes[b][j], 0) << "where b = " << b  << ", j = " << j;
                     if(hIfailRes[b][j] == 0)
                         err++;
                 }

--- a/clients/include/testing_syevx_heevx.hpp
+++ b/clients/include/testing_syevx_heevx.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -309,14 +309,20 @@ void syevx_heevx_getError(const rocblas_handle handle,
     // Check info for non-convergence
     *max_err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
             *max_err += 1;
+    }
 
     // Check number of returned eigenvalues
     double err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hNev[b][0], hNevRes[b][0]) << "where b = " << b;
         if(hNev[b][0] != hNevRes[b][0])
             err++;
+    }
     *max_err = err > *max_err ? err : *max_err;
 
     // (We expect the used input matrices to always converge. Testing

--- a/clients/include/testing_syevx_heevx.hpp
+++ b/clients/include/testing_syevx_heevx.hpp
@@ -379,7 +379,7 @@ void syevx_heevx_getError(const rocblas_handle handle,
                 err = 0;
                 for(int j = 0; j < hinfo[b][0]; j++)
                 {
-                    EXPECT_NE(hIfailRes[b][j], 0) << "where b = " << b  << ", j = " << j;
+                    EXPECT_NE(hIfailRes[b][j], 0) << "where b = " << b << ", j = " << j;
                     if(hIfailRes[b][j] == 0)
                         err++;
                 }

--- a/clients/include/testing_sygv_hegv.hpp
+++ b/clients/include/testing_sygv_hegv.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -304,8 +304,11 @@ void sygv_hegv_getError(const rocblas_handle handle,
     // check info for non-convergence and/or positive-definiteness
     *max_err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             *max_err += 1;
+    }
 
     double err;
 

--- a/clients/include/testing_sygvd_hegvd.hpp
+++ b/clients/include/testing_sygvd_hegvd.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -320,8 +320,11 @@ void sygvd_hegvd_getError(const rocblas_handle handle,
     // check info for non-convergence and/or positive-definiteness
     *max_err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             *max_err += 1;
+    }
 
     double err;
 

--- a/clients/include/testing_sygvdx_hegvdx_inplace.hpp
+++ b/clients/include/testing_sygvdx_hegvdx_inplace.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -386,13 +386,19 @@ void sygvdx_hegvdx_inplace_getError(const rocblas_handle handle,
     // check info for non-convergence and/or positive-definiteness
     *max_err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             *max_err += 1;
+    }
 
     // Check number of returned eigenvalues
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hNev[b][0], hNevRes[b][0]) << "where b = " << b;
         if(hNev[b][0] != hNevRes[b][0])
             *max_err += 1;
+    }
 
     double err;
 

--- a/clients/include/testing_sygvj_hegvj.hpp
+++ b/clients/include/testing_sygvj_hegvj.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -331,18 +331,30 @@ void sygvj_hegvj_getError(const rocblas_handle handle,
     // check info for non-convergence and/or positive-definiteness
     *max_err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             *max_err += 1;
+    }
 
     // Also check validity of residual
     for(rocblas_int b = 0; b < bc; ++b)
-        if(hInfoRes[b][0] == 0 && hResidualRes[b][0] < 0)
-            *max_err += 1;
+        if(hInfoRes[b][0] == 0)
+        {
+            EXPECT_GE(hResidualRes[b][0], 0) << "where b = " << b;
+            if(hResidualRes[b][0] < 0)
+                *max_err += 1;
+        }
 
     // Also check validity of sweeps
     for(rocblas_int b = 0; b < bc; ++b)
-        if(hInfoRes[b][0] == 0 && (hSweepsRes[b][0] < 0 || hSweepsRes[b][0] > max_sweeps))
-            *max_err += 1;
+        if(hInfoRes[b][0] == 0)
+        {
+            EXPECT_GE(hSweepsRes[b][0], 0) << "where b = " << b;
+            EXPECT_LE(hSweepsRes[b][0], max_sweeps) << "where b = " << b;
+            if(hSweepsRes[b][0] < 0 || hSweepsRes[b][0] > max_sweeps)
+                *max_err += 1;
+        }
 
     double err;
 

--- a/clients/include/testing_sygvx_hegvx.hpp
+++ b/clients/include/testing_sygvx_hegvx.hpp
@@ -475,6 +475,7 @@ void sygvx_hegvx_getError(const rocblas_handle handle,
                 err = 0;
                 for(int j = 0; j < hNev[b][0]; j++)
                 {
+                    EXPECT_EQ(hIfailRes[b][j], 0) << "where b = " << b << ", j = " << j;
                     if(hIfailRes[b][j] != 0)
                         err++;
                 }
@@ -529,6 +530,7 @@ void sygvx_hegvx_getError(const rocblas_handle handle,
                 err = 0;
                 for(int j = 0; j < hInfo[b][0]; j++)
                 {
+                    EXPECT_NE(hIfailRes[b][j], 0) << "where b = " << b << ", j = " << j;
                     if(hIfailRes[b][j] == 0)
                         err++;
                 }

--- a/clients/include/testing_sygvx_hegvx.hpp
+++ b/clients/include/testing_sygvx_hegvx.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -435,13 +435,19 @@ void sygvx_hegvx_getError(const rocblas_handle handle,
     // check info for non-convergence and/or positive-definiteness
     *max_err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             *max_err += 1;
+    }
 
     // Check number of returned eigenvalues
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hNev[b][0], hNevRes[b][0]) << "where b = " << b;
         if(hNev[b][0] != hNevRes[b][0])
             *max_err += 1;
+    }
 
     double err;
 

--- a/clients/include/testing_sytf2_sytrf.hpp
+++ b/clients/include/testing_sytf2_sytrf.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -250,16 +250,22 @@ void sytf2_sytrf_getError(const rocblas_handle handle,
         // also check pivoting (count the number of incorrect pivots)
         err = 0;
         for(rocblas_int i = 0; i < n; ++i)
+        {
+            EXPECT_EQ(hIpiv[b][i], hIpivRes[b][i]) << "where b = " << b << ", i = " << i;
             if(hIpiv[b][i] != hIpivRes[b][i])
                 err++;
+        }
         *max_err = err > *max_err ? err : *max_err;
     }
 
     // also check info
     err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             err++;
+    }
     *max_err += err;
 }
 

--- a/clients/include/testing_trtri.hpp
+++ b/clients/include/testing_trtri.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -189,6 +189,7 @@ void trtri_getError(const rocblas_handle handle,
     *max_err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
     {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             err++;
     }

--- a/clients/rocblascommon/rocblas_test.hpp
+++ b/clients/rocblascommon/rocblas_test.hpp
@@ -112,18 +112,12 @@ struct rocsolver_info_accumulator
     }
 };
 
-#define EXPECT_EQ(v1, v2) \
-    rocsolver_info_accumulator {}
-#define EXPECT_NE(v1, v2) \
-    rocsolver_info_accumulator {}
-#define EXPECT_LT(v1, v2) \
-    rocsolver_info_accumulator {}
-#define EXPECT_LE(v1, v2) \
-    rocsolver_info_accumulator {}
-#define EXPECT_GT(v1, v2) \
-    rocsolver_info_accumulator {}
-#define EXPECT_GE(v1, v2) \
-    rocsolver_info_accumulator {}
+#define EXPECT_EQ(v1, v2) rocsolver_info_accumulator()
+#define EXPECT_NE(v1, v2) rocsolver_info_accumulator()
+#define EXPECT_LT(v1, v2) rocsolver_info_accumulator()
+#define EXPECT_LE(v1, v2) rocsolver_info_accumulator()
+#define EXPECT_GT(v1, v2) rocsolver_info_accumulator()
+#define EXPECT_GE(v1, v2) rocsolver_info_accumulator()
 
 #endif // ROCSOLVER_CLIENTS_TEST
 

--- a/clients/rocblascommon/rocblas_test.hpp
+++ b/clients/rocblascommon/rocblas_test.hpp
@@ -103,95 +103,12 @@ inline void rocblas_expect_status(rocblas_status status, rocblas_status expect)
 
 #define EXPECT_ROCBLAS_STATUS rocblas_expect_status
 
-struct rocsolver_info_accumulator
-{
-    template <typename T>
-    rocsolver_info_accumulator& operator<<(T&&)
-    {
-        // todo: implement this so rocsolver-bench can print extra
-        //       info about failures when doing error checking.
-        return *this;
-    }
-};
-
-struct rocsolver_expect_eq : rocsolver_info_accumulator
-{
-    template <typename T1, typename T2>
-    rocsolver_expect_eq(T1&& v1, T2&& v2, fmt::string_view file, int line)
-    {
-        if(!(v1 == v2))
-        {
-            fmt::print(stderr, "{}:{}: expected {} == {}!\n", file, line, v1, v2);
-        }
-    }
-};
-
-struct rocsolver_expect_ne : rocsolver_info_accumulator
-{
-    template <typename T1, typename T2>
-    rocsolver_expect_ne(T1&& v1, T2&& v2, fmt::string_view file, int line)
-    {
-        if(!(v1 != v2))
-        {
-            fmt::print(stderr, "{}:{}: expected {} != {}!\n", file, line, v1, v2);
-        }
-    }
-};
-
-struct rocsolver_expect_lt : rocsolver_info_accumulator
-{
-    template <typename T1, typename T2>
-    rocsolver_expect_lt(T1&& v1, T2&& v2, fmt::string_view file, int line)
-    {
-        if(!(v1 < v2))
-        {
-            fmt::print(stderr, "{}:{}: expected {} < {}!\n", file, line, v1, v2);
-        }
-    }
-};
-
-struct rocsolver_expect_le : rocsolver_info_accumulator
-{
-    template <typename T1, typename T2>
-    rocsolver_expect_le(T1&& v1, T2&& v2, fmt::string_view file, int line)
-    {
-        if(!(v1 <= v2))
-        {
-            fmt::print(stderr, "{}:{}: expected {} <= {}!\n", file, line, v1, v2);
-        }
-    }
-};
-
-struct rocsolver_expect_gt : rocsolver_info_accumulator
-{
-    template <typename T1, typename T2>
-    rocsolver_expect_gt(T1&& v1, T2&& v2, fmt::string_view file, int line)
-    {
-        if(!(v1 > v2))
-        {
-            fmt::print(stderr, "{}:{}: expected {} > {}!\n", file, line, v1, v2);
-        }
-    }
-};
-
-struct rocsolver_expect_ge : rocsolver_info_accumulator
-{
-    template <typename T1, typename T2>
-    rocsolver_expect_ge(T1&& v1, T2&& v2, fmt::string_view file, int line)
-    {
-        if(!(v1 >= v2))
-        {
-            fmt::print(stderr, "{}:{}: expected {} >= {}!\n", file, line, v1, v2);
-        }
-    }
-};
-
-#define EXPECT_EQ(v1, v2) rocsolver_expect_eq(v1, v2, __FILE__, __LINE__)
-#define EXPECT_NE(v1, v2) rocsolver_expect_ne(v1, v2, __FILE__, __LINE__)
-#define EXPECT_LT(v1, v2) rocsolver_expect_lt(v1, v2, __FILE__, __LINE__)
-#define EXPECT_LE(v1, v2) rocsolver_expect_le(v1, v2, __FILE__, __LINE__)
-#define EXPECT_GT(v1, v2) rocsolver_expect_gt(v1, v2, __FILE__, __LINE__)
-#define EXPECT_GE(v1, v2) rocsolver_expect_ge(v1, v2, __FILE__, __LINE__)
+#define EXPECT_EQ(v1, v2)
+#define EXPECT_NE(v1, v2)
+#define EXPECT_LT(v1, v2)
+#define EXPECT_LE(v1, v2)
+#define EXPECT_GT(v1, v2)
+#define EXPECT_GE(v1, v2)
 
 #endif // ROCSOLVER_CLIENTS_TEST
 

--- a/clients/rocblascommon/rocblas_test.hpp
+++ b/clients/rocblascommon/rocblas_test.hpp
@@ -103,21 +103,23 @@ inline void rocblas_expect_status(rocblas_status status, rocblas_status expect)
 
 #define EXPECT_ROCBLAS_STATUS rocblas_expect_status
 
-struct rocsolver_info_accumulator
+// The info provided to EXPECT macros is used in rocsolver-test, but
+// in rocsolver-bench, the information is just discarded.
+struct rocsolver_info_discarder
 {
     template <typename T>
-    rocsolver_info_accumulator& operator<<(T&&)
+    rocsolver_info_discarder& operator<<(T&&)
     {
         return *this;
     }
 };
 
-#define EXPECT_EQ(v1, v2) rocsolver_info_accumulator()
-#define EXPECT_NE(v1, v2) rocsolver_info_accumulator()
-#define EXPECT_LT(v1, v2) rocsolver_info_accumulator()
-#define EXPECT_LE(v1, v2) rocsolver_info_accumulator()
-#define EXPECT_GT(v1, v2) rocsolver_info_accumulator()
-#define EXPECT_GE(v1, v2) rocsolver_info_accumulator()
+#define EXPECT_EQ(v1, v2) rocsolver_info_discarder()
+#define EXPECT_NE(v1, v2) rocsolver_info_discarder()
+#define EXPECT_LT(v1, v2) rocsolver_info_discarder()
+#define EXPECT_LE(v1, v2) rocsolver_info_discarder()
+#define EXPECT_GT(v1, v2) rocsolver_info_discarder()
+#define EXPECT_GE(v1, v2) rocsolver_info_discarder()
 
 #endif // ROCSOLVER_CLIENTS_TEST
 

--- a/clients/rocblascommon/rocblas_test.hpp
+++ b/clients/rocblascommon/rocblas_test.hpp
@@ -108,90 +108,22 @@ struct rocsolver_info_accumulator
     template <typename T>
     rocsolver_info_accumulator& operator<<(T&&)
     {
-        // todo: implement this so rocsolver-bench can print extra
-        //       info about failures when doing error checking.
         return *this;
     }
 };
 
-struct rocsolver_expect_eq : rocsolver_info_accumulator
-{
-    template <typename T1, typename T2>
-    rocsolver_expect_eq(T1&& v1, T2&& v2, fmt::string_view file, int line)
-    {
-        if(!(v1 == v2))
-        {
-            fmt::print(stderr, "{}:{}: expected {} == {}!\n", file, line, v1, v2);
-        }
-    }
-};
-
-struct rocsolver_expect_ne : rocsolver_info_accumulator
-{
-    template <typename T1, typename T2>
-    rocsolver_expect_ne(T1&& v1, T2&& v2, fmt::string_view file, int line)
-    {
-        if(!(v1 != v2))
-        {
-            fmt::print(stderr, "{}:{}: expected {} != {}!\n", file, line, v1, v2);
-        }
-    }
-};
-
-struct rocsolver_expect_lt : rocsolver_info_accumulator
-{
-    template <typename T1, typename T2>
-    rocsolver_expect_lt(T1&& v1, T2&& v2, fmt::string_view file, int line)
-    {
-        if(!(v1 < v2))
-        {
-            fmt::print(stderr, "{}:{}: expected {} < {}!\n", file, line, v1, v2);
-        }
-    }
-};
-
-struct rocsolver_expect_le : rocsolver_info_accumulator
-{
-    template <typename T1, typename T2>
-    rocsolver_expect_le(T1&& v1, T2&& v2, fmt::string_view file, int line)
-    {
-        if(!(v1 <= v2))
-        {
-            fmt::print(stderr, "{}:{}: expected {} <= {}!\n", file, line, v1, v2);
-        }
-    }
-};
-
-struct rocsolver_expect_gt : rocsolver_info_accumulator
-{
-    template <typename T1, typename T2>
-    rocsolver_expect_gt(T1&& v1, T2&& v2, fmt::string_view file, int line)
-    {
-        if(!(v1 > v2))
-        {
-            fmt::print(stderr, "{}:{}: expected {} > {}!\n", file, line, v1, v2);
-        }
-    }
-};
-
-struct rocsolver_expect_ge : rocsolver_info_accumulator
-{
-    template <typename T1, typename T2>
-    rocsolver_expect_ge(T1&& v1, T2&& v2, fmt::string_view file, int line)
-    {
-        if(!(v1 >= v2))
-        {
-            fmt::print(stderr, "{}:{}: expected {} >= {}!\n", file, line, v1, v2);
-        }
-    }
-};
-
-#define EXPECT_EQ(v1, v2) rocsolver_expect_eq(v1, v2, __FILE__, __LINE__)
-#define EXPECT_NE(v1, v2) rocsolver_expect_ne(v1, v2, __FILE__, __LINE__)
-#define EXPECT_LT(v1, v2) rocsolver_expect_lt(v1, v2, __FILE__, __LINE__)
-#define EXPECT_LE(v1, v2) rocsolver_expect_le(v1, v2, __FILE__, __LINE__)
-#define EXPECT_GT(v1, v2) rocsolver_expect_gt(v1, v2, __FILE__, __LINE__)
-#define EXPECT_GE(v1, v2) rocsolver_expect_ge(v1, v2, __FILE__, __LINE__)
+#define EXPECT_EQ(v1, v2) \
+    rocsolver_info_accumulator {}
+#define EXPECT_NE(v1, v2) \
+    rocsolver_info_accumulator {}
+#define EXPECT_LT(v1, v2) \
+    rocsolver_info_accumulator {}
+#define EXPECT_LE(v1, v2) \
+    rocsolver_info_accumulator {}
+#define EXPECT_GT(v1, v2) \
+    rocsolver_info_accumulator {}
+#define EXPECT_GE(v1, v2) \
+    rocsolver_info_accumulator {}
 
 #endif // ROCSOLVER_CLIENTS_TEST
 

--- a/clients/rocblascommon/rocblas_test.hpp
+++ b/clients/rocblascommon/rocblas_test.hpp
@@ -103,12 +103,95 @@ inline void rocblas_expect_status(rocblas_status status, rocblas_status expect)
 
 #define EXPECT_ROCBLAS_STATUS rocblas_expect_status
 
-#define EXPECT_EQ(v1, v2)
-#define EXPECT_NE(v1, v2)
-#define EXPECT_LT(v1, v2)
-#define EXPECT_LE(v1, v2)
-#define EXPECT_GT(v1, v2)
-#define EXPECT_GE(v1, v2)
+struct rocsolver_info_accumulator
+{
+    template <typename T>
+    rocsolver_info_accumulator& operator<<(T&&)
+    {
+        // todo: implement this so rocsolver-bench can print extra
+        //       info about failures when doing error checking.
+        return *this;
+    }
+};
+
+struct rocsolver_expect_eq : rocsolver_info_accumulator
+{
+    template <typename T1, typename T2>
+    rocsolver_expect_eq(T1&& v1, T2&& v2, fmt::string_view file, int line)
+    {
+        if(!(v1 == v2))
+        {
+            fmt::print(stderr, "{}:{}: expected {} == {}!\n", file, line, v1, v2);
+        }
+    }
+};
+
+struct rocsolver_expect_ne : rocsolver_info_accumulator
+{
+    template <typename T1, typename T2>
+    rocsolver_expect_ne(T1&& v1, T2&& v2, fmt::string_view file, int line)
+    {
+        if(!(v1 != v2))
+        {
+            fmt::print(stderr, "{}:{}: expected {} != {}!\n", file, line, v1, v2);
+        }
+    }
+};
+
+struct rocsolver_expect_lt : rocsolver_info_accumulator
+{
+    template <typename T1, typename T2>
+    rocsolver_expect_lt(T1&& v1, T2&& v2, fmt::string_view file, int line)
+    {
+        if(!(v1 < v2))
+        {
+            fmt::print(stderr, "{}:{}: expected {} < {}!\n", file, line, v1, v2);
+        }
+    }
+};
+
+struct rocsolver_expect_le : rocsolver_info_accumulator
+{
+    template <typename T1, typename T2>
+    rocsolver_expect_le(T1&& v1, T2&& v2, fmt::string_view file, int line)
+    {
+        if(!(v1 <= v2))
+        {
+            fmt::print(stderr, "{}:{}: expected {} <= {}!\n", file, line, v1, v2);
+        }
+    }
+};
+
+struct rocsolver_expect_gt : rocsolver_info_accumulator
+{
+    template <typename T1, typename T2>
+    rocsolver_expect_gt(T1&& v1, T2&& v2, fmt::string_view file, int line)
+    {
+        if(!(v1 > v2))
+        {
+            fmt::print(stderr, "{}:{}: expected {} > {}!\n", file, line, v1, v2);
+        }
+    }
+};
+
+struct rocsolver_expect_ge : rocsolver_info_accumulator
+{
+    template <typename T1, typename T2>
+    rocsolver_expect_ge(T1&& v1, T2&& v2, fmt::string_view file, int line)
+    {
+        if(!(v1 >= v2))
+        {
+            fmt::print(stderr, "{}:{}: expected {} >= {}!\n", file, line, v1, v2);
+        }
+    }
+};
+
+#define EXPECT_EQ(v1, v2) rocsolver_expect_eq(v1, v2, __FILE__, __LINE__)
+#define EXPECT_NE(v1, v2) rocsolver_expect_ne(v1, v2, __FILE__, __LINE__)
+#define EXPECT_LT(v1, v2) rocsolver_expect_lt(v1, v2, __FILE__, __LINE__)
+#define EXPECT_LE(v1, v2) rocsolver_expect_le(v1, v2, __FILE__, __LINE__)
+#define EXPECT_GT(v1, v2) rocsolver_expect_gt(v1, v2, __FILE__, __LINE__)
+#define EXPECT_GE(v1, v2) rocsolver_expect_ge(v1, v2, __FILE__, __LINE__)
 
 #endif // ROCSOLVER_CLIENTS_TEST
 

--- a/clients/rocblascommon/rocblas_test.hpp
+++ b/clients/rocblascommon/rocblas_test.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2018-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2018-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -102,6 +102,96 @@ inline void rocblas_expect_status(rocblas_status status, rocblas_status expect)
 #define CHECK_DEVICE_ALLOCATION CHECK_HIP_ERROR
 
 #define EXPECT_ROCBLAS_STATUS rocblas_expect_status
+
+struct rocsolver_info_accumulator
+{
+    template <typename T>
+    rocsolver_info_accumulator& operator<<(T&&)
+    {
+        // todo: implement this so rocsolver-bench can print extra
+        //       info about failures when doing error checking.
+        return *this;
+    }
+};
+
+struct rocsolver_expect_eq : rocsolver_info_accumulator
+{
+    template <typename T1, typename T2>
+    rocsolver_expect_eq(T1&& v1, T2&& v2, fmt::string_view file, int line)
+    {
+        if(!(v1 == v2))
+        {
+            fmt::print(stderr, "{}:{}: expected {} == {}!\n", file, line, v1, v2);
+        }
+    }
+};
+
+struct rocsolver_expect_ne : rocsolver_info_accumulator
+{
+    template <typename T1, typename T2>
+    rocsolver_expect_ne(T1&& v1, T2&& v2, fmt::string_view file, int line)
+    {
+        if(!(v1 != v2))
+        {
+            fmt::print(stderr, "{}:{}: expected {} != {}!\n", file, line, v1, v2);
+        }
+    }
+};
+
+struct rocsolver_expect_lt : rocsolver_info_accumulator
+{
+    template <typename T1, typename T2>
+    rocsolver_expect_lt(T1&& v1, T2&& v2, fmt::string_view file, int line)
+    {
+        if(!(v1 < v2))
+        {
+            fmt::print(stderr, "{}:{}: expected {} < {}!\n", file, line, v1, v2);
+        }
+    }
+};
+
+struct rocsolver_expect_le : rocsolver_info_accumulator
+{
+    template <typename T1, typename T2>
+    rocsolver_expect_le(T1&& v1, T2&& v2, fmt::string_view file, int line)
+    {
+        if(!(v1 <= v2))
+        {
+            fmt::print(stderr, "{}:{}: expected {} <= {}!\n", file, line, v1, v2);
+        }
+    }
+};
+
+struct rocsolver_expect_gt : rocsolver_info_accumulator
+{
+    template <typename T1, typename T2>
+    rocsolver_expect_gt(T1&& v1, T2&& v2, fmt::string_view file, int line)
+    {
+        if(!(v1 > v2))
+        {
+            fmt::print(stderr, "{}:{}: expected {} > {}!\n", file, line, v1, v2);
+        }
+    }
+};
+
+struct rocsolver_expect_ge : rocsolver_info_accumulator
+{
+    template <typename T1, typename T2>
+    rocsolver_expect_ge(T1&& v1, T2&& v2, fmt::string_view file, int line)
+    {
+        if(!(v1 >= v2))
+        {
+            fmt::print(stderr, "{}:{}: expected {} >= {}!\n", file, line, v1, v2);
+        }
+    }
+};
+
+#define EXPECT_EQ(v1, v2) rocsolver_expect_eq(v1, v2, __FILE__, __LINE__)
+#define EXPECT_NE(v1, v2) rocsolver_expect_ne(v1, v2, __FILE__, __LINE__)
+#define EXPECT_LT(v1, v2) rocsolver_expect_lt(v1, v2, __FILE__, __LINE__)
+#define EXPECT_LE(v1, v2) rocsolver_expect_le(v1, v2, __FILE__, __LINE__)
+#define EXPECT_GT(v1, v2) rocsolver_expect_gt(v1, v2, __FILE__, __LINE__)
+#define EXPECT_GE(v1, v2) rocsolver_expect_ge(v1, v2, __FILE__, __LINE__)
 
 #endif // ROCSOLVER_CLIENTS_TEST
 


### PR DESCRIPTION
The rocsolver tests report certain error conditions (like unexpected info values) by adding a positive integer to the measured error and thereby guaranteeing that error exceeds tolerance. This can make it difficult to understand what is wrong when reviewing the logs for a failed set of tests (especially when there are multiple properties that could all increment the error).
    
The Google Test `EXPECT` functions will check a condition, but allow the test to continue. This means that an error can be recorded at the place where it occurs without losing data. The macros are defined to do nothing for rocsolver-bench, so this additional error output is only emitted in rocsolver-test.
