### PR TITLE
Check for test data relative to running executable

### DIFF
--- a/clients/include/rocsolver_test.hpp
+++ b/clients/include/rocsolver_test.hpp
@@ -171,7 +171,7 @@ inline fs::path get_sparse_data_dir()
         return installed;
 
     fmt::print(
-        stderr, "Warning: default sparse data directories ({}, {}) not found, defaulting to current working directory.",
+        stderr, "Warning: default sparse data directories ({}, {}) not found, defaulting to current working directory.\n",
         exe_relative, installed);
 
     return fs::current_path();

--- a/clients/include/rocsolver_test.hpp
+++ b/clients/include/rocsolver_test.hpp
@@ -143,14 +143,7 @@ inline fs::path get_sparse_data_dir()
     fs::path p = fs::current_path();
     fs::path p_parent = p.parent_path();
     fs::path installed = p.root_directory() / "opt" / "rocm" / "share" / "rocsolver" / "test";
-    fs::path exe_relative = rocsolver_exepath() + "../" + "share/" + "rocsolver/" + "test/";
-    try
-    {
-        exe_relative = fs::canonical(exe_relative);
-    }
-    catch(const std::exception& ex)
-    {
-    }
+    fs::path exe_relative = fs::path(rocsolver_exepath()) / ".." / "share" / "rocsolver" / "test";
 
     // check relative to the current directory and relative to each parent
     while(p != p_parent)

--- a/clients/include/rocsolver_test.hpp
+++ b/clients/include/rocsolver_test.hpp
@@ -143,6 +143,14 @@ inline fs::path get_sparse_data_dir()
     fs::path p = fs::current_path();
     fs::path p_parent = p.parent_path();
     fs::path installed = p.root_directory() / "opt" / "rocm" / "share" / "rocsolver" / "test";
+    fs::path exe_relative = rocsolver_exepath() + "../" + "share/" + "rocsolver/" + "test/";
+    try
+    {
+        exe_relative = fs::canonical(exe_relative);
+    }
+    catch(const std::exception& ex)
+    {
+    }
 
     // check relative to the current directory and relative to each parent
     while(p != p_parent)
@@ -154,9 +162,17 @@ inline fs::path get_sparse_data_dir()
         p_parent = p.parent_path();
     }
 
+    // check relative to the running executable
+    if(fs::exists(exe_relative))
+        return exe_relative;
+
     // check relative to default install path
     if(fs::exists(installed))
         return installed;
+
+    fmt::print(
+        stderr, "Warning: default sparse data directories ({}, {}) not found, defaulting to current working directory.",
+        exe_relative, installed);
 
     return fs::current_path();
 }

--- a/clients/rocblascommon/clients_utility.cpp
+++ b/clients/rocblascommon/clients_utility.cpp
@@ -12,6 +12,20 @@
 #include "clients_utility.hpp"
 #include "rocblas_random.hpp"
 
+#ifdef _WIN32
+
+#ifdef __cpp_lib_filesystem
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif
+
+#else
+#include <fcntl.h>
+#endif
+
 // Random number generator
 // Note: We do not use random_device to initialize the RNG, because we want
 // repeatability in case of test failure. TODO: Add seed as an optional CLI
@@ -28,7 +42,7 @@ thread_local rocblas_rng_t rocblas_rng = get_seed();
 // Return the path to the currently running executable
 std::string rocsolver_exepath()
 {
-#ifdef WIN32
+#ifdef _WIN32
 
     std::vector<TCHAR> result(MAX_PATH + 1);
     DWORD length = 0;

--- a/clients/rocblascommon/clients_utility.cpp
+++ b/clients/rocblascommon/clients_utility.cpp
@@ -14,7 +14,8 @@
 
 #ifdef _WIN32
 
-#include <libloaderapi.h>
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 
 #if __has_include(<filesystem>)
 #include <filesystem>

--- a/clients/rocblascommon/clients_utility.cpp
+++ b/clients/rocblascommon/clients_utility.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2018-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2018-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include <cstdlib>
@@ -24,6 +24,46 @@ const std::thread::id main_thread_id = std::this_thread::get_id();
 // For the main thread, we use rocblas_seed; for other threads, we start with a
 // different seed but deterministically based on the thread id's hash function.
 thread_local rocblas_rng_t rocblas_rng = get_seed();
+
+// Return the path to the currently running executable
+std::string rocsolver_exepath()
+{
+#ifdef WIN32
+
+    std::vector<TCHAR> result(MAX_PATH + 1);
+    DWORD length = 0;
+    for(;;)
+    {
+        length = GetModuleFileNameA(nullptr, result.data(), result.size());
+        if(length < result.size() - 1)
+        {
+            result.resize(length + 1);
+            break;
+        }
+        result.resize(result.size() * 2);
+    }
+
+    fs::path exepath(result.begin(), result.end());
+    exepath = exepath.remove_filename();
+    exepath += exepath.empty() ? "" : "/";
+    return exepath.string();
+
+#else
+    std::string pathstr;
+    char* path = realpath("/proc/self/exe", 0);
+    if(path)
+    {
+        char* p = strrchr(path, '/');
+        if(p)
+        {
+            p[1] = 0;
+            pathstr = path;
+        }
+        free(path);
+    }
+    return pathstr;
+#endif
+}
 
 /* ============================================================================================
  */

--- a/clients/rocblascommon/clients_utility.cpp
+++ b/clients/rocblascommon/clients_utility.cpp
@@ -16,7 +16,7 @@
 
 #include <libloaderapi.h>
 
-#ifdef __cpp_lib_filesystem
+#if __has_include(<filesystem>)
 #include <filesystem>
 namespace fs = std::filesystem;
 #else

--- a/clients/rocblascommon/clients_utility.cpp
+++ b/clients/rocblascommon/clients_utility.cpp
@@ -14,6 +14,8 @@
 
 #ifdef _WIN32
 
+#include <libloaderapi.h>
+
 #ifdef __cpp_lib_filesystem
 #include <filesystem>
 namespace fs = std::filesystem;

--- a/clients/rocblascommon/clients_utility.hpp
+++ b/clients/rocblascommon/clients_utility.hpp
@@ -13,21 +13,6 @@
 
 #include "rocblas_test.hpp"
 
-#ifdef WIN32
-#define strcasecmp(A, B) _stricmp(A, B)
-
-#ifdef __cpp_lib_filesystem
-#include <filesystem>
-namespace fs = std::filesystem;
-#else
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
-
-#else
-#include <fcntl.h>
-#endif
-
 /*!\file
  * \brief provide common utilities
  */

--- a/clients/rocblascommon/clients_utility.hpp
+++ b/clients/rocblascommon/clients_utility.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2018-2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2018-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -12,6 +12,21 @@
 #include <vector>
 
 #include "rocblas_test.hpp"
+
+#ifdef WIN32
+#define strcasecmp(A, B) _stricmp(A, B)
+
+#ifdef __cpp_lib_filesystem
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif
+
+#else
+#include <fcntl.h>
+#endif
 
 /*!\file
  * \brief provide common utilities
@@ -26,6 +41,9 @@ static constexpr char LIMITED_MEMORY_STRING[]
 // compared.
 static constexpr char LIMITED_MEMORY_STRING_GTEST[]
     = "Succeeded\nError: Attempting to allocate more memory than available.";
+
+// Return the path to the client executable, for finding test matrices on filesystem
+std::string rocsolver_exepath();
 
 /* ============================================================================================
  */


### PR DESCRIPTION
Adds a utility function to get the path of the running executable in clients.
Adds checks for test data relative to the running executable to fix test data not being found when installed from package.