### PR TITLE
Drop gfx803 and gfx900 from default build targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Full documentation for rocSOLVER is available at [rocsolver.readthedocs.io](http
 ### Changed
 - Relaxed array length requirements for GESVDX with `rocblas_srange_index`.
 
+### Removed
+- Removed gfx803 and gfx900 from default build targets.
+
 ### Fixed
 - Corrected singular vector normalization in BDSVDX and GESVDX
 - Fixed potential memory access fault in STEIN, SYEVX/HEEVX, SYGVX/HEGVX, BDSVDX and GESVDX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##########################################################################
-# Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -167,8 +167,6 @@ if(NOT DEFINED AMDGPU_TARGETS)
       gfx1102
   )
   set(AMDGPU_TARGETS_INIT
-    gfx803
-    gfx900
     gfx906:xnack-
     gfx908:xnack-
     gfx1010


### PR DESCRIPTION
The rocBLAS library has dropped these targets from its default build targets. While users can still build for those targets by specifying them explicitly, there's little point enabling them in the official binary releases when they are not enabled in rocSOLVER dependencies.
    
(cherry picked from commit 2c64a42b390696fe5047360cbdfa3f59e5cfdbc8)