### PR TITLE
Fix for failing large-size getrf tests

### DIFF
--- a/clients/common/lapack_host_reference.cpp
+++ b/clients/common/lapack_host_reference.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,6 +41,43 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+void sgecon_(char* norm,
+             int* n,
+             float* A,
+             int* lda,
+             float* anorm,
+             float* rcond,
+             float* work,
+             int* iwork,
+             int* info);
+void dgecon_(char* norm,
+             int* n,
+             double* A,
+             int* lda,
+             double* anorm,
+             double* rcond,
+             double* work,
+             int* iwork,
+             int* info);
+void cgecon_(char* norm,
+             int* n,
+             rocblas_float_complex* A,
+             int* lda,
+             float* anorm,
+             float* rcond,
+             rocblas_float_complex* work,
+             float* rwork,
+             int* info);
+void zgecon_(char* norm,
+             int* n,
+             rocblas_double_complex* A,
+             int* lda,
+             double* anorm,
+             double* rcond,
+             rocblas_double_complex* work,
+             double* rwork,
+             int* info);
 
 void sgemv_(char* transA,
             int* m,
@@ -2525,6 +2562,72 @@ void dbdsvdx_(char* uplo,
 
 /************************************************************************/
 // These are templated functions used in rocSOLVER clients code
+
+// gecon
+
+template <>
+float cpu_gecon<float, float>(char norm,
+                              rocblas_int n,
+                              float* A,
+                              rocblas_int lda,
+                              float anorm,
+                              float* work,
+                              float* rwork,
+                              rocblas_int* iwork)
+{
+    float rcond;
+    rocblas_int info;
+    sgecon_(&norm, &n, A, &lda, &anorm, &rcond, work, iwork, &info);
+    return rcond;
+}
+
+template <>
+double cpu_gecon<double, double>(char norm,
+                                 rocblas_int n,
+                                 double* A,
+                                 rocblas_int lda,
+                                 double anorm,
+                                 double* work,
+                                 double* rwork,
+                                 rocblas_int* iwork)
+{
+    double rcond;
+    rocblas_int info;
+    dgecon_(&norm, &n, A, &lda, &anorm, &rcond, work, iwork, &info);
+    return rcond;
+}
+
+template <>
+float cpu_gecon<rocblas_float_complex, float>(char norm,
+                                              rocblas_int n,
+                                              rocblas_float_complex* A,
+                                              rocblas_int lda,
+                                              float anorm,
+                                              rocblas_float_complex* work,
+                                              float* rwork,
+                                              rocblas_int* iwork)
+{
+    float rcond;
+    rocblas_int info;
+    cgecon_(&norm, &n, A, &lda, &anorm, &rcond, work, rwork, &info);
+    return rcond;
+}
+
+template <>
+double cpu_gecon<rocblas_double_complex, double>(char norm,
+                                                 rocblas_int n,
+                                                 rocblas_double_complex* A,
+                                                 rocblas_int lda,
+                                                 double anorm,
+                                                 rocblas_double_complex* work,
+                                                 double* rwork,
+                                                 rocblas_int* iwork)
+{
+    double rcond;
+    rocblas_int info;
+    zgecon_(&norm, &n, A, &lda, &anorm, &rcond, work, rwork, &info);
+    return rcond;
+}
 
 // lacgv
 

--- a/clients/common/lapack_host_reference.cpp
+++ b/clients/common/lapack_host_reference.cpp
@@ -42,6 +42,11 @@
 extern "C" {
 #endif
 
+float slange_(char* norm, int* m, int* n, float* A, int* lda, float* work);
+double dlange_(char* norm, int* m, int* n, double* A, int* lda, double* work);
+float clange_(char* norm, int* m, int* n, rocblas_float_complex* A, int* lda, float* work);
+double zlange_(char* norm, int* m, int* n, rocblas_double_complex* A, int* lda, double* work);
+
 void sgecon_(char* norm,
              int* n,
              float* A,
@@ -78,6 +83,21 @@ void zgecon_(char* norm,
              rocblas_double_complex* work,
              double* rwork,
              int* info);
+
+void saxpy_(int* n, float* alpha, float* x, int* incx, float* y, int* incy);
+void daxpy_(int* n, double* alpha, double* x, int* incx, double* y, int* incy);
+void caxpy_(int* n,
+            rocblas_float_complex* alpha,
+            rocblas_float_complex* x,
+            int* incx,
+            rocblas_float_complex* y,
+            int* incy);
+void zaxpy_(int* n,
+            rocblas_double_complex* alpha,
+            rocblas_double_complex* x,
+            int* incx,
+            rocblas_double_complex* y,
+            int* incy);
 
 void sgemv_(char* transA,
             int* m,
@@ -2563,6 +2583,52 @@ void dbdsvdx_(char* uplo,
 /************************************************************************/
 // These are templated functions used in rocSOLVER clients code
 
+// lange
+
+template <>
+float cpu_lange<float, float>(char norm,
+                              rocblas_int m,
+                              rocblas_int n,
+                              float* A,
+                              rocblas_int lda,
+                              float* work)
+{
+    return slange_(&norm, &m, &n, A, &lda, work);
+}
+
+template <>
+double cpu_lange<double, double>(char norm,
+                                 rocblas_int m,
+                                 rocblas_int n,
+                                 double* A,
+                                 rocblas_int lda,
+                                 double* work)
+{
+    return dlange_(&norm, &m, &n, A, &lda, work);
+}
+
+template <>
+float cpu_lange<rocblas_float_complex, float>(char norm,
+                                              rocblas_int m,
+                                              rocblas_int n,
+                                              rocblas_float_complex* A,
+                                              rocblas_int lda,
+                                              float* work)
+{
+    return clange_(&norm, &m, &n, A, &lda, work);
+}
+
+template <>
+double cpu_lange<rocblas_double_complex, double>(char norm,
+                                                 rocblas_int m,
+                                                 rocblas_int n,
+                                                 rocblas_double_complex* A,
+                                                 rocblas_int lda,
+                                                 double* work)
+{
+    return zlange_(&norm, &m, &n, A, &lda, work);
+}
+
 // gecon
 
 template <>
@@ -2627,6 +2693,42 @@ double cpu_gecon<rocblas_double_complex, double>(char norm,
     rocblas_int info;
     zgecon_(&norm, &n, A, &lda, &anorm, &rcond, work, rwork, &info);
     return rcond;
+}
+
+// axpy
+
+template <>
+void cpu_axpy<float>(rocblas_int n, float alpha, float* x, rocblas_int incx, float* y, rocblas_int incy)
+{
+    saxpy_(&n, &alpha, x, &incx, y, &incy);
+}
+
+template <>
+void cpu_axpy<double>(rocblas_int n, double alpha, double* x, rocblas_int incx, double* y, rocblas_int incy)
+{
+    daxpy_(&n, &alpha, x, &incx, y, &incy);
+}
+
+template <>
+void cpu_axpy<rocblas_float_complex>(rocblas_int n,
+                                     rocblas_float_complex alpha,
+                                     rocblas_float_complex* x,
+                                     rocblas_int incx,
+                                     rocblas_float_complex* y,
+                                     rocblas_int incy)
+{
+    caxpy_(&n, &alpha, x, &incx, y, &incy);
+}
+
+template <>
+void cpu_axpy<rocblas_double_complex>(rocblas_int n,
+                                      rocblas_double_complex alpha,
+                                      rocblas_double_complex* x,
+                                      rocblas_int incx,
+                                      rocblas_double_complex* y,
+                                      rocblas_int incy)
+{
+    zaxpy_(&n, &alpha, x, &incx, y, &incy);
 }
 
 // lacgv

--- a/clients/gtest/getrf_large_gtest.cpp
+++ b/clients/gtest/getrf_large_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -112,12 +112,12 @@ TEST_P(GETRF_LARGE, __double)
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRF_LARGE, DISABLED__float_complex)
+TEST_P(GETRF_LARGE, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_LARGE, DISABLED__double_complex)
+TEST_P(GETRF_LARGE, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/clients/include/lapack_host_reference.hpp
+++ b/clients/include/lapack_host_reference.hpp
@@ -48,10 +48,6 @@ template <typename T1, typename T2>
 void cpu_asum(rocblas_int n, const T1 *x, rocblas_int incx, T2 *result);
 
 template <typename T>
-void cpu_axpy(rocblas_int n, const T alpha, T *x, rocblas_int incx, T *y,
-                rocblas_int incy);
-
-template <typename T>
 void cpu_copy(rocblas_int n, T *x, rocblas_int incx, T *y, rocblas_int incy);
 
 template <typename T>
@@ -77,7 +73,13 @@ void cpu_syr(rocblas_fill uplo, rocblas_int n, T alpha, T *x,
 */
 
 template <typename T, typename S>
+S cpu_lange(char norm, rocblas_int m, rocblas_int n, T* A, rocblas_int lda, S* work);
+
+template <typename T, typename S>
 S cpu_gecon(char norm, rocblas_int n, T* A, rocblas_int lda, S anorm, T* work, S* rwork, rocblas_int* iwork);
+
+template <typename T>
+void cpu_axpy(rocblas_int n, T alpha, T* x, rocblas_int incx, T* y, rocblas_int incy);
 
 template <typename T>
 void cpu_gemv(rocblas_operation transA,

--- a/clients/include/lapack_host_reference.hpp
+++ b/clients/include/lapack_host_reference.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -75,6 +75,9 @@ template <typename T>
 void cpu_syr(rocblas_fill uplo, rocblas_int n, T alpha, T *x,
                rocblas_int incx, T *A, rocblas_int lda);
 */
+
+template <typename T, typename S>
+S cpu_gecon(char norm, rocblas_int n, T* A, rocblas_int lda, S anorm, T* work, S* rwork, rocblas_int* iwork);
 
 template <typename T>
 void cpu_gemv(rocblas_operation transA,


### PR DESCRIPTION
This PR improves the condition number of matrices used by the complex large-size getrf tests, and reenables these tests. It also adds gecon to lapack_host_reference, and moves lange and axpy from norm.hpp to lapack_host_reference.

Thanks go to @jibrealkhan for his help in investigating the cause of the failure and in computing the condition numbers for various test cases. I believe I can add him as a co-author on the resulting commit by editing the commit message, which I intend to do.