### PR TITLE
Fix failing Windows build

### DIFF
--- a/clients/include/testing_csrrf_analysis.hpp
+++ b/clients/include/testing_csrrf_analysis.hpp
@@ -160,27 +160,27 @@ void csrrf_analysis_initData(rocblas_handle handle,
 
         // read-in A
         file = testcase / "ptrA";
-        read_matrix(file, 1, n + 1, hptrA.data(), 1);
+        read_matrix(file.string(), 1, n + 1, hptrA.data(), 1);
         file = testcase / "indA";
-        read_matrix(file, 1, nnzA, hindA.data(), 1);
+        read_matrix(file.string(), 1, nnzA, hindA.data(), 1);
         file = testcase / "valA";
-        read_matrix(file, 1, nnzA, hvalA.data(), 1);
+        read_matrix(file.string(), 1, nnzA, hvalA.data(), 1);
 
         // read-in T
         file = testcase / "ptrT";
-        read_matrix(file, 1, n + 1, hptrT.data(), 1);
+        read_matrix(file.string(), 1, n + 1, hptrT.data(), 1);
         file = testcase / "indT";
-        read_matrix(file, 1, nnzT, hindT.data(), 1);
+        read_matrix(file.string(), 1, nnzT, hindT.data(), 1);
         file = testcase / "valT";
-        read_matrix(file, 1, nnzT, hvalT.data(), 1);
+        read_matrix(file.string(), 1, nnzT, hvalT.data(), 1);
 
         // read-in P
         file = testcase / "P";
-        read_matrix(file, 1, n, hpivP.data(), 1);
+        read_matrix(file.string(), 1, n, hpivP.data(), 1);
 
         // read-in Q
         file = testcase / "Q";
-        read_matrix(file, 1, n, hpivQ.data(), 1);
+        read_matrix(file.string(), 1, n, hpivQ.data(), 1);
     }
 
     if(GPU)
@@ -403,9 +403,9 @@ void testing_csrrf_analysis(Arguments& argus)
     fs::path testcase;
     if(n > 0)
     {
-        testcase = get_sparse_data_dir() / fmt::format("mat_{}_{}", n, nnzM);
+        testcase = get_sparse_data_dir() / fmt::format("mat_{}_{}", n, nnzM).c_str();
         fs::path file = testcase / "ptrT";
-        read_last(file, &nnzT);
+        read_last(file.string(), &nnzT);
     }
 
     // memory size query if necessary

--- a/clients/include/testing_csrrf_analysis.hpp
+++ b/clients/include/testing_csrrf_analysis.hpp
@@ -403,7 +403,7 @@ void testing_csrrf_analysis(Arguments& argus)
     fs::path testcase;
     if(n > 0)
     {
-        testcase = get_sparse_data_dir() / fmt::format("mat_{}_{}", n, nnzM).c_str();
+        testcase = get_sparse_data_dir() / fs::path(fmt::format("mat_{}_{}", n, nnzM));
         fs::path file = testcase / "ptrT";
         read_last(file.string(), &nnzT);
     }

--- a/clients/include/testing_csrrf_refactlu.hpp
+++ b/clients/include/testing_csrrf_refactlu.hpp
@@ -145,31 +145,31 @@ void csrrf_refactlu_initData(rocblas_handle handle,
 {
     if(CPU)
     {
-        std::string file;
+        fs::path file;
 
         // read-in A
         file = testcase / "ptrA";
-        read_matrix(file, 1, n + 1, hptrA.data(), 1);
+        read_matrix(file.string(), 1, n + 1, hptrA.data(), 1);
         file = testcase / "indA";
-        read_matrix(file, 1, nnzA, hindA.data(), 1);
+        read_matrix(file.string(), 1, nnzA, hindA.data(), 1);
         file = testcase / "valA";
-        read_matrix(file, 1, nnzA, hvalA.data(), 1);
+        read_matrix(file.string(), 1, nnzA, hvalA.data(), 1);
 
         // read-in T
         file = testcase / "ptrT";
-        read_matrix(file, 1, n + 1, hptrT.data(), 1);
+        read_matrix(file.string(), 1, n + 1, hptrT.data(), 1);
         file = testcase / "indT";
-        read_matrix(file, 1, nnzT, hindT.data(), 1);
+        read_matrix(file.string(), 1, nnzT, hindT.data(), 1);
         file = testcase / "valT";
-        read_matrix(file, 1, nnzT, hvalT.data(), 1);
+        read_matrix(file.string(), 1, nnzT, hvalT.data(), 1);
 
         // read-in P
         file = testcase / "P";
-        read_matrix(file, 1, n, hpivP.data(), 1);
+        read_matrix(file.string(), 1, n, hpivP.data(), 1);
 
         // read-in Q
         file = testcase / "Q";
-        read_matrix(file, 1, n, hpivQ.data(), 1);
+        read_matrix(file.string(), 1, n, hpivQ.data(), 1);
     }
 
     if(GPU)
@@ -380,9 +380,9 @@ void testing_csrrf_refactlu(Arguments& argus)
     fs::path testcase;
     if(n > 0)
     {
-        testcase = get_sparse_data_dir() / fmt::format("mat_{}_{}", n, nnzA);
+        testcase = get_sparse_data_dir() / fmt::format("mat_{}_{}", n, nnzA).c_str();
         fs::path file = testcase / "ptrT";
-        read_last(file, &nnzT);
+        read_last(file.string(), &nnzT);
     }
 
     // memory size query if necessary

--- a/clients/include/testing_csrrf_refactlu.hpp
+++ b/clients/include/testing_csrrf_refactlu.hpp
@@ -380,7 +380,7 @@ void testing_csrrf_refactlu(Arguments& argus)
     fs::path testcase;
     if(n > 0)
     {
-        testcase = get_sparse_data_dir() / fmt::format("mat_{}_{}", n, nnzA).c_str();
+        testcase = get_sparse_data_dir() / fs::path(fmt::format("mat_{}_{}", n, nnzA));
         fs::path file = testcase / "ptrT";
         read_last(file.string(), &nnzT);
     }

--- a/clients/include/testing_csrrf_solve.hpp
+++ b/clients/include/testing_csrrf_solve.hpp
@@ -131,34 +131,34 @@ void csrrf_solve_initData(rocblas_handle handle,
 {
     if(CPU)
     {
-        std::string file;
+        fs::path file;
 
         // read-in T
         file = testcase / "ptrT";
-        read_matrix(file, 1, n + 1, hptrT.data(), 1);
+        read_matrix(file.string(), 1, n + 1, hptrT.data(), 1);
         file = testcase / "indT";
-        read_matrix(file, 1, nnzT, hindT.data(), 1);
+        read_matrix(file.string(), 1, nnzT, hindT.data(), 1);
         file = testcase / "valT";
-        read_matrix(file, 1, nnzT, hvalT.data(), 1);
+        read_matrix(file.string(), 1, nnzT, hvalT.data(), 1);
 
         // read-in P
         file = testcase / "P";
-        read_matrix(file, 1, n, hpivP.data(), 1);
+        read_matrix(file.string(), 1, n, hpivP.data(), 1);
 
         // read-in Q
         file = testcase / "Q";
-        read_matrix(file, 1, n, hpivQ.data(), 1);
+        read_matrix(file.string(), 1, n, hpivQ.data(), 1);
 
         // read-in B
-        file = testcase / fmt::format("B_{}", nrhs);
-        read_matrix(file, n, nrhs, hB.data(), ldb);
+        file = testcase / fmt::format("B_{}", nrhs).c_str();
+        read_matrix(file.string(), n, nrhs, hB.data(), ldb);
 
         // get results (matrix X) if validation is required
         if(test)
         {
             // read-in X
-            file = testcase / fmt::format("X_{}", nrhs);
-            read_matrix(file, n, nrhs, hX.data(), ldb);
+            file = testcase / fmt::format("X_{}", nrhs).c_str();
+            read_matrix(file.string(), n, nrhs, hX.data(), ldb);
         }
     }
 
@@ -363,9 +363,9 @@ void testing_csrrf_solve(Arguments& argus)
     fs::path testcase;
     if(n > 0)
     {
-        testcase = get_sparse_data_dir() / fmt::format("mat_{}_{}", n, nnzA);
+        testcase = get_sparse_data_dir() / fmt::format("mat_{}_{}", n, nnzA).c_str();
         fs::path file = testcase / "ptrT";
-        read_last(file, &nnzT);
+        read_last(file.string(), &nnzT);
     }
 
     // determine existing right-hand-side

--- a/clients/include/testing_csrrf_solve.hpp
+++ b/clients/include/testing_csrrf_solve.hpp
@@ -150,14 +150,14 @@ void csrrf_solve_initData(rocblas_handle handle,
         read_matrix(file.string(), 1, n, hpivQ.data(), 1);
 
         // read-in B
-        file = testcase / fmt::format("B_{}", nrhs).c_str();
+        file = testcase / fs::path(fmt::format("B_{}", nrhs));
         read_matrix(file.string(), n, nrhs, hB.data(), ldb);
 
         // get results (matrix X) if validation is required
         if(test)
         {
             // read-in X
-            file = testcase / fmt::format("X_{}", nrhs).c_str();
+            file = testcase / fs::path(fmt::format("X_{}", nrhs));
             read_matrix(file.string(), n, nrhs, hX.data(), ldb);
         }
     }
@@ -363,7 +363,7 @@ void testing_csrrf_solve(Arguments& argus)
     fs::path testcase;
     if(n > 0)
     {
-        testcase = get_sparse_data_dir() / fmt::format("mat_{}_{}", n, nnzA).c_str();
+        testcase = get_sparse_data_dir() / fs::path(fmt::format("mat_{}_{}", n, nnzA));
         fs::path file = testcase / "ptrT";
         read_last(file.string(), &nnzT);
     }

--- a/clients/include/testing_csrrf_splitlu.hpp
+++ b/clients/include/testing_csrrf_splitlu.hpp
@@ -140,15 +140,15 @@ void csrrf_splitlu_initData(rocblas_handle handle,
     {
         if(CPU)
         {
-            std::string file;
+            fs::path file;
 
             // read-in T
             file = testcase / "ptrT";
-            read_matrix(file, 1, n + 1, hptrT.data(), 1);
+            read_matrix(file.string(), 1, n + 1, hptrT.data(), 1);
             file = testcase / "indT";
-            read_matrix(file, 1, nnzT, hindT.data(), 1);
+            read_matrix(file.string(), 1, nnzT, hindT.data(), 1);
             file = testcase / "valT";
-            read_matrix(file, 1, nnzT, hvalT.data(), 1);
+            read_matrix(file.string(), 1, nnzT, hvalT.data(), 1);
 
             // get results (matrices L and U) if validation is required
             if(test)
@@ -157,21 +157,21 @@ void csrrf_splitlu_initData(rocblas_handle handle,
 
                 // read-in L
                 file = testcase / "ptrL";
-                read_matrix(file, 1, n + 1, hptrL.data(), 1);
+                read_matrix(file.string(), 1, n + 1, hptrL.data(), 1);
                 nnzL = hptrL[0][n];
                 file = testcase / "indL";
-                read_matrix(file, 1, nnzL, hindL.data(), 1);
+                read_matrix(file.string(), 1, nnzL, hindL.data(), 1);
                 file = testcase / "valL";
-                read_matrix(file, 1, nnzL, hvalL.data(), 1);
+                read_matrix(file.string(), 1, nnzL, hvalL.data(), 1);
 
                 // read-in U
                 file = testcase / "ptrU";
-                read_matrix(file, 1, n + 1, hptrU.data(), 1);
+                read_matrix(file.string(), 1, n + 1, hptrU.data(), 1);
                 nnzU = hptrU[0][n];
                 file = testcase / "indU";
-                read_matrix(file, 1, nnzU, hindU.data(), 1);
+                read_matrix(file.string(), 1, nnzU, hindU.data(), 1);
                 file = testcase / "valU";
-                read_matrix(file, 1, nnzU, hvalU.data(), 1);
+                read_matrix(file.string(), 1, nnzU, hvalU.data(), 1);
             }
         }
 
@@ -427,11 +427,11 @@ void testing_csrrf_splitlu(Arguments& argus)
     rocblas_int nnzL = n;
     if(!mat_zero && n > 0)
     {
-        testcase = get_sparse_data_dir() / fmt::format("mat_{}_{}", n, nnzA);
+        testcase = get_sparse_data_dir() / fmt::format("mat_{}_{}", n, nnzA).c_str();
         fs::path file = testcase / "ptrL";
-        read_last(file, &nnzL);
+        read_last(file.string(), &nnzL);
         file = testcase / "ptrU";
-        read_last(file, &nnzU);
+        read_last(file.string(), &nnzU);
     }
     nnzT = nnzL + nnzU - n;
 

--- a/clients/include/testing_csrrf_splitlu.hpp
+++ b/clients/include/testing_csrrf_splitlu.hpp
@@ -427,7 +427,7 @@ void testing_csrrf_splitlu(Arguments& argus)
     rocblas_int nnzL = n;
     if(!mat_zero && n > 0)
     {
-        testcase = get_sparse_data_dir() / fmt::format("mat_{}_{}", n, nnzA).c_str();
+        testcase = get_sparse_data_dir() / fs::path(fmt::format("mat_{}_{}", n, nnzA));
         fs::path file = testcase / "ptrL";
         read_last(file.string(), &nnzL);
         file = testcase / "ptrU";

--- a/clients/include/testing_csrrf_sumlu.hpp
+++ b/clients/include/testing_csrrf_sumlu.hpp
@@ -407,7 +407,7 @@ void testing_csrrf_sumlu(Arguments& argus)
     fs::path testcase;
     if(!mat_zero && n > 0)
     {
-        testcase = get_sparse_data_dir() / fmt::format("mat_{}_{}", n, nnzA).c_str();
+        testcase = get_sparse_data_dir() / fs::path(fmt::format("mat_{}_{}", n, nnzA));
         fs::path file = testcase / "ptrL";
         read_last(file.string(), &nnzL);
         file = testcase / "ptrU";

--- a/clients/include/testing_csrrf_sumlu.hpp
+++ b/clients/include/testing_csrrf_sumlu.hpp
@@ -142,34 +142,34 @@ void csrrf_sumlu_initData(rocblas_handle handle,
     {
         if(CPU)
         {
-            std::string file;
+            fs::path file;
 
             // read-in L
             file = testcase / "ptrL";
-            read_matrix(file, 1, n + 1, hptrL.data(), 1);
+            read_matrix(file.string(), 1, n + 1, hptrL.data(), 1);
             file = testcase / "indL";
-            read_matrix(file, 1, nnzL, hindL.data(), 1);
+            read_matrix(file.string(), 1, nnzL, hindL.data(), 1);
             file = testcase / "valL";
-            read_matrix(file, 1, nnzL, hvalL.data(), 1);
+            read_matrix(file.string(), 1, nnzL, hvalL.data(), 1);
 
             // read-in U
             file = testcase / "ptrU";
-            read_matrix(file, 1, n + 1, hptrU.data(), 1);
+            read_matrix(file.string(), 1, n + 1, hptrU.data(), 1);
             file = testcase / "indU";
-            read_matrix(file, 1, nnzU, hindU.data(), 1);
+            read_matrix(file.string(), 1, nnzU, hindU.data(), 1);
             file = testcase / "valU";
-            read_matrix(file, 1, nnzU, hvalU.data(), 1);
+            read_matrix(file.string(), 1, nnzU, hvalU.data(), 1);
 
             // get results (matrix T) if validation is required
             if(test)
             {
                 rocblas_int nnzT = nnzL + nnzU - n;
                 file = testcase / "ptrT";
-                read_matrix(file, 1, n + 1, hptrT.data(), 1);
+                read_matrix(file.string(), 1, n + 1, hptrT.data(), 1);
                 file = testcase / "indT";
-                read_matrix(file, 1, nnzT, hindT.data(), 1);
+                read_matrix(file.string(), 1, nnzT, hindT.data(), 1);
                 file = testcase / "valT";
-                read_matrix(file, 1, nnzT, hvalT.data(), 1);
+                read_matrix(file.string(), 1, nnzT, hvalT.data(), 1);
             }
         }
 
@@ -407,11 +407,11 @@ void testing_csrrf_sumlu(Arguments& argus)
     fs::path testcase;
     if(!mat_zero && n > 0)
     {
-        testcase = get_sparse_data_dir() / fmt::format("mat_{}_{}", n, nnzA);
+        testcase = get_sparse_data_dir() / fmt::format("mat_{}_{}", n, nnzA).c_str();
         fs::path file = testcase / "ptrL";
-        read_last(file, &nnzL);
+        read_last(file.string(), &nnzL);
         file = testcase / "ptrU";
-        read_last(file, &nnzU);
+        read_last(file.string(), &nnzU);
     }
     rocblas_int nnzT = nnzL + nnzU - n;
 


### PR DESCRIPTION
The Windows build for rocSOLVER appears to be failing because Windows is unable to do implicit conversions between std::string and filesystem::path.