### PR TITLE
cmake: add fmt/rocsparse as package deps if building static lib

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -321,11 +321,11 @@ if(BUILD_WITH_SPARSE)
 endif()
 
 if(ROCSOLVER_EMBED_FMT)
-  target_link_libraries(rocsolver PRIVATE fmt::fmt-header-only)
+  target_link_libraries(rocsolver PRIVATE $<BUILD_INTERFACE:fmt::fmt-header-only>)
 else()
+  list(APPEND static_depends PACKAGE fmt)
   target_link_libraries(rocsolver PRIVATE fmt::fmt)
 endif()
-list(APPEND static_depends PACKAGE fmt)
 
 # In ROCm 4.0 and earlier, the default maximum threads per block is 256
 target_compile_options(rocsolver PRIVATE --gpu-max-threads-per-block=1024)

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -309,7 +309,7 @@ target_link_libraries(rocsolver
     $<$<PLATFORM_ID:Linux>:--unwindlib=libgcc>
 )
 
-set(static_depends)
+set(static_depends PACKAGE rocblas)
 
 if(BUILD_WITH_SPARSE)
   target_link_libraries(rocsolver PRIVATE roc::rocsparse)
@@ -421,7 +421,6 @@ rocm_export_targets(
   TARGETS roc::rocsolver
   DEPENDS
     PACKAGE hip
-    PACKAGE rocblas
   STATIC_DEPENDS
     ${static_depends}
   NAMESPACE roc::

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -309,8 +309,11 @@ target_link_libraries(rocsolver
     $<$<PLATFORM_ID:Linux>:--unwindlib=libgcc>
 )
 
+set(static_depends)
+
 if(BUILD_WITH_SPARSE)
   target_link_libraries(rocsolver PRIVATE roc::rocsparse)
+  list(APPEND static_depends PACKAGE rocsparse)
   set_source_files_properties(${rocsolver_refact_source}
     PROPERTIES
       COMPILE_DEFINITIONS HAVE_ROCSPARSE
@@ -322,6 +325,7 @@ if(ROCSOLVER_EMBED_FMT)
 else()
   target_link_libraries(rocsolver PRIVATE fmt::fmt)
 endif()
+list(APPEND static_depends PACKAGE fmt)
 
 # In ROCm 4.0 and earlier, the default maximum threads per block is 256
 target_compile_options(rocsolver PRIVATE --gpu-max-threads-per-block=1024)
@@ -418,6 +422,8 @@ rocm_export_targets(
   DEPENDS
     PACKAGE hip
     PACKAGE rocblas
+  STATIC_DEPENDS
+    ${static_depends}
   NAMESPACE roc::
 )
 


### PR DESCRIPTION
When a static library is built, no linking is done.  (Basically static libraries are just archives of object files.)

So if `libfoo.a` depends on `libbar.a`, CMake just has to remember that when you link `libfoo.a`, it also needs to pull in `libbar.a`.  The problem is that CMake only knows about `libbar.a` if a `find_package(bar)` is done.  This PR fixes our generated `foo-config.cmake` file to find this dependency, when we're building a static library.