### PR TITLE
Switch from using hipcc to using Clang compiler

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##########################################################################
-# Copyright (C) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -51,6 +51,15 @@ if(WIN32)
     -fms-compatibility
     -Wno-ignored-attributes
     -Wno-unused-command-line-argument
+  )
+endif()
+
+# hipcc adds these options automatically. These options might have an effect
+# on performance, so add them when building with clang directly, just in case.
+if(CMAKE_CXX_COMPILER MATCHES ".*clang++.*")
+  target_compile_options(rocsolver-common INTERFACE
+    "SHELL:-mllvm -amdgpu-early-inline-all=true"
+    "SHELL:-mllvm -amdgpu-function-calls=false"
   )
 endif()
 

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -54,15 +54,6 @@ if(WIN32)
   )
 endif()
 
-# hipcc adds these options automatically. These options might have an effect
-# on performance, so add them when building with clang directly, just in case.
-if(CMAKE_CXX_COMPILER MATCHES ".*clang++.*")
-  target_compile_options(rocsolver-common INTERFACE
-    "SHELL:-mllvm -amdgpu-early-inline-all=true"
-    "SHELL:-mllvm -amdgpu-function-calls=false"
-  )
-endif()
-
 if(WERROR)
   target_compile_options(rocsolver-common INTERFACE
     -Werror=vla

--- a/docs/installation/installlinux.rst
+++ b/docs/installation/installlinux.rst
@@ -221,7 +221,7 @@ information on CMake options).
 .. code-block:: bash
 
     mkdir -p build/release && cd build/release
-    CXX=/opt/rocm/bin/hipcc cmake -DCMAKE_INSTALL_PREFIX=rocsolver-install ../..
+    cmake --toolchain=toolchain-linux.cmake -DCMAKE_INSTALL_PREFIX=rocsolver-install ../..
     make install
 
 This is equivalent to ``./install.sh``.
@@ -229,7 +229,7 @@ This is equivalent to ``./install.sh``.
 .. code-block:: bash
 
     mkdir -p buildoutput/release && cd buildoutput/release
-    CXX=/opt/rocm/bin/hipcc cmake -DCMAKE_INSTALL_PREFIX=/home/user/rocsolverlib ../..
+    cmake --toolchain=toolchain-linux.cmake -DCMAKE_INSTALL_PREFIX=/home/user/rocsolverlib ../..
     make install
 
 This is equivalent to ``./install.sh --lib_dir /home/user/rocsolverlib --build_dir buildoutput``.
@@ -237,7 +237,7 @@ This is equivalent to ``./install.sh --lib_dir /home/user/rocsolverlib --build_d
 .. code-block:: bash
 
     mkdir -p build/release && cd build/release
-    CXX=/opt/rocm/bin/hipcc cmake -DCMAKE_INSTALL_PREFIX=rocsolver-install -DBUILD_WITH_SPARSE=OFF ../..
+    cmake --toolchain=toolchain-linux.cmake -DCMAKE_INSTALL_PREFIX=rocsolver-install -DBUILD_WITH_SPARSE=OFF ../..
     make install
 
 This is equivalent to ``./install.sh --no-sparse``.
@@ -245,7 +245,7 @@ This is equivalent to ``./install.sh --no-sparse``.
 .. code-block:: bash
 
     mkdir -p build/release && cd build/release
-    CXX=/opt/rocm/bin/hipcc cmake -DCMAKE_INSTALL_PREFIX=rocsolver-install -Drocblas_DIR=/alternative/rocblas/location ../..
+    cmake --toolchain=toolchain-linux.cmake -DCMAKE_INSTALL_PREFIX=rocsolver-install -Drocblas_DIR=/alternative/rocblas/location ../..
     make install
 
 This is equivalent to ``./install.sh --rocblas_dir /alternative/rocblas/location``.
@@ -253,7 +253,7 @@ This is equivalent to ``./install.sh --rocblas_dir /alternative/rocblas/location
 .. code-block:: bash
 
     mkdir -p build/debug && cd build/debug
-    CXX=/opt/rocm/bin/hipcc cmake -DCMAKE_INSTALL_PREFIX=rocsolver-install -DCMAKE_BUILD_TYPE=Debug ../..
+    cmake --toolchain=toolchain-linux.cmake -DCMAKE_INSTALL_PREFIX=rocsolver-install -DCMAKE_BUILD_TYPE=Debug ../..
     make install
 
 This is equivalent to ``./install.sh -g``.
@@ -261,7 +261,7 @@ This is equivalent to ``./install.sh -g``.
 .. code-block:: bash
 
     mkdir -p build/release && cd build/release
-    CXX=/opt/rocm/bin/hipcc cmake -DCMAKE_INSTALL_PREFIX=rocsolver-install -DBUILD_SHARED_LIBS=OFF ../..
+    cmake --toolchain=toolchain-linux.cmake -DCMAKE_INSTALL_PREFIX=rocsolver-install -DBUILD_SHARED_LIBS=OFF ../..
     make install
 
 This is equivalent to ``./install.sh -s``.
@@ -269,7 +269,7 @@ This is equivalent to ``./install.sh -s``.
 .. code-block:: bash
 
     mkdir -p build/release && cd build/release
-    CXX=/opt/rocm/bin/hipcc cmake -DCMAKE_INSTALL_PREFIX=rocsolver-install -DBUILD_CLIENTS_TESTS=ON -DBUILD_CLIENTS_BENCHMARKS=ON ../..
+    cmake --toolchain=toolchain-linux.cmake -DCMAKE_INSTALL_PREFIX=rocsolver-install -DBUILD_CLIENTS_TESTS=ON -DBUILD_CLIENTS_BENCHMARKS=ON ../..
     make install
 
 This is equivalent to ``./install.sh -c``.
@@ -277,7 +277,7 @@ This is equivalent to ``./install.sh -c``.
 .. code-block:: bash
 
     mkdir -p build/release && cd build/release
-    CXX=/opt/rocm/bin/hipcc cmake -DCMAKE_INSTALL_PREFIX=rocsolver-install -DCPACK_SET_DESTDIR=OFF -DCPACK_PACKAGING_INSTALL_PREFIX=/opt/rocm ../..
+    cmake --toolchain=toolchain-linux.cmake -DCMAKE_INSTALL_PREFIX=rocsolver-install -DCPACK_SET_DESTDIR=OFF -DCPACK_PACKAGING_INSTALL_PREFIX=/opt/rocm ../..
     make install
     make package
 
@@ -286,7 +286,7 @@ This is equivalent to ``./install.sh -p``.
 .. code-block:: bash
 
     mkdir -p build/release && cd build/release
-    CXX=/opt/rocm/bin/hipcc cmake -DCMAKE_INSTALL_PREFIX=rocsolver-install -DCPACK_SET_DESTDIR=OFF -DCPACK_PACKAGING_INSTALL_PREFIX=/package/install/path ../..
+    cmake --toolchain=toolchain-linux.cmake -DCMAKE_INSTALL_PREFIX=rocsolver-install -DCPACK_SET_DESTDIR=OFF -DCPACK_PACKAGING_INSTALL_PREFIX=/package/install/path ../..
     make install
     make package
     sudo dpkg -i rocsolver[-\_]*.deb

--- a/install.sh
+++ b/install.sh
@@ -480,8 +480,6 @@ case "${ID}" in
   ;;
 esac
 
-export CXX="${rocm_path}/bin/amdclang++"
-export CC="${rocm_path}/bin/amdclang"
 export FC="gfortran"
 export PATH="${rocm_path}/bin:${rocm_path}/hip/bin:${rocm_path}/llvm/bin:${PATH}"
 

--- a/install.sh
+++ b/install.sh
@@ -480,6 +480,8 @@ case "${ID}" in
   ;;
 esac
 
+export CXX="${rocm_path}/bin/amdclang++"
+export CC="${rocm_path}/bin/amdclang"
 export FC="gfortran"
 export PATH="${rocm_path}/bin:${rocm_path}/hip/bin:${rocm_path}/llvm/bin:${PATH}"
 

--- a/install.sh
+++ b/install.sh
@@ -480,8 +480,8 @@ case "${ID}" in
   ;;
 esac
 
-export CXX="hipcc"
-export CC="clang"
+export CXX="${rocm_path}/bin/amdclang++"
+export CC="${rocm_path}/bin/amdclang"
 export FC="gfortran"
 export PATH="${rocm_path}/bin:${rocm_path}/hip/bin:${rocm_path}/llvm/bin:${PATH}"
 
@@ -542,6 +542,7 @@ else
 fi
 
 cmake_common_options+=(
+  "--toolchain=toolchain-linux.cmake"
   "-DROCM_PATH=${rocm_path}"
   '-DCPACK_SET_DESTDIR=OFF'
   "-DCMAKE_INSTALL_PREFIX=${lib_dir}"

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -329,6 +329,15 @@ target_compile_options(rocsolver PRIVATE --gpu-max-threads-per-block=1024)
 # Ignore loop unrolling failures
 target_compile_options(rocsolver PRIVATE -Wno-pass-failed)
 
+# hipcc adds these options automatically. These options might have an effect
+# on performance, so add them when building with clang directly, just in case.
+if(CMAKE_CXX_COMPILER MATCHES ".*clang\\+\\+.*")
+  target_compile_options(rocsolver PRIVATE
+    "SHELL:-mllvm -amdgpu-early-inline-all=true"
+    "SHELL:-mllvm -amdgpu-function-calls=false"
+  )
+endif()
+
 target_include_directories(rocsolver
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/library/include>

--- a/toolchain-linux.cmake
+++ b/toolchain-linux.cmake
@@ -1,0 +1,18 @@
+if (DEFINED ENV{ROCM_PATH})
+  set(rocm_bin "$ENV{ROCM_PATH}/bin")
+else()
+  set(ROCM_PATH "/opt/rocm" CACHE PATH "Path to the ROCm installation.")
+  set(rocm_bin "/opt/rocm/bin")
+endif()
+
+if (NOT DEFINED ENV{CXX})
+  set(CMAKE_CXX_COMPILER "${rocm_bin}/amdclang++")
+else()
+  set(CMAKE_CXX_COMPILER "$ENV{CXX}")
+endif()
+
+if (NOT DEFINED ENV{CC})
+  set(CMAKE_C_COMPILER "${rocm_bin}/amdclang")
+else()
+  set(CMAKE_C_COMPILER "$ENV{CC}")
+endif()


### PR DESCRIPTION
Summary of proposed changes:
-  Change the default compiler from hipcc to amdclang
  - As hipcc is an increasingly thin wrapper around clang, we want to reduce complexity and switch to just use clang as the default.
- Users may still manually specify the compilers using the `CXX` and `CC` environment variables.