### PR TITLE
cmake: add rocblas back as regular package dependency, not just static

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -309,7 +309,7 @@ target_link_libraries(rocsolver
     $<$<PLATFORM_ID:Linux>:--unwindlib=libgcc>
 )
 
-set(static_depends PACKAGE rocblas)
+set(static_depends)
 
 if(BUILD_WITH_SPARSE)
   target_link_libraries(rocsolver PRIVATE roc::rocsparse)
@@ -421,6 +421,7 @@ rocm_export_targets(
   TARGETS roc::rocsolver
   DEPENDS
     PACKAGE hip
+    PACKAGE rocblas
   STATIC_DEPENDS
     ${static_depends}
   NAMESPACE roc::


### PR DESCRIPTION
This fixes a build failure in qmcpack, where it doesn't know what library `roc::rocblas` is.