### PR TITLE
Fix stack overflow in sparse tests on Windows

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -126,6 +126,7 @@ if(BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
 
   set(common_source_files
     common/lapack_host_reference.cpp
+    common/rocsolver_test.cpp
     rocblascommon/clients_utility.cpp
     rocblascommon/program_options.cpp
     ${rocauxiliary_inst_files}

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -140,7 +140,7 @@ if(BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
   # Copy and point to sparse test data
   file(COPY
     ${CMAKE_CURRENT_SOURCE_DIR}/sparsedata/
-    DESTINATION ${PROJECT_BINARY_DIR}/sparsedata/
+    DESTINATION ${PROJECT_BINARY_DIR}/staging/sparsedata/
   )
   install(DIRECTORY
     ${CMAKE_CURRENT_SOURCE_DIR}/sparsedata/

--- a/clients/common/rocsolver_test.cpp
+++ b/clients/common/rocsolver_test.cpp
@@ -1,0 +1,40 @@
+/* ************************************************************************
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include <cstdlib>
+
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+
+#include "rocblascommon/clients_utility.hpp"
+#include "rocsolver_test.hpp"
+
+fs::path get_sparse_data_dir()
+{
+    // first check an environment variable
+    if(const char* datadir = std::getenv("ROCSOLVER_TEST_DATA"))
+        return fs::path{datadir};
+
+    std::vector<std::string> considered;
+
+    // check relative to the running executable
+    fs::path exe_path = fs::path(rocsolver_exepath());
+    std::vector<fs::path> candidates = {"../share/rocsolver/test", "../../../../clients/sparsedata"};
+    for(const fs::path& candidate : candidates)
+    {
+        fs::path exe_relative = fs::weakly_canonical(exe_path / candidate);
+        if(fs::exists(exe_relative))
+            return exe_relative;
+        considered.push_back(exe_relative.string());
+    }
+
+    fmt::print(stderr,
+               "Warning: default sparse data directories not found. "
+               "Defaulting to current working directory.\nExecutable location: {}\n"
+               "Paths considered:\n{}\n",
+               exe_path.string(), fmt::join(considered, "\n"));
+
+    return fs::current_path();
+}

--- a/clients/common/rocsolver_test.cpp
+++ b/clients/common/rocsolver_test.cpp
@@ -21,7 +21,7 @@ fs::path get_sparse_data_dir()
 
     // check relative to the running executable
     fs::path exe_path = fs::path(rocsolver_exepath());
-    std::vector<fs::path> candidates = {"../share/rocsolver/test", "../../../../clients/sparsedata"};
+    std::vector<fs::path> candidates = {"../share/rocsolver/test", "sparsedata"};
     for(const fs::path& candidate : candidates)
     {
         fs::path exe_relative = fs::weakly_canonical(exe_path / candidate);

--- a/clients/common/rocsolver_test.cpp
+++ b/clients/common/rocsolver_test.cpp
@@ -3,6 +3,7 @@
  * ************************************************************************ */
 
 #include <cstdlib>
+#include <system_error>
 
 #include <fmt/core.h>
 #include <fmt/ostream.h>
@@ -24,8 +25,9 @@ fs::path get_sparse_data_dir()
     std::vector<fs::path> candidates = {"../share/rocsolver/test", "sparsedata"};
     for(const fs::path& candidate : candidates)
     {
-        fs::path exe_relative = fs::weakly_canonical(exe_path / candidate);
-        if(fs::exists(exe_relative))
+        std::error_code ec;
+        fs::path exe_relative = fs::canonical(exe_path / candidate, ec);
+        if(!ec)
             return exe_relative;
         considered.push_back(exe_relative.string());
     }

--- a/clients/include/rocsolver_test.hpp
+++ b/clients/include/rocsolver_test.hpp
@@ -21,6 +21,7 @@ namespace fs = std::experimental::filesystem;
 #include <fmt/core.h>
 #include <fmt/ostream.h>
 #include <fmt/ranges.h>
+#include <rocblas/rocblas.h>
 
 // If USE_ROCBLAS_REALLOC_ON_DEMAND is false, automatic reallocation is disable and we will manually
 // reallocate workspace
@@ -133,39 +134,4 @@ inline std::ostream& operator<<(std::ostream& os, printable_char x)
 }
 
 // location of the sparse data directory for the re-factorization tests
-
-inline fs::path get_sparse_data_dir()
-{
-    // first check an environment variable
-    if(const char* datadir = std::getenv("ROCSOLVER_TEST_DATA"))
-        return fs::path{datadir};
-
-    fs::path p = fs::current_path();
-    fs::path p_parent = p.parent_path();
-    fs::path installed = p.root_directory() / "opt" / "rocm" / "share" / "rocsolver" / "test";
-    fs::path exe_relative = fs::path(rocsolver_exepath()) / ".." / "share" / "rocsolver" / "test";
-
-    // check relative to the current directory and relative to each parent
-    while(p != p_parent)
-    {
-        fs::path candidate = p / "clients" / "sparsedata";
-        if(fs::exists(candidate))
-            return candidate;
-        p = p_parent;
-        p_parent = p.parent_path();
-    }
-
-    // check relative to the running executable
-    if(fs::exists(exe_relative))
-        return exe_relative;
-
-    // check relative to default install path
-    if(fs::exists(installed))
-        return installed;
-
-    fmt::print(
-        stderr, "Warning: default sparse data directories ({}, {}) not found, defaulting to current working directory.\n",
-        exe_relative, installed);
-
-    return fs::current_path();
-}
+fs::path get_sparse_data_dir();

--- a/clients/rocblascommon/clients_utility.cpp
+++ b/clients/rocblascommon/clients_utility.cpp
@@ -14,7 +14,6 @@
 
 #ifdef _WIN32
 
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 #if __has_include(<filesystem>)


### PR DESCRIPTION
It appears that the while(p != p_parent) check would create an infinite loop on Windows, ultimately resulting in a stack overflow. With the addition of exe-relative lookups, all other searches are superfluous and can be removed.