### PR TITLE
Add ifndef guards to macros

### DIFF
--- a/library/src/include/ideal_sizes.hpp
+++ b/library/src/include/ideal_sizes.hpp
@@ -301,8 +301,9 @@
 #define GETF2_SSKER_MAX_N 64 //always <= wavefront and <= GETF2_SPKER_MAX_N
 #endif
 #ifndef GETF2_OPTIM_NGRP
-#define GETF2_OPTIM_NGRP #endif
-16, 15, 8, 8, 8, 8, 8, 8, 6, 6, 4, 4, 4, 4, 4, 4, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
+#define GETF2_OPTIM_NGRP \
+    16, 15, 8, 8, 8, 8, 8, 8, 6, 6, 4, 4, 4, 4, 4, 4, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
+#endif
 #ifndef GETRF_NUM_INTERVALS_REAL
 #define GETRF_NUM_INTERVALS_REAL 4
 #endif

--- a/library/src/include/ideal_sizes.hpp
+++ b/library/src/include/ideal_sizes.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,7 +36,9 @@
 /*! \brief Determines the size of the block column factorized at each step
     in the blocked QR or QL algorithm (GEQRF or GEQLF). It also applies to the
     corresponding batched and strided-batched routines. */
+#ifndef GEQxF_BLOCKSIZE
 #define GEQxF_BLOCKSIZE 64
+#endif
 
 /*! \brief Determines the size at which rocSOLVER switches from
     the unblocked to the blocked algorithm when executing GEQRF or GEQLF. It also applies to the
@@ -45,14 +47,18 @@
     \details GEQRF or GEQLF will factorize blocks of GEQxF_BLOCKSIZE columns at a time until
     the rest of the matrix has no more than GEQxF_GEQx2_SWITCHSIZE rows or columns; at this point the last block,
     if any, will be factorized with the unblocked algorithm (GEQR2 or GEQL2).*/
+#ifndef GEQxF_GEQx2_SWITCHSIZE
 #define GEQxF_GEQx2_SWITCHSIZE 128
+#endif
 
 /***************** gerq2/gerqf and gelq2/gelqf ********************************
 *******************************************************************************/
 /*! \brief Determines the size of the block row factorized at each step
     in the blocked RQ or LQ algorithm (GERQF or GELQF). It also applies to the
     corresponding batched and strided-batched routines. */
+#ifndef GExQF_BLOCKSIZE
 #define GExQF_BLOCKSIZE 64
+#endif
 
 /*! \brief Determines the size at which rocSOLVER switches from
     the unblocked to the blocked algorithm when executing GERQF or GELQF. It also applies to the
@@ -61,13 +67,17 @@
     \details GERQF or GELQF will factorize blocks of GExQF_BLOCKSIZE rows at a time until
     the rest of the matrix has no more than GExQF_GExQ2_SWITCHSIZE rows or columns; at this point the last block,
     if any, will be factorized with the unblocked algorithm (GERQ2 or GELQ2).*/
+#ifndef GExQF_GExQ2_SWITCHSIZE
 #define GExQF_GExQ2_SWITCHSIZE 128
+#endif
 
 /******** org2r/orgqr, org2l/orgql, ung2r/ungqr and ung2l/ungql ***************
 *******************************************************************************/
 /*! \brief Determines the size of the block reflector that is applied at each step when
     generating a matrix Q with orthonormal columns with the blocked algorithm (ORGQR/UNGQR or ORGQL/UNGQL). */
+#ifndef xxGQx_BLOCKSIZE
 #define xxGQx_BLOCKSIZE 64
+#endif
 
 /*! \brief Determines the size at which rocSOLVER switches from
     the unblocked to the blocked algorithm when executing ORGQR/UNGQR or ORGQL/UNGQL.
@@ -75,13 +85,17 @@
     \details ORGQR/UNGQR or ORGQL/UNGQL will accumulate xxGQx_BLOCKSIZE reflectors at a time until
     there are no more than xxGQx_xxGQx2_SWITCHSIZE reflectors left; the remaining reflectors, if any,
     are applied one by one using the unblocked algorithm (ORG2R/UNG2R or ORG2L/UNG2L).*/
+#ifndef xxGQx_xxGQx2_SWITCHSIZE
 #define xxGQx_xxGQx2_SWITCHSIZE 128
+#endif
 
 /******** orgr2/orgrq, orgl2/orglq, ungr2/ungrq and ungl2/unglq **************
 *******************************************************************************/
 /*! \brief Determines the size of the block reflector that is applied at each step when
     generating a matrix Q with orthonormal rows with the blocked algorithm (ORGRQ/UNGRQ or ORGLQ/UNGLQ). */
+#ifndef xxGxQ_BLOCKSIZE
 #define xxGxQ_BLOCKSIZE 64
+#endif
 
 /*! \brief Determines the size at which rocSOLVER switches from
     the unblocked to the blocked algorithm when executing ORGRQ/UNGRQ or ORGLQ/UNGLQ.
@@ -89,7 +103,9 @@
     \details ORGRQ/UNGRQ or ORGLQ/UNGLQ will accumulate xxGxQ_BLOCKSIZE reflectors at a time until
     there are no more than xxGxQ_xxGxQ2_SWITCHSIZE reflectors left; the remaining reflectors, if any,
     are applied one by one using the unblocked algorithm (ORGR2/UNGR2 or ORGL2/UNGL2).*/
+#ifndef xxGxQ_xxGxQ2_SWITCHSIZE
 #define xxGxQ_xxGxQ2_SWITCHSIZE 128
+#endif
 
 /********* orm2r/ormqr, orm2l/ormql, unm2r/unmqr and unm2l/unmql **************
 *******************************************************************************/
@@ -99,7 +115,9 @@
     \details xxMQx_BLOCKSIZE also acts as a switch size; if the total number of reflectors is not greater than xxMQx_BLOCKSIZE (k <= xxMQx_BLOCKSIZE),
     ORMQR/UNMQR or ORMQL/UNMQL will directly call the unblocked routines (ORM2R/UNM2R or ORM2L/UNM2L). However, when k is not a multiple of xxMQx_BLOCKSIZE,
     the last block that updates C in the blocked process is allowed to be smaller than xxMQx_BLOCKSIZE.*/
+#ifndef xxMQx_BLOCKSIZE
 #define xxMQx_BLOCKSIZE 64
+#endif
 
 /********* ormr2/ormrq, orml2/ormlq, unmr2/unmrq and unml2/unmlq ***************
 *******************************************************************************/
@@ -109,14 +127,18 @@
     \details xxMxQ_BLOCKSIZE also acts as a switch size; if the total number of reflectors is not greater than xxMxQ_BLOCKSIZE (k <= xxMxQ_BLOCKSIZE),
     ORMRQ/UNMRQ or ORMLQ/UNMLQ will directly call the unblocked routines (ORMR2/UNMR2 or ORML2/UNML2). However, when k is not a multiple of xxMxQ_BLOCKSIZE,
     the last block that updates C in the blocked process is allowed to be smaller than xxMxQ_BLOCKSIZE.*/
+#ifndef xxMxQ_BLOCKSIZE
 #define xxMxQ_BLOCKSIZE 64
+#endif
 
 /**************************** gebd2/gebrd *************************************
 *******************************************************************************/
 /*! \brief Determines the size of the leading block that is reduced to bidiagonal form at each step
     when using the blocked algorithm (GEBRD). It also applies to the
     corresponding batched and strided-batched routines.*/
+#ifndef GEBRD_BLOCKSIZE
 #define GEBRD_BLOCKSIZE 32
+#endif
 
 /*! \brief Determines the size at which rocSOLVER switches from
     the unblocked to the blocked algorithm when executing GEBRD. It also applies to the
@@ -125,7 +147,9 @@
     \details GEBRD will use LABRD to reduce blocks of GEBRD_BLOCKSIZE rows and columns at a time until
     the trailing submatrix has no more than GEBRD_GEBD2_SWITCHSIZE rows or columns; at this point the last block,
     if any, will be reduced with the unblocked algorithm (GEBD2).*/
+#ifndef GEBRD_GEBD2_SWITCHSIZE
 #define GEBRD_GEBD2_SWITCHSIZE 64
+#endif
 
 /******************************* bdsqr ****************************************
 *******************************************************************************/
@@ -134,7 +158,9 @@
 
     \details BDSQR will use BDSQR_SPLIT_GROUPS thread groups in order to process diagonal blocks
     in parallel. */
+#ifndef BDSQR_SPLIT_GROUPS
 #define BDSQR_SPLIT_GROUPS 5
+#endif
 
 /******************************* gesvd ****************************************
 *******************************************************************************/
@@ -144,14 +170,18 @@
 
     \details When a m-by-n matrix A is passed to GESVD, if m >= THIN_SVD_SWITCH*n or
     n >= THIN_SVD_SWITCH*m, then the thin SVD is computed.*/
+#ifndef THIN_SVD_SWITCH
 #define THIN_SVD_SWITCH 1.6
+#endif
 
 /******************* sytd2/sytrd and hetd2/hetrd *******************************
 *******************************************************************************/
 /*! \brief Determines the size of the leading block that is reduced to tridiagonal form at each step
     when using the blocked algorithm (SYTRD/HETRD). It also applies to the
     corresponding batched and strided-batched routines.*/
+#ifndef xxTRD_BLOCKSIZE
 #define xxTRD_BLOCKSIZE 32
+#endif
 
 /*! \brief Determines the size at which rocSOLVER switches from
     the unblocked to the blocked algorithm when executing SYTRD/HETRD. It also applies to the
@@ -160,7 +190,9 @@
     \details SYTRD/HETRD will use LATRD to reduce blocks of xxTRD_BLOCKSIZE rows and columns at a time until
     the rest of the matrix has no more than xxTRD_xxTD2_SWITCHSIZE rows or columns; at this point the last block,
     if any, will be reduced with the unblocked algorithm (SYTD2/HETD2).*/
+#ifndef xxTRD_xxTD2_SWITCHSIZE
 #define xxTRD_xxTD2_SWITCHSIZE 64
+#endif
 
 /***************** sygs2/sygst and hegs2/hegst ********************************
 *******************************************************************************/
@@ -171,7 +203,9 @@
     \details xxGST_BLOCKSIZE also acts as a switch size; if the original size of the problem is not larger than xxGST_BLOCKSIZE (n <= xxGST_BLOCKSIZE),
     SYGST/HEGST will directly call the unblocked routines (SYGS2/HEGS2). However, when n is not a
     multiple of xxGST_BLOCKSIZE, the last block reduced in the blocked process is allowed to be smaller than xxGST_BLOCKSIZE.*/
+#ifndef xxGST_BLOCKSIZE
 #define xxGST_BLOCKSIZE 64
+#endif
 
 /****************************** stedc ******************************************
 *******************************************************************************/
@@ -180,18 +214,24 @@
 
     \details If the size of the block is smaller than STEDC_MIN_DC_SIZE (bs < STEDC_MIN_DC_SIZE),
     the eigenvectors are computed with the normal QR algorithm. */
+#ifndef STEDC_MIN_DC_SIZE
 #define STEDC_MIN_DC_SIZE 16
+#endif
 
 /*! \brief Determines the number of split blocks (independent blocks) of a tridiagonal matrix that
     are analyzed in parallel with the divide & conquer method. */
+#ifndef STEDC_NUM_SPLIT_BLKS
 #define STEDC_NUM_SPLIT_BLKS 8
+#endif
 
 /************************** potf2/potrf ***************************************
 *******************************************************************************/
 /*! \brief Determines the size of the leading block that is factorized at each step
     when using the blocked algorithm (POTRF). It also applies to the
     corresponding batched and strided-batched routines.*/
+#ifndef POTRF_BLOCKSIZE
 #define POTRF_BLOCKSIZE 64
+#endif
 
 /*! \brief Determines the size at which rocSOLVER switches from
     the unblocked to the blocked algorithm when executing POTRF. It also applies to the
@@ -200,7 +240,9 @@
     \details POTRF will factorize blocks of POTRF_BLOCKSIZE columns at a time until
     the rest of the matrix has no more than POTRF_POTF2_SWITCHSIZE columns; at this point the last block,
     if any, will be factorized with the unblocked algorithm (POTF2).*/
+#ifndef POTRF_POTF2_SWITCHSIZE
 #define POTRF_POTF2_SWITCHSIZE 128
+#endif
 
 /************************** syevj/heevj ***************************************
 *******************************************************************************/
@@ -210,14 +252,18 @@
 
     \details If the size of the matrix is not greater than SYEVJ_BLOCKED_SWITCH, the eigenvalues
     and eigenvectors will be computed with a single kernel call. */
+#ifndef SYEVJ_BLOCKED_SWITCH
 #define SYEVJ_BLOCKED_SWITCH 58
+#endif
 
 /*************************** sytf2/sytrf **************************************
 *******************************************************************************/
 /*! \brief Determines the maximum size of the partial factorization executed at each step
     when using the blocked algorithm (SYTRF). It also applies to the
     corresponding batched and strided-batched routines.*/
+#ifndef SYTRF_BLOCKSIZE
 #define SYTRF_BLOCKSIZE 64
+#endif
 
 /*! \brief Determines the size at which rocSOLVER switches from
     the unblocked to the blocked algorithm when executing SYTRF. It also applies to the
@@ -226,7 +272,9 @@
     \details SYTRF will use LASYF to factorize a submatrix of at most SYTRF_BLOCKSIZE columns at a time until
     the rest of the matrix has no more than SYTRF_SYTF2_SWITCHSIZE columns; at this point the last block,
     if any, will be factorized with the unblocked algorithm (SYTF2).*/
+#ifndef SYTRF_SYTF2_SWITCHSIZE
 #define SYTRF_SYTF2_SWITCHSIZE 128
+#endif
 
 /****************************** syevdj ******************************************
 *******************************************************************************/
@@ -234,60 +282,151 @@
 
     \details If the size of the block is smaller than SYEVDJ_MIN_DC_SIZE,
     the eigenvectors are computed with the normal Jacobi algorithm. */
+#ifndef SYEVDJ_MIN_DC_SIZE
 #define SYEVDJ_MIN_DC_SIZE 16
+#endif
 
 /**************************** getf2/getfr *************************************
 *******************************************************************************/
+#ifndef GETF2_SPKER_MAX_M
 #define GETF2_SPKER_MAX_M 1024 //always <= 1024
+#endif
+#ifndef GETF2_SPKER_MAX_N
 #define GETF2_SPKER_MAX_N 256 //always <= 256
+#endif
+#ifndef GETF2_SSKER_MAX_M
 #define GETF2_SSKER_MAX_M 512 //always <= 512 and <= GETF2_SPKER_MAX_M
+#endif
+#ifndef GETF2_SSKER_MAX_N
 #define GETF2_SSKER_MAX_N 64 //always <= wavefront and <= GETF2_SPKER_MAX_N
-#define GETF2_OPTIM_NGRP \
-    16, 15, 8, 8, 8, 8, 8, 8, 6, 6, 4, 4, 4, 4, 4, 4, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
+#endif
+#ifndef GETF2_OPTIM_NGRP
+#define GETF2_OPTIM_NGRP #endif
+16, 15, 8, 8, 8, 8, 8, 8, 6, 6, 4, 4, 4, 4, 4, 4, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
+#ifndef GETRF_NUM_INTERVALS_REAL
 #define GETRF_NUM_INTERVALS_REAL 4
+#endif
+#ifndef GETRF_INTERVALS_REAL
 #define GETRF_INTERVALS_REAL 64, 512, 1856, 2944
+#endif
+#ifndef GETRF_BLKSIZES_REAL
 #define GETRF_BLKSIZES_REAL 0, 1, 32, 256, 512
+#endif
+#ifndef GETRF_BATCH_NUM_INTERVALS_REAL
 #define GETRF_BATCH_NUM_INTERVALS_REAL 9
+#endif
+#ifndef GETRF_BATCH_INTERVALS_REAL
 #define GETRF_BATCH_INTERVALS_REAL 40, 42, 46, 49, 52, 58, 112, 800, 1024
+#endif
+#ifndef GETRF_BATCH_BLKSIZES_REAL
 #define GETRF_BATCH_BLKSIZES_REAL 0, 32, 0, 16, 0, 32, 1, 32, 64, 160
+#endif
+#ifndef GETRF_NPVT_NUM_INTERVALS_REAL
 #define GETRF_NPVT_NUM_INTERVALS_REAL 2
+#endif
+#ifndef GETRF_NPVT_INTERVALS_REAL
 #define GETRF_NPVT_INTERVALS_REAL 64, 512
+#endif
+#ifndef GETRF_NPVT_BLKSIZES_REAL
 #define GETRF_NPVT_BLKSIZES_REAL 0, -1, 512
+#endif
+#ifndef GETRF_NPVT_BATCH_NUM_INTERVALS_REAL
 #define GETRF_NPVT_BATCH_NUM_INTERVALS_REAL 6
+#endif
+#ifndef GETRF_NPVT_BATCH_INTERVALS_REAL
 #define GETRF_NPVT_BATCH_INTERVALS_REAL 40, 168, 448, 512, 896, 1408
+#endif
+#ifndef GETRF_NPVT_BATCH_BLKSIZES_REAL
 #define GETRF_NPVT_BATCH_BLKSIZES_REAL 0, -24, -32, -64, 32, 96, 512
+#endif
 
+#ifndef GETRF_NUM_INTERVALS_COMPLEX
 #define GETRF_NUM_INTERVALS_COMPLEX 4
+#endif
+#ifndef GETRF_INTERVALS_COMPLEX
 #define GETRF_INTERVALS_COMPLEX 64, 512, 1024, 2944
+#endif
+#ifndef GETRF_BLKSIZES_COMPLEX
 #define GETRF_BLKSIZES_COMPLEX 0, 1, 32, 96, 512
+#endif
+#ifndef GETRF_BATCH_NUM_INTERVALS_COMPLEX
 #define GETRF_BATCH_NUM_INTERVALS_COMPLEX 10
+#endif
+#ifndef GETRF_BATCH_INTERVALS_COMPLEX
 #define GETRF_BATCH_INTERVALS_COMPLEX 23, 28, 30, 32, 40, 48, 56, 64, 768, 1024
+#endif
+#ifndef GETRF_BATCH_BLKSIZES_COMPLEX
 #define GETRF_BATCH_BLKSIZES_COMPLEX 0, 16, 0, 1, 24, 16, 24, 16, 48, 64, 160
+#endif
+#ifndef GETRF_NPVT_NUM_INTERVALS_COMPLEX
 #define GETRF_NPVT_NUM_INTERVALS_COMPLEX 2
+#endif
+#ifndef GETRF_NPVT_INTERVALS_COMPLEX
 #define GETRF_NPVT_INTERVALS_COMPLEX 64, 512
+#endif
+#ifndef GETRF_NPVT_BLKSIZES_COMPLEX
 #define GETRF_NPVT_BLKSIZES_COMPLEX 0, -1, 512
+#endif
+#ifndef GETRF_NPVT_BATCH_NUM_INTERVALS_COMPLEX
 #define GETRF_NPVT_BATCH_NUM_INTERVALS_COMPLEX 5
+#endif
+#ifndef GETRF_NPVT_BATCH_INTERVALS_COMPLEX
 #define GETRF_NPVT_BATCH_INTERVALS_COMPLEX 20, 32, 42, 512, 1408
+#endif
+#ifndef GETRF_NPVT_BATCH_BLKSIZES_COMPLEX
 #define GETRF_NPVT_BATCH_BLKSIZES_COMPLEX 0, -16, -32, -48, 64, 128
+#endif
 
 /****************************** getri *****************************************
 *******************************************************************************/
+#ifndef GETRI_MAX_COLS
 #define GETRI_MAX_COLS 64 //always <= wavefront size
+#endif
+#ifndef GETRI_TINY_SIZE
 #define GETRI_TINY_SIZE 43
+#endif
+#ifndef GETRI_NUM_INTERVALS
 #define GETRI_NUM_INTERVALS 1
+#endif
+#ifndef GETRI_INTERVALS
 #define GETRI_INTERVALS 1185
+#endif
+#ifndef GETRI_BLKSIZES
 #define GETRI_BLKSIZES 0, 256
+#endif
+#ifndef GETRI_BATCH_TINY_SIZE
 #define GETRI_BATCH_TINY_SIZE 35
+#endif
+#ifndef GETRI_BATCH_NUM_INTERVALS
 #define GETRI_BATCH_NUM_INTERVALS 2
+#endif
+#ifndef GETRI_BATCH_INTERVALS
 #define GETRI_BATCH_INTERVALS 505, 2049
+#endif
+#ifndef GETRI_BATCH_BLKSIZES
 #define GETRI_BATCH_BLKSIZES 32, 0, 256
+#endif
 
 /***************************** trtri ******************************************
 *******************************************************************************/
+#ifndef TRTRI_MAX_COLS
 #define TRTRI_MAX_COLS 64 //always <= wavefront size
+#endif
+#ifndef TRTRI_NUM_INTERVALS
 #define TRTRI_NUM_INTERVALS 1
+#endif
+#ifndef TRTRI_INTERVALS
 #define TRTRI_INTERVALS 0
+#endif
+#ifndef TRTRI_BLKSIZES
 #define TRTRI_BLKSIZES 0, 0
+#endif
+#ifndef TRTRI_BATCH_NUM_INTERVALS
 #define TRTRI_BATCH_NUM_INTERVALS 3
+#endif
+#ifndef TRTRI_BATCH_INTERVALS
 #define TRTRI_BATCH_INTERVALS 32, 245, 1009
+#endif
+#ifndef TRTRI_BATCH_BLKSIZES
 #define TRTRI_BATCH_BLKSIZES 0, 16, 32, 0
+#endif

--- a/library/src/include/lib_macros.hpp
+++ b/library/src/include/lib_macros.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,4 +33,6 @@
  * ===========================================================================
  */
 
+#ifndef ROCSOLVER_KERNEL
 #define ROCSOLVER_KERNEL static __global__
+#endif


### PR DESCRIPTION
This makes it easier to set the ideal sizes at build time. For example, users could set `export CXXFLAGS="-DGEQxF_BLOCKSIZE=128"` in their environment before calling CMake.

In the future, it might be nice to display information about compiler options set when building rocsolver in the rocsolver-bench output.