### PR TITLE
Final rocblas interface changes

### DIFF
--- a/library/src/auxiliary/rocauxiliary_larfb.hpp
+++ b/library/src/auxiliary/rocauxiliary_larfb.hpp
@@ -302,12 +302,12 @@ rocblas_status rocsolver_larfb_template(rocblas_handle handle,
     if(trap)
     {
         if(leftside)
-            rocblasCall_gemm<BATCHED, STRIDED, T>(handle, transp, rocblas_operation_none, ldw,
+            rocblasCall_gemm(handle, transp, rocblas_operation_none, ldw,
                                                   order, m - k, &one, V, offsetV2, ldv, strideV, A,
                                                   offsetA2, lda, strideA, &one, tmptr, 0, ldw,
                                                   strideW, batch_count, workArr);
         else
-            rocblasCall_gemm<BATCHED, STRIDED, T>(handle, rocblas_operation_none, transp, ldw,
+            rocblasCall_gemm(handle, rocblas_operation_none, transp, ldw,
                                                   order, n - k, &one, A, offsetA2, lda, strideA, V,
                                                   offsetV2, ldv, strideV, &one, tmptr, 0, ldw,
                                                   strideW, batch_count, workArr);
@@ -328,12 +328,12 @@ rocblas_status rocsolver_larfb_template(rocblas_handle handle,
     if(trap)
     {
         if(leftside)
-            rocblasCall_gemm<BATCHED, STRIDED, T>(handle, transp, rocblas_operation_none, m - k,
+            rocblasCall_gemm(handle, transp, rocblas_operation_none, m - k,
                                                   order, ldw, &minone, V, offsetV2, ldv, strideV,
                                                   tmptr, 0, ldw, strideW, &one, A, offsetA2, lda,
                                                   strideA, batch_count, workArr);
         else
-            rocblasCall_gemm<BATCHED, STRIDED, T>(handle, rocblas_operation_none, transp, ldw,
+            rocblasCall_gemm(handle, rocblas_operation_none, transp, ldw,
                                                   n - k, order, &minone, tmptr, 0, ldw, strideW, V,
                                                   offsetV2, ldv, strideV, &one, A, offsetA2, lda,
                                                   strideA, batch_count, workArr);

--- a/library/src/auxiliary/rocauxiliary_larfb.hpp
+++ b/library/src/auxiliary/rocauxiliary_larfb.hpp
@@ -302,15 +302,13 @@ rocblas_status rocsolver_larfb_template(rocblas_handle handle,
     if(trap)
     {
         if(leftside)
-            rocblasCall_gemm(handle, transp, rocblas_operation_none, ldw,
-                                                  order, m - k, &one, V, offsetV2, ldv, strideV, A,
-                                                  offsetA2, lda, strideA, &one, tmptr, 0, ldw,
-                                                  strideW, batch_count, workArr);
+            rocblasCall_gemm(handle, transp, rocblas_operation_none, ldw, order, m - k, &one, V,
+                             offsetV2, ldv, strideV, A, offsetA2, lda, strideA, &one, tmptr, 0, ldw,
+                             strideW, batch_count, workArr);
         else
-            rocblasCall_gemm(handle, rocblas_operation_none, transp, ldw,
-                                                  order, n - k, &one, A, offsetA2, lda, strideA, V,
-                                                  offsetV2, ldv, strideV, &one, tmptr, 0, ldw,
-                                                  strideW, batch_count, workArr);
+            rocblasCall_gemm(handle, rocblas_operation_none, transp, ldw, order, n - k, &one, A,
+                             offsetA2, lda, strideA, V, offsetV2, ldv, strideV, &one, tmptr, 0, ldw,
+                             strideW, batch_count, workArr);
     }
 
     // compute: trans(T) * (V1' * A1 + V2' * A2)
@@ -328,15 +326,13 @@ rocblas_status rocsolver_larfb_template(rocblas_handle handle,
     if(trap)
     {
         if(leftside)
-            rocblasCall_gemm(handle, transp, rocblas_operation_none, m - k,
-                                                  order, ldw, &minone, V, offsetV2, ldv, strideV,
-                                                  tmptr, 0, ldw, strideW, &one, A, offsetA2, lda,
-                                                  strideA, batch_count, workArr);
+            rocblasCall_gemm(handle, transp, rocblas_operation_none, m - k, order, ldw, &minone, V,
+                             offsetV2, ldv, strideV, tmptr, 0, ldw, strideW, &one, A, offsetA2, lda,
+                             strideA, batch_count, workArr);
         else
-            rocblasCall_gemm(handle, rocblas_operation_none, transp, ldw,
-                                                  n - k, order, &minone, tmptr, 0, ldw, strideW, V,
-                                                  offsetV2, ldv, strideV, &one, A, offsetA2, lda,
-                                                  strideA, batch_count, workArr);
+            rocblasCall_gemm(handle, rocblas_operation_none, transp, ldw, n - k, order, &minone,
+                             tmptr, 0, ldw, strideW, V, offsetV2, ldv, strideV, &one, A, offsetA2,
+                             lda, strideA, batch_count, workArr);
     }
 
     // compute: V1 * trans(T) * (V1' * A1 + V2' * A2)

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1380,7 +1380,7 @@ void local_gemm(rocblas_handle handle,
     S zero = 0.0;
 
     // temp = A*B
-    rocblasCall_gemm<BATCHED, STRIDED, T>(
+    rocblasCall_gemm(
         handle, rocblas_operation_none, rocblas_operation_none, n, n, n, &one, A, shiftA, lda,
         strideA, B, shiftT, ldt, strideT, &zero, temp, shiftT, ldt, strideT, batch_count, workArr);
 

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1380,9 +1380,9 @@ void local_gemm(rocblas_handle handle,
     S zero = 0.0;
 
     // temp = A*B
-    rocblasCall_gemm(
-        handle, rocblas_operation_none, rocblas_operation_none, n, n, n, &one, A, shiftA, lda,
-        strideA, B, shiftT, ldt, strideT, &zero, temp, shiftT, ldt, strideT, batch_count, workArr);
+    rocblasCall_gemm(handle, rocblas_operation_none, rocblas_operation_none, n, n, n, &one, A,
+                     shiftA, lda, strideA, B, shiftT, ldt, strideT, &zero, temp, shiftT, ldt,
+                     strideT, batch_count, workArr);
 
     // A = temp
     hipStream_t stream;
@@ -1433,9 +1433,9 @@ void local_gemm(rocblas_handle handle,
                             strideA, work, rocblas_fill_full);
 
     // temp = work*B
-    rocblasCall_gemm(
-        handle, rocblas_operation_none, rocblas_operation_none, n, n, n, &one, work, shiftT, ldt,
-        strideT, B, shiftT, ldt, strideT, &zero, temp, shiftT, ldt, strideT, batch_count, workArr);
+    rocblasCall_gemm(handle, rocblas_operation_none, rocblas_operation_none, n, n, n, &one, work,
+                     shiftT, ldt, strideT, B, shiftT, ldt, strideT, &zero, temp, shiftT, ldt,
+                     strideT, batch_count, workArr);
 
     // real(A) = temp
     ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, S, true>), dim3(blocks, blocks, batch_count),
@@ -1448,9 +1448,9 @@ void local_gemm(rocblas_handle handle,
                             strideA, work, rocblas_fill_full);
 
     // temp = work*B
-    rocblasCall_gemm(
-        handle, rocblas_operation_none, rocblas_operation_none, n, n, n, &one, work, shiftT, ldt,
-        strideT, B, shiftT, ldt, strideT, &zero, temp, shiftT, ldt, strideT, batch_count, workArr);
+    rocblasCall_gemm(handle, rocblas_operation_none, rocblas_operation_none, n, n, n, &one, work,
+                     shiftT, ldt, strideT, B, shiftT, ldt, strideT, &zero, temp, shiftT, ldt,
+                     strideT, batch_count, workArr);
 
     // imag(A) = temp
     ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, S, false>), dim3(blocks, blocks, batch_count),

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1433,7 +1433,7 @@ void local_gemm(rocblas_handle handle,
                             strideA, work, rocblas_fill_full);
 
     // temp = work*B
-    rocblasCall_gemm<BATCHED, STRIDED, S>(
+    rocblasCall_gemm(
         handle, rocblas_operation_none, rocblas_operation_none, n, n, n, &one, work, shiftT, ldt,
         strideT, B, shiftT, ldt, strideT, &zero, temp, shiftT, ldt, strideT, batch_count, workArr);
 
@@ -1448,7 +1448,7 @@ void local_gemm(rocblas_handle handle,
                             strideA, work, rocblas_fill_full);
 
     // temp = work*B
-    rocblasCall_gemm<BATCHED, STRIDED, S>(
+    rocblasCall_gemm(
         handle, rocblas_operation_none, rocblas_operation_none, n, n, n, &one, work, shiftT, ldt,
         strideT, B, shiftT, ldt, strideT, &zero, temp, shiftT, ldt, strideT, batch_count, workArr);
 

--- a/library/src/include/rocblas.hpp
+++ b/library/src/include/rocblas.hpp
@@ -1590,6 +1590,46 @@ rocblas_status rocblasCall_symv_hemv(rocblas_handle handle,
                                               offsety, incy, stridey, batch_count, work);
 }
 
+// symv/hemv batched
+template <typename T>
+rocblas_status rocblasCall_symv_hemv(rocblas_handle handle,
+                                     rocblas_fill uplo,
+                                     rocblas_int n,
+                                     const T* alpha,
+                                     rocblas_stride stridea,
+                                     const T* const* A,
+                                     rocblas_stride offsetA,
+                                     rocblas_int lda,
+                                     rocblas_stride strideA,
+                                     const T* const* x,
+                                     rocblas_stride offsetx,
+                                     rocblas_int incx,
+                                     rocblas_stride stridex,
+                                     const T* beta,
+                                     rocblas_stride strideb,
+                                     T* const* y,
+                                     rocblas_stride offsety,
+                                     rocblas_int incy,
+                                     rocblas_stride stridey,
+                                     rocblas_int batch_count,
+                                     T* work,
+                                     T** workArr)
+{
+    constexpr auto name = rocblas_is_complex<T> ? "hemv" : "symv";
+    // TODO: How to get alpha and beta for trace logging
+    ROCBLAS_ENTER(name, "uplo:", uplo, "n:", n, "shiftA:", offsetA, "lda:", lda, "shiftX:", offsetx,
+                  "incx:", incx, "shiftY:", offsety, "incy:", incy, "bc:", batch_count);
+
+    if constexpr(!rocblas_is_complex<T>)
+        return rocblas_internal_symv_batched_template(
+            handle, uplo, n, alpha, stridea, A, offsetA, lda, strideA, x, offsetx, incx, stridex,
+            beta, strideb, y, offsety, incy, stridey, batch_count, work);
+    else
+        return rocblas_internal_hemv_batched_template(
+            handle, uplo, n, alpha, stridea, A, offsetA, lda, strideA, x, offsetx, incx, stridex,
+            beta, strideb, y, offsety, incy, stridey, batch_count, work);
+}
+
 // symv/hemv overload - batched with strided y
 template <typename T>
 rocblas_status rocblasCall_symv_hemv(rocblas_handle handle,

--- a/library/src/include/rocblas.hpp
+++ b/library/src/include/rocblas.hpp
@@ -260,13 +260,13 @@ rocblas_status rocblasCall_ger(rocblas_handle handle,
                   "incy:", incy, "shiftA:", offsetA, "lda:", lda, "bc:", batch_count);
 
     if constexpr(CONJ)
-        return rocblas_internal_gerc_template(
-            handle, m, n, alpha, stridea, x, offsetx, incx, stridex,
-            y, offsety, incy, stridey, A, offsetA, lda, strideA, batch_count);
+        return rocblas_internal_gerc_template(handle, m, n, alpha, stridea, x, offsetx, incx,
+                                              stridex, y, offsety, incy, stridey, A, offsetA, lda,
+                                              strideA, batch_count);
     else
-        return rocblas_internal_ger_template(
-            handle, m, n, alpha, stridea, x, offsetx, incx, stridex,
-            y, offsety, incy, stridey, A, offsetA, lda, strideA, batch_count);
+        return rocblas_internal_ger_template(handle, m, n, alpha, stridea, x, offsetx, incx,
+                                             stridex, y, offsety, incy, stridey, A, offsetA, lda,
+                                             strideA, batch_count);
 }
 
 // ger batched
@@ -296,13 +296,13 @@ rocblas_status rocblasCall_ger(rocblas_handle handle,
                   "incy:", incy, "shiftA:", offsetA, "lda:", lda, "bc:", batch_count);
 
     if constexpr(CONJ)
-        return rocblas_internal_gerc_batched_template(
-            handle, m, n, alpha, stridea, x, offsetx, incx, stridex,
-            y, offsety, incy, stridey, A, offsetA, lda, strideA, batch_count);
+        return rocblas_internal_gerc_batched_template(handle, m, n, alpha, stridea, x, offsetx,
+                                                      incx, stridex, y, offsety, incy, stridey, A,
+                                                      offsetA, lda, strideA, batch_count);
     else
-        return rocblas_internal_ger_batched_template(
-            handle, m, n, alpha, stridea, x, offsetx, incx, stridex,
-            y, offsety, incy, stridey, A, offsetA, lda, strideA, batch_count);
+        return rocblas_internal_ger_batched_template(handle, m, n, alpha, stridea, x, offsetx, incx,
+                                                     stridex, y, offsety, incy, stridey, A, offsetA,
+                                                     lda, strideA, batch_count);
 }
 
 // ger overload - batched with strided y
@@ -340,12 +340,12 @@ rocblas_status rocblasCall_ger(rocblas_handle handle,
 
     if constexpr(CONJ)
         return rocblas_internal_gerc_batched_template(
-            handle, m, n, alpha, stridea, x, offsetx, incx, stridex,
-            cast2constType<T>(work), offsety, incy, stridey, A, offsetA, lda, strideA, batch_count);
+            handle, m, n, alpha, stridea, x, offsetx, incx, stridex, cast2constType<T>(work),
+            offsety, incy, stridey, A, offsetA, lda, strideA, batch_count);
     else
-        return rocblas_internal_ger_batched_template(
-            handle, m, n, alpha, stridea, x, offsetx, incx, stridex,
-            cast2constType<T>(work), offsety, incy, stridey, A, offsetA, lda, strideA, batch_count);
+        return rocblas_internal_ger_batched_template(handle, m, n, alpha, stridea, x, offsetx, incx,
+                                                     stridex, cast2constType<T>(work), offsety, incy,
+                                                     stridey, A, offsetA, lda, strideA, batch_count);
 }
 
 // ger overload - batched with strided x
@@ -383,12 +383,12 @@ rocblas_status rocblasCall_ger(rocblas_handle handle,
 
     if constexpr(CONJ)
         return rocblas_internal_gerc_batched_template(
-            handle, m, n, alpha, stridea, cast2constType<T>(work), offsetx, incx, stridex,
-            y, offsety, incy, stridey, A, offsetA, lda, strideA, batch_count);
+            handle, m, n, alpha, stridea, cast2constType<T>(work), offsetx, incx, stridex, y,
+            offsety, incy, stridey, A, offsetA, lda, strideA, batch_count);
     else
         return rocblas_internal_ger_batched_template(
-            handle, m, n, alpha, stridea, cast2constType<T>(work), offsetx, incx, stridex,
-            y, offsety, incy, stridey, A, offsetA, lda, strideA, batch_count);
+            handle, m, n, alpha, stridea, cast2constType<T>(work), offsetx, incx, stridex, y,
+            offsety, incy, stridey, A, offsetA, lda, strideA, batch_count);
 }
 
 // gemv - non batched
@@ -421,10 +421,9 @@ rocblas_status rocblasCall_gemv(rocblas_handle handle,
                   "shiftX:", offsetx, "incx:", incx, "shiftY:", offsety, "incy:", incy,
                   "bc:", batch_count);
 
-    return rocblas_internal_gemv_template(handle, transA, m, n, alpha, stride_alpha,
-                                             A, offseta, lda, strideA,
-                                             x, offsetx, incx, stridex, beta,
-                                             stride_beta, y, offsety, incy, stridey, batch_count);
+    return rocblas_internal_gemv_template(handle, transA, m, n, alpha, stride_alpha, A, offseta,
+                                          lda, strideA, x, offsetx, incx, stridex, beta,
+                                          stride_beta, y, offsety, incy, stridey, batch_count);
 }
 
 // gemv - batched
@@ -457,10 +456,9 @@ rocblas_status rocblasCall_gemv(rocblas_handle handle,
                   "shiftX:", offsetx, "incx:", incx, "shiftY:", offsety, "incy:", incy,
                   "bc:", batch_count);
 
-    return rocblas_internal_gemv_batched_template(handle, transA, m, n, alpha, stride_alpha,
-                                             A, offseta, lda, strideA,
-                                             x, offsetx, incx, stridex, beta,
-                                             stride_beta, y, offsety, incy, stridey, batch_count);
+    return rocblas_internal_gemv_batched_template(
+        handle, transA, m, n, alpha, stride_alpha, A, offseta, lda, strideA, x, offsetx, incx,
+        stridex, beta, stride_beta, y, offsety, incy, stridey, batch_count);
 }
 
 // gemv overload - batched with strided A
@@ -500,10 +498,9 @@ rocblas_status rocblasCall_gemv(rocblas_handle handle,
     ROCSOLVER_LAUNCH_KERNEL(get_array, dim3(blocks), dim3(256), 0, stream, work, A, strideA,
                             batch_count);
 
-    return rocblas_internal_gemv_batched_template(handle, transA, m, n, alpha, stride_alpha,
-                                             cast2constType<T>(work), offseta, lda, strideA,
-                                             x, offsetx, incx, stridex, beta,
-                                             stride_beta, y, offsety, incy, stridey, batch_count);
+    return rocblas_internal_gemv_batched_template(
+        handle, transA, m, n, alpha, stride_alpha, cast2constType<T>(work), offseta, lda, strideA,
+        x, offsetx, incx, stridex, beta, stride_beta, y, offsety, incy, stridey, batch_count);
 }
 
 // gemv overload - batched with strided x
@@ -543,10 +540,10 @@ rocblas_status rocblasCall_gemv(rocblas_handle handle,
     ROCSOLVER_LAUNCH_KERNEL(get_array, dim3(blocks), dim3(256), 0, stream, work, x, stridex,
                             batch_count);
 
-    return rocblas_internal_gemv_batched_template(handle, transA, m, n, alpha, stride_alpha,
-                                             A, offseta, lda, strideA,
-                                             cast2constType<T>(work), offsetx, incx, stridex, beta,
-                                             stride_beta, y, offsety, incy, stridey, batch_count);
+    return rocblas_internal_gemv_batched_template(handle, transA, m, n, alpha, stride_alpha, A,
+                                                  offseta, lda, strideA, cast2constType<T>(work),
+                                                  offsetx, incx, stridex, beta, stride_beta, y,
+                                                  offsety, incy, stridey, batch_count);
 }
 
 // gemv overload - batched with strided y
@@ -586,10 +583,10 @@ rocblas_status rocblasCall_gemv(rocblas_handle handle,
     ROCSOLVER_LAUNCH_KERNEL(get_array, dim3(blocks), dim3(256), 0, stream, work, y, stridey,
                             batch_count);
 
-    return rocblas_internal_gemv_batched_template(
-        handle, transA, m, n, alpha, stride_alpha, A, offseta, lda, strideA,
-        x, offsetx, incx, stridex, beta, stride_beta, cast2constPointer<T>(work),
-        offsety, incy, stridey, batch_count);
+    return rocblas_internal_gemv_batched_template(handle, transA, m, n, alpha, stride_alpha, A,
+                                                  offseta, lda, strideA, x, offsetx, incx, stridex,
+                                                  beta, stride_beta, cast2constPointer<T>(work),
+                                                  offsety, incy, stridey, batch_count);
 }
 
 // gemv overload - batched with strided x and y
@@ -678,8 +675,8 @@ rocblas_status rocblasCall_gemv(rocblas_handle handle,
 
     return rocblas_internal_gemv_batched_template(
         handle, transA, m, n, alpha, stride_alpha, cast2constType<T>(work), offseta, lda, strideA,
-        x, offsetx, incx, stridex, beta, stride_beta,
-        cast2constPointer<T>(work + batch_count), offsety, incy, stridey, batch_count);
+        x, offsetx, incx, stridex, beta, stride_beta, cast2constPointer<T>(work + batch_count),
+        offsety, incy, stridey, batch_count);
 }
 
 // trmv
@@ -704,9 +701,8 @@ rocblas_status rocblasCall_trmv(rocblas_handle handle,
     ROCBLAS_ENTER("trmv", "trans:", transa, "diag:", diag, "m:", m, "shiftA:", offseta, "lda:", lda,
                   "shiftX:", offsetx, "incx:", incx, "bc:", batch_count);
 
-    return rocblas_internal_trmv_template(handle, uplo, transa, diag, m, a,
-                                          offseta, lda, stridea, x, offsetx, incx, stridex, w,
-                                          stridew, batch_count);
+    return rocblas_internal_trmv_template(handle, uplo, transa, diag, m, a, offseta, lda, stridea,
+                                          x, offsetx, incx, stridex, w, stridew, batch_count);
 }
 
 template <typename T>
@@ -730,9 +726,9 @@ rocblas_status rocblasCall_trmv(rocblas_handle handle,
     ROCBLAS_ENTER("trmv", "trans:", transa, "diag:", diag, "m:", m, "shiftA:", offseta, "lda:", lda,
                   "shiftX:", offsetx, "incx:", incx, "bc:", batch_count);
 
-    return rocblas_internal_trmv_batched_template(handle, uplo, transa, diag, m, a,
-                                          offseta, lda, stridea, x, offsetx, incx, stridex, w,
-                                          stridew, batch_count);
+    return rocblas_internal_trmv_batched_template(handle, uplo, transa, diag, m, a, offseta, lda,
+                                                  stridea, x, offsetx, incx, stridex, w, stridew,
+                                                  batch_count);
 }
 
 // gemm - non batched
@@ -765,10 +761,9 @@ rocblas_status rocblasCall_gemm(rocblas_handle handle,
                   "shiftA:", offset_a, "lda:", ld_a, "shiftB:", offset_b, "ldb:", ld_b,
                   "shiftC:", offset_c, "ldc:", ld_c, "bc:", batch_count);
 
-    return rocblas_internal_gemm_template(
-        handle, trans_a, trans_b, m, n, k, alpha, A, offset_a, ld_a, stride_a,
-        B, offset_b, ld_b, stride_b, beta, C, offset_c, ld_c, stride_c,
-        batch_count);
+    return rocblas_internal_gemm_template(handle, trans_a, trans_b, m, n, k, alpha, A, offset_a,
+                                          ld_a, stride_a, B, offset_b, ld_b, stride_b, beta, C,
+                                          offset_c, ld_c, stride_c, batch_count);
 }
 
 // gemm - batched
@@ -780,7 +775,7 @@ rocblas_status rocblasCall_gemm(rocblas_handle handle,
                                 rocblas_int n,
                                 rocblas_int k,
                                 const T* alpha,
-                                const T* const *A,
+                                const T* const* A,
                                 rocblas_stride offset_a,
                                 rocblas_int ld_a,
                                 rocblas_stride stride_a,
@@ -802,9 +797,8 @@ rocblas_status rocblasCall_gemm(rocblas_handle handle,
                   "shiftC:", offset_c, "ldc:", ld_c, "bc:", batch_count);
 
     return rocblas_internal_gemm_batched_template(
-        handle, trans_a, trans_b, m, n, k, alpha, A, offset_a, ld_a, stride_a,
-        B, offset_b, ld_b, stride_b, beta, C, offset_c, ld_c, stride_c,
-        batch_count);
+        handle, trans_a, trans_b, m, n, k, alpha, A, offset_a, ld_a, stride_a, B, offset_b, ld_b,
+        stride_b, beta, C, offset_c, ld_c, stride_c, batch_count);
 }
 
 // gemm overload - batched with strided A
@@ -846,8 +840,7 @@ rocblas_status rocblasCall_gemm(rocblas_handle handle,
 
     return rocblas_internal_gemm_batched_template(
         handle, trans_a, trans_b, m, n, k, alpha, cast2constType<T>(work), offset_a, ld_a, stride_a,
-        B, offset_b, ld_b, stride_b, beta, C, offset_c, ld_c, stride_c,
-        batch_count);
+        B, offset_b, ld_b, stride_b, beta, C, offset_c, ld_c, stride_c, batch_count);
 }
 
 // gemm overload - batched with strided B
@@ -887,10 +880,10 @@ rocblas_status rocblasCall_gemm(rocblas_handle handle,
     ROCSOLVER_LAUNCH_KERNEL(get_array, dim3(blocks), dim3(256), 0, stream, work, B, stride_b,
                             batch_count);
 
-    return rocblas_internal_gemm_batched_template(
-        handle, trans_a, trans_b, m, n, k, alpha, A, offset_a, ld_a, stride_a,
-        cast2constType<T>(work), offset_b, ld_b, stride_b, beta, C, offset_c, ld_c, stride_c,
-        batch_count);
+    return rocblas_internal_gemm_batched_template(handle, trans_a, trans_b, m, n, k, alpha, A,
+                                                  offset_a, ld_a, stride_a, cast2constType<T>(work),
+                                                  offset_b, ld_b, stride_b, beta, C, offset_c, ld_c,
+                                                  stride_c, batch_count);
 }
 
 // gemm overload - batched with strided C
@@ -931,9 +924,8 @@ rocblas_status rocblasCall_gemm(rocblas_handle handle,
                             batch_count);
 
     return rocblas_internal_gemm_batched_template(
-        handle, trans_a, trans_b, m, n, k, alpha, A, offset_a, ld_a, stride_a,
-        B, offset_b, ld_b, stride_b, beta, cast2constPointer(work), offset_c,
-        ld_c, stride_c, batch_count);
+        handle, trans_a, trans_b, m, n, k, alpha, A, offset_a, ld_a, stride_a, B, offset_b, ld_b,
+        stride_b, beta, cast2constPointer(work), offset_c, ld_c, stride_c, batch_count);
 }
 
 // gemm overload - batched with strided B and C
@@ -1022,8 +1014,8 @@ rocblas_status rocblasCall_gemm(rocblas_handle handle,
 
     return rocblas_internal_gemm_batched_template(
         handle, trans_a, trans_b, m, n, k, alpha, cast2constType<T>(work), offset_a, ld_a, stride_a,
-        B, offset_b, ld_b, stride_b, beta, cast2constPointer(work + batch_count),
-        offset_c, ld_c, stride_c, batch_count);
+        B, offset_b, ld_b, stride_b, beta, cast2constPointer(work + batch_count), offset_c, ld_c,
+        stride_c, batch_count);
 }
 
 // gemm overload - batched with strided A and B
@@ -1197,18 +1189,17 @@ rocblas_status rocblasCall_syr2_her2(rocblas_handle handle,
 {
     constexpr auto name = rocblas_is_complex<T> ? "her2" : "syr2";
     // TODO: How to get alpha for trace logging
-    ROCBLAS_ENTER(name, "uplo:", uplo, "n:", n, "shiftX:", offsetx, "incx:", incx,
-                  "shiftY:", offsety, "incy:", incy, "shiftA:", offsetA, "lda:", lda,
-                  "bc:", batch_count);
+    ROCBLAS_ENTER(name, "uplo:", uplo, "n:", n, "shiftX:", offsetx, "incx:", incx, "shiftY:", offsety,
+                  "incy:", incy, "shiftA:", offsetA, "lda:", lda, "bc:", batch_count);
 
     if constexpr(!rocblas_is_complex<T>)
-        return rocblas_internal_syr2_template(
-            handle, uplo, n, alpha, x, offsetx, incx, stridex,
-            y, offsety, incy, stridey, A, lda, offsetA, strideA, batch_count);
+        return rocblas_internal_syr2_template(handle, uplo, n, alpha, x, offsetx, incx, stridex, y,
+                                              offsety, incy, stridey, A, lda, offsetA, strideA,
+                                              batch_count);
     else
-        return rocblas_internal_her2_template(
-            handle, uplo, n, alpha, x, offsetx, incx, stridex,
-            y, offsety, incy, stridey, A, lda, offsetA, strideA, batch_count);
+        return rocblas_internal_her2_template(handle, uplo, n, alpha, x, offsetx, incx, stridex, y,
+                                              offsety, incy, stridey, A, lda, offsetA, strideA,
+                                              batch_count);
 }
 
 // syr2/her2 batched
@@ -1234,18 +1225,17 @@ rocblas_status rocblasCall_syr2_her2(rocblas_handle handle,
 {
     constexpr auto name = rocblas_is_complex<T> ? "her2" : "syr2";
     // TODO: How to get alpha for trace logging
-    ROCBLAS_ENTER(name, "uplo:", uplo, "n:", n, "shiftX:", offsetx, "incx:", incx,
-                  "shiftY:", offsety, "incy:", incy, "shiftA:", offsetA, "lda:", lda,
-                  "bc:", batch_count);
+    ROCBLAS_ENTER(name, "uplo:", uplo, "n:", n, "shiftX:", offsetx, "incx:", incx, "shiftY:", offsety,
+                  "incy:", incy, "shiftA:", offsetA, "lda:", lda, "bc:", batch_count);
 
     if constexpr(!rocblas_is_complex<T>)
-        return rocblas_internal_syr2_batched_template(
-            handle, uplo, n, alpha, x, offsetx, incx, stridex,
-            y, offsety, incy, stridey, A, lda, offsetA, strideA, batch_count);
+        return rocblas_internal_syr2_batched_template(handle, uplo, n, alpha, x, offsetx, incx,
+                                                      stridex, y, offsety, incy, stridey, A, lda,
+                                                      offsetA, strideA, batch_count);
     else
-        return rocblas_internal_her2_batched_template(
-            handle, uplo, n, alpha, x, offsetx, incx, stridex,
-            y, offsety, incy, stridey, A, lda, offsetA, strideA, batch_count);
+        return rocblas_internal_her2_batched_template(handle, uplo, n, alpha, x, offsetx, incx,
+                                                      stridex, y, offsety, incy, stridey, A, lda,
+                                                      offsetA, strideA, batch_count);
 }
 
 // syr2/her2 overload - complex with strided y
@@ -1271,9 +1261,8 @@ rocblas_status rocblasCall_syr2_her2(rocblas_handle handle,
 {
     constexpr auto name = rocblas_is_complex<T> ? "her2" : "syr2";
     // TODO: How to get alpha for trace logging
-    ROCBLAS_ENTER(name, "uplo:", uplo, "n:", n, "shiftX:", offsetx, "incx:", incx,
-                  "shiftY:", offsety, "incy:", incy, "shiftA:", offsetA, "lda:", lda,
-                  "bc:", batch_count);
+    ROCBLAS_ENTER(name, "uplo:", uplo, "n:", n, "shiftX:", offsetx, "incx:", incx, "shiftY:", offsety,
+                  "incy:", incy, "shiftA:", offsetA, "lda:", lda, "bc:", batch_count);
 
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
@@ -1283,13 +1272,13 @@ rocblas_status rocblasCall_syr2_her2(rocblas_handle handle,
                             batch_count);
 
     if constexpr(!rocblas_is_complex<T>)
-        return rocblas_internal_syr2_batched_template(
-            handle, uplo, n, alpha, x, offsetx, incx, stridex,
-            work, offsety, incy, stridey, A, lda, offsetA, strideA, batch_count);
+        return rocblas_internal_syr2_batched_template(handle, uplo, n, alpha, x, offsetx, incx,
+                                                      stridex, work, offsety, incy, stridey, A, lda,
+                                                      offsetA, strideA, batch_count);
     else
-        return rocblas_internal_her2_batched_template(
-            handle, uplo, n, alpha, x, offsetx, incx, stridex,
-            work, offsety, incy, stridey, A, lda, offsetA, strideA, batch_count);
+        return rocblas_internal_her2_batched_template(handle, uplo, n, alpha, x, offsetx, incx,
+                                                      stridex, work, offsety, incy, stridey, A, lda,
+                                                      offsetA, strideA, batch_count);
 }
 
 // syrk
@@ -1592,15 +1581,13 @@ rocblas_status rocblasCall_symv_hemv(rocblas_handle handle,
                   "incx:", incx, "shiftY:", offsety, "incy:", incy, "bc:", batch_count);
 
     if constexpr(!rocblas_is_complex<T>)
-        return rocblas_internal_symv_template(
-            handle, uplo, n, alpha, stridea, A, offsetA, lda,
-            strideA, x, offsetx, incx, stridex, beta, strideb, y,
-            offsety, incy, stridey, batch_count, work);
+        return rocblas_internal_symv_template(handle, uplo, n, alpha, stridea, A, offsetA, lda,
+                                              strideA, x, offsetx, incx, stridex, beta, strideb, y,
+                                              offsety, incy, stridey, batch_count, work);
     else
-        return rocblas_internal_hemv_template(
-            handle, uplo, n, alpha, stridea, A, offsetA, lda,
-            strideA, x, offsetx, incx, stridex, beta, strideb, y,
-            offsety, incy, stridey, batch_count, work);
+        return rocblas_internal_hemv_template(handle, uplo, n, alpha, stridea, A, offsetA, lda,
+                                              strideA, x, offsetx, incx, stridex, beta, strideb, y,
+                                              offsety, incy, stridey, batch_count, work);
 }
 
 // symv/hemv overload - batched with strided y
@@ -1641,15 +1628,15 @@ rocblas_status rocblasCall_symv_hemv(rocblas_handle handle,
                             batch_count);
 
     if constexpr(!rocblas_is_complex<T>)
-        return rocblas_internal_symv_batched_template(
-            handle, uplo, n, alpha, stridea, A, offsetA, lda,
-            strideA, x, offsetx, incx, stridex, beta, strideb,
-            cast2constPointer<T>(workArr), offsety, incy, stridey, batch_count, work);
+        return rocblas_internal_symv_batched_template(handle, uplo, n, alpha, stridea, A, offsetA,
+                                                      lda, strideA, x, offsetx, incx, stridex, beta,
+                                                      strideb, cast2constPointer<T>(workArr),
+                                                      offsety, incy, stridey, batch_count, work);
     else
-        return rocblas_internal_hemv_batched_template(
-            handle, uplo, n, alpha, stridea, A, offsetA, lda,
-            strideA, x, offsetx, incx, stridex, beta, strideb,
-            cast2constPointer<T>(workArr), offsety, incy, stridey, batch_count, work);
+        return rocblas_internal_hemv_batched_template(handle, uplo, n, alpha, stridea, A, offsetA,
+                                                      lda, strideA, x, offsetx, incx, stridex, beta,
+                                                      strideb, cast2constPointer<T>(workArr),
+                                                      offsety, incy, stridey, batch_count, work);
 }
 
 // symm/hemm
@@ -1682,15 +1669,13 @@ rocblas_status rocblasCall_symm_hemm(rocblas_handle handle,
                   "bc:", batch_count);
 
     if constexpr(!rocblas_is_complex<T>)
-        return rocblas_internal_symm_template(
-            handle, side, uplo, m, n, alpha, A, offsetA, lda,
-            strideA, B, offsetB, ldb, strideB, beta, C, offsetC,
-            ldc, strideC, batch_count);
+        return rocblas_internal_symm_template(handle, side, uplo, m, n, alpha, A, offsetA, lda,
+                                              strideA, B, offsetB, ldb, strideB, beta, C, offsetC,
+                                              ldc, strideC, batch_count);
     else
-        return rocblas_internal_hemm_template(
-            handle, side, uplo, m, n, alpha, A, offsetA, lda,
-            strideA, B, offsetB, ldb, strideB, beta, C, offsetC,
-            ldc, strideC, batch_count);
+        return rocblas_internal_hemm_template(handle, side, uplo, m, n, alpha, A, offsetA, lda,
+                                              strideA, B, offsetB, ldb, strideB, beta, C, offsetC,
+                                              ldc, strideC, batch_count);
 }
 
 // symm/hemm batched
@@ -1723,15 +1708,13 @@ rocblas_status rocblasCall_symm_hemm(rocblas_handle handle,
                   "bc:", batch_count);
 
     if constexpr(!rocblas_is_complex<T>)
-        return rocblas_internal_symm_batched_template(
-            handle, side, uplo, m, n, alpha, A, offsetA, lda,
-            strideA, B, offsetB, ldb, strideB, beta, C, offsetC,
-            ldc, strideC, batch_count);
+        return rocblas_internal_symm_batched_template(handle, side, uplo, m, n, alpha, A, offsetA,
+                                                      lda, strideA, B, offsetB, ldb, strideB, beta,
+                                                      C, offsetC, ldc, strideC, batch_count);
     else
-        return rocblas_internal_hemm_batched_template(
-            handle, side, uplo, m, n, alpha, A, offsetA, lda,
-            strideA, B, offsetB, ldb, strideB, beta, C, offsetC,
-            ldc, strideC, batch_count);
+        return rocblas_internal_hemm_batched_template(handle, side, uplo, m, n, alpha, A, offsetA,
+                                                      lda, strideA, B, offsetB, ldb, strideB, beta,
+                                                      C, offsetC, ldc, strideC, batch_count);
 }
 
 // trsv

--- a/library/src/lapack/roclapack_geblttrf_npvt.hpp
+++ b/library/src/lapack/roclapack_geblttrf_npvt.hpp
@@ -174,10 +174,10 @@ rocblas_status rocsolver_geblttrf_npvt_template(rocblas_handle handle,
             0, C, shiftC + k * ldc * nb, ldc, strideC, batch_count, work1, work2, work3, work4,
             optim_mem, false);
 
-        rocblasCall_gemm<T>(
-            handle, rocblas_operation_none, rocblas_operation_none, nb, nb, nb, &minone, A,
-            shiftA + k * lda * nb, lda, strideA, C, shiftC + k * ldc * nb, ldc, strideC, &one, B,
-            shiftB + (k + 1) * ldb * nb, ldb, strideB, batch_count, nullptr);
+        rocblasCall_gemm<T>(handle, rocblas_operation_none, rocblas_operation_none, nb, nb, nb,
+                            &minone, A, shiftA + k * lda * nb, lda, strideA, C,
+                            shiftC + k * ldc * nb, ldc, strideC, &one, B,
+                            shiftB + (k + 1) * ldb * nb, ldb, strideB, batch_count, nullptr);
 
         rocsolver_getrf_template<BATCHED, STRIDED, T>(
             handle, nb, nb, B, shiftB + (k + 1) * ldb * nb, ldb, strideB, nullptr, 0, 0, iinfo2,

--- a/library/src/lapack/roclapack_geblttrf_npvt.hpp
+++ b/library/src/lapack/roclapack_geblttrf_npvt.hpp
@@ -174,7 +174,7 @@ rocblas_status rocsolver_geblttrf_npvt_template(rocblas_handle handle,
             0, C, shiftC + k * ldc * nb, ldc, strideC, batch_count, work1, work2, work3, work4,
             optim_mem, false);
 
-        rocblasCall_gemm<BATCHED, STRIDED, T>(
+        rocblasCall_gemm(
             handle, rocblas_operation_none, rocblas_operation_none, nb, nb, nb, &minone, A,
             shiftA + k * lda * nb, lda, strideA, C, shiftC + k * ldc * nb, ldc, strideC, &one, B,
             shiftB + (k + 1) * ldb * nb, ldb, strideB, batch_count, nullptr);

--- a/library/src/lapack/roclapack_geblttrf_npvt.hpp
+++ b/library/src/lapack/roclapack_geblttrf_npvt.hpp
@@ -174,7 +174,7 @@ rocblas_status rocsolver_geblttrf_npvt_template(rocblas_handle handle,
             0, C, shiftC + k * ldc * nb, ldc, strideC, batch_count, work1, work2, work3, work4,
             optim_mem, false);
 
-        rocblasCall_gemm(
+        rocblasCall_gemm<T>(
             handle, rocblas_operation_none, rocblas_operation_none, nb, nb, nb, &minone, A,
             shiftA + k * lda * nb, lda, strideA, C, shiftC + k * ldc * nb, ldc, strideC, &one, B,
             shiftB + (k + 1) * ldb * nb, ldb, strideB, batch_count, nullptr);

--- a/library/src/lapack/roclapack_geblttrs_npvt.hpp
+++ b/library/src/lapack/roclapack_geblttrs_npvt.hpp
@@ -118,7 +118,7 @@ rocblas_status rocsolver_geblttrs_npvt_template(rocblas_handle handle,
     for(rocblas_int k = 0; k < nblocks; k++)
     {
         if(k > 0)
-            rocblasCall_gemm<BATCHED, STRIDED, T>(
+            rocblasCall_gemm(
                 handle, rocblas_operation_none, rocblas_operation_none, nb, nrhs, nb, &minone, A,
                 shiftA + (k - 1) * lda * nb, lda, strideA, X, shiftX + (k - 1) * ldx * nrhs, ldx,
                 strideX, &one, X, shiftX + k * ldx * nrhs, ldx, strideX, batch_count, nullptr);
@@ -132,7 +132,7 @@ rocblas_status rocsolver_geblttrs_npvt_template(rocblas_handle handle,
     // backward solve
     for(rocblas_int k = nblocks - 2; k >= 0; k--)
     {
-        rocblasCall_gemm<BATCHED, STRIDED, T>(
+        rocblasCall_gemm(
             handle, rocblas_operation_none, rocblas_operation_none, nb, nrhs, nb, &minone, C,
             shiftC + k * ldc * nb, ldc, strideC, X, shiftX + (k + 1) * ldx * nrhs, ldx, strideX,
             &one, X, shiftX + k * ldx * nrhs, ldx, strideX, batch_count, nullptr);

--- a/library/src/lapack/roclapack_geblttrs_npvt.hpp
+++ b/library/src/lapack/roclapack_geblttrs_npvt.hpp
@@ -118,7 +118,7 @@ rocblas_status rocsolver_geblttrs_npvt_template(rocblas_handle handle,
     for(rocblas_int k = 0; k < nblocks; k++)
     {
         if(k > 0)
-            rocblasCall_gemm(
+            rocblasCall_gemm<T>(
                 handle, rocblas_operation_none, rocblas_operation_none, nb, nrhs, nb, &minone, A,
                 shiftA + (k - 1) * lda * nb, lda, strideA, X, shiftX + (k - 1) * ldx * nrhs, ldx,
                 strideX, &one, X, shiftX + k * ldx * nrhs, ldx, strideX, batch_count, nullptr);
@@ -132,7 +132,7 @@ rocblas_status rocsolver_geblttrs_npvt_template(rocblas_handle handle,
     // backward solve
     for(rocblas_int k = nblocks - 2; k >= 0; k--)
     {
-        rocblasCall_gemm(
+        rocblasCall_gemm<T>(
             handle, rocblas_operation_none, rocblas_operation_none, nb, nrhs, nb, &minone, C,
             shiftC + k * ldc * nb, ldc, strideC, X, shiftX + (k + 1) * ldx * nrhs, ldx, strideX,
             &one, X, shiftX + k * ldx * nrhs, ldx, strideX, batch_count, nullptr);

--- a/library/src/lapack/roclapack_geblttrs_npvt.hpp
+++ b/library/src/lapack/roclapack_geblttrs_npvt.hpp
@@ -118,10 +118,10 @@ rocblas_status rocsolver_geblttrs_npvt_template(rocblas_handle handle,
     for(rocblas_int k = 0; k < nblocks; k++)
     {
         if(k > 0)
-            rocblasCall_gemm<T>(
-                handle, rocblas_operation_none, rocblas_operation_none, nb, nrhs, nb, &minone, A,
-                shiftA + (k - 1) * lda * nb, lda, strideA, X, shiftX + (k - 1) * ldx * nrhs, ldx,
-                strideX, &one, X, shiftX + k * ldx * nrhs, ldx, strideX, batch_count, nullptr);
+            rocblasCall_gemm<T>(handle, rocblas_operation_none, rocblas_operation_none, nb, nrhs,
+                                nb, &minone, A, shiftA + (k - 1) * lda * nb, lda, strideA, X,
+                                shiftX + (k - 1) * ldx * nrhs, ldx, strideX, &one, X,
+                                shiftX + k * ldx * nrhs, ldx, strideX, batch_count, nullptr);
 
         rocsolver_getrs_template<BATCHED, STRIDED, T>(
             handle, rocblas_operation_none, nb, nrhs, B, shiftB + k * ldb * nb, ldb, strideB,
@@ -132,10 +132,10 @@ rocblas_status rocsolver_geblttrs_npvt_template(rocblas_handle handle,
     // backward solve
     for(rocblas_int k = nblocks - 2; k >= 0; k--)
     {
-        rocblasCall_gemm<T>(
-            handle, rocblas_operation_none, rocblas_operation_none, nb, nrhs, nb, &minone, C,
-            shiftC + k * ldc * nb, ldc, strideC, X, shiftX + (k + 1) * ldx * nrhs, ldx, strideX,
-            &one, X, shiftX + k * ldx * nrhs, ldx, strideX, batch_count, nullptr);
+        rocblasCall_gemm<T>(handle, rocblas_operation_none, rocblas_operation_none, nb, nrhs, nb,
+                            &minone, C, shiftC + k * ldc * nb, ldc, strideC, X,
+                            shiftX + (k + 1) * ldx * nrhs, ldx, strideX, &one, X,
+                            shiftX + k * ldx * nrhs, ldx, strideX, batch_count, nullptr);
     }
 
     return rocblas_status_success;

--- a/library/src/lapack/roclapack_gebrd.hpp
+++ b/library/src/lapack/roclapack_gebrd.hpp
@@ -134,13 +134,13 @@ rocblas_status rocsolver_gebrd_template(rocblas_handle handle,
                                     strideY, batch_count, scalars, work_workArr, Abyx_norms);
 
         // update the rest of the matrix
-        rocblasCall_gemm<BATCHED, STRIDED, T>(
+        rocblasCall_gemm(
             handle, rocblas_operation_none, rocblas_operation_conjugate_transpose, m - j - jb,
             n - j - jb, jb, &minone, A, shiftA + idx2D(j + jb, j, lda), lda, strideA, Y,
             shiftY + jb, ldy, strideY, &one, A, shiftA + idx2D(j + jb, j + jb, lda), lda, strideA,
             batch_count, (T**)work_workArr);
 
-        rocblasCall_gemm<BATCHED, STRIDED, T>(handle, rocblas_operation_none, rocblas_operation_none,
+        rocblasCall_gemm(handle, rocblas_operation_none, rocblas_operation_none,
                                               m - j - jb, n - j - jb, jb, &minone, X, shiftX + jb,
                                               ldx, strideX, A, shiftA + idx2D(j, j + jb, lda), lda,
                                               strideA, &one, A, shiftA + idx2D(j + jb, j + jb, lda),

--- a/library/src/lapack/roclapack_gebrd.hpp
+++ b/library/src/lapack/roclapack_gebrd.hpp
@@ -134,17 +134,17 @@ rocblas_status rocsolver_gebrd_template(rocblas_handle handle,
                                     strideY, batch_count, scalars, work_workArr, Abyx_norms);
 
         // update the rest of the matrix
-        rocblasCall_gemm(
-            handle, rocblas_operation_none, rocblas_operation_conjugate_transpose, m - j - jb,
-            n - j - jb, jb, &minone, A, shiftA + idx2D(j + jb, j, lda), lda, strideA, Y,
-            shiftY + jb, ldy, strideY, &one, A, shiftA + idx2D(j + jb, j + jb, lda), lda, strideA,
-            batch_count, (T**)work_workArr);
+        rocblasCall_gemm(handle, rocblas_operation_none, rocblas_operation_conjugate_transpose,
+                         m - j - jb, n - j - jb, jb, &minone, A, shiftA + idx2D(j + jb, j, lda),
+                         lda, strideA, Y, shiftY + jb, ldy, strideY, &one, A,
+                         shiftA + idx2D(j + jb, j + jb, lda), lda, strideA, batch_count,
+                         (T**)work_workArr);
 
-        rocblasCall_gemm(handle, rocblas_operation_none, rocblas_operation_none,
-                                              m - j - jb, n - j - jb, jb, &minone, X, shiftX + jb,
-                                              ldx, strideX, A, shiftA + idx2D(j, j + jb, lda), lda,
-                                              strideA, &one, A, shiftA + idx2D(j + jb, j + jb, lda),
-                                              lda, strideA, batch_count, (T**)work_workArr);
+        rocblasCall_gemm(handle, rocblas_operation_none, rocblas_operation_none, m - j - jb,
+                         n - j - jb, jb, &minone, X, shiftX + jb, ldx, strideX, A,
+                         shiftA + idx2D(j, j + jb, lda), lda, strideA, &one, A,
+                         shiftA + idx2D(j + jb, j + jb, lda), lda, strideA, batch_count,
+                         (T**)work_workArr);
 
         blocks = (jb - 1) / 64 + 1;
         if(m >= n)

--- a/library/src/lapack/roclapack_gesvd.hpp
+++ b/library/src/lapack/roclapack_gesvd.hpp
@@ -621,15 +621,13 @@ rocblas_status rocsolver_gesvd_template(rocblas_handle handle,
 
                 // update
                 if(row)
-                    rocblasCall_gemm(
-                        handle, rocblas_operation_none, rocblas_operation_none, m, n, k, &one, A,
-                        shiftA, lda, strideA, bufferT, shiftT, ldt, strideT, &zero, bufferC, shiftC,
-                        ldc, strideC, batch_count, workArr);
+                    rocblasCall_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n,
+                                     k, &one, A, shiftA, lda, strideA, bufferT, shiftT, ldt, strideT,
+                                     &zero, bufferC, shiftC, ldc, strideC, batch_count, workArr);
                 else
-                    rocblasCall_gemm(
-                        handle, rocblas_operation_none, rocblas_operation_none, m, n, k, &one,
-                        bufferT, shiftT, ldt, strideT, A, shiftA, lda, strideA, &zero, bufferC,
-                        shiftC, ldc, strideC, batch_count, workArr);
+                    rocblasCall_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n,
+                                     k, &one, bufferT, shiftT, ldt, strideT, A, shiftA, lda, strideA,
+                                     &zero, bufferC, shiftC, ldc, strideC, batch_count, workArr);
 
                 // copy to overwrite A
                 ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(blocks_m, blocks_n, batch_count),
@@ -640,15 +638,13 @@ rocblas_status rocsolver_gesvd_template(rocblas_handle handle,
             {
                 // update
                 if(row)
-                    rocblasCall_gemm(
-                        handle, rocblas_operation_none, rocblas_operation_none, m, n, k, &one, A,
-                        shiftA, lda, strideA, bufferT, shiftT, ldt, strideT, &zero, UV, shiftUV,
-                        lduv, strideUV, batch_count, workArr);
+                    rocblasCall_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n,
+                                     k, &one, A, shiftA, lda, strideA, bufferT, shiftT, ldt, strideT,
+                                     &zero, UV, shiftUV, lduv, strideUV, batch_count, workArr);
                 else
-                    rocblasCall_gemm(
-                        handle, rocblas_operation_none, rocblas_operation_none, m, n, k, &one,
-                        bufferT, shiftT, ldt, strideT, A, shiftA, lda, strideA, &zero, UV, shiftUV,
-                        lduv, strideUV, batch_count, workArr);
+                    rocblasCall_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n,
+                                     k, &one, bufferT, shiftT, ldt, strideT, A, shiftA, lda, strideA,
+                                     &zero, UV, shiftUV, lduv, strideUV, batch_count, workArr);
 
                 // overwrite A if required
                 if(othervO)
@@ -660,15 +656,13 @@ rocblas_status rocsolver_gesvd_template(rocblas_handle handle,
             {
                 // update
                 if(row)
-                    rocblasCall_gemm(
-                        handle, rocblas_operation_none, rocblas_operation_none, m, n, k, &one, UV,
-                        shiftUV, lduv, strideUV, bufferT, shiftT, ldt, strideT, &zero, A, shiftA,
-                        lda, strideA, batch_count, workArr);
+                    rocblasCall_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n,
+                                     k, &one, UV, shiftUV, lduv, strideUV, bufferT, shiftT, ldt,
+                                     strideT, &zero, A, shiftA, lda, strideA, batch_count, workArr);
                 else
-                    rocblasCall_gemm(
-                        handle, rocblas_operation_none, rocblas_operation_none, m, n, k, &one,
-                        bufferT, shiftT, ldt, strideT, UV, shiftUV, lduv, strideUV, &zero, A,
-                        shiftA, lda, strideA, batch_count, workArr);
+                    rocblasCall_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n,
+                                     k, &one, bufferT, shiftT, ldt, strideT, UV, shiftUV, lduv,
+                                     strideUV, &zero, A, shiftA, lda, strideA, batch_count, workArr);
 
                 // copy back to U/V
                 ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(blocks_m, blocks_n, batch_count),

--- a/library/src/lapack/roclapack_gesvd.hpp
+++ b/library/src/lapack/roclapack_gesvd.hpp
@@ -621,12 +621,12 @@ rocblas_status rocsolver_gesvd_template(rocblas_handle handle,
 
                 // update
                 if(row)
-                    rocblasCall_gemm<BATCHED, STRIDED>(
+                    rocblasCall_gemm(
                         handle, rocblas_operation_none, rocblas_operation_none, m, n, k, &one, A,
                         shiftA, lda, strideA, bufferT, shiftT, ldt, strideT, &zero, bufferC, shiftC,
                         ldc, strideC, batch_count, workArr);
                 else
-                    rocblasCall_gemm<BATCHED, STRIDED>(
+                    rocblasCall_gemm(
                         handle, rocblas_operation_none, rocblas_operation_none, m, n, k, &one,
                         bufferT, shiftT, ldt, strideT, A, shiftA, lda, strideA, &zero, bufferC,
                         shiftC, ldc, strideC, batch_count, workArr);
@@ -640,12 +640,12 @@ rocblas_status rocsolver_gesvd_template(rocblas_handle handle,
             {
                 // update
                 if(row)
-                    rocblasCall_gemm<BATCHED, STRIDED>(
+                    rocblasCall_gemm(
                         handle, rocblas_operation_none, rocblas_operation_none, m, n, k, &one, A,
                         shiftA, lda, strideA, bufferT, shiftT, ldt, strideT, &zero, UV, shiftUV,
                         lduv, strideUV, batch_count, workArr);
                 else
-                    rocblasCall_gemm<BATCHED, STRIDED>(
+                    rocblasCall_gemm(
                         handle, rocblas_operation_none, rocblas_operation_none, m, n, k, &one,
                         bufferT, shiftT, ldt, strideT, A, shiftA, lda, strideA, &zero, UV, shiftUV,
                         lduv, strideUV, batch_count, workArr);
@@ -660,12 +660,12 @@ rocblas_status rocsolver_gesvd_template(rocblas_handle handle,
             {
                 // update
                 if(row)
-                    rocblasCall_gemm<BATCHED, STRIDED>(
+                    rocblasCall_gemm(
                         handle, rocblas_operation_none, rocblas_operation_none, m, n, k, &one, UV,
                         shiftUV, lduv, strideUV, bufferT, shiftT, ldt, strideT, &zero, A, shiftA,
                         lda, strideA, batch_count, workArr);
                 else
-                    rocblasCall_gemm<BATCHED, STRIDED>(
+                    rocblasCall_gemm(
                         handle, rocblas_operation_none, rocblas_operation_none, m, n, k, &one,
                         bufferT, shiftT, ldt, strideT, UV, shiftUV, lduv, strideUV, &zero, A,
                         shiftA, lda, strideA, batch_count, workArr);

--- a/library/src/lapack/roclapack_gesvdj.hpp
+++ b/library/src/lapack/roclapack_gesvdj.hpp
@@ -291,10 +291,9 @@ rocblas_status rocsolver_gesvdj_template(rocblas_handle handle,
         rocblas_int ldv_gemm = n;
         rocblas_int strideV_gemm = n * n;
 
-        rocblasCall_gemm(
-            handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, n, n, m, &minone,
-            A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero, V_gemm, 0, ldv_gemm,
-            strideV_gemm, batch_count, (T**)work6_workArr);
+        rocblasCall_gemm(handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, n,
+                         n, m, &minone, A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero,
+                         V_gemm, 0, ldv_gemm, strideV_gemm, batch_count, (T**)work6_workArr);
 
         // apply eigenvalue decomposition to -A'A, obtaining V as eigenvectors
         rocsolver_syevj_heevj_template<false, STRIDED, T>(
@@ -308,10 +307,9 @@ rocblas_status rocsolver_gesvdj_template(rocblas_handle handle,
         rocblas_int ldu_gemm = (leftv ? ldu : m);
         rocblas_int strideU_gemm = (leftv ? strideU : m * n);
 
-        rocblasCall_gemm(handle, rocblas_operation_none, rocblas_operation_none,
-                                              m, n, n, &one, A, shiftA, lda, strideA, V_gemm, 0,
-                                              ldv_gemm, strideV_gemm, &zero, U_gemm, 0, ldu_gemm,
-                                              strideU_gemm, batch_count, (T**)work6_workArr);
+        rocblasCall_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n, n, &one, A,
+                         shiftA, lda, strideA, V_gemm, 0, ldv_gemm, strideV_gemm, &zero, U_gemm, 0,
+                         ldu_gemm, strideU_gemm, batch_count, (T**)work6_workArr);
 
         // apply QR factorization to AV, obtaining U = Q and S = R
         rocsolver_geqrf_template<false, STRIDED, T>(handle, m, n, U_gemm, 0, ldu_gemm, strideU_gemm,
@@ -345,10 +343,9 @@ rocblas_status rocsolver_gesvdj_template(rocblas_handle handle,
         rocblas_int ldu_gemm = (leftv ? ldu : m);
         rocblas_int strideU_gemm = (leftv ? strideU : m * m);
 
-        rocblasCall_gemm(
-            handle, rocblas_operation_none, rocblas_operation_conjugate_transpose, m, m, n, &minone,
-            A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero, U_gemm, 0, ldu_gemm,
-            strideU_gemm, batch_count, (T**)work6_workArr);
+        rocblasCall_gemm(handle, rocblas_operation_none, rocblas_operation_conjugate_transpose, m,
+                         m, n, &minone, A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero,
+                         U_gemm, 0, ldu_gemm, strideU_gemm, batch_count, (T**)work6_workArr);
 
         // apply eigenvalue decomposition to -AA', obtaining U as eigenvectors
         rocsolver_syevj_heevj_template<false, STRIDED, T>(
@@ -362,10 +359,9 @@ rocblas_status rocsolver_gesvdj_template(rocblas_handle handle,
         rocblas_int ldv_gemm = (rightv ? ldv : m);
         rocblas_int strideV_gemm = (rightv ? strideV : m * n);
 
-        rocblasCall_gemm(
-            handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, m, n, m, &one,
-            U_gemm, 0, ldu_gemm, strideU_gemm, A, shiftA, lda, strideA, &zero, V_gemm, 0, ldv_gemm,
-            strideV_gemm, batch_count, (T**)work6_workArr);
+        rocblasCall_gemm(handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, m,
+                         n, m, &one, U_gemm, 0, ldu_gemm, strideU_gemm, A, shiftA, lda, strideA,
+                         &zero, V_gemm, 0, ldv_gemm, strideV_gemm, batch_count, (T**)work6_workArr);
 
         // apply LQ factorization to U'A, obtaining S = L and V' = Q
         rocsolver_gelqf_template<false, STRIDED, T>(handle, m, n, V_gemm, 0, ldv_gemm, strideV_gemm,

--- a/library/src/lapack/roclapack_gesvdj.hpp
+++ b/library/src/lapack/roclapack_gesvdj.hpp
@@ -291,7 +291,7 @@ rocblas_status rocsolver_gesvdj_template(rocblas_handle handle,
         rocblas_int ldv_gemm = n;
         rocblas_int strideV_gemm = n * n;
 
-        rocblasCall_gemm<BATCHED, STRIDED, T>(
+        rocblasCall_gemm(
             handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, n, n, m, &minone,
             A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero, V_gemm, 0, ldv_gemm,
             strideV_gemm, batch_count, (T**)work6_workArr);
@@ -308,7 +308,7 @@ rocblas_status rocsolver_gesvdj_template(rocblas_handle handle,
         rocblas_int ldu_gemm = (leftv ? ldu : m);
         rocblas_int strideU_gemm = (leftv ? strideU : m * n);
 
-        rocblasCall_gemm<BATCHED, STRIDED, T>(handle, rocblas_operation_none, rocblas_operation_none,
+        rocblasCall_gemm(handle, rocblas_operation_none, rocblas_operation_none,
                                               m, n, n, &one, A, shiftA, lda, strideA, V_gemm, 0,
                                               ldv_gemm, strideV_gemm, &zero, U_gemm, 0, ldu_gemm,
                                               strideU_gemm, batch_count, (T**)work6_workArr);
@@ -345,7 +345,7 @@ rocblas_status rocsolver_gesvdj_template(rocblas_handle handle,
         rocblas_int ldu_gemm = (leftv ? ldu : m);
         rocblas_int strideU_gemm = (leftv ? strideU : m * m);
 
-        rocblasCall_gemm<BATCHED, STRIDED, T>(
+        rocblasCall_gemm(
             handle, rocblas_operation_none, rocblas_operation_conjugate_transpose, m, m, n, &minone,
             A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero, U_gemm, 0, ldu_gemm,
             strideU_gemm, batch_count, (T**)work6_workArr);
@@ -362,7 +362,7 @@ rocblas_status rocsolver_gesvdj_template(rocblas_handle handle,
         rocblas_int ldv_gemm = (rightv ? ldv : m);
         rocblas_int strideV_gemm = (rightv ? strideV : m * n);
 
-        rocblasCall_gemm<BATCHED, STRIDED, T>(
+        rocblasCall_gemm(
             handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, m, n, m, &one,
             U_gemm, 0, ldu_gemm, strideU_gemm, A, shiftA, lda, strideA, &zero, V_gemm, 0, ldv_gemm,
             strideV_gemm, batch_count, (T**)work6_workArr);

--- a/library/src/lapack/roclapack_gesvdj_notransv.hpp
+++ b/library/src/lapack/roclapack_gesvdj_notransv.hpp
@@ -254,10 +254,9 @@ rocblas_status rocsolver_gesvdj_notransv_template(rocblas_handle handle,
         rocblas_int ldv_gemm = (rightv ? ldv : n);
         rocblas_int strideV_gemm = (rightv ? strideV : n * n);
 
-        rocblasCall_gemm(
-            handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, n, n, m, &minone,
-            A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero, V_gemm, 0, ldv_gemm,
-            strideV_gemm, batch_count, (T**)work6_workArr);
+        rocblasCall_gemm(handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, n,
+                         n, m, &minone, A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero,
+                         V_gemm, 0, ldv_gemm, strideV_gemm, batch_count, (T**)work6_workArr);
 
         // apply eigenvalue decomposition to -A'A, obtaining V as eigenvectors
         rocsolver_syevj_heevj_template<false, STRIDED, T>(
@@ -271,10 +270,9 @@ rocblas_status rocsolver_gesvdj_notransv_template(rocblas_handle handle,
         rocblas_int ldu_gemm = (leftv ? ldu : m);
         rocblas_int strideU_gemm = (leftv ? strideU : m * n);
 
-        rocblasCall_gemm(handle, rocblas_operation_none, rocblas_operation_none,
-                                              m, n, n, &one, A, shiftA, lda, strideA, V_gemm, 0,
-                                              ldv_gemm, strideV_gemm, &zero, U_gemm, 0, ldu_gemm,
-                                              strideU_gemm, batch_count, (T**)work6_workArr);
+        rocblasCall_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n, n, &one, A,
+                         shiftA, lda, strideA, V_gemm, 0, ldv_gemm, strideV_gemm, &zero, U_gemm, 0,
+                         ldu_gemm, strideU_gemm, batch_count, (T**)work6_workArr);
 
         // apply QR factorization to AV, obtaining U = Q and S = R
         rocsolver_geqrf_template<false, STRIDED, T>(handle, m, n, U_gemm, 0, ldu_gemm, strideU_gemm,
@@ -298,10 +296,9 @@ rocblas_status rocsolver_gesvdj_notransv_template(rocblas_handle handle,
         rocblas_int ldu_gemm = (leftv ? ldu : m);
         rocblas_int strideU_gemm = (leftv ? strideU : m * m);
 
-        rocblasCall_gemm(
-            handle, rocblas_operation_none, rocblas_operation_conjugate_transpose, m, m, n, &minone,
-            A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero, U_gemm, 0, ldu_gemm,
-            strideU_gemm, batch_count, (T**)work6_workArr);
+        rocblasCall_gemm(handle, rocblas_operation_none, rocblas_operation_conjugate_transpose, m,
+                         m, n, &minone, A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero,
+                         U_gemm, 0, ldu_gemm, strideU_gemm, batch_count, (T**)work6_workArr);
 
         // apply eigenvalue decomposition to -AA', obtaining U as eigenvectors
         rocsolver_syevj_heevj_template<false, STRIDED, T>(
@@ -315,10 +312,9 @@ rocblas_status rocsolver_gesvdj_notransv_template(rocblas_handle handle,
         rocblas_int ldv_gemm = (rightv ? ldv : n);
         rocblas_int strideV_gemm = (rightv ? strideV : n * m);
 
-        rocblasCall_gemm(
-            handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, n, m, m, &one, A,
-            shiftA, lda, strideA, U_gemm, 0, ldu_gemm, strideU_gemm, &zero, V_gemm, 0, ldv_gemm,
-            strideV_gemm, batch_count, (T**)work6_workArr);
+        rocblasCall_gemm(handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, n,
+                         m, m, &one, A, shiftA, lda, strideA, U_gemm, 0, ldu_gemm, strideU_gemm,
+                         &zero, V_gemm, 0, ldv_gemm, strideV_gemm, batch_count, (T**)work6_workArr);
 
         // apply QR factorization to A'U, obtaining V = Q and S = R
         rocsolver_geqrf_template<false, STRIDED, T>(handle, n, m, V_gemm, 0, ldv_gemm, strideV_gemm,

--- a/library/src/lapack/roclapack_gesvdj_notransv.hpp
+++ b/library/src/lapack/roclapack_gesvdj_notransv.hpp
@@ -254,7 +254,7 @@ rocblas_status rocsolver_gesvdj_notransv_template(rocblas_handle handle,
         rocblas_int ldv_gemm = (rightv ? ldv : n);
         rocblas_int strideV_gemm = (rightv ? strideV : n * n);
 
-        rocblasCall_gemm<BATCHED, STRIDED, T>(
+        rocblasCall_gemm(
             handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, n, n, m, &minone,
             A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero, V_gemm, 0, ldv_gemm,
             strideV_gemm, batch_count, (T**)work6_workArr);
@@ -271,7 +271,7 @@ rocblas_status rocsolver_gesvdj_notransv_template(rocblas_handle handle,
         rocblas_int ldu_gemm = (leftv ? ldu : m);
         rocblas_int strideU_gemm = (leftv ? strideU : m * n);
 
-        rocblasCall_gemm<BATCHED, STRIDED, T>(handle, rocblas_operation_none, rocblas_operation_none,
+        rocblasCall_gemm(handle, rocblas_operation_none, rocblas_operation_none,
                                               m, n, n, &one, A, shiftA, lda, strideA, V_gemm, 0,
                                               ldv_gemm, strideV_gemm, &zero, U_gemm, 0, ldu_gemm,
                                               strideU_gemm, batch_count, (T**)work6_workArr);
@@ -298,7 +298,7 @@ rocblas_status rocsolver_gesvdj_notransv_template(rocblas_handle handle,
         rocblas_int ldu_gemm = (leftv ? ldu : m);
         rocblas_int strideU_gemm = (leftv ? strideU : m * m);
 
-        rocblasCall_gemm<BATCHED, STRIDED, T>(
+        rocblasCall_gemm(
             handle, rocblas_operation_none, rocblas_operation_conjugate_transpose, m, m, n, &minone,
             A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero, U_gemm, 0, ldu_gemm,
             strideU_gemm, batch_count, (T**)work6_workArr);
@@ -315,7 +315,7 @@ rocblas_status rocsolver_gesvdj_notransv_template(rocblas_handle handle,
         rocblas_int ldv_gemm = (rightv ? ldv : n);
         rocblas_int strideV_gemm = (rightv ? strideV : n * m);
 
-        rocblasCall_gemm<BATCHED, STRIDED, T>(
+        rocblasCall_gemm(
             handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, n, m, m, &one, A,
             shiftA, lda, strideA, U_gemm, 0, ldu_gemm, strideU_gemm, &zero, V_gemm, 0, ldv_gemm,
             strideV_gemm, batch_count, (T**)work6_workArr);

--- a/library/src/lapack/roclapack_getrf.hpp
+++ b/library/src/lapack/roclapack_getrf.hpp
@@ -500,11 +500,11 @@ rocblas_status getrf_panelLU(rocblas_handle handle,
                 work3, work4);
 
             if(k + jb < mm)
-                rocblasCall_gemm(
+                rocblasCall_gemm<T>(
                     handle, rocblas_operation_none, rocblas_operation_none, mm - k - jb,
                     nn - k - jb, jb, &minone, A, shiftA + idx2D(k + jb, k, lda), lda, strideA, A,
                     shiftA + idx2D(k, k + jb, lda), lda, strideA, &one, A,
-                    shiftA + idx2D(k + jb, k + jb, lda), lda, strideA, batch_count, nullptr);
+                    shiftA + idx2D(k + jb, k + jb, lda), lda, strideA, batch_count, (T**)nullptr);
             /** This would be the call to the internal gemm, leaving it
                     commented here until we are sure it won't be needed **/
             /*dimx = std::min({mm - k - jb, (4096 / jb) / 2, 32});
@@ -725,11 +725,11 @@ rocblas_status rocsolver_getrf_template(rocblas_handle handle,
 
             if(nextpiv < m)
             {
-                rocblasCall_gemm(
+                rocblasCall_gemm<T>(
                     handle, rocblas_operation_none, rocblas_operation_none, mm, nn, jb, &minone, A,
                     shiftA + idx2D(nextpiv, j, lda), lda, strideA, A,
                     shiftA + idx2D(j, nextpiv, lda), lda, strideA, &one, A,
-                    shiftA + idx2D(nextpiv, nextpiv, lda), lda, strideA, batch_count, nullptr);
+                    shiftA + idx2D(nextpiv, nextpiv, lda), lda, strideA, batch_count, (T**)nullptr);
                 /** This would be the call to the internal gemm, leaving it
                         commented here until we are sure it won't be needed **/
                 /*dimx = std::min({mm, (4096 / jb) / 2, 32});

--- a/library/src/lapack/roclapack_getrf.hpp
+++ b/library/src/lapack/roclapack_getrf.hpp
@@ -725,11 +725,11 @@ rocblas_status rocsolver_getrf_template(rocblas_handle handle,
 
             if(nextpiv < m)
             {
-                rocblasCall_gemm<T>(
-                    handle, rocblas_operation_none, rocblas_operation_none, mm, nn, jb, &minone, A,
-                    shiftA + idx2D(nextpiv, j, lda), lda, strideA, A,
-                    shiftA + idx2D(j, nextpiv, lda), lda, strideA, &one, A,
-                    shiftA + idx2D(nextpiv, nextpiv, lda), lda, strideA, batch_count, (T**)nullptr);
+                rocblasCall_gemm<T>(handle, rocblas_operation_none, rocblas_operation_none, mm, nn,
+                                    jb, &minone, A, shiftA + idx2D(nextpiv, j, lda), lda, strideA,
+                                    A, shiftA + idx2D(j, nextpiv, lda), lda, strideA, &one, A,
+                                    shiftA + idx2D(nextpiv, nextpiv, lda), lda, strideA,
+                                    batch_count, (T**)nullptr);
                 /** This would be the call to the internal gemm, leaving it
                         commented here until we are sure it won't be needed **/
                 /*dimx = std::min({mm, (4096 / jb) / 2, 32});

--- a/library/src/lapack/roclapack_getrf.hpp
+++ b/library/src/lapack/roclapack_getrf.hpp
@@ -500,7 +500,7 @@ rocblas_status getrf_panelLU(rocblas_handle handle,
                 work3, work4);
 
             if(k + jb < mm)
-                rocblasCall_gemm<BATCHED, STRIDED, T>(
+                rocblasCall_gemm(
                     handle, rocblas_operation_none, rocblas_operation_none, mm - k - jb,
                     nn - k - jb, jb, &minone, A, shiftA + idx2D(k + jb, k, lda), lda, strideA, A,
                     shiftA + idx2D(k, k + jb, lda), lda, strideA, &one, A,
@@ -725,7 +725,7 @@ rocblas_status rocsolver_getrf_template(rocblas_handle handle,
 
             if(nextpiv < m)
             {
-                rocblasCall_gemm<BATCHED, STRIDED, T>(
+                rocblasCall_gemm(
                     handle, rocblas_operation_none, rocblas_operation_none, mm, nn, jb, &minone, A,
                     shiftA + idx2D(nextpiv, j, lda), lda, strideA, A,
                     shiftA + idx2D(j, nextpiv, lda), lda, strideA, &one, A,

--- a/library/src/lapack/roclapack_getri.hpp
+++ b/library/src/lapack/roclapack_getri.hpp
@@ -356,10 +356,10 @@ rocblas_status rocsolver_getri_template(rocblas_handle handle,
                                 0, stream, n, j, jb, A, shiftA, lda, strideA, info, tmpcopy, strideW);
 
         if(j + jb < n)
-            rocblasCall_gemm(
-                handle, rocblas_operation_none, rocblas_operation_none, n, jb, n - j - jb, &minone,
-                A, shiftA + idx2D(0, j + jb, lda), lda, strideA, tmpcopy, j + jb, ldw, strideW,
-                &one, A, shiftA + idx2D(0, j, lda), lda, strideA, batch_count, workArr);
+            rocblasCall_gemm(handle, rocblas_operation_none, rocblas_operation_none, n, jb,
+                             n - j - jb, &minone, A, shiftA + idx2D(0, j + jb, lda), lda, strideA,
+                             tmpcopy, j + jb, ldw, strideW, &one, A, shiftA + idx2D(0, j, lda), lda,
+                             strideA, batch_count, workArr);
 
         rocblasCall_trsm(handle, rocblas_side_right, rocblas_fill_lower, rocblas_operation_none,
                          rocblas_diagonal_unit, n, jb, &one, tmpcopy, j, ldw, strideW, A,

--- a/library/src/lapack/roclapack_getri.hpp
+++ b/library/src/lapack/roclapack_getri.hpp
@@ -356,7 +356,7 @@ rocblas_status rocsolver_getri_template(rocblas_handle handle,
                                 0, stream, n, j, jb, A, shiftA, lda, strideA, info, tmpcopy, strideW);
 
         if(j + jb < n)
-            rocblasCall_gemm<BATCHED, STRIDED>(
+            rocblasCall_gemm(
                 handle, rocblas_operation_none, rocblas_operation_none, n, jb, n - j - jb, &minone,
                 A, shiftA + idx2D(0, j + jb, lda), lda, strideA, tmpcopy, j + jb, ldw, strideW,
                 &one, A, shiftA + idx2D(0, j, lda), lda, strideA, batch_count, workArr);

--- a/library/src/lapack/roclapack_sygst_hegst.hpp
+++ b/library/src/lapack/roclapack_sygst_hegst.hpp
@@ -162,11 +162,10 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                         ldb, strideB, A, shiftA + idx2D(k, k + kb, lda), lda, strideA, batch_count,
                         optim_mem, work_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr);
 
-                    rocblasCall_symm_hemm(
-                        handle, rocblas_side_left, uplo, kb, n - k - kb, &t_minhalf, A,
-                        shiftA + idx2D(k, k, lda), lda, strideA, B, shiftB + idx2D(k, k + kb, ldb),
-                        ldb, strideB, &t_one, A, shiftA + idx2D(k, k + kb, lda), lda, strideA,
-                        batch_count);
+                    rocblasCall_symm_hemm(handle, rocblas_side_left, uplo, kb, n - k - kb,
+                                          &t_minhalf, A, shiftA + idx2D(k, k, lda), lda, strideA, B,
+                                          shiftB + idx2D(k, k + kb, ldb), ldb, strideB, &t_one, A,
+                                          shiftA + idx2D(k, k + kb, lda), lda, strideA, batch_count);
 
                     rocblasCall_syr2k_her2k<BATCHED, T>(
                         handle, uplo, rocblas_operation_conjugate_transpose, n - k - kb, kb,
@@ -174,11 +173,10 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                         shiftB + idx2D(k, k + kb, ldb), ldb, strideB, &s_one, A,
                         shiftA + idx2D(k + kb, k + kb, lda), lda, strideA, batch_count);
 
-                    rocblasCall_symm_hemm(
-                        handle, rocblas_side_left, uplo, kb, n - k - kb, &t_minhalf, A,
-                        shiftA + idx2D(k, k, lda), lda, strideA, B, shiftB + idx2D(k, k + kb, ldb),
-                        ldb, strideB, &t_one, A, shiftA + idx2D(k, k + kb, lda), lda, strideA,
-                        batch_count);
+                    rocblasCall_symm_hemm(handle, rocblas_side_left, uplo, kb, n - k - kb,
+                                          &t_minhalf, A, shiftA + idx2D(k, k, lda), lda, strideA, B,
+                                          shiftB + idx2D(k, k + kb, ldb), ldb, strideB, &t_one, A,
+                                          shiftA + idx2D(k, k + kb, lda), lda, strideA, batch_count);
 
                     rocsolver_trsm_upper<BATCHED, STRIDED, T>(
                         handle, rocblas_side_right, rocblas_operation_none, rocblas_diagonal_non_unit,
@@ -208,11 +206,10 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                         ldb, strideB, A, shiftA + idx2D(k + kb, k, lda), lda, strideA, batch_count,
                         optim_mem, work_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr);
 
-                    rocblasCall_symm_hemm(
-                        handle, rocblas_side_right, uplo, n - k - kb, kb, &t_minhalf, A,
-                        shiftA + idx2D(k, k, lda), lda, strideA, B, shiftB + idx2D(k + kb, k, ldb),
-                        ldb, strideB, &t_one, A, shiftA + idx2D(k + kb, k, lda), lda, strideA,
-                        batch_count);
+                    rocblasCall_symm_hemm(handle, rocblas_side_right, uplo, n - k - kb, kb,
+                                          &t_minhalf, A, shiftA + idx2D(k, k, lda), lda, strideA, B,
+                                          shiftB + idx2D(k + kb, k, ldb), ldb, strideB, &t_one, A,
+                                          shiftA + idx2D(k + kb, k, lda), lda, strideA, batch_count);
 
                     rocblasCall_syr2k_her2k<BATCHED, T>(
                         handle, uplo, rocblas_operation_none, n - k - kb, kb, &t_minone, A,
@@ -220,11 +217,10 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                         shiftB + idx2D(k + kb, k, ldb), ldb, strideB, &s_one, A,
                         shiftA + idx2D(k + kb, k + kb, lda), lda, strideA, batch_count);
 
-                    rocblasCall_symm_hemm(
-                        handle, rocblas_side_right, uplo, n - k - kb, kb, &t_minhalf, A,
-                        shiftA + idx2D(k, k, lda), lda, strideA, B, shiftB + idx2D(k + kb, k, ldb),
-                        ldb, strideB, &t_one, A, shiftA + idx2D(k + kb, k, lda), lda, strideA,
-                        batch_count);
+                    rocblasCall_symm_hemm(handle, rocblas_side_right, uplo, n - k - kb, kb,
+                                          &t_minhalf, A, shiftA + idx2D(k, k, lda), lda, strideA, B,
+                                          shiftB + idx2D(k + kb, k, ldb), ldb, strideB, &t_one, A,
+                                          shiftA + idx2D(k + kb, k, lda), lda, strideA, batch_count);
 
                     rocsolver_trsm_lower<BATCHED, STRIDED, T>(
                         handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit,
@@ -249,20 +245,20 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                                  strideB, A, shiftA + idx2D(0, k, lda), lda, strideA, batch_count,
                                  (T**)workArr_temp_arr);
 
-                rocblasCall_symm_hemm(
-                    handle, rocblas_side_right, uplo, k, kb, &t_half, A, shiftA + idx2D(k, k, lda),
-                    lda, strideA, B, shiftB + idx2D(0, k, ldb), ldb, strideB, &t_one, A,
-                    shiftA + idx2D(0, k, lda), lda, strideA, batch_count);
+                rocblasCall_symm_hemm(handle, rocblas_side_right, uplo, k, kb, &t_half, A,
+                                      shiftA + idx2D(k, k, lda), lda, strideA, B,
+                                      shiftB + idx2D(0, k, ldb), ldb, strideB, &t_one, A,
+                                      shiftA + idx2D(0, k, lda), lda, strideA, batch_count);
 
                 rocblasCall_syr2k_her2k<BATCHED, T>(
                     handle, uplo, rocblas_operation_none, k, kb, &t_one, A,
                     shiftA + idx2D(0, k, lda), lda, strideA, B, shiftB + idx2D(0, k, ldb), ldb,
                     strideB, &s_one, A, shiftA, lda, strideA, batch_count);
 
-                rocblasCall_symm_hemm(
-                    handle, rocblas_side_right, uplo, k, kb, &t_half, A, shiftA + idx2D(k, k, lda),
-                    lda, strideA, B, shiftB + idx2D(0, k, ldb), ldb, strideB, &t_one, A,
-                    shiftA + idx2D(0, k, lda), lda, strideA, batch_count);
+                rocblasCall_symm_hemm(handle, rocblas_side_right, uplo, k, kb, &t_half, A,
+                                      shiftA + idx2D(k, k, lda), lda, strideA, B,
+                                      shiftB + idx2D(0, k, ldb), ldb, strideB, &t_one, A,
+                                      shiftA + idx2D(0, k, lda), lda, strideA, batch_count);
 
                 rocblasCall_trmm(handle, rocblas_side_right, uplo,
                                  rocblas_operation_conjugate_transpose, rocblas_diagonal_non_unit,
@@ -288,20 +284,20 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                                  strideB, A, shiftA + idx2D(k, 0, lda), lda, strideA, batch_count,
                                  (T**)workArr_temp_arr);
 
-                rocblasCall_symm_hemm(
-                    handle, rocblas_side_left, uplo, kb, k, &t_half, A, shiftA + idx2D(k, k, lda),
-                    lda, strideA, B, shiftB + idx2D(k, 0, ldb), ldb, strideB, &t_one, A,
-                    shiftA + idx2D(k, 0, lda), lda, strideA, batch_count);
+                rocblasCall_symm_hemm(handle, rocblas_side_left, uplo, kb, k, &t_half, A,
+                                      shiftA + idx2D(k, k, lda), lda, strideA, B,
+                                      shiftB + idx2D(k, 0, ldb), ldb, strideB, &t_one, A,
+                                      shiftA + idx2D(k, 0, lda), lda, strideA, batch_count);
 
                 rocblasCall_syr2k_her2k<BATCHED, T>(
                     handle, uplo, rocblas_operation_conjugate_transpose, k, kb, &t_one, A,
                     shiftA + idx2D(k, 0, lda), lda, strideA, B, shiftB + idx2D(k, 0, ldb), ldb,
                     strideB, &s_one, A, shiftA, lda, strideA, batch_count);
 
-                rocblasCall_symm_hemm(
-                    handle, rocblas_side_left, uplo, kb, k, &t_half, A, shiftA + idx2D(k, k, lda),
-                    lda, strideA, B, shiftB + idx2D(k, 0, ldb), ldb, strideB, &t_one, A,
-                    shiftA + idx2D(k, 0, lda), lda, strideA, batch_count);
+                rocblasCall_symm_hemm(handle, rocblas_side_left, uplo, kb, k, &t_half, A,
+                                      shiftA + idx2D(k, k, lda), lda, strideA, B,
+                                      shiftB + idx2D(k, 0, ldb), ldb, strideB, &t_one, A,
+                                      shiftA + idx2D(k, 0, lda), lda, strideA, batch_count);
 
                 rocblasCall_trmm(handle, rocblas_side_left, uplo,
                                  rocblas_operation_conjugate_transpose, rocblas_diagonal_non_unit,

--- a/library/src/lapack/roclapack_sygst_hegst.hpp
+++ b/library/src/lapack/roclapack_sygst_hegst.hpp
@@ -162,7 +162,7 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                         ldb, strideB, A, shiftA + idx2D(k, k + kb, lda), lda, strideA, batch_count,
                         optim_mem, work_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr);
 
-                    rocblasCall_symm_hemm<BATCHED, T>(
+                    rocblasCall_symm_hemm(
                         handle, rocblas_side_left, uplo, kb, n - k - kb, &t_minhalf, A,
                         shiftA + idx2D(k, k, lda), lda, strideA, B, shiftB + idx2D(k, k + kb, ldb),
                         ldb, strideB, &t_one, A, shiftA + idx2D(k, k + kb, lda), lda, strideA,
@@ -174,7 +174,7 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                         shiftB + idx2D(k, k + kb, ldb), ldb, strideB, &s_one, A,
                         shiftA + idx2D(k + kb, k + kb, lda), lda, strideA, batch_count);
 
-                    rocblasCall_symm_hemm<BATCHED, T>(
+                    rocblasCall_symm_hemm(
                         handle, rocblas_side_left, uplo, kb, n - k - kb, &t_minhalf, A,
                         shiftA + idx2D(k, k, lda), lda, strideA, B, shiftB + idx2D(k, k + kb, ldb),
                         ldb, strideB, &t_one, A, shiftA + idx2D(k, k + kb, lda), lda, strideA,
@@ -208,7 +208,7 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                         ldb, strideB, A, shiftA + idx2D(k + kb, k, lda), lda, strideA, batch_count,
                         optim_mem, work_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr);
 
-                    rocblasCall_symm_hemm<BATCHED, T>(
+                    rocblasCall_symm_hemm(
                         handle, rocblas_side_right, uplo, n - k - kb, kb, &t_minhalf, A,
                         shiftA + idx2D(k, k, lda), lda, strideA, B, shiftB + idx2D(k + kb, k, ldb),
                         ldb, strideB, &t_one, A, shiftA + idx2D(k + kb, k, lda), lda, strideA,
@@ -220,7 +220,7 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                         shiftB + idx2D(k + kb, k, ldb), ldb, strideB, &s_one, A,
                         shiftA + idx2D(k + kb, k + kb, lda), lda, strideA, batch_count);
 
-                    rocblasCall_symm_hemm<BATCHED, T>(
+                    rocblasCall_symm_hemm(
                         handle, rocblas_side_right, uplo, n - k - kb, kb, &t_minhalf, A,
                         shiftA + idx2D(k, k, lda), lda, strideA, B, shiftB + idx2D(k + kb, k, ldb),
                         ldb, strideB, &t_one, A, shiftA + idx2D(k + kb, k, lda), lda, strideA,
@@ -249,7 +249,7 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                                  strideB, A, shiftA + idx2D(0, k, lda), lda, strideA, batch_count,
                                  (T**)workArr_temp_arr);
 
-                rocblasCall_symm_hemm<BATCHED, T>(
+                rocblasCall_symm_hemm(
                     handle, rocblas_side_right, uplo, k, kb, &t_half, A, shiftA + idx2D(k, k, lda),
                     lda, strideA, B, shiftB + idx2D(0, k, ldb), ldb, strideB, &t_one, A,
                     shiftA + idx2D(0, k, lda), lda, strideA, batch_count);
@@ -259,7 +259,7 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                     shiftA + idx2D(0, k, lda), lda, strideA, B, shiftB + idx2D(0, k, ldb), ldb,
                     strideB, &s_one, A, shiftA, lda, strideA, batch_count);
 
-                rocblasCall_symm_hemm<BATCHED, T>(
+                rocblasCall_symm_hemm(
                     handle, rocblas_side_right, uplo, k, kb, &t_half, A, shiftA + idx2D(k, k, lda),
                     lda, strideA, B, shiftB + idx2D(0, k, ldb), ldb, strideB, &t_one, A,
                     shiftA + idx2D(0, k, lda), lda, strideA, batch_count);
@@ -288,7 +288,7 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                                  strideB, A, shiftA + idx2D(k, 0, lda), lda, strideA, batch_count,
                                  (T**)workArr_temp_arr);
 
-                rocblasCall_symm_hemm<BATCHED, T>(
+                rocblasCall_symm_hemm(
                     handle, rocblas_side_left, uplo, kb, k, &t_half, A, shiftA + idx2D(k, k, lda),
                     lda, strideA, B, shiftB + idx2D(k, 0, ldb), ldb, strideB, &t_one, A,
                     shiftA + idx2D(k, 0, lda), lda, strideA, batch_count);
@@ -298,7 +298,7 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                     shiftA + idx2D(k, 0, lda), lda, strideA, B, shiftB + idx2D(k, 0, ldb), ldb,
                     strideB, &s_one, A, shiftA, lda, strideA, batch_count);
 
-                rocblasCall_symm_hemm<BATCHED, T>(
+                rocblasCall_symm_hemm(
                     handle, rocblas_side_left, uplo, kb, k, &t_half, A, shiftA + idx2D(k, k, lda),
                     lda, strideA, B, shiftB + idx2D(k, 0, ldb), ldb, strideB, &t_one, A,
                     shiftA + idx2D(k, 0, lda), lda, strideA, batch_count);

--- a/library/src/specialized/roclapack_trsm_specialized_kernels.hpp
+++ b/library/src/specialized/roclapack_trsm_specialized_kernels.hpp
@@ -838,11 +838,11 @@ void rocsolver_trsm_lower(rocblas_handle handle,
                 FORWARD_SUBSTITUTIONS;
 
                 // update right hand sides
-                rocblasCall_gemm(
+                rocblasCall_gemm<T>(
                     handle, rocblas_operation_none, rocblas_operation_none, m - nextpiv, n, blk,
                     &minone, A, shiftA + idx2D(nextpiv, j, lda), lda, strideA, B,
                     shiftB + idx2D(j, 0, ldb), ldb, strideB, &one, B,
-                    shiftB + idx2D(nextpiv, 0, ldb), ldb, strideB, batch_count, nullptr);
+                    shiftB + idx2D(nextpiv, 0, ldb), ldb, strideB, batch_count, (T**)nullptr);
 
                 j = nextpiv;
             }
@@ -878,11 +878,11 @@ void rocsolver_trsm_lower(rocblas_handle handle,
                 BACKWARD_SUBSTITUTIONS;
 
                 // update right hand sides
-                rocblasCall_gemm(
+                rocblasCall_gemm<T>(
                     handle, trans, rocblas_operation_none, m - nextpiv, n, blk, &minone, A,
                     shiftA + idx2D(m - nextpiv, 0, lda), lda, strideA, B,
                     shiftB + idx2D(m - nextpiv, 0, ldb), ldb, strideB, &one, B,
-                    shiftB + idx2D(0, 0, ldb), ldb, strideB, batch_count, nullptr);
+                    shiftB + idx2D(0, 0, ldb), ldb, strideB, batch_count, (T**)nullptr);
 
                 j = nextpiv;
             }
@@ -931,11 +931,11 @@ void rocsolver_trsm_lower(rocblas_handle handle,
                 BACKWARD_SUBSTITUTIONS;
 
                 // update left hand sides
-                rocblasCall_gemm(
+                rocblasCall_gemm<T>(
                     handle, rocblas_operation_none, rocblas_operation_none, m, n - nextpiv, blk,
                     &minone, B, shiftB + idx2D(0, n - nextpiv, ldb), ldb, strideB, A,
                     shiftA + idx2D(n - nextpiv, 0, lda), lda, strideA, &one, B,
-                    shiftB + idx2D(0, 0, ldb), ldb, strideB, batch_count, nullptr);
+                    shiftB + idx2D(0, 0, ldb), ldb, strideB, batch_count, (T**)nullptr);
 
                 j = nextpiv;
             }
@@ -971,11 +971,11 @@ void rocsolver_trsm_lower(rocblas_handle handle,
                 FORWARD_SUBSTITUTIONS;
 
                 // update left hand sides
-                rocblasCall_gemm(
+                rocblasCall_gemm<T>(
                     handle, rocblas_operation_none, trans, m, n - nextpiv, blk, &minone, B,
                     shiftB + idx2D(0, j, ldb), ldb, strideB, A, shiftA + idx2D(nextpiv, j, lda),
                     lda, strideA, &one, B, shiftB + idx2D(0, nextpiv, ldb), ldb, strideB,
-                    batch_count, nullptr);
+                    batch_count, (T**)nullptr);
 
                 j = nextpiv;
             }
@@ -1090,11 +1090,11 @@ void rocsolver_trsm_upper(rocblas_handle handle,
                 FORWARD_SUBSTITUTIONS;
 
                 // update right hand sides
-                rocblasCall_gemm(
+                rocblasCall_gemm<T>(
                     handle, trans, rocblas_operation_none, m - nextpiv, n, blk, &minone, A,
                     shiftA + idx2D(j, nextpiv, lda), lda, strideA, B, shiftB + idx2D(j, 0, ldb),
                     ldb, strideB, &one, B, shiftB + idx2D(nextpiv, 0, ldb), ldb, strideB,
-                    batch_count, nullptr);
+                    batch_count, (T**)nullptr);
 
                 j = nextpiv;
             }
@@ -1130,11 +1130,11 @@ void rocsolver_trsm_upper(rocblas_handle handle,
                 BACKWARD_SUBSTITUTIONS;
 
                 // update right hand sides
-                rocblasCall_gemm(
+                rocblasCall_gemm<T>(
                     handle, rocblas_operation_none, rocblas_operation_none, m - nextpiv, n, blk,
                     &minone, A, shiftA + idx2D(0, m - nextpiv, lda), lda, strideA, B,
                     shiftB + idx2D(m - nextpiv, 0, ldb), ldb, strideB, &one, B,
-                    shiftB + idx2D(0, 0, ldb), ldb, strideB, batch_count, nullptr);
+                    shiftB + idx2D(0, 0, ldb), ldb, strideB, batch_count, (T**)nullptr);
 
                 j = nextpiv;
             }
@@ -1183,11 +1183,11 @@ void rocsolver_trsm_upper(rocblas_handle handle,
                 BACKWARD_SUBSTITUTIONS;
 
                 // update left hand sides
-                rocblasCall_gemm(
+                rocblasCall_gemm<T>(
                     handle, rocblas_operation_none, trans, m, n - nextpiv, blk, &minone, B,
                     shiftB + idx2D(0, n - nextpiv, ldb), ldb, strideB, A,
                     shiftA + idx2D(0, n - nextpiv, lda), lda, strideA, &one, B,
-                    shiftB + idx2D(0, 0, ldb), ldb, strideB, batch_count, nullptr);
+                    shiftB + idx2D(0, 0, ldb), ldb, strideB, batch_count, (T**)nullptr);
 
                 j = nextpiv;
             }
@@ -1223,11 +1223,11 @@ void rocsolver_trsm_upper(rocblas_handle handle,
                 FORWARD_SUBSTITUTIONS;
 
                 // update left hand sides
-                rocblasCall_gemm(
+                rocblasCall_gemm<T>(
                     handle, rocblas_operation_none, rocblas_operation_none, m, n - nextpiv, blk,
                     &minone, B, shiftB + idx2D(0, j, ldb), ldb, strideB, A,
                     shiftA + idx2D(j, nextpiv, lda), lda, strideA, &one, B,
-                    shiftB + idx2D(0, nextpiv, ldb), ldb, strideB, batch_count, nullptr);
+                    shiftB + idx2D(0, nextpiv, ldb), ldb, strideB, batch_count, (T**)nullptr);
 
                 j = nextpiv;
             }

--- a/library/src/specialized/roclapack_trsm_specialized_kernels.hpp
+++ b/library/src/specialized/roclapack_trsm_specialized_kernels.hpp
@@ -838,11 +838,11 @@ void rocsolver_trsm_lower(rocblas_handle handle,
                 FORWARD_SUBSTITUTIONS;
 
                 // update right hand sides
-                rocblasCall_gemm<T>(
-                    handle, rocblas_operation_none, rocblas_operation_none, m - nextpiv, n, blk,
-                    &minone, A, shiftA + idx2D(nextpiv, j, lda), lda, strideA, B,
-                    shiftB + idx2D(j, 0, ldb), ldb, strideB, &one, B,
-                    shiftB + idx2D(nextpiv, 0, ldb), ldb, strideB, batch_count, (T**)nullptr);
+                rocblasCall_gemm<T>(handle, rocblas_operation_none, rocblas_operation_none,
+                                    m - nextpiv, n, blk, &minone, A, shiftA + idx2D(nextpiv, j, lda),
+                                    lda, strideA, B, shiftB + idx2D(j, 0, ldb), ldb, strideB, &one,
+                                    B, shiftB + idx2D(nextpiv, 0, ldb), ldb, strideB, batch_count,
+                                    (T**)nullptr);
 
                 j = nextpiv;
             }
@@ -878,11 +878,11 @@ void rocsolver_trsm_lower(rocblas_handle handle,
                 BACKWARD_SUBSTITUTIONS;
 
                 // update right hand sides
-                rocblasCall_gemm<T>(
-                    handle, trans, rocblas_operation_none, m - nextpiv, n, blk, &minone, A,
-                    shiftA + idx2D(m - nextpiv, 0, lda), lda, strideA, B,
-                    shiftB + idx2D(m - nextpiv, 0, ldb), ldb, strideB, &one, B,
-                    shiftB + idx2D(0, 0, ldb), ldb, strideB, batch_count, (T**)nullptr);
+                rocblasCall_gemm<T>(handle, trans, rocblas_operation_none, m - nextpiv, n, blk,
+                                    &minone, A, shiftA + idx2D(m - nextpiv, 0, lda), lda, strideA,
+                                    B, shiftB + idx2D(m - nextpiv, 0, ldb), ldb, strideB, &one, B,
+                                    shiftB + idx2D(0, 0, ldb), ldb, strideB, batch_count,
+                                    (T**)nullptr);
 
                 j = nextpiv;
             }
@@ -931,11 +931,11 @@ void rocsolver_trsm_lower(rocblas_handle handle,
                 BACKWARD_SUBSTITUTIONS;
 
                 // update left hand sides
-                rocblasCall_gemm<T>(
-                    handle, rocblas_operation_none, rocblas_operation_none, m, n - nextpiv, blk,
-                    &minone, B, shiftB + idx2D(0, n - nextpiv, ldb), ldb, strideB, A,
-                    shiftA + idx2D(n - nextpiv, 0, lda), lda, strideA, &one, B,
-                    shiftB + idx2D(0, 0, ldb), ldb, strideB, batch_count, (T**)nullptr);
+                rocblasCall_gemm<T>(handle, rocblas_operation_none, rocblas_operation_none, m,
+                                    n - nextpiv, blk, &minone, B, shiftB + idx2D(0, n - nextpiv, ldb),
+                                    ldb, strideB, A, shiftA + idx2D(n - nextpiv, 0, lda), lda,
+                                    strideA, &one, B, shiftB + idx2D(0, 0, ldb), ldb, strideB,
+                                    batch_count, (T**)nullptr);
 
                 j = nextpiv;
             }
@@ -971,11 +971,11 @@ void rocsolver_trsm_lower(rocblas_handle handle,
                 FORWARD_SUBSTITUTIONS;
 
                 // update left hand sides
-                rocblasCall_gemm<T>(
-                    handle, rocblas_operation_none, trans, m, n - nextpiv, blk, &minone, B,
-                    shiftB + idx2D(0, j, ldb), ldb, strideB, A, shiftA + idx2D(nextpiv, j, lda),
-                    lda, strideA, &one, B, shiftB + idx2D(0, nextpiv, ldb), ldb, strideB,
-                    batch_count, (T**)nullptr);
+                rocblasCall_gemm<T>(handle, rocblas_operation_none, trans, m, n - nextpiv, blk,
+                                    &minone, B, shiftB + idx2D(0, j, ldb), ldb, strideB, A,
+                                    shiftA + idx2D(nextpiv, j, lda), lda, strideA, &one, B,
+                                    shiftB + idx2D(0, nextpiv, ldb), ldb, strideB, batch_count,
+                                    (T**)nullptr);
 
                 j = nextpiv;
             }
@@ -1090,11 +1090,11 @@ void rocsolver_trsm_upper(rocblas_handle handle,
                 FORWARD_SUBSTITUTIONS;
 
                 // update right hand sides
-                rocblasCall_gemm<T>(
-                    handle, trans, rocblas_operation_none, m - nextpiv, n, blk, &minone, A,
-                    shiftA + idx2D(j, nextpiv, lda), lda, strideA, B, shiftB + idx2D(j, 0, ldb),
-                    ldb, strideB, &one, B, shiftB + idx2D(nextpiv, 0, ldb), ldb, strideB,
-                    batch_count, (T**)nullptr);
+                rocblasCall_gemm<T>(handle, trans, rocblas_operation_none, m - nextpiv, n, blk,
+                                    &minone, A, shiftA + idx2D(j, nextpiv, lda), lda, strideA, B,
+                                    shiftB + idx2D(j, 0, ldb), ldb, strideB, &one, B,
+                                    shiftB + idx2D(nextpiv, 0, ldb), ldb, strideB, batch_count,
+                                    (T**)nullptr);
 
                 j = nextpiv;
             }
@@ -1183,11 +1183,11 @@ void rocsolver_trsm_upper(rocblas_handle handle,
                 BACKWARD_SUBSTITUTIONS;
 
                 // update left hand sides
-                rocblasCall_gemm<T>(
-                    handle, rocblas_operation_none, trans, m, n - nextpiv, blk, &minone, B,
-                    shiftB + idx2D(0, n - nextpiv, ldb), ldb, strideB, A,
-                    shiftA + idx2D(0, n - nextpiv, lda), lda, strideA, &one, B,
-                    shiftB + idx2D(0, 0, ldb), ldb, strideB, batch_count, (T**)nullptr);
+                rocblasCall_gemm<T>(handle, rocblas_operation_none, trans, m, n - nextpiv, blk,
+                                    &minone, B, shiftB + idx2D(0, n - nextpiv, ldb), ldb, strideB,
+                                    A, shiftA + idx2D(0, n - nextpiv, lda), lda, strideA, &one, B,
+                                    shiftB + idx2D(0, 0, ldb), ldb, strideB, batch_count,
+                                    (T**)nullptr);
 
                 j = nextpiv;
             }
@@ -1223,11 +1223,11 @@ void rocsolver_trsm_upper(rocblas_handle handle,
                 FORWARD_SUBSTITUTIONS;
 
                 // update left hand sides
-                rocblasCall_gemm<T>(
-                    handle, rocblas_operation_none, rocblas_operation_none, m, n - nextpiv, blk,
-                    &minone, B, shiftB + idx2D(0, j, ldb), ldb, strideB, A,
-                    shiftA + idx2D(j, nextpiv, lda), lda, strideA, &one, B,
-                    shiftB + idx2D(0, nextpiv, ldb), ldb, strideB, batch_count, (T**)nullptr);
+                rocblasCall_gemm<T>(handle, rocblas_operation_none, rocblas_operation_none, m,
+                                    n - nextpiv, blk, &minone, B, shiftB + idx2D(0, j, ldb), ldb,
+                                    strideB, A, shiftA + idx2D(j, nextpiv, lda), lda, strideA, &one,
+                                    B, shiftB + idx2D(0, nextpiv, ldb), ldb, strideB, batch_count,
+                                    (T**)nullptr);
 
                 j = nextpiv;
             }

--- a/library/src/specialized/roclapack_trsm_specialized_kernels.hpp
+++ b/library/src/specialized/roclapack_trsm_specialized_kernels.hpp
@@ -838,7 +838,7 @@ void rocsolver_trsm_lower(rocblas_handle handle,
                 FORWARD_SUBSTITUTIONS;
 
                 // update right hand sides
-                rocblasCall_gemm<BATCHED, STRIDED, T>(
+                rocblasCall_gemm(
                     handle, rocblas_operation_none, rocblas_operation_none, m - nextpiv, n, blk,
                     &minone, A, shiftA + idx2D(nextpiv, j, lda), lda, strideA, B,
                     shiftB + idx2D(j, 0, ldb), ldb, strideB, &one, B,
@@ -878,7 +878,7 @@ void rocsolver_trsm_lower(rocblas_handle handle,
                 BACKWARD_SUBSTITUTIONS;
 
                 // update right hand sides
-                rocblasCall_gemm<BATCHED, STRIDED, T>(
+                rocblasCall_gemm(
                     handle, trans, rocblas_operation_none, m - nextpiv, n, blk, &minone, A,
                     shiftA + idx2D(m - nextpiv, 0, lda), lda, strideA, B,
                     shiftB + idx2D(m - nextpiv, 0, ldb), ldb, strideB, &one, B,
@@ -931,7 +931,7 @@ void rocsolver_trsm_lower(rocblas_handle handle,
                 BACKWARD_SUBSTITUTIONS;
 
                 // update left hand sides
-                rocblasCall_gemm<BATCHED, STRIDED, T>(
+                rocblasCall_gemm(
                     handle, rocblas_operation_none, rocblas_operation_none, m, n - nextpiv, blk,
                     &minone, B, shiftB + idx2D(0, n - nextpiv, ldb), ldb, strideB, A,
                     shiftA + idx2D(n - nextpiv, 0, lda), lda, strideA, &one, B,
@@ -971,7 +971,7 @@ void rocsolver_trsm_lower(rocblas_handle handle,
                 FORWARD_SUBSTITUTIONS;
 
                 // update left hand sides
-                rocblasCall_gemm<BATCHED, STRIDED, T>(
+                rocblasCall_gemm(
                     handle, rocblas_operation_none, trans, m, n - nextpiv, blk, &minone, B,
                     shiftB + idx2D(0, j, ldb), ldb, strideB, A, shiftA + idx2D(nextpiv, j, lda),
                     lda, strideA, &one, B, shiftB + idx2D(0, nextpiv, ldb), ldb, strideB,
@@ -1090,7 +1090,7 @@ void rocsolver_trsm_upper(rocblas_handle handle,
                 FORWARD_SUBSTITUTIONS;
 
                 // update right hand sides
-                rocblasCall_gemm<BATCHED, STRIDED, T>(
+                rocblasCall_gemm(
                     handle, trans, rocblas_operation_none, m - nextpiv, n, blk, &minone, A,
                     shiftA + idx2D(j, nextpiv, lda), lda, strideA, B, shiftB + idx2D(j, 0, ldb),
                     ldb, strideB, &one, B, shiftB + idx2D(nextpiv, 0, ldb), ldb, strideB,
@@ -1130,7 +1130,7 @@ void rocsolver_trsm_upper(rocblas_handle handle,
                 BACKWARD_SUBSTITUTIONS;
 
                 // update right hand sides
-                rocblasCall_gemm<BATCHED, STRIDED, T>(
+                rocblasCall_gemm(
                     handle, rocblas_operation_none, rocblas_operation_none, m - nextpiv, n, blk,
                     &minone, A, shiftA + idx2D(0, m - nextpiv, lda), lda, strideA, B,
                     shiftB + idx2D(m - nextpiv, 0, ldb), ldb, strideB, &one, B,
@@ -1183,7 +1183,7 @@ void rocsolver_trsm_upper(rocblas_handle handle,
                 BACKWARD_SUBSTITUTIONS;
 
                 // update left hand sides
-                rocblasCall_gemm<BATCHED, STRIDED, T>(
+                rocblasCall_gemm(
                     handle, rocblas_operation_none, trans, m, n - nextpiv, blk, &minone, B,
                     shiftB + idx2D(0, n - nextpiv, ldb), ldb, strideB, A,
                     shiftA + idx2D(0, n - nextpiv, lda), lda, strideA, &one, B,
@@ -1223,7 +1223,7 @@ void rocsolver_trsm_upper(rocblas_handle handle,
                 FORWARD_SUBSTITUTIONS;
 
                 // update left hand sides
-                rocblasCall_gemm<BATCHED, STRIDED, T>(
+                rocblasCall_gemm(
                     handle, rocblas_operation_none, rocblas_operation_none, m, n - nextpiv, blk,
                     &minone, B, shiftB + idx2D(0, j, ldb), ldb, strideB, A,
                     shiftA + idx2D(j, nextpiv, lda), lda, strideA, &one, B,


### PR DESCRIPTION
Cleans up the rest of the rocBLAS internal interface. Ideally there will be no more changes needed to coordinate rocBLAS/rocSOLVER internal interface after this.

See https://github.com/ROCmSoftwarePlatform/rocBLAS-internal/pull/1743 for rocBLAS changes. No CI for now until rocBLAS is in.