### PR TITLE
Add explicit certifi version and m2r2 dependency to docs build

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -2,4 +2,4 @@ FROM readthedocs/build:latest
 
 USER root:root
 RUN apt-get install -qq doxygen
-RUN pip3 install breathe sphinx sphinx_rtd_theme
+RUN pip3 install breathe sphinx m2r2 sphinx_rtd_theme

--- a/docs/source/requirements.in
+++ b/docs/source/requirements.in
@@ -6,3 +6,4 @@ breathe==4.28.0
 m2r2==0.3.1
 mistune==0.8.4
 jinja2==3.0.3
+certifi==2022.12.7


### PR DESCRIPTION
This fixes a security concern with dependabot, I also found I had to add m2r2 as an explicit pip install argument to get the docs to compile locally.