### PR TITLE
Merge updated build architectures to develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,15 +135,32 @@ if(NOT DEFINED AMDGPU_TARGETS)
     TARGETS
       gfx90a:xnack-
       gfx90a:xnack+
+      gfx940
+      gfx941
+      gfx942
       gfx1100
       gfx1101
       gfx1102
   )
+  set(AMDGPU_TARGETS_INIT
+    gfx803
+    gfx900
+    gfx906:xnack-
+    gfx908:xnack-
+    gfx1010
+    gfx1030
+    ${OPTIONAL_AMDGPU_TARGETS}
+  )
+  # The library would be too large to link (>2 GiB) if it were built for all architectures with
+  # address sanitizer enabled.
+  if(BUILD_ADDRESS_SANITIZER)
+     list(REMOVE_ITEM AMDGPU_TARGETS_INIT gfx803 gfx906:xnack- gfx908:xnack- gfx90a:xnack- gfx1010)
+  endif()
 endif()
 
 # Set this before finding hip so that hip::device has the required arch flags
 # added as usage requirements on its interface
-set(AMDGPU_TARGETS "gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx1010;gfx1030;${OPTIONAL_AMDGPU_TARGETS}"
+set(AMDGPU_TARGETS "${AMDGPU_TARGETS_INIT}"
   CACHE STRING "List of specific machine types for library to target")
 
 # Find HIP dependencies


### PR DESCRIPTION
* Reduce default build architectures for ASAN

The library would exceed the 2 GiB size limit for 32-bit relative addressing if all architectures were enabled. In theory, this could be resolved by the use of the compiler flag `-mcmodel=large`, but it seems that the problem persists regardless.

For ROCm 5.7, we can limit the ASAN builds to a smaller selection of GPU architectures. We should also begin to explore options to reduce the library size for future releases.

* Add gfx940, gfx941 and gfx942