### PR TITLE
fix new float 8 type warnings

### DIFF
--- a/common/include/rocblas_utility.hpp
+++ b/common/include/rocblas_utility.hpp
@@ -14,6 +14,9 @@
 #include <rocblas/rocblas.h>
 #include <rocsolver/rocsolver.h>
 
+#define ROCSOLVER_ROCBLAS_HAS_F8_DATATYPES \
+    (ROCBLAS_VERSION_MAJOR >= 4 || (ROCBLAS_VERSION_MAJOR == 3 && ROCBLAS_VERSION_MINOR >= 1))
+
 #pragma STDC CX_LIMITED_RANGE ON
 
 // half vectors
@@ -239,6 +242,10 @@ constexpr const char* rocblas_datatype_string(rocblas_datatype type)
     case rocblas_datatype_bf16_r:  return "bf16_r";
     case rocblas_datatype_bf16_c:  return "bf16_c";
     case rocblas_datatype_invalid: return "invalid";
+#if ROCSOLVER_ROCBLAS_HAS_F8_DATATYPES
+    case rocblas_datatype_f8_r:    return "f8_r";
+    case rocblas_datatype_bf8_r:   return "bf8_r";
+#endif
     }
     return "invalid";
 }
@@ -265,6 +272,10 @@ constexpr size_t rocblas_sizeof_datatype(rocblas_datatype type)
     case rocblas_datatype_bf16_r:  return 2;
     case rocblas_datatype_bf16_c:  return 4;
     case rocblas_datatype_invalid: return 4;
+#if ROCSOLVER_ROCBLAS_HAS_F8_DATATYPES
+    case rocblas_datatype_f8_r:    return 1;
+    case rocblas_datatype_bf8_r:   return 1;
+#endif
     }
     return 0;
 }
@@ -281,6 +292,10 @@ template <> static constexpr auto rocblas_datatype_from_type<uint8_t>           
 template <> static constexpr auto rocblas_datatype_from_type<int32_t>                = rocblas_datatype_i32_r;
 template <> static constexpr auto rocblas_datatype_from_type<uint32_t>               = rocblas_datatype_u32_r;
 template <> static constexpr auto rocblas_datatype_from_type<rocblas_bfloat16>       = rocblas_datatype_bf16_r;
+#if ROCSOLVER_ROCBLAS_HAS_F8_DATATYPES
+template <> static constexpr auto rocblas_datatype_from_type<rocblas_f8>             = rocblas_datatype_f8_r;
+template <> static constexpr auto rocblas_datatype_from_type<rocblas_bf8>            = rocblas_datatype_bf8_r;
+#endif
 
 // return precision string for data type
 template <typename> static constexpr char rocblas_precision_string                [] = "invalid";
@@ -300,6 +315,10 @@ template <> static constexpr char rocblas_precision_string<rocblas_i8_complex   
 template <> static constexpr char rocblas_precision_string<rocblas_u8_complex    >[] = "u8_c";
 template <> static constexpr char rocblas_precision_string<rocblas_i32_complex   >[] = "i32_c";
 template <> static constexpr char rocblas_precision_string<rocblas_u32_complex   >[] = "u32_c";
+#if ROCSOLVER_ROCBLAS_HAS_F8_DATATYPES
+template <> static constexpr char rocblas_precision_string<rocblas_f8            >[] = "f8_r";
+template <> static constexpr char rocblas_precision_string<rocblas_bf8           >[] = "bf8_r";
+#endif
 #endif
 
 // clang-format on
@@ -422,3 +441,5 @@ catch(...)
 {
     return rocblas_status_internal_error;
 }
+
+#undef ROCSOLVER_ROCBLAS_HAS_F8_DATATYPES

--- a/common/include/rocsolver_datatype2string.hpp
+++ b/common/include/rocsolver_datatype2string.hpp
@@ -11,7 +11,6 @@
 #define ROCSOLVER_ROCBLAS_HAS_F8_DATATYPES \
     (ROCBLAS_VERSION_MAJOR >= 4 || (ROCBLAS_VERSION_MAJOR == 3 && ROCBLAS_VERSION_MINOR >= 1))
 
-
 typedef enum rocblas_initialization_ : int
 {
     rocblas_initialization_random_int = 111,

--- a/common/include/rocsolver_datatype2string.hpp
+++ b/common/include/rocsolver_datatype2string.hpp
@@ -8,6 +8,10 @@
 #include "rocsolver/rocsolver.h"
 #include <string>
 
+#define ROCSOLVER_ROCBLAS_HAS_F8_DATATYPES \
+    (ROCBLAS_VERSION_MAJOR >= 4 || (ROCBLAS_VERSION_MAJOR == 3 && ROCBLAS_VERSION_MINOR >= 1))
+
+
 typedef enum rocblas_initialization_ : int
 {
     rocblas_initialization_random_int = 111,
@@ -201,6 +205,10 @@ constexpr auto rocblas2string_datatype(rocblas_datatype type)
     case rocblas_datatype_bf16_r: return "bf16_r";
     case rocblas_datatype_bf16_c: return "bf16_c";
     case rocblas_datatype_invalid: return "invalid";
+#if ROCSOLVER_ROCBLAS_HAS_F8_DATATYPES
+    case rocblas_datatype_f8_r: return "f8_r";
+    case rocblas_datatype_bf8_r: return "bf8_r";
+#endif
     }
     return "invalid";
 }
@@ -397,6 +405,10 @@ inline rocblas_datatype string2rocblas_datatype(const std::string& value)
         value == "u32_r"                 ? rocblas_datatype_u32_r :
         value == "u8_c"                  ? rocblas_datatype_u8_c  :
         value == "u32_c"                 ? rocblas_datatype_u32_c :
+#if ROCSOLVER_ROCBLAS_HAS_F8_DATATYPES
+        value == "f8_r"                  ? rocblas_datatype_f8_r  :
+        value == "bf8_r"                 ? rocblas_datatype_bf8_r :
+#endif
         rocblas_datatype_invalid;
 }
 
@@ -409,3 +421,5 @@ inline rocblas_initialization string2rocblas_initialization(const std::string& v
         static_cast<rocblas_initialization>(0);
 }
 // clang-format on
+
+#undef ROCSOLVER_ROCBLAS_HAS_F8_DATATYPES


### PR DESCRIPTION
* updates so new data type for float 8 isn't generating warnings
* these types were introduced late into rocm5.7