### PR TITLE
Remove unused immintrin.h include

### DIFF
--- a/clients/rocblascommon/rocblas_math.hpp
+++ b/clients/rocblascommon/rocblas_math.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2018-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,6 @@
 
 #include <cmath>
 #include <hip/hip_runtime.h>
-#include <immintrin.h>
 #include <rocblas/rocblas.h>
 #include <type_traits>
 


### PR DESCRIPTION
This header is not used and breaks the build on non-x86 platforms.