### PR TITLE
add explicit string conversion for read_path to fix a build error

### DIFF
--- a/clients/include/testing_csrrf_solve.hpp
+++ b/clients/include/testing_csrrf_solve.hpp
@@ -365,7 +365,7 @@ void testing_csrrf_solve(Arguments& argus)
     {
         testcase = get_sparse_data_dir() / fmt::format("mat_{}_{}", n, nnzA);
         fs::path file = testcase / "ptrT";
-        read_last(file, &nnzT);
+        read_last(file.string(), &nnzT);
     }
 
     // determine existing right-hand-side

--- a/clients/include/testing_csrrf_sumlu.hpp
+++ b/clients/include/testing_csrrf_sumlu.hpp
@@ -409,9 +409,9 @@ void testing_csrrf_sumlu(Arguments& argus)
     {
         testcase = get_sparse_data_dir() / fmt::format("mat_{}_{}", n, nnzA);
         fs::path file = testcase / "ptrL";
-        read_last(file, &nnzL);
+        read_last(file.string(), &nnzL);
         file = testcase / "ptrU";
-        read_last(file, &nnzU);
+        read_last(file.string(), &nnzU);
     }
     rocblas_int nnzT = nnzL + nnzU - n;
 


### PR DESCRIPTION
Adds some explicit conversions for calls the read_last function to fix a master specific build failure. This is the same solution we used for develop.