### PR TITLE
Check HIP errors in test teardown

### DIFF
--- a/clients/gtest/bdsqr_gtest.cpp
+++ b/clients/gtest/bdsqr_gtest.cpp
@@ -115,9 +115,10 @@ Arguments bdsqr_setup_arguments(bdsqr_tuple tup)
 class BDSQR : public ::TestWithParam<bdsqr_tuple>
 {
 protected:
-    BDSQR() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/bdsvdx_gtest.cpp
+++ b/clients/gtest/bdsvdx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -120,9 +120,10 @@ Arguments bdsvdx_setup_arguments(bdsvdx_tuple tup)
 class BDSVDX : public ::TestWithParam<bdsvdx_tuple>
 {
 protected:
-    BDSVDX() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/csrrf_analysis_gtest.cpp
+++ b/clients/gtest/csrrf_analysis_gtest.cpp
@@ -102,13 +102,15 @@ Arguments csrrf_analysis_setup_arguments(csrrf_analysis_tuple tup)
 class CSRRF_ANALYSIS : public ::TestWithParam<csrrf_analysis_tuple>
 {
 protected:
-    CSRRF_ANALYSIS() {}
-    virtual void SetUp()
+    void SetUp() override
     {
         if(rocsolver_create_rfinfo(nullptr, nullptr) == rocblas_status_not_implemented)
             GTEST_SKIP() << "Sparse functionality is not enabled";
     }
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/csrrf_refactchol_gtest.cpp
+++ b/clients/gtest/csrrf_refactchol_gtest.cpp
@@ -93,13 +93,15 @@ Arguments csrrf_refactchol_setup_arguments(csrrf_refactchol_tuple tup)
 class CSRRF_REFACTCHOL : public ::TestWithParam<csrrf_refactchol_tuple>
 {
 protected:
-    CSRRF_REFACTCHOL() {}
-    virtual void SetUp()
+    void SetUp() override
     {
         if(rocsolver_create_rfinfo(nullptr, nullptr) == rocblas_status_not_implemented)
             GTEST_SKIP() << "Sparse functionality is not enabled";
     }
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/csrrf_refactlu_gtest.cpp
+++ b/clients/gtest/csrrf_refactlu_gtest.cpp
@@ -92,13 +92,15 @@ Arguments csrrf_refactlu_setup_arguments(csrrf_refactlu_tuple tup)
 class CSRRF_REFACTLU : public ::TestWithParam<csrrf_refactlu_tuple>
 {
 protected:
-    CSRRF_REFACTLU() {}
-    virtual void SetUp()
+    void SetUp() override
     {
         if(rocsolver_create_rfinfo(nullptr, nullptr) == rocblas_status_not_implemented)
             GTEST_SKIP() << "Sparse functionality is not enabled";
     }
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/csrrf_solve_gtest.cpp
+++ b/clients/gtest/csrrf_solve_gtest.cpp
@@ -112,13 +112,15 @@ Arguments csrrf_solve_setup_arguments(csrrf_solve_tuple tup)
 class CSRRF_SOLVE : public ::TestWithParam<csrrf_solve_tuple>
 {
 protected:
-    CSRRF_SOLVE() {}
-    virtual void SetUp()
+    void SetUp() override
     {
         if(rocsolver_create_rfinfo(nullptr, nullptr) == rocblas_status_not_implemented)
             GTEST_SKIP() << "Sparse functionality is not enabled";
     }
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/csrrf_splitlu_gtest.cpp
+++ b/clients/gtest/csrrf_splitlu_gtest.cpp
@@ -92,13 +92,15 @@ Arguments csrrf_splitlu_setup_arguments(csrrf_splitlu_tuple tup)
 class CSRRF_SPLITLU : public ::TestWithParam<csrrf_splitlu_tuple>
 {
 protected:
-    CSRRF_SPLITLU() {}
-    virtual void SetUp()
+    void SetUp() override
     {
         if(rocsolver_create_rfinfo(nullptr, nullptr) == rocblas_status_not_implemented)
             GTEST_SKIP() << "Sparse functionality is not enabled";
     }
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/csrrf_sumlu_gtest.cpp
+++ b/clients/gtest/csrrf_sumlu_gtest.cpp
@@ -93,13 +93,15 @@ Arguments csrrf_sumlu_setup_arguments(csrrf_sumlu_tuple tup)
 class CSRRF_SUMLU : public ::TestWithParam<csrrf_sumlu_tuple>
 {
 protected:
-    CSRRF_SUMLU() {}
-    virtual void SetUp()
+    void SetUp() override
     {
         if(rocsolver_create_rfinfo(nullptr, nullptr) == rocblas_status_not_implemented)
             GTEST_SKIP() << "Sparse functionality is not enabled";
     }
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/csrrf_workflow_gtest.cpp
+++ b/clients/gtest/csrrf_workflow_gtest.cpp
@@ -85,13 +85,15 @@ Arguments csrrf_workflow_setup_arguments(csrrf_workflow_tuple tup)
 class CSRRF_WORKFLOW : public ::TestWithParam<csrrf_workflow_tuple>
 {
 protected:
-    CSRRF_WORKFLOW() {}
-    virtual void SetUp()
+    void SetUp() override
     {
         if(rocsolver_create_rfinfo(nullptr, nullptr) == rocblas_status_not_implemented)
             GTEST_SKIP() << "Sparse functionality is not enabled";
     }
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/gebd2_gebrd_gtest.cpp
+++ b/clients/gtest/gebd2_gebrd_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -91,9 +91,10 @@ template <bool BLOCKED>
 class GEBD2_GEBRD : public ::TestWithParam<gebrd_tuple>
 {
 protected:
-    GEBD2_GEBRD() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/geblttrf_gtest.cpp
+++ b/clients/gtest/geblttrf_gtest.cpp
@@ -106,9 +106,10 @@ Arguments geblttrf_setup_arguments(geblttrf_tuple tup, bool interleaved)
 class GEBLTTRF_NPVT : public ::TestWithParam<geblttrf_tuple>
 {
 protected:
-    GEBLTTRF_NPVT() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()
@@ -130,9 +131,10 @@ protected:
 class GEBLTTRF_NPVT_INTERLEAVED : public ::TestWithParam<geblttrf_tuple>
 {
 protected:
-    GEBLTTRF_NPVT_INTERLEAVED() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/geblttrs_gtest.cpp
+++ b/clients/gtest/geblttrs_gtest.cpp
@@ -111,9 +111,10 @@ Arguments geblttrs_setup_arguments(geblttrs_tuple tup, bool interleaved)
 class GEBLTTRS_NPVT : public ::TestWithParam<geblttrs_tuple>
 {
 protected:
-    GEBLTTRS_NPVT() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()
@@ -132,9 +133,10 @@ protected:
 class GEBLTTRS_NPVT_INTERLEAVED : public ::TestWithParam<geblttrs_tuple>
 {
 protected:
-    GEBLTTRS_NPVT_INTERLEAVED() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/gelq2_gelqf_gtest.cpp
+++ b/clients/gtest/gelq2_gelqf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -92,9 +92,10 @@ template <bool BLOCKED>
 class GELQ2_GELQF : public ::TestWithParam<gelqf_tuple>
 {
 protected:
-    GELQ2_GELQF() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/gels_gtest.cpp
+++ b/clients/gtest/gels_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -120,9 +120,10 @@ Arguments gels_setup_arguments(gels_tuple tup, bool outofplace)
 class GELS : public ::TestWithParam<gels_tuple>
 {
 protected:
-    GELS() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()
@@ -144,9 +145,10 @@ protected:
 class GELS_OUTOFPLACE : public ::TestWithParam<gels_tuple>
 {
 protected:
-    GELS_OUTOFPLACE() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/geql2_geqlf_gtest.cpp
+++ b/clients/gtest/geql2_geqlf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -92,9 +92,10 @@ template <bool BLOCKED>
 class GEQL2_GEQLF : public ::TestWithParam<geqlf_tuple>
 {
 protected:
-    GEQL2_GEQLF() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/geqr2_geqrf_gtest.cpp
+++ b/clients/gtest/geqr2_geqrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -92,9 +92,10 @@ template <bool BLOCKED>
 class GEQR2_GEQRF : public ::TestWithParam<geqrf_tuple>
 {
 protected:
-    GEQR2_GEQRF() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/gerq2_gerqf_gtest.cpp
+++ b/clients/gtest/gerq2_gerqf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -92,9 +92,10 @@ template <bool BLOCKED>
 class GERQ2_GERQF : public ::TestWithParam<gerqf_tuple>
 {
 protected:
-    GERQ2_GERQF() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/gesv_gtest.cpp
+++ b/clients/gtest/gesv_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -104,9 +104,10 @@ Arguments gesv_setup_arguments(gesv_tuple tup, bool outofplace)
 class GESV : public ::TestWithParam<gesv_tuple>
 {
 protected:
-    GESV() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()
@@ -128,9 +129,10 @@ protected:
 class GESV_OUTOFPLACE : public ::TestWithParam<gesv_tuple>
 {
 protected:
-    GESV_OUTOFPLACE() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/gesvd_gtest.cpp
+++ b/clients/gtest/gesvd_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -157,9 +157,10 @@ Arguments gesvd_setup_arguments(gesvd_tuple tup)
 class GESVD : public ::TestWithParam<gesvd_tuple>
 {
 protected:
-    GESVD() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/gesvdj_gtest.cpp
+++ b/clients/gtest/gesvdj_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -139,9 +139,10 @@ Arguments gesvdj_setup_arguments(gesvdj_tuple tup, bool notransv)
 class GESVDJ : public ::TestWithParam<gesvdj_tuple>
 {
 protected:
-    GESVDJ() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()
@@ -160,9 +161,10 @@ protected:
 class GESVDJ_NOTRANSV : public ::TestWithParam<gesvdj_tuple>
 {
 protected:
-    GESVDJ_NOTRANSV() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/gesvdx_gtest.cpp
+++ b/clients/gtest/gesvdx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -148,9 +148,10 @@ Arguments gesvdx_setup_arguments(gesvdx_tuple tup)
 class GESVDX : public ::TestWithParam<gesvdx_tuple>
 {
 protected:
-    GESVDX() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/getf2_getrf_gtest.cpp
+++ b/clients/gtest/getf2_getrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -100,9 +100,10 @@ template <bool BLOCKED>
 class GETF2_GETRF : public ::TestWithParam<getrf_tuple>
 {
 protected:
-    GETF2_GETRF() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()
@@ -125,9 +126,10 @@ template <bool BLOCKED>
 class GETF2_GETRF_NPVT : public ::TestWithParam<getrf_tuple>
 {
 protected:
-    GETF2_GETRF_NPVT() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/getrf_large_gtest.cpp
+++ b/clients/gtest/getrf_large_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -65,9 +65,10 @@ Arguments getrf_large_setup_arguments(getrf_large_tuple tup)
 class GETRF_LARGE : public ::TestWithParam<getrf_large_tuple>
 {
 protected:
-    GETRF_LARGE() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()
@@ -84,9 +85,10 @@ protected:
 class GETRF_LARGE_NPVT : public ::TestWithParam<getrf_large_tuple>
 {
 protected:
-    GETRF_LARGE_NPVT() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/getri_gtest.cpp
+++ b/clients/gtest/getri_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -82,9 +82,10 @@ Arguments getri_setup_arguments(getri_tuple tup, bool outofplace)
 class GETRI : public ::TestWithParam<getri_tuple>
 {
 protected:
-    GETRI() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()
@@ -106,9 +107,10 @@ protected:
 class GETRI_NPVT : public ::TestWithParam<getri_tuple>
 {
 protected:
-    GETRI_NPVT() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()
@@ -130,9 +132,10 @@ protected:
 class GETRI_OUTOFPLACE : public ::TestWithParam<getri_tuple>
 {
 protected:
-    GETRI_OUTOFPLACE() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()
@@ -154,9 +157,10 @@ protected:
 class GETRI_NPVT_OUTOFPLACE : public ::TestWithParam<getri_tuple>
 {
 protected:
-    GETRI_NPVT_OUTOFPLACE() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/getrs_gtest.cpp
+++ b/clients/gtest/getrs_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -105,9 +105,10 @@ Arguments getrs_setup_arguments(getrs_tuple tup)
 class GETRS : public ::TestWithParam<getrs_tuple>
 {
 protected:
-    GETRS() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/labrd_gtest.cpp
+++ b/clients/gtest/labrd_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -106,9 +106,10 @@ Arguments labrd_setup_arguments(labrd_tuple tup)
 class LABRD : public ::TestWithParam<labrd_tuple>
 {
 protected:
-    LABRD() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/lacgv_gtest.cpp
+++ b/clients/gtest/lacgv_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -71,9 +71,10 @@ Arguments lacgv_setup_arguments(lacgv_tuple tup)
 class LACGV : public ::TestWithParam<lacgv_tuple>
 {
 protected:
-    LACGV() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/larf_gtest.cpp
+++ b/clients/gtest/larf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -95,9 +95,10 @@ Arguments larf_setup_arguments(larf_tuple tup)
 class LARF : public ::TestWithParam<larf_tuple>
 {
 protected:
-    LARF() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/larfb_gtest.cpp
+++ b/clients/gtest/larfb_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -119,9 +119,10 @@ Arguments larfb_setup_arguments(larfb_tuple tup)
 class LARFB : public ::TestWithParam<larfb_tuple>
 {
 protected:
-    LARFB() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/larfg_gtest.cpp
+++ b/clients/gtest/larfg_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -88,9 +88,10 @@ Arguments larfg_setup_arguments(larfg_tuple tup)
 class LARFG : public ::TestWithParam<larfg_tuple>
 {
 protected:
-    LARFG() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/larft_gtest.cpp
+++ b/clients/gtest/larft_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -98,9 +98,10 @@ Arguments larft_setup_arguments(larft_tuple tup)
 class LARFT : public ::TestWithParam<larft_tuple>
 {
 protected:
-    LARFT() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/laswp_gtest.cpp
+++ b/clients/gtest/laswp_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -91,9 +91,10 @@ Arguments laswp_setup_arguments(laswp_tuple tup)
 class LASWP : public ::TestWithParam<laswp_tuple>
 {
 protected:
-    LASWP() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/lasyf_gtest.cpp
+++ b/clients/gtest/lasyf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -98,9 +98,10 @@ Arguments lasyf_setup_arguments(lasyf_tuple tup)
 class LASYF : public ::TestWithParam<lasyf_tuple>
 {
 protected:
-    LASYF() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/latrd_gtest.cpp
+++ b/clients/gtest/latrd_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -98,9 +98,10 @@ Arguments latrd_setup_arguments(latrd_tuple tup)
 class LATRD : public ::TestWithParam<latrd_tuple>
 {
 protected:
-    LATRD() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/lauum_gtest.cpp
+++ b/clients/gtest/lauum_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -74,9 +74,10 @@ Arguments lauum_setup_arguments(lauum_tuple tup)
 class LAUUM : public ::TestWithParam<lauum_tuple>
 {
 protected:
-    LAUUM() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/managed_malloc_gtest.cpp
+++ b/clients/gtest/managed_malloc_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -80,9 +80,10 @@ Arguments managed_malloc_setup_arguments(managed_malloc_tuple tup)
 class MANAGED_MALLOC : public ::TestWithParam<managed_malloc_tuple>
 {
 protected:
-    MANAGED_MALLOC() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/orgbr_ungbr_gtest.cpp
+++ b/clients/gtest/orgbr_ungbr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -109,9 +109,10 @@ Arguments orgbr_setup_arguments(orgbr_tuple tup)
 class ORGBR_UNGBR : public ::TestWithParam<orgbr_tuple>
 {
 protected:
-    ORGBR_UNGBR() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/orglx_unglx_gtest.cpp
+++ b/clients/gtest/orglx_unglx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -93,9 +93,10 @@ template <bool BLOCKED>
 class ORGLX_UNGLX : public ::TestWithParam<orglq_tuple>
 {
 protected:
-    ORGLX_UNGLX() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/orgtr_ungtr_gtest.cpp
+++ b/clients/gtest/orgtr_ungtr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -78,9 +78,10 @@ Arguments orgtr_setup_arguments(orgtr_tuple tup)
 class ORGTR_UNGTR : public ::TestWithParam<orgtr_tuple>
 {
 protected:
-    ORGTR_UNGTR() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/orgxl_ungxl_gtest.cpp
+++ b/clients/gtest/orgxl_ungxl_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -98,9 +98,10 @@ template <bool BLOCKED>
 class ORGXL_UNGXL : public ::TestWithParam<orgql_tuple>
 {
 protected:
-    ORGXL_UNGXL() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/orgxr_ungxr_gtest.cpp
+++ b/clients/gtest/orgxr_ungxr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -97,9 +97,10 @@ template <bool BLOCKED>
 class ORGXR_UNGXR : public ::TestWithParam<orgqr_tuple>
 {
 protected:
-    ORGXR_UNGXR() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/ormbr_unmbr_gtest.cpp
+++ b/clients/gtest/ormbr_unmbr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -133,9 +133,10 @@ Arguments ormbr_setup_arguments(ormbr_tuple tup)
 class ORMBR_UNMBR : public ::TestWithParam<ormbr_tuple>
 {
 protected:
-    ORMBR_UNMBR() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/ormlx_unmlx_gtest.cpp
+++ b/clients/gtest/ormlx_unmlx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -117,9 +117,10 @@ template <bool BLOCKED>
 class ORMLX_UNMLX : public ::TestWithParam<ormlq_tuple>
 {
 protected:
-    ORMLX_UNMLX() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/ormtr_unmtr_gtest.cpp
+++ b/clients/gtest/ormtr_unmtr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -126,9 +126,10 @@ Arguments ormtr_setup_arguments(ormtr_tuple tup)
 class ORMTR_UNMTR : public ::TestWithParam<ormtr_tuple>
 {
 protected:
-    ORMTR_UNMTR() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/ormxl_unmxl_gtest.cpp
+++ b/clients/gtest/ormxl_unmxl_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -120,9 +120,10 @@ template <bool BLOCKED>
 class ORMXL_UNMXL : public ::TestWithParam<ormql_tuple>
 {
 protected:
-    ORMXL_UNMXL() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/ormxr_unmxr_gtest.cpp
+++ b/clients/gtest/ormxr_unmxr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -120,9 +120,10 @@ template <bool BLOCKED>
 class ORMXR_UNMXR : public ::TestWithParam<ormqr_tuple>
 {
 protected:
-    ORMXR_UNMXR() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/posv_gtest.cpp
+++ b/clients/gtest/posv_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -107,9 +107,10 @@ Arguments posv_setup_arguments(posv_tuple tup)
 class POSV : public ::TestWithParam<posv_tuple>
 {
 protected:
-    POSV() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/potf2_potrf_gtest.cpp
+++ b/clients/gtest/potf2_potrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -87,9 +87,10 @@ template <bool BLOCKED>
 class POTF2_POTRF : public ::TestWithParam<potrf_tuple>
 {
 protected:
-    POTF2_POTRF() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/potri_gtest.cpp
+++ b/clients/gtest/potri_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -85,9 +85,10 @@ Arguments potri_setup_arguments(potri_tuple tup)
 class POTRI : public ::TestWithParam<potri_tuple>
 {
 protected:
-    POTRI() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/potrs_gtest.cpp
+++ b/clients/gtest/potrs_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -102,9 +102,10 @@ Arguments potrs_setup_arguments(potrs_tuple tup)
 class POTRS : public ::TestWithParam<potrs_tuple>
 {
 protected:
-    POTRS() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/stebz_gtest.cpp
+++ b/clients/gtest/stebz_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -112,9 +112,10 @@ Arguments stebz_setup_arguments(stebz_tuple tup)
 class STEBZ : public ::TestWithParam<stebz_tuple>
 {
 protected:
-    STEBZ() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/stedc_gtest.cpp
+++ b/clients/gtest/stedc_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -80,9 +80,10 @@ Arguments stedc_setup_arguments(stedc_tuple tup)
 class STEDC : public ::TestWithParam<stedc_tuple>
 {
 protected:
-    STEDC() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/stein_gtest.cpp
+++ b/clients/gtest/stein_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -80,9 +80,10 @@ Arguments stein_setup_arguments(stein_tuple tup)
 class STEIN : public ::TestWithParam<stein_tuple>
 {
 protected:
-    STEIN() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/steqr_gtest.cpp
+++ b/clients/gtest/steqr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -80,9 +80,10 @@ Arguments steqr_setup_arguments(steqr_tuple tup)
 class STEQR : public ::TestWithParam<steqr_tuple>
 {
 protected:
-    STEQR() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/sterf_gtest.cpp
+++ b/clients/gtest/sterf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -68,9 +68,10 @@ Arguments sterf_setup_arguments(sterf_tuple tup)
 class STERF : public ::TestWithParam<sterf_tuple>
 {
 protected:
-    STERF() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <typename T>
     void run_tests()

--- a/clients/gtest/syev_heev_gtest.cpp
+++ b/clients/gtest/syev_heev_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -84,9 +84,10 @@ Arguments syev_heev_setup_arguments(syev_heev_tuple tup)
 class SYEV_HEEV : public ::TestWithParam<syev_heev_tuple>
 {
 protected:
-    SYEV_HEEV() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/syevd_heevd_gtest.cpp
+++ b/clients/gtest/syevd_heevd_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -84,9 +84,10 @@ Arguments syevd_heevd_setup_arguments(syevd_heevd_tuple tup)
 class SYEVD_HEEVD : public ::TestWithParam<syevd_heevd_tuple>
 {
 protected:
-    SYEVD_HEEVD() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/syevdx_heevdx_gtest.cpp
+++ b/clients/gtest/syevdx_heevdx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -102,9 +102,10 @@ Arguments syevdx_heevdx_setup_arguments(syevdx_heevdx_tuple tup, bool inplace)
 class SYEVDX_HEEVDX_INPLACE : public ::TestWithParam<syevdx_heevdx_tuple>
 {
 protected:
-    SYEVDX_HEEVDX_INPLACE() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/syevj_heevj_gtest.cpp
+++ b/clients/gtest/syevj_heevj_gtest.cpp
@@ -92,9 +92,10 @@ Arguments syevj_heevj_setup_arguments(syevj_heevj_tuple tup)
 class SYEVJ_HEEVJ : public ::TestWithParam<syevj_heevj_tuple>
 {
 protected:
-    SYEVJ_HEEVJ() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/syevx_heevx_gtest.cpp
+++ b/clients/gtest/syevx_heevx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -101,9 +101,10 @@ Arguments syevx_heevx_setup_arguments(syevx_heevx_tuple tup)
 class SYEVX_HEEVX : public ::TestWithParam<syevx_heevx_tuple>
 {
 protected:
-    SYEVX_HEEVX() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/sygsx_hegsx_gtest.cpp
+++ b/clients/gtest/sygsx_hegsx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -90,9 +90,10 @@ template <bool BLOCKED>
 class SYGSX_HEGSX : public ::TestWithParam<sygst_tuple>
 {
 protected:
-    SYGSX_HEGSX() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/sygv_hegv_gtest.cpp
+++ b/clients/gtest/sygv_hegv_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -92,9 +92,10 @@ Arguments sygv_setup_arguments(sygv_tuple tup)
 class SYGV_HEGV : public ::TestWithParam<sygv_tuple>
 {
 protected:
-    SYGV_HEGV() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/sygvd_hegvd_gtest.cpp
+++ b/clients/gtest/sygvd_hegvd_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -93,9 +93,10 @@ Arguments sygvd_setup_arguments(sygvd_tuple tup)
 class SYGVD_HEGVD : public ::TestWithParam<sygvd_tuple>
 {
 protected:
-    SYGVD_HEGVD() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/sygvdx_hegvdx_gtest.cpp
+++ b/clients/gtest/sygvdx_hegvdx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -107,9 +107,10 @@ Arguments sygvdx_setup_arguments(sygvdx_tuple tup, bool inplace)
 class SYGVDX_HEGVDX_INPLACE : public ::TestWithParam<sygvdx_tuple>
 {
 protected:
-    SYGVDX_HEGVDX_INPLACE() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/sygvj_hegvj_gtest.cpp
+++ b/clients/gtest/sygvj_hegvj_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -95,9 +95,10 @@ Arguments sygvj_setup_arguments(sygvj_tuple tup)
 class SYGVJ_HEGVJ : public ::TestWithParam<sygvj_tuple>
 {
 protected:
-    SYGVJ_HEGVJ() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/sygvx_hegvx_gtest.cpp
+++ b/clients/gtest/sygvx_hegvx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -106,9 +106,10 @@ Arguments sygvx_setup_arguments(sygvx_tuple tup)
 class SYGVX_HEGVX : public ::TestWithParam<sygvx_tuple>
 {
 protected:
-    SYGVX_HEGVX() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/sytf2_sytrf_gtest.cpp
+++ b/clients/gtest/sytf2_sytrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -88,9 +88,10 @@ template <bool BLOCKED>
 class SYTF2_SYTRF : public ::TestWithParam<sytrf_tuple>
 {
 protected:
-    SYTF2_SYTRF() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/sytxx_hetxx_gtest.cpp
+++ b/clients/gtest/sytxx_hetxx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -85,9 +85,10 @@ template <bool BLOCKED>
 class SYTXX_HETXX : public ::TestWithParam<sytrd_tuple>
 {
 protected:
-    SYTXX_HETXX() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()

--- a/clients/gtest/trtri_gtest.cpp
+++ b/clients/gtest/trtri_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -98,9 +98,10 @@ Arguments trtri_setup_arguments(trtri_tuple tup)
 class TRTRI : public ::TestWithParam<trtri_tuple>
 {
 protected:
-    TRTRI() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
 
     template <bool BATCHED, bool STRIDED, typename T>
     void run_tests()


### PR DESCRIPTION
In ROCm 6.0, the behaviour of the HIP API is expected to change such that successful calls do not reset the last error status. By checking the HIP error status in the teardown of the test, we can ensure that there were no unchecked errors within the test itself. This will also ensure that the error status is reset for the next test, thereby preventing a problem in one test to cause another test to fail.

This check is of limited value until the behaviour of HIP changes, but it is harmless to check anyway.