### PR TITLE
Fix build with rocSPARSE 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,10 +172,10 @@ message(STATUS "Found rocBLAS: ${location}")
 set(rocsolver_pkgdeps "rocblas >= 4.0" "rocblas < 4.1")
 
 if(BUILD_WITH_SPARSE)
-  find_package(rocsparse 2.2 REQUIRED CONFIG PATHS ${ROCM_PATH})
+  find_package(rocsparse REQUIRED CONFIG PATHS ${ROCM_PATH})
   get_imported_target_location(location roc::rocsparse)
   message(STATUS "Found rocSPARSE: ${location}")
-  list(APPEND rocsolver_pkgdeps "rocsparse >= 2.2" "rocsparse < 3.0")
+  list(APPEND rocsolver_pkgdeps "rocsparse >= 2.2")
 endif()
 
 add_subdirectory(common)


### PR DESCRIPTION
The version check in find_package is overly-restrictive. While rocSPARSE 3 is not entirely compatible with rocSPARSE 2, the parts that we need are all there.

Ticket: SWDEV-412758