### PR TITLE
use std::max(), std::min(), instead of max(), min()  to avoid 32bit overflow

### DIFF
--- a/common/include/rocblas_utility.hpp
+++ b/common/include/rocblas_utility.hpp
@@ -466,3 +466,15 @@ catch(...)
 }
 
 #undef ROCSOLVER_ROCBLAS_HAS_F8_DATATYPES
+
+template <typename T>
+static T max(T x, T y)
+{
+    return (std::max<T>(x, y));
+}
+
+template <typename T>
+static T min(T x, T y)
+{
+    return (std::min<T>(x, y));
+}

--- a/common/include/rocblas_utility.hpp
+++ b/common/include/rocblas_utility.hpp
@@ -468,13 +468,13 @@ catch(...)
 #undef ROCSOLVER_ROCBLAS_HAS_F8_DATATYPES
 
 template <typename T>
-static T max(T x, T y)
+static inline T max(T x, T y)
 {
     return (std::max<T>(x, y));
 }
 
 template <typename T>
-static T min(T x, T y)
+static inline T min(T x, T y)
 {
     return (std::min<T>(x, y));
 }

--- a/library/src/lapack/roclapack_getri.hpp
+++ b/library/src/lapack/roclapack_getri.hpp
@@ -242,11 +242,11 @@ void rocsolver_getri_getMemorySize(const rocblas_int n,
     rocblasCall_trsm_mem<BATCHED, T>(rocblas_side_right, rocblas_operation_none, n, blk + 1,
                                      batch_count, &w1a, &w2a, &w3a, &w4a);
 
-    *size_work1 = max(w1a, w1b);
-    *size_work2 = max(w2a, w2b);
-    *size_work3 = max(w3a, w3b);
-    *size_work4 = max(w4a, w4b);
-    *size_tmpcopy = max(t1, t2);
+    *size_work1 = std::max(w1a, w1b);
+    *size_work2 = std::max(w2a, w2b);
+    *size_work3 = std::max(w3a, w3b);
+    *size_work4 = std::max(w4a, w4b);
+    *size_tmpcopy = std::max(t1, t2);
 
     // always allocate all required memory for TRSM optimal performance
     opt2 = true;

--- a/library/src/lapack/roclapack_trtri.hpp
+++ b/library/src/lapack/roclapack_trtri.hpp
@@ -174,8 +174,8 @@ void rocsolver_trtri_getMemorySize(const rocblas_diagonal diag,
     {
         rocblasCall_trsm_mem<BATCHED, T>(rocblas_side_right, rocblas_operation_none, n, blk,
                                          batch_count, &w1b, size_work2, &w3b, size_work4);
-        *size_work1 = max(w1a, w1b);
-        *size_work3 = max(w3a, w3b);
+        *size_work1 = std::max(w1a, w1b);
+        *size_work3 = std::max(w3a, w3b);
 
         // always allocate all required memory for TRSM optimal performance
         *optim_mem = true;


### PR DESCRIPTION
The original max(t1,t2) function computes as 32bit signed integer even if t1, t2 are of type size_t unsigned 64 bit.  

This can lead to problems related to  32bit overflow such as getri_strided_batched for n=260, batch_count=2500, type rocblas_double_complex. 

This update creates an overloaded function that performs std::max(t1,t2) instead of max(t1,t2) to use 64bit arithmetic when t1, t2 are of type size_t.

There is an overloaded funtion for std::min(t1,t2) to replace min(t1,t2) as well.