### PR TITLE
Update ReadtheDocs links to new documentation sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log for rocSOLVER
 
-Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](https://rocsolver.readthedocs.io/en/latest/).
+Full documentation for rocSOLVER is available at the [rocSOLVER documentation](https://rocm.docs.amd.com/projects/rocSOLVER/en/latest/index.html).
 
 ## (Unreleased) rocSOLVER
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,5 @@ with `--gtest_filter='daily*'`.
 Unfortunately, sometimes a contribution cannot be accepted. The rationale for a decision may or may
 not be disclosed.
 
-
-[1]: https://rocsolver.readthedocs.io/en/latest/userguide_install.html
+[1]: https://rocm.docs.amd.com/projects/rocSOLVER/en/latest/userguide/install.html
 [2]: https://github.com/google/googletest/blob/release-1.10.0/googletest/docs/advanced.md#running-a-subset-of-the-tests

--- a/clients/samples/example_basic.c
+++ b/clients/samples/example_basic.c
@@ -31,7 +31,7 @@ double *create_example_matrix(rocblas_int *M_out,
 }
 
 // We use rocsolver_dgeqrf to factor a real M-by-N matrix, A.
-// See https://rocsolver.readthedocs.io/en/latest/api_lapackfunc.html#c.rocsolver_dgeqrf
+// See https://rocm.docs.amd.com/projects/rocSOLVER/en/latest/api/lapack.html#rocsolver-type-geqrf
 int main() {
   rocblas_int M;          // rows
   rocblas_int N;          // cols

--- a/clients/samples/example_basic.cpp
+++ b/clients/samples/example_basic.cpp
@@ -29,7 +29,7 @@ void get_example_matrix(std::vector<double>& hA,
 }
 
 // We use rocsolver_dgeqrf to factor a real M-by-N matrix, A.
-// See https://rocsolver.readthedocs.io/en/latest/api_lapackfunc.html#c.rocsolver_dgeqrf
+// See https://rocm.docs.amd.com/projects/rocSOLVER/en/latest/api/lapack.html#rocsolver-type-geqrf
 int main() {
   rocblas_int M;          // rows
   rocblas_int N;          // cols

--- a/clients/samples/example_graph.c
+++ b/clients/samples/example_graph.c
@@ -31,7 +31,7 @@ double *create_example_matrix(rocblas_int *M_out,
 }
 
 // We use rocsolver_dgeqrf to factor a real M-by-N matrix, A.
-// See https://rocsolver.readthedocs.io/en/latest/api_lapackfunc.html#c.rocsolver_dgeqrf
+// See https://rocm.docs.amd.com/projects/rocSOLVER/en/latest/api/lapack.html#rocsolver-type-geqrf
 int main() {
   const rocblas_int ITER_COUNT = 10;
   rocblas_int M;          // rows

--- a/clients/samples/example_hmm.c
+++ b/clients/samples/example_hmm.c
@@ -33,7 +33,7 @@ double* create_example_matrix(rocblas_int *M_out,
 }
 
 // We use rocsolver_dgeqrf to factor a real M-by-N matrix, A.
-// See https://rocsolver.readthedocs.io/en/latest/api_lapackfunc.html#c.rocsolver_dgeqrf
+// See https://rocm.docs.amd.com/projects/rocSOLVER/en/latest/api/lapack.html#rocsolver-type-geqrf
 int main() {
   rocblas_int M;          // rows
   rocblas_int N;          // cols

--- a/clients/samples/example_logging.cpp
+++ b/clients/samples/example_logging.cpp
@@ -29,8 +29,8 @@ void get_example_matrix(std::vector<double>& hA,
 }
 
 // We use rocsolver_dgeqrf to factor a real M-by-N matrix, A.
-// See https://rocsolver.readthedocs.io/en/latest/api_lapackfunc.html#c.rocsolver_dgeqrf
-// and https://rocsolver.readthedocs.io/en/latest/userguide_logging.html
+// See https://rocm.docs.amd.com/projects/rocSOLVER/en/latest/api/lapack.html#rocsolver-type-geqrf
+// and https://rocm.docs.amd.com/projects/rocSOLVER/en/latest/userguide/logging.html
 int main() {
   rocblas_int M;          // rows
   rocblas_int N;          // cols

--- a/docs/api/deprecated.rst
+++ b/docs/api/deprecated.rst
@@ -4,8 +4,8 @@ Deprecated
 ************
 
 Originally, rocSOLVER maintained its own types and helpers as aliases to those of rocBLAS.
-These aliases are now deprecated. See the `rocBLAS types <https://rocblas.readthedocs.io/en/latest/API_Reference_Guide.html#rocblas-datatypes>`_
-and `rocBLAS auxiliary functions <https://rocblas.readthedocs.io/en/latest/API_Reference_Guide.html#auxiliary-functions>`_
+These aliases are now deprecated. See the `rocBLAS types <https://rocm.docs.amd.com/projects/rocBLAS/en/latest/API_Reference_Guide.html#rocblas-datatypes>`_
+and `rocBLAS auxiliary functions <https://rocm.docs.amd.com/projects/rocBLAS/en/latest/API_Reference_Guide.html#auxiliary-functions>`_
 documentation for information on the suggested replacements.
 
 * Deprecated :ref:`deptypes`.

--- a/docs/api/types.rst
+++ b/docs/api/types.rst
@@ -5,8 +5,8 @@ Types
 
 rocSOLVER uses most types and enumerations defined in rocBLAS for the general operation and
 dense matrix computations, and some defined in rocSPARSE for sparse matrix computations (direct solvers).
-For more information, see the `rocBLAS types <https://rocblas.readthedocs.io/en/latest/API_Reference_Guide.html#rocblas-datatypes>`_ and
-`rocSPARSE types <https://rocsparse.readthedocs.io/en/master/usermanual.html#types>`_ documentation.
+For more information, see the `rocBLAS types <https://rocm.docs.amd.com/projects/rocBLAS/en/latest/API_Reference_Guide.html#rocblas-datatypes>`_ and
+`rocSPARSE types <https://rocm.docs.amd.com/projects/rocSPARSE/en/latest/types.html>`_ documentation.
 Next we present additional types, only used in rocSOLVER, that extend the rocBLAS and rocSPARSE APIs.
 
 

--- a/docs/userguide/clients.rst
+++ b/docs/userguide/clients.rst
@@ -5,7 +5,7 @@ Clients
 *********
 
 rocSOLVER has an infrastructure for testing and benchmarking similar to that of
-`rocBLAS's testing and benchmarking <https://rocblas.readthedocs.io/en/latest/Programmers_Guide.html#rocblas-benchmarking-testing>`_,
+`rocBLAS's testing and benchmarking <https://rocm.docs.amd.com/projects/rocBLAS/en/latest/Programmers_Guide.html#rocblas-benchmarking-and-testing>`_,
 as well as sample code illustrating basic use of the library.
 
 Client binaries are not built by default; they require specific flags to be passed to the install script

--- a/docs/userguide/install.rst
+++ b/docs/userguide/install.rst
@@ -15,8 +15,8 @@ rocSOLVER requires a ROCm-enabled platform. For more information, see the
 `ROCm install guide <https://rocm.docs.amd.com/en/latest/deploy/linux/index.html>`_.
 
 rocSOLVER also requires compatible versions of rocBLAS and rocSPARSE installed on the system.
-For more information, see the `rocBLAS install guide <https://rocblas.readthedocs.io/en/latest/Linux_Install_Guide.html#building-and-installing-rocblas>`_
-and `rocSPARSE install guide <https://rocsparse.readthedocs.io/en/latest/usermanual.html#building-and-installing>`_.
+For more information, see the `rocBLAS install guide <https://rocm.docs.amd.com/projects/rocBLAS/en/latest/Linux_Install_Guide.html>`_
+and `rocSPARSE install guide <https://rocm.docs.amd.com/projects/rocSPARSE/en/latest/install.html>`_.
 
 rocBLAS, rocSPARSE, and rocSOLVER are still under active development, and it is hard to define minimal
 compatibility versions. For now, a good rule of thumb is to always use rocSOLVER together with the

--- a/docs/userguide/logging.rst
+++ b/docs/userguide/logging.rst
@@ -4,7 +4,7 @@
 Multi-level Logging
 *************************
 
-Similar to `rocBLAS logging <https://rocblas.readthedocs.io/en/latest/API_Reference_Guide.html#logging-in-rocblas>`_,
+Similar to `rocBLAS logging <https://rocm.docs.amd.com/projects/rocBLAS/en/latest/API_Reference_Guide.html#logging-in-rocblas>`_,
 rocSOLVER provides logging facilities that can be used to output information
 on rocSOLVER function calls. Three modes of logging are supported: trace logging, bench logging,
 and profile logging.

--- a/docs/userguide/memory.rst
+++ b/docs/userguide/memory.rst
@@ -120,5 +120,5 @@ as the workspace for rocSOLVER. For example:
 For more details on the rocBLAS APIs, see `Device Memory Allocation Functions in rocBLAS`_.
 
 
-.. _the rocBLAS memory model: https://rocblas.readthedocs.io/en/latest/API_Reference_Guide.html#device-memory-allocation-in-rocblas
-.. _Device Memory Allocation Functions in rocBLAS: https://rocblas.readthedocs.io/en/latest/API_Reference_Guide.html#device-memory-allocation-functions
+.. _the rocBLAS memory model: https://rocm.docs.amd.com/projects/rocBLAS/en/latest/API_Reference_Guide.html#device-memory-allocation-in-rocblas
+.. _Device Memory Allocation Functions in rocBLAS: https://rocm.docs.amd.com/projects/rocBLAS/en/latest/API_Reference_Guide.html#device-memory-allocation-in-rocblas

--- a/install.sh
+++ b/install.sh
@@ -75,7 +75,7 @@ Options:
   --address-sanitizer         Pass this flag to build with address sanitizer enabled
 
   --docs                      (experimental) Pass this flag to build the documentation from source.
-                              Official documentation is available online at https://rocsolver.readthedocs.io/
+                              Official documentation is available online at https://rocm.docs.amd.com/projects/rocSOLVER/en/latest/index.html
                               Building locally with this flag will require docker on your machine. If you are
                               familiar with doxygen, sphinx and documentation tools, you can alternatively
                               use the scripts provided in the docs directory.


### PR DESCRIPTION
Replaces ReadtheDocs for Community links (.io) (being retired) with for Business (.com)