### PR TITLE
Add AOCL BLAS/LAPACK find modules

### DIFF
--- a/cmake/Modules/FindBLAS.cmake
+++ b/cmake/Modules/FindBLAS.cmake
@@ -122,7 +122,6 @@ BLAS/LAPACK Vendors
   AMD Core Math Library
 
 ``AOCL``, ``AOCL_mt``
-  .. versionadded:: 3.26
   AMD Optimizing CPU Libraries
 
 ``Apple``, ``NAS``

--- a/cmake/Modules/FindBLAS.cmake
+++ b/cmake/Modules/FindBLAS.cmake
@@ -1,0 +1,1416 @@
+# Copyright 2000-2022 Kitware, Inc. and Contributors
+# All rights reserved.
+# Modifications Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+# * Neither the name of Kitware, Inc. nor the names of Contributors
+#   may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#[=======================================================================[.rst:
+FindBLAS
+--------
+
+Find Basic Linear Algebra Subprograms (BLAS) library
+
+This module finds an installed Fortran library that implements the
+`BLAS linear-algebra interface`_.
+
+At least one of the ``C``, ``CXX``, or ``Fortran`` languages must be enabled.
+
+.. _`BLAS linear-algebra interface`: https://netlib.org/blas/
+
+Input Variables
+^^^^^^^^^^^^^^^
+
+The following variables may be set to influence this module's behavior:
+
+``BLA_STATIC``
+  if ``ON`` use static linkage
+
+``BLA_VENDOR``
+  Set to one of the :ref:`BLAS/LAPACK Vendors` to search for BLAS only
+  from the specified vendor.  If not set, all vendors are considered.
+
+``BLA_F95``
+  if ``ON`` tries to find the BLAS95 interfaces
+
+``BLA_PREFER_PKGCONFIG``
+  .. versionadded:: 3.11
+
+  if set ``pkg-config`` will be used to search for a BLAS library first
+  and if one is found that is preferred
+
+``BLA_PKGCONFIG_BLAS``
+  .. versionadded:: 3.25
+
+  If set, the ``pkg-config`` method will look for this module name instead of
+  just ``blas``.
+
+``BLA_SIZEOF_INTEGER``
+  .. versionadded:: 3.22
+
+  Specify the BLAS/LAPACK library integer size:
+
+  ``4``
+    Search for a BLAS/LAPACK with 32-bit integer interfaces.
+  ``8``
+    Search for a BLAS/LAPACK with 64-bit integer interfaces.
+  ``ANY``
+    Search for any BLAS/LAPACK.
+    Most likely, a BLAS/LAPACK with 32-bit integer interfaces will be found.
+
+Imported targets
+^^^^^^^^^^^^^^^^
+
+This module defines the following :prop_tgt:`IMPORTED` targets:
+
+``BLAS::BLAS``
+  .. versionadded:: 3.18
+
+  The libraries to use for BLAS, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+``BLAS_FOUND``
+  library implementing the BLAS interface is found
+``BLAS_LINKER_FLAGS``
+  uncached list of required linker flags (excluding ``-l`` and ``-L``).
+``BLAS_LIBRARIES``
+  uncached list of libraries (using full path name) to link against
+  to use BLAS (may be empty if compiler implicitly links BLAS)
+``BLAS95_LIBRARIES``
+  uncached list of libraries (using full path name) to link against
+  to use BLAS95 interface
+``BLAS95_FOUND``
+  library implementing the BLAS95 interface is found
+
+.. _`BLAS/LAPACK Vendors`:
+
+BLAS/LAPACK Vendors
+^^^^^^^^^^^^^^^^^^^
+
+``Generic``
+  Generic reference implementation
+
+``ACML``, ``ACML_MP``, ``ACML_GPU``
+  AMD Core Math Library
+
+``AOCL``, ``AOCL_mt``
+  .. versionadded:: 3.26
+  AMD Optimizing CPU Libraries
+
+``Apple``, ``NAS``
+  Apple BLAS (Accelerate), and Apple NAS (vecLib)
+
+``Arm``, ``Arm_mp``, ``Arm_ilp64``, ``Arm_ilp64_mp``
+  .. versionadded:: 3.18
+
+  Arm Performance Libraries
+
+``ATLAS``
+  Automatically Tuned Linear Algebra Software
+
+``CXML``, ``DXML``
+  Compaq/Digital Extended Math Library
+
+``EML``, ``EML_mt``
+  .. versionadded:: 3.20
+
+  Elbrus Math Library
+
+``FLAME``
+  .. versionadded:: 3.11
+
+  BLIS Framework
+
+``FlexiBLAS``
+  .. versionadded:: 3.19
+
+``Fujitsu_SSL2``, ``Fujitsu_SSL2BLAMP``, ``Fujitsu_SSL2SVE``, ``Fujitsu_SSL2BLAMPSVE``
+  .. versionadded:: 3.20
+
+  Fujitsu SSL2 serial and parallel blas/lapack with SVE instructions
+
+``Goto``
+  GotoBLAS
+
+``IBMESSL``, ``IBMESSL_SMP``
+
+  IBM Engineering and Scientific Subroutine Library
+
+``Intel``
+  Intel MKL 32 bit and 64 bit obsolete versions
+
+``Intel10_32``
+  Intel MKL v10 32 bit, threaded code
+
+``Intel10_64lp``
+  Intel MKL v10+ 64 bit, threaded code, lp64 model
+
+``Intel10_64lp_seq``
+  Intel MKL v10+ 64 bit, sequential code, lp64 model
+
+``Intel10_64ilp``
+  .. versionadded:: 3.13
+
+  Intel MKL v10+ 64 bit, threaded code, ilp64 model
+
+``Intel10_64ilp_seq``
+  .. versionadded:: 3.13
+
+  Intel MKL v10+ 64 bit, sequential code, ilp64 model
+
+``Intel10_64_dyn``
+  .. versionadded:: 3.17
+
+  Intel MKL v10+ 64 bit, single dynamic library
+
+``NVHPC``
+  .. versionadded:: 3.21
+
+  NVIDIA HPC SDK
+
+``OpenBLAS``
+  .. versionadded:: 3.6
+
+``PhiPACK``
+  Portable High Performance ANSI C (PHiPAC)
+
+``SCSL``, ``SCSL_mp``
+  Scientific Computing Software Library
+
+``SGIMATH``
+  SGI Scientific Mathematical Library
+
+``SunPerf``
+  Sun Performance Library
+
+.. _`Intel MKL`:
+
+Intel MKL
+^^^^^^^^^
+
+To use the Intel MKL implementation of BLAS, a project must enable at least
+one of the ``C`` or ``CXX`` languages.  Set ``BLA_VENDOR`` to an Intel MKL
+variant either on the command-line as ``-DBLA_VENDOR=Intel10_64lp`` or in
+project code:
+
+.. code-block:: cmake
+
+  set(BLA_VENDOR Intel10_64lp)
+  find_package(BLAS)
+
+In order to build a project using Intel MKL, and end user must first
+establish an Intel MKL environment:
+
+Intel oneAPI
+  Source the full Intel environment script:
+
+  .. code-block:: shell
+
+    . /opt/intel/oneapi/setvars.sh
+
+  Or, source the MKL component environment script:
+
+  .. code-block:: shell
+
+    . /opt/intel/oneapi/mkl/latest/env/vars.sh
+
+Intel Classic
+  Source the full Intel environment script:
+
+  .. code-block:: shell
+
+    . /opt/intel/bin/compilervars.sh intel64
+
+  Or, source the MKL component environment script:
+
+  .. code-block:: shell
+
+    . /opt/intel/mkl/bin/mklvars.sh intel64
+
+The above environment scripts set the ``MKLROOT`` environment variable
+to the top of the MKL installation.  They also add the location of the
+runtime libraries to the dynamic library loader environment variable for
+your platform (e.g. ``LD_LIBRARY_PATH``).  This is necessary for programs
+linked against MKL to run.
+
+.. note::
+
+  As of Intel oneAPI 2021.2, loading only the MKL component does not
+  make all of its dependencies available.  In particular, the ``iomp5``
+  library must be available separately, or provided by also loading
+  the compiler component environment:
+
+  .. code-block:: shell
+
+    . /opt/intel/oneapi/compiler/latest/env/vars.sh
+
+#]=======================================================================]
+
+# The approach follows that of the ``autoconf`` macro file, ``acx_blas.m4``
+# (distributed at http://ac-archive.sourceforge.net/ac-archive/acx_blas.html).
+
+# Check the language being used
+if(NOT (CMAKE_C_COMPILER_LOADED OR CMAKE_CXX_COMPILER_LOADED OR CMAKE_Fortran_COMPILER_LOADED))
+  if(BLAS_FIND_REQUIRED)
+    message(FATAL_ERROR "FindBLAS requires Fortran, C, or C++ to be enabled.")
+  else()
+    message(STATUS "Looking for BLAS... - NOT found (Unsupported languages)")
+    return()
+  endif()
+endif()
+
+function(_add_blas_target)
+  if(BLAS_FOUND AND NOT TARGET BLAS::BLAS)
+    add_library(BLAS::BLAS INTERFACE IMPORTED)
+    if(BLAS_LIBRARIES)
+      set_target_properties(BLAS::BLAS PROPERTIES
+        INTERFACE_LINK_LIBRARIES "${BLAS_LIBRARIES}"
+      )
+    endif()
+    if(BLAS_LINKER_FLAGS)
+      set_target_properties(BLAS::BLAS PROPERTIES
+        INTERFACE_LINK_OPTIONS "${BLAS_LINKER_FLAGS}"
+      )
+    endif()
+  endif()
+endfunction()
+
+if(CMAKE_Fortran_COMPILER_LOADED)
+  include(${CMAKE_CURRENT_LIST_DIR}/CheckFortranFunctionExists.cmake)
+else()
+  include(${CMAKE_CURRENT_LIST_DIR}/CheckFunctionExists.cmake)
+endif()
+include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
+
+if(BLA_PREFER_PKGCONFIG)
+  if(NOT BLA_PKGCONFIG_BLAS)
+    set(BLA_PKGCONFIG_BLAS "blas")
+  endif()
+  find_package(PkgConfig QUIET)
+  pkg_check_modules(PKGC_BLAS QUIET ${BLA_PKGCONFIG_BLAS})
+  if(PKGC_BLAS_FOUND)
+    set(BLAS_FOUND ${PKGC_BLAS_FOUND})
+    set(BLAS_LIBRARIES "${PKGC_BLAS_LINK_LIBRARIES}")
+    _add_blas_target()
+    return()
+  endif()
+endif()
+
+# TODO: move this stuff to a separate module
+
+function(CHECK_BLAS_LIBRARIES LIBRARIES _prefix _name _flags _list _deps _addlibdir _subdirs)
+  # This function checks for the existence of the combination of libraries
+  # given by _list.  If the combination is found, this checks whether can link
+  # against that library combination using the name of a routine given by _name
+  # using the linker flags given by _flags.  If the combination of libraries is
+  # found and passes the link test, ${LIBRARIES} is set to the list of complete
+  # library paths that have been found.  Otherwise, ${LIBRARIES} is set to FALSE.
+
+  set(_libraries_work TRUE)
+  set(_libraries)
+  set(_combined_name)
+
+  if(BLA_STATIC)
+    if(WIN32)
+      set(CMAKE_FIND_LIBRARY_SUFFIXES .lib ${CMAKE_FIND_LIBRARY_SUFFIXES})
+    else()
+      set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+    endif()
+  else()
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+      # for ubuntu's libblas3gf and liblapack3gf packages
+      set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} .so.3gf)
+    endif()
+  endif()
+
+  set(_extaddlibdir "${_addlibdir}")
+  if(WIN32)
+    list(APPEND _extaddlibdir ENV LIB)
+  elseif(APPLE)
+    list(APPEND _extaddlibdir ENV DYLD_LIBRARY_PATH)
+  else()
+    list(APPEND _extaddlibdir ENV LD_LIBRARY_PATH)
+  endif()
+  list(APPEND _extaddlibdir "${CMAKE_C_IMPLICIT_LINK_DIRECTORIES}")
+
+  foreach(_library ${_list})
+    if(_library MATCHES "^-")
+      # Respect linker flags as-is (required by MKL)
+      list(APPEND _libraries "${_library}")
+    else()
+      string(REGEX REPLACE "[^A-Za-z0-9]" "_" _lib_var "${_library}")
+      string(APPEND _combined_name "_${_lib_var}")
+      if(NOT "${_deps}" STREQUAL "")
+        string(APPEND _combined_name "_deps")
+      endif()
+      if(_libraries_work)
+        find_library(${_prefix}_${_lib_var}_LIBRARY
+          NAMES ${_library}
+          NAMES_PER_DIR
+          PATHS ${_extaddlibdir}
+          PATH_SUFFIXES ${_subdirs}
+        )
+        mark_as_advanced(${_prefix}_${_lib_var}_LIBRARY)
+        list(APPEND _libraries ${${_prefix}_${_lib_var}_LIBRARY})
+        set(_libraries_work ${${_prefix}_${_lib_var}_LIBRARY})
+      endif()
+    endif()
+  endforeach()
+
+  foreach(_flag ${_flags})
+    string(REGEX REPLACE "[^A-Za-z0-9]" "_" _flag_var "${_flag}")
+    string(APPEND _combined_name "_${_flag_var}")
+  endforeach()
+  if(_libraries_work)
+    # Test this combination of libraries.
+    set(CMAKE_REQUIRED_LIBRARIES ${_flags} ${_libraries} ${_deps})
+    set(CMAKE_REQUIRED_QUIET ${BLAS_FIND_QUIETLY})
+    if(CMAKE_Fortran_COMPILER_LOADED)
+      check_fortran_function_exists("${_name}" ${_prefix}${_combined_name}_WORKS)
+    else()
+      check_function_exists("${_name}_" ${_prefix}${_combined_name}_WORKS)
+    endif()
+    set(CMAKE_REQUIRED_LIBRARIES)
+    set(_libraries_work ${${_prefix}${_combined_name}_WORKS})
+  endif()
+
+  if(_libraries_work)
+    if("${_list}" STREQUAL "")
+      set(_libraries "${LIBRARIES}-PLACEHOLDER-FOR-EMPTY-LIBRARIES")
+    else()
+      list(APPEND _libraries ${_deps})
+    endif()
+  else()
+    set(_libraries FALSE)
+  endif()
+  set(${LIBRARIES} "${_libraries}" PARENT_SCOPE)
+endfunction()
+
+set(BLAS_LINKER_FLAGS)
+set(BLAS_LIBRARIES)
+set(BLAS95_LIBRARIES)
+set(_blas_fphsa_req_var BLAS_LIBRARIES)
+if(NOT $ENV{BLA_VENDOR} STREQUAL "")
+  set(BLA_VENDOR $ENV{BLA_VENDOR})
+else()
+  if(NOT BLA_VENDOR)
+    set(BLA_VENDOR "All")
+  endif()
+endif()
+
+if(NOT BLA_SIZEOF_INTEGER)
+  # in the reality we do not know which API of BLAS/LAPACK is masked in library
+  set(_blas_sizeof_integer "ANY")
+elseif((BLA_SIZEOF_INTEGER STREQUAL "ANY") OR
+       (BLA_SIZEOF_INTEGER STREQUAL "4") OR
+       (BLA_SIZEOF_INTEGER STREQUAL "8"))
+  set(_blas_sizeof_integer ${BLA_SIZEOF_INTEGER})
+else()
+  message(FATAL_ERROR "BLA_SIZEOF_INTEGER can have only <no value>, ANY, 4, or 8 values")
+endif()
+
+# Implicitly linked BLAS libraries?
+if(BLA_VENDOR STREQUAL "All")
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      ""
+      ""
+      ""
+      ""
+      )
+  endif()
+  if(BLAS_WORKS)
+    # Give a more helpful "found" message
+    set(BLAS_WORKS "implicitly linked")
+    set(_blas_fphsa_req_var BLAS_WORKS)
+  endif()
+endif()
+
+# BLAS in the Intel MKL 10+ library?
+if(BLA_VENDOR MATCHES "Intel" OR BLA_VENDOR STREQUAL "All")
+  if(NOT BLAS_LIBRARIES)
+    if(CMAKE_C_COMPILER_LOADED OR CMAKE_CXX_COMPILER_LOADED)
+      # System-specific settings
+      if(WIN32)
+        if(BLA_STATIC)
+          set(BLAS_mkl_DLL_SUFFIX "")
+        else()
+          set(BLAS_mkl_DLL_SUFFIX "_dll")
+        endif()
+      else()
+        if(BLA_STATIC)
+          set(BLAS_mkl_START_GROUP "-Wl,--start-group")
+          set(BLAS_mkl_END_GROUP "-Wl,--end-group")
+        else()
+          set(BLAS_mkl_START_GROUP "")
+          set(BLAS_mkl_END_GROUP "")
+        endif()
+        # Switch to GNU Fortran support layer if needed (but not on Apple, where MKL does not provide it)
+        if(CMAKE_Fortran_COMPILER_LOADED AND (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU" OR CMAKE_Fortran_COMPILER_ID STREQUAL "LCC") AND NOT APPLE)
+            set(BLAS_mkl_INTFACE "gf")
+            set(BLAS_mkl_THREADING "gnu")
+            set(BLAS_mkl_OMP "gomp")
+        else()
+            set(BLAS_mkl_INTFACE "intel")
+            set(BLAS_mkl_THREADING "intel")
+            set(BLAS_mkl_OMP "iomp5")
+        endif()
+        set(BLAS_mkl_LM "-lm")
+        set(BLAS_mkl_LDL "-ldl")
+      endif()
+
+      if(BLAS_FIND_QUIETLY OR NOT BLAS_FIND_REQUIRED)
+        find_package(Threads)
+      else()
+        find_package(Threads REQUIRED)
+      endif()
+
+      if(_blas_sizeof_integer EQUAL 8)
+        set(BLAS_mkl_ILP_MODE "ilp64")
+      elseif(_blas_sizeof_integer EQUAL 4)
+        set(BLAS_mkl_ILP_MODE "lp64")
+      else()
+        if(BLA_VENDOR MATCHES "_64ilp")
+          set(BLAS_mkl_ILP_MODE "ilp64")
+        else()
+          set(BLAS_mkl_ILP_MODE "lp64")
+        endif()
+      endif()
+
+      set(BLAS_SEARCH_LIBS "")
+
+      if(BLA_F95)
+        set(BLAS_mkl_SEARCH_SYMBOL "sgemm_f95")
+        set(_BLAS_LIBRARIES BLAS95_LIBRARIES)
+        if(WIN32)
+          # Find the main file (32-bit or 64-bit)
+          set(BLAS_SEARCH_LIBS_WIN_MAIN "")
+          if(BLA_VENDOR STREQUAL "Intel10_32" OR BLA_VENDOR STREQUAL "All")
+            list(APPEND BLAS_SEARCH_LIBS_WIN_MAIN
+              "mkl_blas95${BLAS_mkl_DLL_SUFFIX} mkl_intel_c${BLAS_mkl_DLL_SUFFIX}")
+          endif()
+
+          if(BLA_VENDOR MATCHES "^Intel10_64i?lp" OR BLA_VENDOR STREQUAL "All")
+            list(APPEND BLAS_SEARCH_LIBS_WIN_MAIN
+              "mkl_blas95_${BLAS_mkl_ILP_MODE}${BLAS_mkl_DLL_SUFFIX} mkl_intel_${BLAS_mkl_ILP_MODE}${BLAS_mkl_DLL_SUFFIX}")
+          endif()
+
+          # Add threading/sequential libs
+          set(BLAS_SEARCH_LIBS_WIN_THREAD "")
+          if(BLA_VENDOR MATCHES "^Intel10_64i?lp$" OR BLA_VENDOR STREQUAL "All")
+            # old version
+            list(APPEND BLAS_SEARCH_LIBS_WIN_THREAD
+              "libguide40 mkl_intel_thread${BLAS_mkl_DLL_SUFFIX}")
+            # mkl >= 10.3
+            list(APPEND BLAS_SEARCH_LIBS_WIN_THREAD
+              "libiomp5md mkl_intel_thread${BLAS_mkl_DLL_SUFFIX}")
+          endif()
+          if(BLA_VENDOR MATCHES "^Intel10_64i?lp_seq$" OR BLA_VENDOR STREQUAL "All")
+            list(APPEND BLAS_SEARCH_LIBS_WIN_THREAD
+              "mkl_sequential${BLAS_mkl_DLL_SUFFIX}")
+          endif()
+
+          # Cartesian product of the above
+          foreach(MAIN ${BLAS_SEARCH_LIBS_WIN_MAIN})
+            foreach(THREAD ${BLAS_SEARCH_LIBS_WIN_THREAD})
+              list(APPEND BLAS_SEARCH_LIBS
+                "${MAIN} ${THREAD} mkl_core${BLAS_mkl_DLL_SUFFIX}")
+            endforeach()
+          endforeach()
+        else()
+          if(BLA_VENDOR STREQUAL "Intel10_32" OR BLA_VENDOR STREQUAL "All")
+            # old version
+            list(APPEND BLAS_SEARCH_LIBS
+              "mkl_blas95 mkl_${BLAS_mkl_INTFACE} mkl_${BLAS_mkl_THREADING}_thread mkl_core guide")
+
+            # mkl >= 10.3
+            list(APPEND BLAS_SEARCH_LIBS
+              "${BLAS_mkl_START_GROUP} mkl_blas95 mkl_${BLAS_mkl_INTFACE} mkl_${BLAS_mkl_THREADING}_thread mkl_core ${BLAS_mkl_END_GROUP} ${BLAS_mkl_OMP}")
+          endif()
+          if(BLA_VENDOR MATCHES "^Intel10_64i?lp$" OR BLA_VENDOR STREQUAL "All")
+            # old version
+            list(APPEND BLAS_SEARCH_LIBS
+              "mkl_blas95 mkl_${BLAS_mkl_INTFACE}_${BLAS_mkl_ILP_MODE} mkl_${BLAS_mkl_THREADING}_thread mkl_core guide")
+
+            # mkl >= 10.3
+            list(APPEND BLAS_SEARCH_LIBS
+              "${BLAS_mkl_START_GROUP} mkl_blas95_${BLAS_mkl_ILP_MODE} mkl_${BLAS_mkl_INTFACE}_${BLAS_mkl_ILP_MODE} mkl_${BLAS_mkl_THREADING}_thread mkl_core ${BLAS_mkl_END_GROUP} ${BLAS_mkl_OMP}")
+          endif()
+          if(BLA_VENDOR MATCHES "^Intel10_64i?lp_seq$" OR BLA_VENDOR STREQUAL "All")
+            list(APPEND BLAS_SEARCH_LIBS
+              "${BLAS_mkl_START_GROUP} mkl_blas95_${BLAS_mkl_ILP_MODE} mkl_${BLAS_mkl_INTFACE}_${BLAS_mkl_ILP_MODE} mkl_sequential mkl_core ${BLAS_mkl_END_GROUP}")
+          endif()
+        endif()
+      else()
+        set(BLAS_mkl_SEARCH_SYMBOL sgemm)
+        set(_BLAS_LIBRARIES BLAS_LIBRARIES)
+        if(WIN32)
+          # Find the main file (32-bit or 64-bit)
+          set(BLAS_SEARCH_LIBS_WIN_MAIN "")
+          if(BLA_VENDOR STREQUAL "Intel10_32" OR BLA_VENDOR STREQUAL "All")
+            list(APPEND BLAS_SEARCH_LIBS_WIN_MAIN
+              "mkl_intel_c${BLAS_mkl_DLL_SUFFIX}")
+          endif()
+          if(BLA_VENDOR MATCHES "^Intel10_64i?lp" OR BLA_VENDOR STREQUAL "All")
+            list(APPEND BLAS_SEARCH_LIBS_WIN_MAIN
+              "mkl_intel_${BLAS_mkl_ILP_MODE}${BLAS_mkl_DLL_SUFFIX}")
+          endif()
+
+          # Add threading/sequential libs
+          set(BLAS_SEARCH_LIBS_WIN_THREAD "")
+          if(BLA_VENDOR STREQUAL "Intel10_32" OR BLA_VENDOR STREQUAL "All")
+            list(APPEND BLAS_SEARCH_LIBS_WIN_THREAD
+              "libiomp5md mkl_intel_thread${BLAS_mkl_DLL_SUFFIX}")
+          endif()
+          if(BLA_VENDOR MATCHES "^Intel10_64i?lp$" OR BLA_VENDOR STREQUAL "All")
+            # old version
+            list(APPEND BLAS_SEARCH_LIBS_WIN_THREAD
+              "libguide40 mkl_intel_thread${BLAS_mkl_DLL_SUFFIX}")
+            # mkl >= 10.3
+            list(APPEND BLAS_SEARCH_LIBS_WIN_THREAD
+              "libiomp5md mkl_intel_thread${BLAS_mkl_DLL_SUFFIX}")
+          endif()
+          if(BLA_VENDOR MATCHES "^Intel10_64i?lp_seq$" OR BLA_VENDOR STREQUAL "All")
+            list(APPEND BLAS_SEARCH_LIBS_WIN_THREAD
+              "mkl_sequential${BLAS_mkl_DLL_SUFFIX}")
+          endif()
+
+          # Cartesian product of the above
+          foreach(MAIN ${BLAS_SEARCH_LIBS_WIN_MAIN})
+            foreach(THREAD ${BLAS_SEARCH_LIBS_WIN_THREAD})
+              list(APPEND BLAS_SEARCH_LIBS
+                "${MAIN} ${THREAD} mkl_core${BLAS_mkl_DLL_SUFFIX}")
+            endforeach()
+          endforeach()
+        else()
+          if(BLA_VENDOR STREQUAL "Intel10_32" OR BLA_VENDOR STREQUAL "All")
+            # old version
+            list(APPEND BLAS_SEARCH_LIBS
+              "mkl_${BLAS_mkl_INTFACE} mkl_${BLAS_mkl_THREADING}_thread mkl_core guide")
+
+            # mkl >= 10.3
+            list(APPEND BLAS_SEARCH_LIBS
+              "${BLAS_mkl_START_GROUP} mkl_${BLAS_mkl_INTFACE} mkl_${BLAS_mkl_THREADING}_thread mkl_core ${BLAS_mkl_END_GROUP} ${BLAS_mkl_OMP}")
+          endif()
+          if(BLA_VENDOR MATCHES "^Intel10_64i?lp$" OR BLA_VENDOR STREQUAL "All")
+            # old version
+            list(APPEND BLAS_SEARCH_LIBS
+              "mkl_${BLAS_mkl_INTFACE}_${BLAS_mkl_ILP_MODE} mkl_${BLAS_mkl_THREADING}_thread mkl_core guide")
+
+            # mkl >= 10.3
+            list(APPEND BLAS_SEARCH_LIBS
+              "${BLAS_mkl_START_GROUP} mkl_${BLAS_mkl_INTFACE}_${BLAS_mkl_ILP_MODE} mkl_${BLAS_mkl_THREADING}_thread mkl_core ${BLAS_mkl_END_GROUP} ${BLAS_mkl_OMP}")
+          endif()
+          if(BLA_VENDOR MATCHES "^Intel10_64i?lp_seq$" OR BLA_VENDOR STREQUAL "All")
+            list(APPEND BLAS_SEARCH_LIBS
+              "${BLAS_mkl_START_GROUP} mkl_${BLAS_mkl_INTFACE}_${BLAS_mkl_ILP_MODE} mkl_sequential mkl_core ${BLAS_mkl_END_GROUP}")
+          endif()
+
+          #older versions of intel mkl libs
+          if(BLA_VENDOR STREQUAL "Intel" OR BLA_VENDOR STREQUAL "All")
+            list(APPEND BLAS_SEARCH_LIBS
+              "mkl")
+            list(APPEND BLAS_SEARCH_LIBS
+              "mkl_ia32")
+            list(APPEND BLAS_SEARCH_LIBS
+              "mkl_em64t")
+          endif()
+        endif()
+      endif()
+
+      if(BLA_VENDOR MATCHES "^Intel10_64_dyn$" OR BLA_VENDOR STREQUAL "All")
+        # mkl >= 10.3 with single dynamic library
+        list(APPEND BLAS_SEARCH_LIBS
+          "mkl_rt")
+      endif()
+
+      # MKL uses a multitude of partially platform-specific subdirectories:
+      if(BLA_VENDOR STREQUAL "Intel10_32")
+        set(BLAS_mkl_ARCH_NAME "ia32")
+      else()
+        set(BLAS_mkl_ARCH_NAME "intel64")
+      endif()
+      if(WIN32)
+        set(BLAS_mkl_OS_NAME "win")
+      elseif(APPLE)
+        set(BLAS_mkl_OS_NAME "mac")
+      else()
+        set(BLAS_mkl_OS_NAME "lin")
+      endif()
+      if(DEFINED ENV{MKLROOT})
+        file(TO_CMAKE_PATH "$ENV{MKLROOT}" BLAS_mkl_MKLROOT)
+        # If MKLROOT points to the subdirectory 'mkl', use the parent directory instead
+        # so we can better detect other relevant libraries in 'compiler' or 'tbb':
+        get_filename_component(BLAS_mkl_MKLROOT_LAST_DIR "${BLAS_mkl_MKLROOT}" NAME)
+        if(BLAS_mkl_MKLROOT_LAST_DIR STREQUAL "mkl")
+            get_filename_component(BLAS_mkl_MKLROOT "${BLAS_mkl_MKLROOT}" DIRECTORY)
+        endif()
+      endif()
+      set(BLAS_mkl_LIB_PATH_SUFFIXES
+          "compiler/lib" "compiler/lib/${BLAS_mkl_ARCH_NAME}_${BLAS_mkl_OS_NAME}"
+          "compiler/lib/${BLAS_mkl_ARCH_NAME}"
+          "mkl/lib" "mkl/lib/${BLAS_mkl_ARCH_NAME}_${BLAS_mkl_OS_NAME}"
+          "mkl/lib/${BLAS_mkl_ARCH_NAME}"
+          "lib" "lib/${BLAS_mkl_ARCH_NAME}_${BLAS_mkl_OS_NAME}"
+          "lib/${BLAS_mkl_ARCH_NAME}"
+          )
+
+      foreach(_search ${BLAS_SEARCH_LIBS})
+        string(REPLACE " " ";" _search ${_search})
+        if(NOT ${_BLAS_LIBRARIES})
+          check_blas_libraries(
+            ${_BLAS_LIBRARIES}
+            BLAS
+            ${BLAS_mkl_SEARCH_SYMBOL}
+            ""
+            "${_search}"
+            "${CMAKE_THREAD_LIBS_INIT};${BLAS_mkl_LM};${BLAS_mkl_LDL}"
+            "${BLAS_mkl_MKLROOT}"
+            "${BLAS_mkl_LIB_PATH_SUFFIXES}"
+            )
+        endif()
+      endforeach()
+
+      unset(_search)
+      unset(BLAS_mkl_ILP_MODE)
+      unset(BLAS_mkl_INTFACE)
+      unset(BLAS_mkl_THREADING)
+      unset(BLAS_mkl_OMP)
+      unset(BLAS_mkl_DLL_SUFFIX)
+      unset(BLAS_mkl_LM)
+      unset(BLAS_mkl_LDL)
+      unset(BLAS_mkl_MKLROOT)
+      unset(BLAS_mkl_MKLROOT_LAST_DIR)
+      unset(BLAS_mkl_ARCH_NAME)
+      unset(BLAS_mkl_OS_NAME)
+      unset(BLAS_mkl_LIB_PATH_SUFFIXES)
+    endif()
+  endif()
+endif()
+
+if(BLA_F95)
+  find_package_handle_standard_args(BLAS REQUIRED_VARS BLAS95_LIBRARIES)
+  set(BLAS95_FOUND ${BLAS_FOUND})
+  if(BLAS_FOUND)
+    set(BLAS_LIBRARIES "${BLAS95_LIBRARIES}")
+  endif()
+endif()
+
+# gotoblas? (http://www.tacc.utexas.edu/tacc-projects/gotoblas2)
+if(BLA_VENDOR STREQUAL "Goto" OR BLA_VENDOR STREQUAL "All")
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "goto2"
+      ""
+      ""
+      ""
+      )
+  endif()
+endif()
+
+# FlexiBLAS? (http://www.mpi-magdeburg.mpg.de/mpcsc/software/FlexiBLAS/)
+if(BLA_VENDOR STREQUAL "FlexiBLAS" OR BLA_VENDOR STREQUAL "All")
+  set(_blas_flexiblas_lib "flexiblas")
+
+  if(_blas_sizeof_integer EQUAL 8)
+    string(APPEND _blas_flexiblas_lib "64")
+  endif()
+
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "${_blas_flexiblas_lib}"
+      ""
+      ""
+      ""
+      )
+  endif()
+
+  unset(_blas_flexiblas_lib)
+endif()
+
+# OpenBLAS? (http://www.openblas.net)
+if(BLA_VENDOR STREQUAL "OpenBLAS" OR BLA_VENDOR STREQUAL "All")
+  set(_blas_openblas_lib "openblas")
+
+  if(_blas_sizeof_integer EQUAL 8)
+    string(APPEND _blas_openblas_lib "64")
+  endif()
+
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "${_blas_openblas_lib}"
+      ""
+      ""
+      ""
+      )
+  endif()
+  if(NOT BLAS_LIBRARIES AND (CMAKE_C_COMPILER_LOADED OR CMAKE_CXX_COMPILER_LOADED))
+    if(BLAS_FIND_QUIETLY OR NOT BLAS_FIND_REQUIRED)
+      find_package(Threads)
+    else()
+      find_package(Threads REQUIRED)
+    endif()
+    set(_threadlibs "${CMAKE_THREAD_LIBS_INIT}")
+    if(BLA_STATIC)
+      if (CMAKE_C_COMPILER_LOADED)
+        find_package(OpenMP QUIET COMPONENTS C)
+        list(PREPEND _threadlibs "${OpenMP_C_LIBRARIES}")
+      elseif(CMAKE_CXX_COMPILER_LOADED)
+        find_package(OpenMP QUIET COMPONENTS CXX)
+        list(PREPEND _threadlibs "${OpenMP_CXX_LIBRARIES}")
+      endif()
+    endif()
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "${_blas_openblas_lib}"
+      "${_threadlibs}"
+      ""
+      ""
+      )
+    unset(_threadlibs)
+  endif()
+
+  unset(_blas_openblas_lib)
+endif()
+
+# ArmPL blas library? (https://developer.arm.com/tools-and-software/server-and-hpc/compile/arm-compiler-for-linux/arm-performance-libraries)
+if(BLA_VENDOR MATCHES "Arm" OR BLA_VENDOR STREQUAL "All")
+
+   # Check for 64bit Integer support
+  if(_blas_sizeof_integer EQUAL 8)
+    set(_blas_armpl_lib "armpl_ilp64")
+  elseif(_blas_sizeof_integer EQUAL 4)
+    set(_blas_armpl_lib "armpl_lp64")
+  else()
+    if(BLA_VENDOR MATCHES "_ilp64")
+      set(_blas_armpl_lib "armpl_ilp64")
+    else()
+      set(_blas_armpl_lib "armpl_lp64")
+    endif()
+  endif()
+
+   # Check for OpenMP support, VIA BLA_VENDOR of Arm_mp or Arm_ipl64_mp
+   if(BLA_VENDOR MATCHES "_mp")
+     string(APPEND _blas_armpl_lib "_mp")
+   endif()
+
+   if(NOT BLAS_LIBRARIES)
+     check_blas_libraries(
+       BLAS_LIBRARIES
+       BLAS
+       sgemm
+       ""
+       "${_blas_armpl_lib}"
+       ""
+       ""
+       ""
+       )
+  endif()
+  unset(_blas_armpl_lib)
+endif()
+
+# FLAME's blis library? (https://github.com/flame/blis)
+if(BLA_VENDOR STREQUAL "FLAME" OR BLA_VENDOR STREQUAL "All")
+  set(_blas_flame_lib "blis")
+
+  if(_blas_sizeof_integer EQUAL 8)
+    string(APPEND _blas_flame_lib "64")
+  endif()
+
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "${_blas_flame_lib}"
+      ""
+      ""
+      ""
+      )
+  endif()
+
+  unset(_blas_flame_lib)
+endif()
+
+# AOCL's blis library? (https://developer.amd.com/amd-aocl/)
+if(BLA_VENDOR MATCHES "AOCL" OR BLA_VENDOR STREQUAL "All")
+  set(_blas_aocl_lib "blis")
+
+  if(_blas_sizeof_integer EQUAL 8)
+    set(_blas_aocl_subdir "ILP64")
+  else()
+    set(_blas_aocl_subdir "LP64")
+  endif()
+
+  # Check for multi-threaded support
+  if(BLA_VENDOR MATCHES "_mt")
+    string(APPEND _blas_aocl_lib "-mt")
+  endif()
+
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "${_blas_aocl_lib}"
+      ""
+      ""
+      "${_blas_aocl_subdir}"
+      )
+  endif()
+
+  unset(_blas_aocl_lib)
+  unset(_blas_aocl_subdir)
+endif()
+
+# BLAS in the ATLAS library? (http://math-atlas.sourceforge.net/)
+if(BLA_VENDOR STREQUAL "ATLAS" OR BLA_VENDOR STREQUAL "All")
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      dgemm
+      ""
+      "blas;f77blas;atlas"
+      ""
+      ""
+      ""
+      )
+  endif()
+endif()
+
+# BLAS in PhiPACK libraries? (requires generic BLAS lib, too)
+if(BLA_VENDOR STREQUAL "PhiPACK" OR BLA_VENDOR STREQUAL "All")
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "sgemm;dgemm;blas"
+      ""
+      ""
+      ""
+      )
+  endif()
+endif()
+
+# BLAS in Alpha CXML library?
+if(BLA_VENDOR STREQUAL "CXML" OR BLA_VENDOR STREQUAL "All")
+  if(_blas_sizeof_integer EQUAL 8)
+    if(BLA_VENDOR STREQUAL "CXML")
+      message(FATAL_ERROR "CXML does not support Int64 type")
+    endif()
+  else()
+    if(NOT BLAS_LIBRARIES)
+      check_blas_libraries(
+        BLAS_LIBRARIES
+        BLAS
+        sgemm
+        ""
+        "cxml"
+        ""
+        ""
+        ""
+        )
+    endif()
+  endif()
+endif()
+
+# BLAS in Alpha DXML library? (now called CXML, see above)
+if(BLA_VENDOR STREQUAL "DXML" OR BLA_VENDOR STREQUAL "All")
+  if(_blas_sizeof_integer EQUAL 8)
+    if(BLA_VENDOR STREQUAL "DXML")
+      message(FATAL_ERROR "DXML does not support Int64 type")
+    endif()
+  else()
+    if(NOT BLAS_LIBRARIES)
+      check_blas_libraries(
+        BLAS_LIBRARIES
+        BLAS
+        sgemm
+        ""
+        "dxml"
+        ""
+        ""
+        ""
+        )
+    endif()
+  endif()
+endif()
+
+# BLAS in Sun Performance library?
+if(BLA_VENDOR STREQUAL "SunPerf" OR BLA_VENDOR STREQUAL "All")
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      "-xlic_lib=sunperf"
+      "sunperf;sunmath"
+      ""
+      ""
+      ""
+      )
+    if(BLAS_LIBRARIES)
+      set(BLAS_LINKER_FLAGS "-xlic_lib=sunperf")
+    endif()
+  endif()
+endif()
+
+# BLAS in SCSL library?  (SGI/Cray Scientific Library)
+if(BLA_VENDOR MATCHES "SCSL" OR BLA_VENDOR STREQUAL "All")
+  set(_blas_scsl_lib "scs")
+
+  if(_blas_sizeof_integer EQUAL 8)
+    string(APPEND _blas_scsl_lib "_i8")
+  endif()
+  if(BLA_VENDOR MATCHES "_mp")
+    string(APPEND _blas_scsl_lib "_mp")
+  endif()
+
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "${_blas_scsl_lib}"
+      ""
+      ""
+      ""
+      )
+  endif()
+
+  unset(_blas_scsl_lib)
+endif()
+
+# BLAS in SGIMATH library?
+if(BLA_VENDOR STREQUAL "SGIMATH" OR BLA_VENDOR STREQUAL "All")
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "complib.sgimath"
+      ""
+      ""
+      ""
+      )
+  endif()
+endif()
+
+# BLAS in IBM ESSL library?
+if(BLA_VENDOR MATCHES "IBMESSL" OR BLA_VENDOR STREQUAL "All")
+  set(_blas_essl_lib "essl")
+
+  if(BLA_VENDOR MATCHES "_SMP")
+    string(APPEND _blas_essl_lib "smp")
+  endif()
+  if(_blas_sizeof_integer EQUAL 8)
+    string(APPEND _blas_essl_lib "6464")
+  endif()
+
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "${_blas_essl_lib}"
+      ""
+      ""
+      ""
+      )
+  endif()
+
+  unset(_blas_essl_lib)
+endif()
+
+# BLAS in acml library?
+if(BLA_VENDOR MATCHES "ACML" OR BLA_VENDOR STREQUAL "All")
+  if(((BLA_VENDOR STREQUAL "ACML") AND (NOT BLAS_ACML_LIB_DIRS)) OR
+    ((BLA_VENDOR STREQUAL "ACML_MP") AND (NOT BLAS_ACML_MP_LIB_DIRS)) OR
+    ((BLA_VENDOR STREQUAL "ACML_GPU") AND (NOT BLAS_ACML_GPU_LIB_DIRS))
+    )
+  # try to find acml in "standard" paths
+  if(WIN32)
+    file(GLOB _ACML_ROOT "C:/AMD/acml*/ACML-EULA.txt")
+  else()
+    file(GLOB _ACML_ROOT "/opt/acml*/ACML-EULA.txt")
+  endif()
+  if(WIN32)
+    file(GLOB _ACML_GPU_ROOT "C:/AMD/acml*/GPGPUexamples")
+  else()
+    file(GLOB _ACML_GPU_ROOT "/opt/acml*/GPGPUexamples")
+  endif()
+  list(GET _ACML_ROOT 0 _ACML_ROOT)
+  list(GET _ACML_GPU_ROOT 0 _ACML_GPU_ROOT)
+  if(_ACML_ROOT)
+    get_filename_component(_ACML_ROOT ${_ACML_ROOT} PATH)
+    if(_blas_sizeof_integer EQUAL 8)
+      set(_ACML_PATH_SUFFIX "_int64")
+    else()
+      set(_ACML_PATH_SUFFIX "")
+    endif()
+    if(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
+      set(_ACML_COMPILER32 "ifort32")
+      set(_ACML_COMPILER64 "ifort64")
+    elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM")
+      # 32-bit not supported
+      set(_ACML_COMPILER64 "ifx")
+    elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "SunPro")
+      set(_ACML_COMPILER32 "sun32")
+      set(_ACML_COMPILER64 "sun64")
+    elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "PGI")
+      set(_ACML_COMPILER32 "pgi32")
+      if(WIN32)
+        set(_ACML_COMPILER64 "win64")
+      else()
+        set(_ACML_COMPILER64 "pgi64")
+      endif()
+    elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Open64")
+      # 32 bit builds not supported on Open64 but for code simplicity
+      # We'll just use the same directory twice
+      set(_ACML_COMPILER32 "open64_64")
+      set(_ACML_COMPILER64 "open64_64")
+    elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "NAG")
+      set(_ACML_COMPILER32 "nag32")
+      set(_ACML_COMPILER64 "nag64")
+    else()
+      set(_ACML_COMPILER32 "gfortran32")
+      set(_ACML_COMPILER64 "gfortran64")
+    endif()
+
+    if(BLA_VENDOR STREQUAL "ACML_MP")
+      set(_ACML_MP_LIB_DIRS
+        "${_ACML_ROOT}/${_ACML_COMPILER32}_mp${_ACML_PATH_SUFFIX}/lib"
+        "${_ACML_ROOT}/${_ACML_COMPILER64}_mp${_ACML_PATH_SUFFIX}/lib")
+    else()
+      set(_ACML_LIB_DIRS
+        "${_ACML_ROOT}/${_ACML_COMPILER32}${_ACML_PATH_SUFFIX}/lib"
+        "${_ACML_ROOT}/${_ACML_COMPILER64}${_ACML_PATH_SUFFIX}/lib")
+    endif()
+  endif()
+elseif(BLAS_${BLA_VENDOR}_LIB_DIRS)
+  set(_${BLA_VENDOR}_LIB_DIRS ${BLAS_${BLA_VENDOR}_LIB_DIRS})
+endif()
+
+if(BLA_VENDOR STREQUAL "ACML_MP")
+  foreach(BLAS_ACML_MP_LIB_DIRS ${_ACML_MP_LIB_DIRS})
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      "" "acml_mp;acml_mv" "" ${BLAS_ACML_MP_LIB_DIRS} ""
+      )
+    if(BLAS_LIBRARIES)
+      break()
+    endif()
+  endforeach()
+elseif(BLA_VENDOR STREQUAL "ACML_GPU")
+  foreach(BLAS_ACML_GPU_LIB_DIRS ${_ACML_GPU_LIB_DIRS})
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      "" "acml;acml_mv;CALBLAS" "" ${BLAS_ACML_GPU_LIB_DIRS} ""
+      )
+    if(BLAS_LIBRARIES)
+      break()
+    endif()
+  endforeach()
+else()
+  foreach(BLAS_ACML_LIB_DIRS ${_ACML_LIB_DIRS})
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      "" "acml;acml_mv" "" ${BLAS_ACML_LIB_DIRS} ""
+      )
+    if(BLAS_LIBRARIES)
+      break()
+    endif()
+  endforeach()
+endif()
+
+# Either acml or acml_mp should be in LD_LIBRARY_PATH but not both
+if(NOT BLAS_LIBRARIES)
+  check_blas_libraries(
+    BLAS_LIBRARIES
+    BLAS
+    sgemm
+    ""
+    "acml;acml_mv"
+    ""
+    ""
+    ""
+    )
+endif()
+if(NOT BLAS_LIBRARIES)
+  check_blas_libraries(
+    BLAS_LIBRARIES
+    BLAS
+    sgemm
+    ""
+    "acml_mp;acml_mv"
+    ""
+    ""
+    ""
+    )
+endif()
+if(NOT BLAS_LIBRARIES)
+  check_blas_libraries(
+    BLAS_LIBRARIES
+    BLAS
+    sgemm
+    ""
+    "acml;acml_mv;CALBLAS"
+    ""
+    ""
+    ""
+    )
+endif()
+endif() # ACML
+
+# Apple BLAS library?
+if(BLA_VENDOR STREQUAL "Apple" OR BLA_VENDOR STREQUAL "All")
+  if(_blas_sizeof_integer EQUAL 8)
+    if(BLA_VENDOR STREQUAL "Apple")
+      message(FATAL_ERROR "Accelerate Framework does not support Int64 type")
+    endif()
+  else()
+    if(NOT BLAS_LIBRARIES)
+      check_blas_libraries(
+        BLAS_LIBRARIES
+        BLAS
+        dgemm
+        ""
+        "Accelerate"
+        ""
+        ""
+        ""
+        )
+    endif()
+  endif()
+endif()
+
+# Apple NAS (vecLib) library?
+if(BLA_VENDOR STREQUAL "NAS" OR BLA_VENDOR STREQUAL "All")
+  if(_blas_sizeof_integer EQUAL 8)
+    if(BLA_VENDOR STREQUAL "NAS")
+      message(FATAL_ERROR "Accelerate Framework does not support Int64 type")
+    endif()
+  else()
+    if(NOT BLAS_LIBRARIES)
+      check_blas_libraries(
+        BLAS_LIBRARIES
+        BLAS
+        dgemm
+        ""
+        "vecLib"
+        ""
+        ""
+        ""
+        )
+    endif()
+  endif()
+endif()
+
+# Elbrus Math Library?
+if(BLA_VENDOR MATCHES "EML" OR BLA_VENDOR STREQUAL "All")
+
+  set(_blas_eml_lib "eml")
+
+  if(_blas_sizeof_integer EQUAL 8)
+    string(APPEND _blas_eml_lib "_ilp64")
+  endif()
+  # Check for OpenMP support, VIA BLA_VENDOR of eml_mt
+  if(BLA_VENDOR MATCHES "_mt")
+    string(APPEND _blas_eml_lib "_mt")
+  endif()
+
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "${_blas_eml_lib}"
+      ""
+      ""
+      ""
+      )
+  endif()
+  unset(_blas_eml_lib)
+endif()
+
+# Fujitsu SSL2 Library?
+if(NOT BLAS_LIBRARIES
+    AND (BLA_VENDOR MATCHES "^Fujitsu_SSL2" OR BLA_VENDOR STREQUAL "All"))
+  set(_blas_fjlapack_lib "fjlapack")
+  set(_blas_fjlapack_flags "-Kopenmp")
+
+  if(BLA_VENDOR MATCHES "BLAMP")
+    string(APPEND _blas_fjlapack_lib "ex")
+  endif()
+  if(BLA_VENDOR MATCHES "SVE")
+    string(APPEND _blas_fjlapack_lib "sve")
+  endif()
+  if(_blas_sizeof_integer EQUAL 8)
+    string(APPEND _blas_fjlapack_lib "_ilp64")
+  endif()
+
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      "${_blas_fjlapack_flags}"
+      "${_blas_fjlapack_lib}"
+      ""
+      ""
+      ""
+      )
+    if(BLAS_LIBRARIES)
+      set(BLAS_LINKER_FLAGS ${_blas_fjlapack_flags})
+    endif()
+  endif()
+
+  unset(_blas_fjlapack_flags)
+  unset(_blas_fjlapack_lib)
+endif()
+
+# BLAS in nVidia HPC SDK? (https://developer.nvidia.com/hpc-sdk)
+if(BLA_VENDOR STREQUAL "NVHPC" OR BLA_VENDOR STREQUAL "All")
+  set(_blas_nvhpc_lib "blas")
+
+  if(_blas_sizeof_integer EQUAL 8)
+    string(APPEND _blas_nvhpc_lib "_ilp64")
+  elseif(_blas_sizeof_integer EQUAL 4)
+    string(APPEND _blas_nvhpc_lib "_lp64")
+  endif()
+
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "${_blas_nvhpc_lib}"
+      ""
+      ""
+      ""
+      )
+  endif()
+
+  # an additional check for NVHPC 2020
+  # which does not have differentiation
+  # between lp64 and ilp64 modes
+  if(NOT BLAS_LIBRARIES AND NOT _blas_sizeof_integer EQUAL 8)
+    set(_blas_nvhpc_lib "blas")
+
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "${_blas_nvhpc_lib}"
+      ""
+      ""
+      ""
+      )
+  endif()
+
+  unset(_blas_nvhpc_lib)
+endif()
+
+# Generic BLAS library?
+if(BLA_VENDOR STREQUAL "Generic" OR
+   BLA_VENDOR STREQUAL "All")
+  set(_blas_generic_lib "blas")
+
+  if(_blas_sizeof_integer EQUAL 8)
+    string(APPEND _blas_generic_lib "64")
+  endif()
+
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "${_blas_generic_lib}"
+      ""
+      ""
+      ""
+      )
+  endif()
+
+  unset(_blas_generic_lib)
+endif()
+
+# On compilers that implicitly link BLAS (i.e. CrayPrgEnv) we used a
+# placeholder for empty BLAS_LIBRARIES to get through our logic above.
+if(BLAS_LIBRARIES STREQUAL "BLAS_LIBRARIES-PLACEHOLDER-FOR-EMPTY-LIBRARIES")
+  set(BLAS_LIBRARIES "")
+endif()
+
+if(NOT BLA_F95)
+  find_package_handle_standard_args(BLAS REQUIRED_VARS ${_blas_fphsa_req_var})
+endif()
+
+_add_blas_target()
+unset(_blas_fphsa_req_var)
+unset(_blas_sizeof_integer)
+unset(_BLAS_LIBRARIES)

--- a/cmake/Modules/FindLAPACK.cmake
+++ b/cmake/Modules/FindLAPACK.cmake
@@ -1,0 +1,827 @@
+# Copyright 2000-2022 Kitware, Inc. and Contributors
+# All rights reserved.
+# Modifications Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+# * Neither the name of Kitware, Inc. nor the names of Contributors
+#   may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#[=======================================================================[.rst:
+FindLAPACK
+----------
+
+Find Linear Algebra PACKage (LAPACK) library
+
+This module finds an installed Fortran library that implements the
+`LAPACK linear-algebra interface`_.
+
+At least one of the ``C``, ``CXX``, or ``Fortran`` languages must be enabled.
+
+.. _`LAPACK linear-algebra interface`: https://netlib.org/lapack/
+
+Input Variables
+^^^^^^^^^^^^^^^
+
+The following variables may be set to influence this module's behavior:
+
+``BLA_STATIC``
+  if ``ON`` use static linkage
+
+``BLA_VENDOR``
+  Set to one of the :ref:`BLAS/LAPACK Vendors` to search for BLAS only
+  from the specified vendor.  If not set, all vendors are considered.
+
+``BLA_F95``
+  if ``ON`` tries to find the BLAS95/LAPACK95 interfaces
+
+``BLA_PREFER_PKGCONFIG``
+  .. versionadded:: 3.20
+
+  if set ``pkg-config`` will be used to search for a LAPACK library first
+  and if one is found that is preferred
+
+``BLA_PKGCONFIG_LAPACK``
+  .. versionadded:: 3.25
+
+  If set, the ``pkg-config`` method will look for this module name instead of
+  just ``lapack``.
+
+
+``BLA_SIZEOF_INTEGER``
+  .. versionadded:: 3.22
+
+  Specify the BLAS/LAPACK library integer size:
+
+  ``4``
+    Search for a BLAS/LAPACK with 32-bit integer interfaces.
+  ``8``
+    Search for a BLAS/LAPACK with 64-bit integer interfaces.
+  ``ANY``
+    Search for any BLAS/LAPACK.
+    Most likely, a BLAS/LAPACK with 32-bit integer interfaces will be found.
+
+Imported targets
+^^^^^^^^^^^^^^^^
+
+This module defines the following :prop_tgt:`IMPORTED` targets:
+
+``LAPACK::LAPACK``
+  .. versionadded:: 3.18
+
+  The libraries to use for LAPACK, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+``LAPACK_FOUND``
+  library implementing the LAPACK interface is found
+``LAPACK_LINKER_FLAGS``
+  uncached list of required linker flags (excluding ``-l`` and ``-L``).
+``LAPACK_LIBRARIES``
+  uncached list of libraries (using full path name) to link against
+  to use LAPACK
+``LAPACK95_LIBRARIES``
+  uncached list of libraries (using full path name) to link against
+  to use LAPACK95
+``LAPACK95_FOUND``
+  library implementing the LAPACK95 interface is found
+
+Intel MKL
+^^^^^^^^^
+
+To use the Intel MKL implementation of LAPACK, a project must enable at least
+one of the ``C`` or ``CXX`` languages.  Set ``BLA_VENDOR`` to an Intel MKL
+variant either on the command-line as ``-DBLA_VENDOR=Intel10_64lp`` or in
+project code:
+
+.. code-block:: cmake
+
+  set(BLA_VENDOR Intel10_64lp)
+  find_package(LAPACK)
+
+In order to build a project using Intel MKL, and end user must first
+establish an Intel MKL environment.  See the :module:`FindBLAS` module
+section on :ref:`Intel MKL` for details.
+
+#]=======================================================================]
+
+# The approach follows that of the ``autoconf`` macro file, ``acx_lapack.m4``
+# (distributed at http://ac-archive.sourceforge.net/ac-archive/acx_lapack.html).
+
+if(CMAKE_Fortran_COMPILER_LOADED)
+  include(${CMAKE_CURRENT_LIST_DIR}/CheckFortranFunctionExists.cmake)
+else()
+  include(${CMAKE_CURRENT_LIST_DIR}/CheckFunctionExists.cmake)
+endif()
+include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
+
+function(_add_lapack_target)
+  if(LAPACK_FOUND AND NOT TARGET LAPACK::LAPACK)
+    add_library(LAPACK::LAPACK INTERFACE IMPORTED)
+
+    # Filter out redundant BLAS info and replace with the BLAS target
+    set(_lapack_libs "${LAPACK_LIBRARIES}")
+    set(_lapack_flags "${LAPACK_LINKER_FLAGS}")
+    if(TARGET BLAS::BLAS)
+      if(_lapack_libs AND BLAS_LIBRARIES)
+        foreach(_blas_lib IN LISTS BLAS_LIBRARIES)
+          list(REMOVE_ITEM _lapack_libs "${_blas_lib}")
+        endforeach()
+      endif()
+      if(_lapack_flags AND BLAS_LINKER_FLAGS)
+        foreach(_blas_flag IN LISTS BLAS_LINKER_FLAGS)
+          list(REMOVE_ITEM _lapack_flags "${_blas_flag}")
+        endforeach()
+      endif()
+      list(APPEND _lapack_libs BLAS::BLAS)
+    endif()
+    if(_lapack_libs)
+      set_target_properties(LAPACK::LAPACK PROPERTIES
+        INTERFACE_LINK_LIBRARIES "${_lapack_libs}"
+      )
+    endif()
+    if(_lapack_flags)
+      set_target_properties(LAPACK::LAPACK PROPERTIES
+        INTERFACE_LINK_OPTIONS "${_lapack_flags}"
+      )
+    endif()
+  endif()
+endfunction()
+
+# TODO: move this stuff to a separate module
+
+function(CHECK_LAPACK_LIBRARIES LIBRARIES _prefix _name _flags _list _deps _addlibdir _subdirs _blas)
+  # This function checks for the existence of the combination of libraries
+  # given by _list.  If the combination is found, this checks whether can link
+  # against that library combination using the name of a routine given by _name
+  # using the linker flags given by _flags.  If the combination of libraries is
+  # found and passes the link test, ${LIBRARIES} is set to the list of complete
+  # library paths that have been found.  Otherwise, ${LIBRARIES} is set to FALSE.
+
+  set(_libraries_work TRUE)
+  set(_libraries)
+  set(_combined_name)
+
+  if(BLA_STATIC)
+    if(WIN32)
+      set(CMAKE_FIND_LIBRARY_SUFFIXES .lib ${CMAKE_FIND_LIBRARY_SUFFIXES})
+    else()
+      set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+    endif()
+  else()
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+      # for ubuntu's libblas3gf and liblapack3gf packages
+      set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} .so.3gf)
+    endif()
+  endif()
+
+  set(_extaddlibdir "${_addlibdir}")
+  if(WIN32)
+    list(APPEND _extaddlibdir ENV LIB)
+  elseif(APPLE)
+    list(APPEND _extaddlibdir ENV DYLD_LIBRARY_PATH)
+  else()
+    list(APPEND _extaddlibdir ENV LD_LIBRARY_PATH)
+  endif()
+  list(APPEND _extaddlibdir "${CMAKE_C_IMPLICIT_LINK_DIRECTORIES}")
+
+  foreach(_library ${_list})
+    if(_library MATCHES "^-")
+      # Respect linker flags as-is (required by MKL)
+      list(APPEND _libraries "${_library}")
+    else()
+      string(REGEX REPLACE "[^A-Za-z0-9]" "_" _lib_var "${_library}")
+      string(APPEND _combined_name "_${_lib_var}")
+      if(NOT "${_deps}" STREQUAL "")
+        string(APPEND _combined_name "_deps")
+      endif()
+      if(_libraries_work)
+        find_library(${_prefix}_${_lib_var}_LIBRARY
+          NAMES ${_library}
+          NAMES_PER_DIR
+          PATHS ${_extaddlibdir}
+          PATH_SUFFIXES ${_subdirs}
+        )
+        mark_as_advanced(${_prefix}_${_lib_var}_LIBRARY)
+        list(APPEND _libraries ${${_prefix}_${_lib_var}_LIBRARY})
+        set(_libraries_work ${${_prefix}_${_lib_var}_LIBRARY})
+      endif()
+    endif()
+  endforeach()
+
+  foreach(_flag ${_flags})
+    string(REGEX REPLACE "[^A-Za-z0-9]" "_" _flag_var "${_flag}")
+    string(APPEND _combined_name "_${_flag_var}")
+  endforeach()
+  if(_libraries_work)
+    # Test this combination of libraries.
+    set(CMAKE_REQUIRED_LIBRARIES ${_flags} ${_libraries} ${_blas} ${_deps})
+    set(CMAKE_REQUIRED_QUIET ${LAPACK_FIND_QUIETLY})
+    if(CMAKE_Fortran_COMPILER_LOADED)
+      check_fortran_function_exists("${_name}" ${_prefix}${_combined_name}_WORKS)
+    else()
+      check_function_exists("${_name}_" ${_prefix}${_combined_name}_WORKS)
+    endif()
+    set(CMAKE_REQUIRED_LIBRARIES)
+    set(_libraries_work ${${_prefix}${_combined_name}_WORKS})
+  endif()
+
+  if(_libraries_work)
+    if("${_list}${_blas}" STREQUAL "")
+      set(_libraries "${LIBRARIES}-PLACEHOLDER-FOR-EMPTY-LIBRARIES")
+    else()
+      list(APPEND _libraries ${_blas} ${_deps})
+    endif()
+  else()
+    set(_libraries FALSE)
+  endif()
+  set(${LIBRARIES} "${_libraries}" PARENT_SCOPE)
+endfunction()
+
+macro(_lapack_find_dependency dep)
+  set(_lapack_quiet_arg)
+  if(LAPACK_FIND_QUIETLY)
+    set(_lapack_quiet_arg QUIET)
+  endif()
+  set(_lapack_required_arg)
+  if(LAPACK_FIND_REQUIRED)
+    set(_lapack_required_arg REQUIRED)
+  endif()
+  find_package(${dep} ${ARGN}
+    ${_lapack_quiet_arg}
+    ${_lapack_required_arg}
+  )
+  if (NOT ${dep}_FOUND)
+    set(LAPACK_NOT_FOUND_MESSAGE "LAPACK could not be found because dependency ${dep} could not be found.")
+  endif()
+
+  set(_lapack_required_arg)
+  set(_lapack_quiet_arg)
+endmacro()
+
+set(LAPACK_LINKER_FLAGS)
+set(LAPACK_LIBRARIES)
+set(LAPACK95_LIBRARIES)
+set(_lapack_fphsa_req_var LAPACK_LIBRARIES)
+
+# Check the language being used
+if(NOT (CMAKE_C_COMPILER_LOADED OR CMAKE_CXX_COMPILER_LOADED OR CMAKE_Fortran_COMPILER_LOADED))
+  set(LAPACK_NOT_FOUND_MESSAGE
+    "FindLAPACK requires Fortran, C, or C++ to be enabled.")
+endif()
+
+if(NOT BLA_SIZEOF_INTEGER)
+  # in the reality we do not know which API of BLAS/LAPACK is masked in library
+  set(_lapack_sizeof_integer "ANY")
+elseif((BLA_SIZEOF_INTEGER STREQUAL "ANY") OR
+       (BLA_SIZEOF_INTEGER STREQUAL "4") OR
+       (BLA_SIZEOF_INTEGER STREQUAL "8"))
+  set(_lapack_sizeof_integer ${BLA_SIZEOF_INTEGER})
+else()
+  message(FATAL_ERROR "BLA_SIZEOF_INTEGER can have only <no value>, ANY, 4, or 8 values")
+endif()
+
+# Load BLAS
+if(NOT LAPACK_NOT_FOUND_MESSAGE)
+  _lapack_find_dependency(BLAS)
+endif()
+
+# Search with pkg-config if specified
+if(BLA_PREFER_PKGCONFIG)
+  if(NOT BLA_PKGCONFIG_LAPACK)
+    set(BLA_PKGCONFIG_LAPACK "lapack")
+  endif()
+  find_package(PkgConfig QUIET)
+  pkg_check_modules(PKGC_LAPACK QUIET ${BLA_PKGCONFIG_LAPACK})
+  if(PKGC_LAPACK_FOUND)
+    set(LAPACK_FOUND TRUE)
+    set(LAPACK_LIBRARIES "${PKGC_LAPACK_LINK_LIBRARIES}")
+    if (BLAS_LIBRARIES)
+      list(APPEND LAPACK_LIBRARIES "${BLAS_LIBRARIES}")
+    endif()
+    _add_lapack_target()
+    return()
+  endif()
+endif()
+
+# Search for different LAPACK distributions if BLAS is found
+if(NOT LAPACK_NOT_FOUND_MESSAGE)
+  set(LAPACK_LINKER_FLAGS ${BLAS_LINKER_FLAGS})
+  if(NOT $ENV{BLA_VENDOR} STREQUAL "")
+    set(BLA_VENDOR $ENV{BLA_VENDOR})
+  elseif(NOT BLA_VENDOR)
+    set(BLA_VENDOR "All")
+  endif()
+
+  # LAPACK in the Intel MKL 10+ library?
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR MATCHES "Intel" OR BLA_VENDOR STREQUAL "All")
+      AND (CMAKE_C_COMPILER_LOADED OR CMAKE_CXX_COMPILER_LOADED))
+    # System-specific settings
+    if(NOT WIN32)
+      set(LAPACK_mkl_LM "-lm")
+      set(LAPACK_mkl_LDL "-ldl")
+    endif()
+
+    _lapack_find_dependency(Threads)
+
+    if(_lapack_sizeof_integer EQUAL 8)
+      set(LAPACK_mkl_ILP_MODE "ilp64")
+    elseif(_lapack_sizeof_integer EQUAL 4)
+      set(LAPACK_mkl_ILP_MODE "lp64")
+    else()
+      if(BLA_VENDOR MATCHES "_64ilp")
+        set(LAPACK_mkl_ILP_MODE "ilp64")
+      else()
+        set(LAPACK_mkl_ILP_MODE "lp64")
+      endif()
+    endif()
+
+    set(LAPACK_SEARCH_LIBS "")
+
+    if(BLA_F95)
+      set(LAPACK_mkl_SEARCH_SYMBOL "cheev_f95")
+      set(_LAPACK_LIBRARIES LAPACK95_LIBRARIES)
+      set(_BLAS_LIBRARIES ${BLAS95_LIBRARIES})
+
+      # old
+      list(APPEND LAPACK_SEARCH_LIBS
+        "mkl_lapack95")
+      # new >= 10.3
+      list(APPEND LAPACK_SEARCH_LIBS
+        "mkl_intel_c")
+      list(APPEND LAPACK_SEARCH_LIBS
+        "mkl_lapack95_${LAPACK_mkl_ILP_MODE}")
+    else()
+      set(LAPACK_mkl_SEARCH_SYMBOL "cheev")
+      set(_LAPACK_LIBRARIES LAPACK_LIBRARIES)
+      set(_BLAS_LIBRARIES ${BLAS_LIBRARIES})
+
+      # old and new >= 10.3
+      list(APPEND LAPACK_SEARCH_LIBS
+        "mkl_lapack")
+    endif()
+
+    # MKL uses a multitude of partially platform-specific subdirectories:
+    if(BLA_VENDOR STREQUAL "Intel10_32")
+      set(LAPACK_mkl_ARCH_NAME "ia32")
+    else()
+      set(LAPACK_mkl_ARCH_NAME "intel64")
+    endif()
+    if(WIN32)
+      set(LAPACK_mkl_OS_NAME "win")
+    elseif(APPLE)
+      set(LAPACK_mkl_OS_NAME "mac")
+    else()
+      set(LAPACK_mkl_OS_NAME "lin")
+    endif()
+    if(DEFINED ENV{MKLROOT})
+      file(TO_CMAKE_PATH "$ENV{MKLROOT}" LAPACK_mkl_MKLROOT)
+      # If MKLROOT points to the subdirectory 'mkl', use the parent directory instead
+      # so we can better detect other relevant libraries in 'compiler' or 'tbb':
+      get_filename_component(LAPACK_mkl_MKLROOT_LAST_DIR "${LAPACK_mkl_MKLROOT}" NAME)
+      if(LAPACK_mkl_MKLROOT_LAST_DIR STREQUAL "mkl")
+          get_filename_component(LAPACK_mkl_MKLROOT "${LAPACK_mkl_MKLROOT}" DIRECTORY)
+      endif()
+    endif()
+    set(LAPACK_mkl_LIB_PATH_SUFFIXES
+        "compiler/lib" "compiler/lib/${LAPACK_mkl_ARCH_NAME}_${LAPACK_mkl_OS_NAME}"
+        "compiler/lib/${LAPACK_mkl_ARCH_NAME}"
+        "mkl/lib" "mkl/lib/${LAPACK_mkl_ARCH_NAME}_${LAPACK_mkl_OS_NAME}"
+        "mkl/lib/${LAPACK_mkl_ARCH_NAME}"
+        "lib" "lib/${LAPACK_mkl_ARCH_NAME}_${LAPACK_mkl_OS_NAME}"
+        "lib/${LAPACK_mkl_ARCH_NAME}"
+        )
+
+    # First try empty lapack libs (implicitly linked or automatic from BLAS)
+    if(NOT ${_LAPACK_LIBRARIES})
+      check_lapack_libraries(
+        ${_LAPACK_LIBRARIES}
+        LAPACK
+        ${LAPACK_mkl_SEARCH_SYMBOL}
+        ""
+        ""
+        "${CMAKE_THREAD_LIBS_INIT};${LAPACK_mkl_LM};${LAPACK_mkl_LDL}"
+        "${LAPACK_mkl_MKLROOT}"
+        "${LAPACK_mkl_LIB_PATH_SUFFIXES}"
+        "${_BLAS_LIBRARIES}"
+      )
+      if(LAPACK_WORKS AND NOT _BLAS_LIBRARIES)
+        # Give a more helpful "found" message
+        set(LAPACK_WORKS "implicitly linked")
+        set(_lapack_fphsa_req_var LAPACK_WORKS)
+      endif()
+    endif()
+
+    # Then try the search libs
+    foreach(_search ${LAPACK_SEARCH_LIBS})
+      string(REPLACE " " ";" _search ${_search})
+      if(NOT ${_LAPACK_LIBRARIES})
+        check_lapack_libraries(
+          ${_LAPACK_LIBRARIES}
+          LAPACK
+          ${LAPACK_mkl_SEARCH_SYMBOL}
+          ""
+          "${_search}"
+          "${CMAKE_THREAD_LIBS_INIT};${LAPACK_mkl_LM};${LAPACK_mkl_LDL}"
+          "${LAPACK_mkl_MKLROOT}"
+          "${LAPACK_mkl_LIB_PATH_SUFFIXES}"
+          "${_BLAS_LIBRARIES}"
+        )
+      endif()
+    endforeach()
+
+    unset(_search)
+    unset(LAPACK_mkl_ILP_MODE)
+    unset(LAPACK_mkl_SEARCH_SYMBOL)
+    unset(LAPACK_mkl_LM)
+    unset(LAPACK_mkl_LDL)
+    unset(LAPACK_mkl_MKLROOT)
+    unset(LAPACK_mkl_ARCH_NAME)
+    unset(LAPACK_mkl_OS_NAME)
+    unset(LAPACK_mkl_LIB_PATH_SUFFIXES)
+  endif()
+
+  # gotoblas? (http://www.tacc.utexas.edu/tacc-projects/gotoblas2)
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR STREQUAL "Goto" OR BLA_VENDOR STREQUAL "All"))
+    check_lapack_libraries(
+      LAPACK_LIBRARIES
+      LAPACK
+      cheev
+      ""
+      "goto2"
+      ""
+      ""
+      ""
+      "${BLAS_LIBRARIES}"
+    )
+  endif()
+
+  # FlexiBLAS? (http://www.mpi-magdeburg.mpg.de/mpcsc/software/FlexiBLAS/)
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR STREQUAL "FlexiBLAS" OR BLA_VENDOR STREQUAL "All"))
+    set(_lapack_flexiblas_lib "flexiblas")
+
+    if(_lapack_sizeof_integer EQUAL 8)
+      string(APPEND _lapack_flexiblas_lib "64")
+    endif()
+
+    check_lapack_libraries(
+      LAPACK_LIBRARIES
+      LAPACK
+      cheev
+      ""
+      "${_lapack_flexiblas_lib}"
+      ""
+      ""
+      ""
+      "${BLAS_LIBRARIES}"
+    )
+
+    unset(_lapack_flexiblas_lib)
+  endif()
+
+  # OpenBLAS? (http://www.openblas.net)
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR STREQUAL "OpenBLAS" OR BLA_VENDOR STREQUAL "All"))
+    set(_lapack_openblas_lib "openblas")
+
+    if(_lapack_sizeof_integer EQUAL 8)
+      string(APPEND _lapack_openblas_lib "64")
+    endif()
+
+    check_lapack_libraries(
+      LAPACK_LIBRARIES
+      LAPACK
+      cheev
+      ""
+      "${_lapack_openblas_lib}"
+      ""
+      ""
+      ""
+      "${BLAS_LIBRARIES}"
+    )
+
+    unset(_lapack_openblas_lib)
+  endif()
+
+  # ArmPL? (https://developer.arm.com/tools-and-software/server-and-hpc/compile/arm-compiler-for-linux/arm-performance-libraries)
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR MATCHES "Arm" OR BLA_VENDOR STREQUAL "All"))
+    # Check for 64bit Integer support
+    if(_lapack_sizeof_integer EQUAL 8)
+      set(LAPACK_armpl_LIB "armpl_ilp64")
+    elseif(_lapack_sizeof_integer EQUAL 4)
+      set(LAPACK_armpl_LIB "armpl_lp64")
+    else()
+      if(BLA_VENDOR MATCHES "_ilp64")
+        set(LAPACK_armpl_LIB "armpl_ilp64")
+      else()
+        set(LAPACK_armpl_LIB "armpl_lp64")
+      endif()
+    endif()
+
+    # Check for OpenMP support, VIA BLA_VENDOR of Arm_mp or Arm_ipl64_mp
+    if(BLA_VENDOR MATCHES "_mp")
+      string(APPEND LAPACK_armpl_LIB "_mp")
+    endif()
+
+    check_lapack_libraries(
+      LAPACK_LIBRARIES
+      LAPACK
+      cheev
+      ""
+      "${LAPACK_armpl_LIB}"
+      ""
+      ""
+      ""
+      "${BLAS_LIBRARIES}"
+    )
+  endif()
+
+  # FLAME's blis library? (https://github.com/flame/blis)
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR STREQUAL "FLAME" OR BLA_VENDOR STREQUAL "All"))
+    if(_lapack_sizeof_integer EQUAL 8)
+      if(BLA_VENDOR STREQUAL "FLAME")
+        message(FATAL_ERROR "libFLAME does not support Int64 type")
+      endif()
+    else()
+      check_lapack_libraries(
+        LAPACK_LIBRARIES
+        LAPACK
+        cheev
+        ""
+        "flame"
+        ""
+        ""
+        ""
+        "${BLAS_LIBRARIES}"
+      )
+    endif()
+  endif()
+
+  # AOCL? (https://developer.amd.com/amd-aocl/)
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR MATCHES "AOCL" OR BLA_VENDOR STREQUAL "All"))
+    if(_lapack_sizeof_integer EQUAL 8)
+      set(_lapack_aocl_subdir "ILP64")
+    else()
+      set(_lapack_aocl_subdir "LP64")
+    endif()
+
+    check_lapack_libraries(
+      LAPACK_LIBRARIES
+      LAPACK
+      cheev
+      ""
+      "flame"
+      "-fopenmp"
+      ""
+      "${_lapack_aocl_subdir}"
+      "${BLAS_LIBRARIES}"
+    )
+    unset(_lapack_aocl_subdir)
+  endif()
+
+  # LAPACK in SCSL library? (SGI/Cray Scientific Library)
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR MATCHES "SCSL" OR BLA_VENDOR STREQUAL "All"))
+    set(_lapack_scsl_lib "scs")
+
+    if(_lapack_sizeof_integer EQUAL 8)
+      string(APPEND _lapack_scsl_lib "_i8")
+    endif()
+    # Check for OpenMP support, VIA BLA_VENDOR of scs_mp
+    if(BLA_VENDOR MATCHES "_mp")
+      string(APPEND _lapack_scsl_lib "_mp")
+    endif()
+
+    check_lapack_libraries(
+      LAPACK_LIBRARIES
+      LAPACK
+      cheev
+      ""
+      "${_lapack_scsl_lib}"
+      ""
+      ""
+      ""
+      "${BLAS_LIBRARIES}"
+    )
+    unset(_lapack_scsl_lib)
+  endif()
+
+  # BLAS in acml library?
+  if(BLA_VENDOR MATCHES "ACML" OR BLA_VENDOR STREQUAL "All")
+    if(BLAS_LIBRARIES MATCHES ".+acml.+")
+      set(LAPACK_LIBRARIES ${BLAS_LIBRARIES})
+    endif()
+  endif()
+
+  # Apple LAPACK library?
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR STREQUAL "Apple" OR BLA_VENDOR STREQUAL "All"))
+    if(_lapack_sizeof_integer EQUAL 8)
+      if(BLA_VENDOR STREQUAL "Apple")
+        message(FATAL_ERROR "Accelerate Framework does not support Int64 type")
+      endif()
+    else()
+      check_lapack_libraries(
+        LAPACK_LIBRARIES
+        LAPACK
+        cheev
+        ""
+        "Accelerate"
+        ""
+        ""
+        ""
+        "${BLAS_LIBRARIES}"
+      )
+    endif()
+  endif()
+
+  # Apple NAS (vecLib) library?
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR STREQUAL "NAS" OR BLA_VENDOR STREQUAL "All"))
+    if(_lapack_sizeof_integer EQUAL 8)
+      if(BLA_VENDOR STREQUAL "NAS")
+        message(FATAL_ERROR "Accelerate Framework does not support Int64 type")
+      endif()
+    else()
+      check_lapack_libraries(
+        LAPACK_LIBRARIES
+        LAPACK
+        cheev
+        ""
+        "vecLib"
+        ""
+        ""
+        ""
+        "${BLAS_LIBRARIES}"
+      )
+    endif()
+  endif()
+
+  # Elbrus Math Library?
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR MATCHES "EML" OR BLA_VENDOR STREQUAL "All"))
+    if(BLAS_LIBRARIES MATCHES "eml.+")
+      set(LAPACK_LIBRARIES ${BLAS_LIBRARIES})
+    endif()
+  endif()
+
+  # Fujitsu SSL2 Library?
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR MATCHES "Fujitsu_SSL2" OR BLA_VENDOR STREQUAL "All"))
+    if(BLAS_LIBRARIES MATCHES "fjlapack.+")
+      set(LAPACK_LIBRARIES ${BLAS_LIBRARIES})
+      set(LAPACK_LINKER_FLAGS ${BLAS_LINKER_FLAGS})
+    endif()
+  endif()
+
+  # LAPACK in IBM ESSL library?
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR MATCHES "IBMESSL" OR BLA_VENDOR STREQUAL "All"))
+    if(BLAS_LIBRARIES MATCHES "essl.+")
+      set(LAPACK_LIBRARIES ${BLAS_LIBRARIES})
+    endif()
+  endif()
+
+  # NVHPC Library?
+
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR MATCHES "NVHPC" OR BLA_VENDOR STREQUAL "All"))
+    set(_lapack_nvhpc_lib "lapack")
+
+    if(_lapack_sizeof_integer EQUAL 8)
+      string(APPEND _lapack_nvhpc_lib "_ilp64")
+    elseif(_lapack_sizeof_integer EQUAL 4)
+      string(APPEND _lapack_nvhpc_lib "_lp64")
+    endif()
+    set(_lapack_nvhpc_flags)
+    if(";${CMAKE_C_COMPILER_ID};${CMAKE_CXX_COMPILER_ID};${CMAKE_Fortran_COMPILER_ID};" MATCHES ";(NVHPC|PGI);")
+      set(_lapack_nvhpc_flags "-fortranlibs")
+    endif()
+
+    check_lapack_libraries(
+      LAPACK_LIBRARIES
+      LAPACK
+      cheev
+      ""
+      "${_lapack_nvhpc_lib}"
+      "${_lapack_nvhpc_flags}"
+      ""
+      ""
+      "${BLAS_LIBRARIES}"
+    )
+
+    # an additional check for NVHPC 2020
+    # which does not have differentiation
+    # between lp64 and ilp64 modes
+    if(NOT LAPACK_LIBRARIES AND NOT _lapack_sizeof_integer EQUAL 8)
+      set(_lapack_nvhpc_lib "lapack")
+
+      check_lapack_libraries(
+        LAPACK_LIBRARIES
+        LAPACK
+        cheev
+        ""
+        "${_lapack_nvhpc_lib}"
+        "${_lapack_nvhpc_flags}"
+        ""
+        ""
+        "${BLAS_LIBRARIES}"
+      )
+    endif()
+
+    unset(_lapack_nvhpc_lib)
+    unset(_lapack_nvhpc_flags)
+  endif()
+
+  # Generic LAPACK library?
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR STREQUAL "Generic"
+           OR BLA_VENDOR STREQUAL "ATLAS"
+           OR BLA_VENDOR STREQUAL "All"))
+    set(_lapack_generic_lib "lapack")
+    if(BLA_STATIC)
+      # We do not know for sure how the LAPACK reference implementation
+      # is built on this host.  Guess typical dependencies.
+      set(_lapack_generic_deps "-lgfortran;-lm")
+    else()
+      set(_lapack_generic_deps "")
+    endif()
+
+    if(_lapack_sizeof_integer EQUAL 8)
+      string(APPEND _lapack_generic_lib "64")
+    endif()
+
+    check_lapack_libraries(
+      LAPACK_LIBRARIES
+      LAPACK
+      cheev
+      ""
+      "${_lapack_generic_lib}"
+      "${_lapack_generic_deps}"
+      ""
+      ""
+      "${BLAS_LIBRARIES}"
+    )
+
+    unset(_lapack_generic_deps)
+    unset(_lapack_generic_lib)
+  endif()
+endif()
+
+if(BLA_F95)
+  set(LAPACK_LIBRARIES "${LAPACK95_LIBRARIES}")
+endif()
+
+if(LAPACK_NOT_FOUND_MESSAGE)
+  set(LAPACK_NOT_FOUND_MESSAGE
+    REASON_FAILURE_MESSAGE ${LAPACK_NOT_FOUND_MESSAGE})
+endif()
+find_package_handle_standard_args(LAPACK REQUIRED_VARS ${_lapack_fphsa_req_var}
+  ${LAPACK_NOT_FOUND_MESSAGE})
+unset(LAPACK_NOT_FOUND_MESSAGE)
+
+if(BLA_F95)
+  set(LAPACK95_FOUND ${LAPACK_FOUND})
+endif()
+
+# On compilers that implicitly link LAPACK (such as ftn, cc, and CC on Cray HPC machines)
+# we used a placeholder for empty LAPACK_LIBRARIES to get through our logic above.
+if(LAPACK_LIBRARIES STREQUAL "LAPACK_LIBRARIES-PLACEHOLDER-FOR-EMPTY-LIBRARIES")
+  set(LAPACK_LIBRARIES "")
+endif()
+
+_add_lapack_target()
+unset(_lapack_fphsa_req_var)
+unset(_lapack_sizeof_integer)
+unset(_LAPACK_LIBRARIES)


### PR DESCRIPTION
These are the FindBLAS and FindLAPACK from CMake 3.25.2, with a few modifications to support finding AOCL BLIS and libFLAME (including the multi-threaded variant, which the upstream FindBLAS is unable to find).

They are added to rocSOLVER in the `cmake/Modules` subfolder, so that one can choose to build rocsolver-test or rocsolver-bench with AOCL as the CPU reference library using the CMake arguments

    -DROCSOLVER_FIND_PACKAGE_LAPACK_CONFIG=ON \
    -DCMAKE_MODULE_PATH=<srcdir>/cmake/Modules \
    -DBLA_VENDOR=AOCL (or -DBLA_VENDOR=AOCL_mt)

These custom find modules are not automatically added to the `CMAKE_MODULE_PATH`. This ensures that they are entirely optional. One can imagine that users with future versions of CMake may still want to be able to use their built-in find modules, rather than being stuck using the version from 3.25.2 (even with our improvements).