### PR TITLE
Fix incorrect CMake version check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
+# Copyright (c) 2019-2023 Advanced Micro Devices, Inc.
 # ########################################################################
 
 cmake_minimum_required(VERSION 3.13)
@@ -20,7 +20,7 @@ unset(ENV{ROCM_BUILD_ID})
 
 # Disable ROCMClang detection to make CMake v3.21 work the same as CMake v3.20 and earlier.
 # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/6533
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.22.0 AND CMAKE_VERSION VERSION_LESS 3.21.3)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.21.0 AND CMAKE_VERSION VERSION_LESS 3.21.3)
   set(__skip_rocmclang ON)
 endif()
 message(STATUS "Using CMake ${CMAKE_VERSION}")


### PR DESCRIPTION
It looks like the last version bump accidentally changed a CMake version check as well. We should fix this for the upcoming release and possibly for 5.5 as well.