### PR TITLE
ROCm 5.7 cherry-picks for ASAN and Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 - Linear system solver without pivoting for block tridiagonal matrices:
     - GEBLTTRS_NPVT now supports interleaved\_batched format
 
+### Fixed
+- Fixed stack overflow in sparse tests on Windows
+
+### Changed
+- Changed rocsolver-test sparse input data search paths to be relative to the test executable
+- Changed build scripts to default to compressed debug symbols in Debug builds
+
 
 ## rocSOLVER 3.22.0 for ROCm 5.6.0
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ cmake_dependent_option(BUILD_CLIENTS_EXTRA_TESTS "Build extra tests" OFF BUILD_T
 option(BUILD_ADDRESS_SANITIZER "Build with address sanitizer enabled" OFF)
 option(BUILD_CODE_COVERAGE "Build rocSOLVER with code coverage enabled" OFF)
 option(WERROR "Treat warnings as errors" OFF)
+option(BUILD_COMPRESSED_DBG "Enable compressed debug symbols" ON)
 
 cmake_dependent_option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY
   "Build with file/folder reorg backward compatibility enabled" ON "NOT WIN32" OFF)
@@ -151,11 +152,6 @@ if(NOT DEFINED AMDGPU_TARGETS)
     gfx1030
     ${OPTIONAL_AMDGPU_TARGETS}
   )
-  # The library would be too large to link (>2 GiB) if it were built for all architectures with
-  # address sanitizer enabled.
-  if(BUILD_ADDRESS_SANITIZER)
-     list(REMOVE_ITEM AMDGPU_TARGETS_INIT gfx803 gfx906:xnack- gfx908:xnack- gfx90a:xnack- gfx1010)
-  endif()
 endif()
 
 # Set this before finding hip so that hip::device has the required arch flags

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -126,6 +126,7 @@ if(BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
 
   set(common_source_files
     common/lapack_host_reference.cpp
+    common/rocsolver_test.cpp
     rocblascommon/clients_utility.cpp
     rocblascommon/program_options.cpp
     ${rocauxiliary_inst_files}
@@ -139,7 +140,7 @@ if(BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
   # Copy and point to sparse test data
   file(COPY
     ${CMAKE_CURRENT_SOURCE_DIR}/sparsedata/
-    DESTINATION ${PROJECT_BINARY_DIR}/sparsedata/
+    DESTINATION ${PROJECT_BINARY_DIR}/staging/sparsedata/
   )
   install(DIRECTORY
     ${CMAKE_CURRENT_SOURCE_DIR}/sparsedata/

--- a/clients/common/rocsolver_test.cpp
+++ b/clients/common/rocsolver_test.cpp
@@ -1,0 +1,42 @@
+/* ************************************************************************
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include <cstdlib>
+#include <system_error>
+
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+
+#include "rocblascommon/clients_utility.hpp"
+#include "rocsolver_test.hpp"
+
+fs::path get_sparse_data_dir()
+{
+    // first check an environment variable
+    if(const char* datadir = std::getenv("ROCSOLVER_TEST_DATA"))
+        return fs::path{datadir};
+
+    std::vector<std::string> considered;
+
+    // check relative to the running executable
+    fs::path exe_path = fs::path(rocsolver_exepath());
+    std::vector<fs::path> candidates = {"../share/rocsolver/test", "sparsedata"};
+    for(const fs::path& candidate : candidates)
+    {
+        std::error_code ec;
+        fs::path exe_relative = fs::canonical(exe_path / candidate, ec);
+        if(!ec)
+            return exe_relative;
+        considered.push_back(exe_relative.string());
+    }
+
+    fmt::print(stderr,
+               "Warning: default sparse data directories not found. "
+               "Defaulting to current working directory.\nExecutable location: {}\n"
+               "Paths considered:\n{}\n",
+               exe_path.string(), fmt::join(considered, "\n"));
+
+    return fs::current_path();
+}

--- a/clients/include/rocsolver_test.hpp
+++ b/clients/include/rocsolver_test.hpp
@@ -21,6 +21,7 @@ namespace fs = std::experimental::filesystem;
 #include <fmt/core.h>
 #include <fmt/ostream.h>
 #include <fmt/ranges.h>
+#include <rocblas/rocblas.h>
 
 // If USE_ROCBLAS_REALLOC_ON_DEMAND is false, automatic reallocation is disable and we will manually
 // reallocate workspace
@@ -133,39 +134,4 @@ inline std::ostream& operator<<(std::ostream& os, printable_char x)
 }
 
 // location of the sparse data directory for the re-factorization tests
-
-inline fs::path get_sparse_data_dir()
-{
-    // first check an environment variable
-    if(const char* datadir = std::getenv("ROCSOLVER_TEST_DATA"))
-        return fs::path{datadir};
-
-    fs::path p = fs::current_path();
-    fs::path p_parent = p.parent_path();
-    fs::path installed = p.root_directory() / "opt" / "rocm" / "share" / "rocsolver" / "test";
-    fs::path exe_relative = fs::path(rocsolver_exepath()) / ".." / "share" / "rocsolver" / "test";
-
-    // check relative to the current directory and relative to each parent
-    while(p != p_parent)
-    {
-        fs::path candidate = p / "clients" / "sparsedata";
-        if(fs::exists(candidate))
-            return candidate;
-        p = p_parent;
-        p_parent = p.parent_path();
-    }
-
-    // check relative to the running executable
-    if(fs::exists(exe_relative))
-        return exe_relative;
-
-    // check relative to default install path
-    if(fs::exists(installed))
-        return installed;
-
-    fmt::print(
-        stderr, "Warning: default sparse data directories ({}, {}) not found, defaulting to current working directory.\n",
-        exe_relative, installed);
-
-    return fs::current_path();
-}
+fs::path get_sparse_data_dir();

--- a/clients/rocblascommon/clients_utility.cpp
+++ b/clients/rocblascommon/clients_utility.cpp
@@ -14,7 +14,6 @@
 
 #ifdef _WIN32
 
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 #if __has_include(<filesystem>)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -58,3 +58,10 @@ if(BUILD_CODE_COVERAGE)
   )
   target_link_options(rocsolver-common INTERFACE --coverage)
 endif()
+
+if(BUILD_COMPRESSED_DBG)
+  target_compile_options(rocsolver-common INTERFACE
+    "$<$<CONFIG:Debug>:-gz>"
+    "$<$<CONFIG:RelWithDebInfo>:-gz>"
+  )
+endif()


### PR DESCRIPTION
This change cherry-picks two fixes for rocSOLVER Debug build for ASAN and the sparse tests on Windows.

Tickets: SWDEV-410834, SWDEV-406005