### PR TITLE
Restore deprecated functions and types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 
 ### Deprecated
 ### Removed
-- Removed deprecated aliases for rocBLAS functions and types.
-
 ### Fixed
 ### Known Issues
 ### Security

--- a/docs/source/api_deprecated.rst
+++ b/docs/source/api_deprecated.rst
@@ -1,0 +1,137 @@
+
+************
+Deprecated
+************
+
+Originally, rocSOLVER maintained its own types and helpers as aliases to those of rocBLAS.
+These aliases are now deprecated. See the `rocBLAS types <https://rocblas.readthedocs.io/en/latest/API_Reference_Guide.html#rocblas-datatypes>`_
+and `rocBLAS auxiliary functions <https://rocblas.readthedocs.io/en/latest/API_Reference_Guide.html#auxiliary-functions>`_
+documentation for information on the suggested replacements.
+
+* Deprecated :ref:`deptypes`.
+* Deprecated :ref:`dephelpers`.
+
+
+
+.. _deptypes:
+
+Types
+==============
+
+.. contents:: List of deprecated types
+   :local:
+   :backlinks: top
+
+rocsolver_int
+---------------------
+.. doxygentypedef:: rocsolver_int
+.. deprecated:: 3.5
+   Use :c:type:`rocblas_int`.
+
+rocsolver_handle
+---------------------
+.. doxygentypedef:: rocsolver_handle
+.. deprecated:: 3.5
+   Use :c:type:`rocblas_handle`.
+
+rocsolver_direction
+---------------------
+.. doxygentypedef:: rocsolver_direction
+.. deprecated:: 3.5
+   Use :c:enum:`rocblas_direct`.
+
+rocsolver_storev
+---------------------
+.. doxygentypedef:: rocsolver_storev
+.. deprecated:: 3.5
+   Use :c:enum:`rocblas_storev`.
+
+rocsolver_operation
+---------------------
+.. doxygentypedef:: rocsolver_operation
+.. deprecated:: 3.5
+   Use :c:enum:`rocblas_operation`.
+
+rocsolver_fill
+---------------------
+.. doxygentypedef:: rocsolver_fill
+.. deprecated:: 3.5
+   Use :c:enum:`rocblas_fill`.
+
+rocsolver_diagonal
+---------------------
+.. doxygentypedef:: rocsolver_diagonal
+.. deprecated:: 3.5
+   Use :c:enum:`rocblas_diagonal`.
+
+rocsolver_side
+---------------------
+.. doxygentypedef:: rocsolver_side
+.. deprecated:: 3.5
+   Use :c:enum:`rocblas_side`.
+
+rocsolver_status
+---------------------
+.. doxygentypedef:: rocsolver_status
+.. deprecated:: 3.5
+   Use :c:enum:`rocblas_status`.
+
+
+
+.. _dephelpers:
+
+Auxiliary functions
+======================
+
+.. contents:: List of deprecated helpers
+   :local:
+   :backlinks: top
+
+rocsolver_create_handle()
+--------------------------
+.. doxygenfunction:: rocsolver_create_handle
+.. deprecated:: 3.5
+   Use :c:func:`rocblas_create_handle`.
+
+rocsolver_destroy_handle()
+--------------------------
+.. doxygenfunction:: rocsolver_destroy_handle
+.. deprecated:: 3.5
+   Use :c:func:`rocblas_destroy_handle`.
+
+rocsolver_set_stream()
+--------------------------
+.. doxygenfunction:: rocsolver_set_stream
+.. deprecated:: 3.5
+   Use :c:func:`rocblas_set_stream`.
+
+rocsolver_get_stream()
+--------------------------
+.. doxygenfunction:: rocsolver_get_stream
+.. deprecated:: 3.5
+   Use :c:func:`rocblas_get_stream`.
+
+rocsolver_set_vector()
+--------------------------
+.. doxygenfunction:: rocsolver_set_vector
+.. deprecated:: 3.5
+   Use :c:func:`rocblas_set_vector`.
+
+rocsolver_get_vector()
+--------------------------
+.. doxygenfunction:: rocsolver_get_vector
+.. deprecated:: 3.5
+   Use :c:func:`rocblas_get_vector`.
+
+rocsolver_set_matrix()
+--------------------------
+.. doxygenfunction:: rocsolver_set_matrix
+.. deprecated:: 3.5
+   Use :c:func:`rocblas_set_matrix`.
+
+rocsolver_get_matrix()
+--------------------------
+.. doxygenfunction:: rocsolver_get_matrix
+.. deprecated:: 3.5
+   Use :c:func:`rocblas_get_matrix`.
+

--- a/docs/source/api_index.rst
+++ b/docs/source/api_index.rst
@@ -12,4 +12,5 @@ rocSOLVER API
    api_lapackfunc
    api_lapacklike
    api_loggingfunc
+   api_deprecated
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -8,4 +8,16 @@ set(rocsolver_SOVERSION 0.1)
 # Create version header from templated .in file using CMake info
 configure_file(include/rocsolver/internal/rocsolver-version.h.in "${PROJECT_BINARY_DIR}/include/rocsolver/internal/rocsolver-version.h")
 
+set(rocsolver_headers_public
+  include/rocsolver/rocsolver.h
+  include/rocsolver/internal/rocsolver-extra-types.h
+  include/rocsolver/internal/rocsolver-aliases.h
+  include/rocsolver/internal/rocsolver-functions.h
+  ${PROJECT_BINARY_DIR}/include/rocsolver/internal/rocsolver-version.h
+  ${PROJECT_BINARY_DIR}/include/rocsolver/internal/rocsolver-export.h
+)
+
+# For IDE integration
+source_group("Header Files\\Public" FILES ${rocsolver_headers_public})
+
 add_subdirectory(src)

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -8,16 +8,4 @@ set(rocsolver_SOVERSION 0.1)
 # Create version header from templated .in file using CMake info
 configure_file(include/rocsolver/internal/rocsolver-version.h.in "${PROJECT_BINARY_DIR}/include/rocsolver/internal/rocsolver-version.h")
 
-set(rocsolver_headers_public
-  include/rocsolver/rocsolver.h
-  include/rocsolver/internal/rocsolver-extra-types.h
-  include/rocsolver/internal/rocsolver-aliases.h
-  include/rocsolver/internal/rocsolver-functions.h
-  ${PROJECT_BINARY_DIR}/include/rocsolver/internal/rocsolver-version.h
-  ${PROJECT_BINARY_DIR}/include/rocsolver/internal/rocsolver-export.h
-)
-
-# For IDE integration
-source_group("Header Files\\Public" FILES ${rocsolver_headers_public})
-
 add_subdirectory(src)

--- a/library/include/rocsolver/internal/rocsolver-aliases.h
+++ b/library/include/rocsolver/internal/rocsolver-aliases.h
@@ -1,0 +1,187 @@
+/* ************************************************************************
+ * Copyright (c) 2019-2023 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+//
+//
+// IMPORTANT:
+//
+// THESE ALIASES ARE NOT MAINTAINED ANYMORE. THEY EXIST ONLY FOR BACKWARDS
+// COMPATIBILITY. USE ROCBLAS TYPES AND FUNCTIONS DIRECTLY.
+//
+//
+
+#ifndef ROCSOLVER_ALIASES_H_
+#define ROCSOLVER_ALIASES_H_
+
+#include <rocblas/rocblas.h>
+
+#ifndef ROCSOLVER_DEPRECATED_X
+#if defined(__GNUC__)
+#define ROCSOLVER_DEPRECATED_X(x) __attribute__((deprecated(x))) // GCC or Clang
+#elif defined(_MSC_VER)
+#define ROCSOLVER_DEPRECATED_X(x) __declspec(deprecated(x)) // MSVC
+#else
+#define ROCSOLVER_DEPRECATED_X(x) // other compilers
+#endif
+#endif
+
+// rocblas original types
+
+/*! \deprecated Use \c rocblas_int.
+ */
+ROCSOLVER_DEPRECATED_X("use rocblas_int") typedef rocblas_int rocsolver_int;
+
+/*! \deprecated Use \c rocblas_stride.
+ */
+ROCSOLVER_DEPRECATED_X("use rocblas_stride") typedef rocblas_stride rocsolver_stride;
+
+/*! \deprecated Use \c rocblas_float_complex.
+ */
+ROCSOLVER_DEPRECATED_X("use rocblas_float_complex")
+typedef rocblas_float_complex rocsolver_float_complex;
+
+/*! \deprecated Use \c rocblas_double_complex.
+ */
+ROCSOLVER_DEPRECATED_X("use rocblas_double_complex")
+typedef rocblas_double_complex rocsolver_double_complex;
+
+/*! \deprecated Use \c rocblas_half.
+ */
+ROCSOLVER_DEPRECATED_X("use rocblas_half") typedef rocblas_half rocsolver_half;
+
+/*! \deprecated Use \c rocblas_handle.
+ */
+ROCSOLVER_DEPRECATED_X("use rocblas_handle") typedef rocblas_handle rocsolver_handle;
+
+/*! \deprecated Use \c rocblas_operation.
+ */
+ROCSOLVER_DEPRECATED_X("use rocblas_operation") typedef rocblas_operation rocsolver_operation;
+
+/*! \deprecated Use \c rocblas_fill.
+ */
+ROCSOLVER_DEPRECATED_X("use rocblas_fill") typedef rocblas_fill rocsolver_fill;
+
+/*! \deprecated Use \c rocblas_diagonal.
+ */
+ROCSOLVER_DEPRECATED_X("use rocblas_diagonal") typedef rocblas_diagonal rocsolver_diagonal;
+
+/*! \deprecated Use \c rocblas_stide.
+ */
+ROCSOLVER_DEPRECATED_X("use rocblas_side") typedef rocblas_side rocsolver_side;
+
+/*! \deprecated Use \c rocblas_status.
+ */
+ROCSOLVER_DEPRECATED_X("use rocblas_status") typedef rocblas_status rocsolver_status;
+
+/*! \deprecated Use \c rocblas_layer_mode.
+ */
+ROCSOLVER_DEPRECATED_X("use rocblas_layer_mode") typedef rocblas_layer_mode rocsolver_layer_mode;
+
+// extras types only used in rocsolver
+
+/*! \deprecated Use \c rocblas_direct
+ */
+ROCSOLVER_DEPRECATED_X("use rocblas_direct") typedef rocblas_direct rocsolver_direction;
+
+/*! \deprecated Use \c rocblas_storev.
+ */
+ROCSOLVER_DEPRECATED_X("use rocblas_storev") typedef rocblas_storev rocsolver_storev;
+
+// auxiliaries
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// deprecated functions use deprecated types, so ignore the warnings
+#if defined(__GNUC__) // GCC or Clang
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER) // MSVC
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+
+/*! \deprecated Use \c rocblas_create_handle.
+ */
+ROCSOLVER_DEPRECATED_X("use rocblas_create_handle")
+ROCSOLVER_EXPORT rocsolver_status rocsolver_create_handle(rocsolver_handle* handle);
+
+/*! \deprecated Use \c rocblas_destroy_handle.
+ */
+ROCSOLVER_DEPRECATED_X("use rocblas_destroy_handle")
+ROCSOLVER_EXPORT rocsolver_status rocsolver_destroy_handle(rocsolver_handle handle);
+
+// rocblas_add_stream was removed in ROCm 3.6; use rocblas_set_stream
+//
+// ROCSOLVER_EXPORT rocsolver_status
+// rocsolver_add_stream(rocsolver_handle handle, hipStream_t stream) {
+//  return rocblas_add_stream(handle, stream);
+//}
+
+/*! \deprecated Use \c rocblas_set_stream.
+ */
+ROCSOLVER_DEPRECATED_X("use rocblas_set_stream")
+ROCSOLVER_EXPORT rocsolver_status rocsolver_set_stream(rocsolver_handle handle, hipStream_t stream);
+
+/*! \deprecated Use \c rocblas_get_stream.
+ */
+ROCSOLVER_DEPRECATED_X("use rocblas_get_stream")
+ROCSOLVER_EXPORT rocsolver_status rocsolver_get_stream(rocsolver_handle handle, hipStream_t* stream);
+
+/*! \deprecated Use \c rocblas_set_vector.
+ */
+ROCSOLVER_DEPRECATED_X("use rocblas_set_vector")
+ROCSOLVER_EXPORT rocsolver_status rocsolver_set_vector(rocsolver_int n,
+                                                       rocsolver_int elem_size,
+                                                       const void* x,
+                                                       rocsolver_int incx,
+                                                       void* y,
+                                                       rocsolver_int incy);
+
+/*! \deprecated Use \c rocblas_get_vector.
+ */
+ROCSOLVER_DEPRECATED_X("use rocblas_get_vector")
+ROCSOLVER_EXPORT rocsolver_status rocsolver_get_vector(rocsolver_int n,
+                                                       rocsolver_int elem_size,
+                                                       const void* x,
+                                                       rocsolver_int incx,
+                                                       void* y,
+                                                       rocsolver_int incy);
+
+/*! \deprecated Use \c rocblas_set_matrix.
+ */
+ROCSOLVER_DEPRECATED_X("use rocblas_set_matrix")
+ROCSOLVER_EXPORT rocsolver_status rocsolver_set_matrix(rocsolver_int rows,
+                                                       rocsolver_int cols,
+                                                       rocsolver_int elem_size,
+                                                       const void* a,
+                                                       rocsolver_int lda,
+                                                       void* b,
+                                                       rocsolver_int ldb);
+
+/*! \deprecated Use \c rocblas_get_matrix.
+ */
+ROCSOLVER_DEPRECATED_X("use rocblas_get_matrix")
+ROCSOLVER_EXPORT rocsolver_status rocsolver_get_matrix(rocsolver_int rows,
+                                                       rocsolver_int cols,
+                                                       rocsolver_int elem_size,
+                                                       const void* a,
+                                                       rocsolver_int lda,
+                                                       void* b,
+                                                       rocsolver_int ldb);
+
+// reenable deprecation warnings
+#if defined(__GNUC__) // GCC or Clang
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER) // MSVC
+#pragma warning(pop)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#undef ROCSOLVER_DEPRECATED_X
+
+#endif /* ROCSOLVER_ALIASES_H_ */

--- a/library/include/rocsolver/internal/rocsolver-aliases.h
+++ b/library/include/rocsolver/internal/rocsolver-aliases.h
@@ -11,8 +11,8 @@
 //
 //
 
-#ifndef ROCSOLVER_ALIASES_H_
-#define ROCSOLVER_ALIASES_H_
+#ifndef ROCSOLVER_ALIASES_H
+#define ROCSOLVER_ALIASES_H
 
 #include <rocblas/rocblas.h>
 
@@ -184,4 +184,4 @@ ROCSOLVER_EXPORT rocsolver_status rocsolver_get_matrix(rocsolver_int rows,
 
 #undef ROCSOLVER_DEPRECATED_X
 
-#endif /* ROCSOLVER_ALIASES_H_ */
+#endif /* ROCSOLVER_ALIASES_H */

--- a/library/include/rocsolver/rocsolver.h
+++ b/library/include/rocsolver/rocsolver.h
@@ -12,6 +12,7 @@
 /* clang-format off */
 #include "internal/rocsolver-export.h"
 #include "internal/rocsolver-extra-types.h"
+#include "internal/rocsolver-aliases.h"
 #include "internal/rocsolver-functions.h"
 #include "internal/rocsolver-version.h"
 /* clang-format on */

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -233,10 +233,7 @@ set(auxiliaries
   common/rocsolver_logger.cpp
 )
 
-prepend_path(".." rocsolver_headers_public relative_rocsolver_headers_public)
-
 add_library(rocsolver
-  ${relative_rocsolver_headers_public}
   ${auxiliaries}
   ${rocsolver_specialized_source}
   ${rocsolver_auxiliary_source}

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -150,6 +150,7 @@ set(rocsolver_lapack_source
 
 set(rocsolver_auxiliary_source
   # vector & matrix manipulations
+  auxiliary/rocauxiliary_aliases.cpp
   auxiliary/rocauxiliary_lacgv.cpp
   auxiliary/rocauxiliary_laswp.cpp
   # householder reflections
@@ -232,7 +233,10 @@ set(auxiliaries
   common/rocsolver_logger.cpp
 )
 
+prepend_path(".." rocsolver_headers_public relative_rocsolver_headers_public)
+
 add_library(rocsolver
+  ${relative_rocsolver_headers_public}
   ${auxiliaries}
   ${rocsolver_specialized_source}
   ${rocsolver_auxiliary_source}

--- a/library/src/auxiliary/rocauxiliary_aliases.cpp
+++ b/library/src/auxiliary/rocauxiliary_aliases.cpp
@@ -1,0 +1,85 @@
+/* ************************************************************************
+ * Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include "rocsolver/rocsolver.h"
+
+// We need to include extern definitions for these inline functions to ensure
+// that librocsolver.so will contain these symbols for FFI or when inlining
+// is disabled.
+
+extern "C" {
+
+// deprecated functions use deprecated types
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+rocsolver_status rocsolver_create_handle(rocsolver_handle* handle)
+{
+    const rocblas_status stat = rocblas_create_handle(handle);
+    if(stat != rocblas_status_success)
+    {
+        return stat;
+    }
+    return rocblas_set_pointer_mode(*handle, rocblas_pointer_mode_device);
+}
+
+rocsolver_status rocsolver_destroy_handle(rocsolver_handle handle)
+{
+    return rocblas_destroy_handle(handle);
+}
+
+rocsolver_status rocsolver_set_stream(rocsolver_handle handle, hipStream_t stream)
+{
+    return rocblas_set_stream(handle, stream);
+}
+
+rocsolver_status rocsolver_get_stream(rocsolver_handle handle, hipStream_t* stream)
+{
+    return rocblas_get_stream(handle, stream);
+}
+
+rocsolver_status rocsolver_set_vector(rocsolver_int n,
+                                      rocsolver_int elem_size,
+                                      const void* x,
+                                      rocsolver_int incx,
+                                      void* y,
+                                      rocsolver_int incy)
+{
+    return rocblas_set_vector(n, elem_size, x, incx, y, incy);
+}
+
+rocsolver_status rocsolver_get_vector(rocsolver_int n,
+                                      rocsolver_int elem_size,
+                                      const void* x,
+                                      rocsolver_int incx,
+                                      void* y,
+                                      rocsolver_int incy)
+{
+    return rocblas_get_vector(n, elem_size, x, incx, y, incy);
+}
+
+rocsolver_status rocsolver_set_matrix(rocsolver_int rows,
+                                      rocsolver_int cols,
+                                      rocsolver_int elem_size,
+                                      const void* a,
+                                      rocsolver_int lda,
+                                      void* b,
+                                      rocsolver_int ldb)
+{
+    return rocblas_set_matrix(rows, cols, elem_size, a, lda, b, ldb);
+}
+
+rocsolver_status rocsolver_get_matrix(rocsolver_int rows,
+                                      rocsolver_int cols,
+                                      rocsolver_int elem_size,
+                                      const void* a,
+                                      rocsolver_int lda,
+                                      void* b,
+                                      rocsolver_int ldb)
+{
+    return rocblas_get_matrix(rows, cols, elem_size, a, lda, b, ldb);
+}
+
+#pragma GCC diagnostic pop // reenable deprecation warnings
+}


### PR DESCRIPTION
This mostly reverts #511. I suppose the deprecated functions will live on for one more release.