### PR TITLE
Remove undefined ger instantiations

### DIFF
--- a/library/src/specialized/roclapack_ger_specialized_kernels.hpp
+++ b/library/src/specialized/roclapack_ger_specialized_kernels.hpp
@@ -81,6 +81,10 @@ rocblas_status rocsolver_ger(rocblas_handle handle,
                                         shiftY, incy, strideY, A, shiftA, lda, strideA, batch_count,
                                         work);
 
+    // TODO: add interleaved support for conjugation
+    if(CONJ)
+        return rocblas_status_not_implemented;
+
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
 

--- a/library/src/specialized/roclapack_ger_specialized_kernels_d.cpp
+++ b/library/src/specialized/roclapack_ger_specialized_kernels_d.cpp
@@ -9,6 +9,4 @@
 *************************************************************/
 
 INSTANTIATE_GER(false, double, double*);
-INSTANTIATE_GER(true, double, double*);
 INSTANTIATE_GER(false, double, double* const*);
-INSTANTIATE_GER(true, double, double* const*);

--- a/library/src/specialized/roclapack_ger_specialized_kernels_s.cpp
+++ b/library/src/specialized/roclapack_ger_specialized_kernels_s.cpp
@@ -9,6 +9,4 @@
 *************************************************************/
 
 INSTANTIATE_GER(false, float, float*);
-INSTANTIATE_GER(true, float, float*);
 INSTANTIATE_GER(false, float, float* const*);
-INSTANTIATE_GER(true, float, float* const*);


### PR DESCRIPTION
With PR #549 I accidentally introduced an undefined reference by instantiating sger and dger with CONJ set to true. This is causing our dlopen test to fail. Removing them should address the issue.