### PR TITLE
fix argument checking for invalid pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
 ### Changed
 - Renamed install script arguments of the form *_dir to *-path. Arguments of the form *_dir remain functional for
   backwards compatibility.
+- Functions working with arrays of size n - 1 can now accept null pointers when n = 1.
 
 ### Deprecated
 ### Removed

--- a/clients/include/testing_gebd2_gebrd.hpp
+++ b/clients/include/testing_gebd2_gebrd.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -107,9 +107,9 @@ void testing_gebd2_gebrd_bad_arg()
 
     // safe arguments
     rocblas_local_handle handle;
-    rocblas_int m = 1;
-    rocblas_int n = 1;
-    rocblas_int lda = 1;
+    rocblas_int m = 2;
+    rocblas_int n = 2;
+    rocblas_int lda = 2;
     rocblas_stride stA = 1;
     rocblas_stride stD = 1;
     rocblas_stride stE = 1;

--- a/clients/include/testing_orgtr_ungtr.hpp
+++ b/clients/include/testing_orgtr_ungtr.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -68,8 +68,8 @@ void testing_orgtr_ungtr_bad_arg()
     // safe arguments
     rocblas_local_handle handle;
     rocblas_fill uplo = rocblas_fill_upper;
-    rocblas_int n = 1;
-    rocblas_int lda = 1;
+    rocblas_int n = 2;
+    rocblas_int lda = 2;
 
     // memory allocation
     device_strided_batch_vector<T> dA(1, 1, 1, 1);

--- a/clients/include/testing_ormtr_unmtr.hpp
+++ b/clients/include/testing_ormtr_unmtr.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -101,10 +101,10 @@ void testing_ormtr_unmtr_bad_arg()
     rocblas_side side = rocblas_side_left;
     rocblas_fill uplo = rocblas_fill_upper;
     rocblas_operation trans = rocblas_operation_none;
-    rocblas_int m = 1;
-    rocblas_int n = 1;
-    rocblas_int lda = 1;
-    rocblas_int ldc = 1;
+    rocblas_int m = 2;
+    rocblas_int n = 2;
+    rocblas_int lda = 2;
+    rocblas_int ldc = 2;
 
     // memory allocation
     device_strided_batch_vector<T> dA(1, 1, 1, 1);

--- a/clients/include/testing_stedc.hpp
+++ b/clients/include/testing_stedc.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -77,8 +77,8 @@ void testing_stedc_bad_arg()
     // safe arguments
     rocblas_local_handle handle;
     rocblas_evect evect = rocblas_evect_original;
-    rocblas_int n = 1;
-    rocblas_int ldc = 1;
+    rocblas_int n = 2;
+    rocblas_int ldc = 2;
 
     // memory allocations
     device_strided_batch_vector<S> dD(1, 1, 1, 1);

--- a/clients/include/testing_stedcj.hpp
+++ b/clients/include/testing_stedcj.hpp
@@ -77,8 +77,8 @@ void testing_stedcj_bad_arg()
     // safe arguments
     rocblas_local_handle handle;
     rocblas_evect evect = rocblas_evect_original;
-    rocblas_int n = 1;
-    rocblas_int ldc = 1;
+    rocblas_int n = 2;
+    rocblas_int ldc = 2;
 
     // memory allocations
     device_strided_batch_vector<S> dD(1, 1, 1, 1);

--- a/clients/include/testing_steqr.hpp
+++ b/clients/include/testing_steqr.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -77,8 +77,8 @@ void testing_steqr_bad_arg()
     // safe arguments
     rocblas_local_handle handle;
     rocblas_evect evect = rocblas_evect_original;
-    rocblas_int n = 1;
-    rocblas_int ldc = 1;
+    rocblas_int n = 2;
+    rocblas_int ldc = 2;
 
     // memory allocations
     device_strided_batch_vector<S> dD(1, 1, 1, 1);

--- a/clients/include/testing_sterf.hpp
+++ b/clients/include/testing_sterf.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -62,7 +62,7 @@ void testing_sterf_bad_arg()
 {
     // safe arguments
     rocblas_local_handle handle;
-    rocblas_int n = 1;
+    rocblas_int n = 2;
 
     // memory allocations
     device_strided_batch_vector<T> dD(1, 1, 1, 1);

--- a/clients/include/testing_sytxx_hetxx.hpp
+++ b/clients/include/testing_sytxx_hetxx.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -101,8 +101,8 @@ void testing_sytxx_hetxx_bad_arg()
     // safe arguments
     rocblas_local_handle handle;
     rocblas_fill uplo = rocblas_fill_upper;
-    rocblas_int n = 1;
-    rocblas_int lda = 1;
+    rocblas_int n = 2;
+    rocblas_int lda = 2;
     rocblas_stride stA = 1;
     rocblas_stride stD = 1;
     rocblas_stride stE = 1;

--- a/library/src/auxiliary/rocauxiliary_bdsqr.hpp
+++ b/library/src/auxiliary/rocauxiliary_bdsqr.hpp
@@ -998,7 +998,7 @@ rocblas_status rocsolver_bdsqr_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((n && !D) || (n > 1 && !E) || (n * nv && !V) || (n * nu && !U) || (n * nc && !C) || !info)
+    if((n && !D) || (n > 1 && !E) || (n && nv && !V) || (n && nu && !U) || (n && nc && !C) || !info)
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;
@@ -1064,14 +1064,14 @@ rocblas_status rocsolver_bdsqr_template(rocblas_handle handle,
     rocblas_stride strideW = 2 + incW * n;
 
     // grid dimensions
-    rocblas_int nuc_max = max(nu, nc);
-    rocblas_int nvuc_max = max(nv, nuc_max);
+    rocblas_int nuc_max = std::max(nu, nc);
+    rocblas_int nvuc_max = std::max(nv, nuc_max);
 
     dim3 grid1(1, batch_count, 1);
     dim3 grid2(1, BDSQR_SPLIT_GROUPS, batch_count);
     dim3 threads1(1, 1, 1);
-    dim3 threads2((nu || nc ? min(nuc_max, BS1) : 1), 1, 1);
-    dim3 threads3((nv || nu || nc ? min(nvuc_max, BS1) : 1), 1, 1);
+    dim3 threads2((nu || nc ? std::min(nuc_max, BS1) : 1), 1, 1);
+    dim3 threads3((nv || nu || nc ? std::min(nvuc_max, BS1) : 1), 1, 1);
 
     // check for NaNs and Infs in input
     ROCSOLVER_LAUNCH_KERNEL((bdsqr_init<T>), grid1, threads1, 0, stream, n, D, strideD, E, strideE,

--- a/library/src/auxiliary/rocauxiliary_labrd.hpp
+++ b/library/src/auxiliary/rocauxiliary_labrd.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     June 2017
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -67,10 +67,10 @@ void rocsolver_labrd_getMemorySize(const rocblas_int m,
         s1 = 0;
 
     // extra requirements for calling larfg
-    rocsolver_larfg_getMemorySize<T>(max(m, n), batch_count, &s2, size_norms);
+    rocsolver_larfg_getMemorySize<T>(std::max(m, n), batch_count, &s2, size_norms);
 
     // size_work_workArr is maximum of re-usable work space and array of pointers to workspace
-    *size_work_workArr = max(s1, s2);
+    *size_work_workArr = std::max(s1, s2);
 }
 
 template <typename T, typename S, typename U>
@@ -96,7 +96,8 @@ rocblas_status rocsolver_labrd_argCheck(rocblas_handle handle,
     // N/A
 
     // 2. invalid size
-    if(m < 0 || n < 0 || nb < 0 || nb > min(m, n) || lda < m || ldx < m || ldy < n || batch_count < 0)
+    if(m < 0 || n < 0 || nb < 0 || nb > std::min(m, n) || lda < m || ldx < m || ldy < n
+       || batch_count < 0)
         return rocblas_status_invalid_size;
 
     // skip pointer check if querying memory size
@@ -104,8 +105,8 @@ rocblas_status rocsolver_labrd_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((m * n && !A) || (nb && !D) || (nb && !E) || (nb && !tauq) || (nb && !taup) || (m * nb && !X)
-       || (n * nb && !Y))
+    if((m && n && !A) || (nb && !D) || (nb && !E) || (nb && !tauq) || (nb && !taup)
+       || (m && nb && !X) || (n && nb && !Y))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;
@@ -183,13 +184,14 @@ rocblas_status rocsolver_labrd_template(rocblas_handle handle,
                                 strideA, batch_count, (T**)work_workArr);
 
             // generate Householder reflector to work on column j
-            rocsolver_larfg_template(handle,
-                                     m - j, // order of reflector
-                                     A, shiftA + idx2D(j, j, lda), // value of alpha
-                                     A, shiftA + idx2D(min(j + 1, m - 1), j, lda), // vector x to work on
-                                     1, strideA, // inc of x
-                                     (tauq + j), strideQ, // tau
-                                     batch_count, (T*)work_workArr, norms);
+            rocsolver_larfg_template(
+                handle,
+                m - j, // order of reflector
+                A, shiftA + idx2D(j, j, lda), // value of alpha
+                A, shiftA + idx2D(std::min(j + 1, m - 1), j, lda), // vector x to work on
+                1, strideA, // inc of x
+                (tauq + j), strideQ, // tau
+                batch_count, (T*)work_workArr, norms);
 
             ROCSOLVER_LAUNCH_KERNEL(set_diag<T>, dim3(batch_count, 1, 1), dim3(1, 1, 1), 0, stream,
                                     D, j, strideD, A, shiftA + idx2D(j, j, lda), lda, strideA, 1,
@@ -259,7 +261,7 @@ rocblas_status rocsolver_labrd_template(rocblas_handle handle,
                     handle,
                     n - j - 1, // order of reflector
                     A, shiftA + idx2D(j, j + 1, lda), // value of alpha
-                    A, shiftA + idx2D(j, min(j + 2, n - 1), lda), // vector x to work on
+                    A, shiftA + idx2D(j, std::min(j + 2, n - 1), lda), // vector x to work on
                     lda, strideA, // inc of x
                     (taup + j), strideP, // tau
                     batch_count, (T*)work_workArr, norms);
@@ -340,13 +342,14 @@ rocblas_status rocsolver_labrd_template(rocblas_handle handle,
                                             batch_count);
 
             // generate Householder reflector to work on row j
-            rocsolver_larfg_template(handle,
-                                     n - j, // order of reflector
-                                     A, shiftA + idx2D(j, j, lda), // value of alpha
-                                     A, shiftA + idx2D(j, min(j + 1, n - 1), lda), // vector x to work on
-                                     lda, strideA, // inc of x
-                                     (taup + j), strideP, // tau
-                                     batch_count, (T*)work_workArr, norms);
+            rocsolver_larfg_template(
+                handle,
+                n - j, // order of reflector
+                A, shiftA + idx2D(j, j, lda), // value of alpha
+                A, shiftA + idx2D(j, std::min(j + 1, n - 1), lda), // vector x to work on
+                lda, strideA, // inc of x
+                (taup + j), strideP, // tau
+                batch_count, (T*)work_workArr, norms);
 
             ROCSOLVER_LAUNCH_KERNEL(set_diag<T>, dim3(batch_count, 1, 1), dim3(1, 1, 1), 0, stream,
                                     D, j, strideD, A, shiftA + idx2D(j, j, lda), lda, strideA, 1,
@@ -413,7 +416,7 @@ rocblas_status rocsolver_labrd_template(rocblas_handle handle,
                     handle,
                     m - j - 1, // order of reflector
                     A, shiftA + idx2D(j + 1, j, lda), // value of alpha
-                    A, shiftA + idx2D(min(j + 2, m - 1), j, lda), // vector x to work on
+                    A, shiftA + idx2D(std::min(j + 2, m - 1), j, lda), // vector x to work on
                     1, strideA, // inc of x
                     (tauq + j), strideQ, // tau
                     batch_count, (T*)work_workArr, norms);

--- a/library/src/auxiliary/rocauxiliary_larf.hpp
+++ b/library/src/auxiliary/rocauxiliary_larf.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -62,7 +62,7 @@ void rocsolver_larf_getMemorySize(const rocblas_side side,
     else if(side == rocblas_side_right)
         *size_Abyx = m;
     else
-        *size_Abyx = max(m, n);
+        *size_Abyx = std::max(m, n);
     *size_Abyx *= sizeof(T) * batch_count;
 
     // size of array of pointers to workspace
@@ -99,7 +99,7 @@ rocblas_status rocsolver_larf_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((m * n && !A) || (left && m && (!alpha || !x)) || (!left && n && (!alpha || !x)))
+    if((m && n && !A) || (left && m && (!alpha || !x)) || (!left && n && (!alpha || !x)))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/auxiliary/rocauxiliary_larfb.hpp
+++ b/library/src/auxiliary/rocauxiliary_larfb.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     June 2013
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -163,7 +163,7 @@ rocblas_status rocsolver_larfb_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((left && m && !V) || (!left && n && !V) || (m * n && !A) || !F)
+    if((left && m && !V) || (!left && n && !V) || (m && n && !A) || !F)
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/auxiliary/rocauxiliary_lasyf.hpp
+++ b/library/src/auxiliary/rocauxiliary_lasyf.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     June 2017
- * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -150,7 +150,7 @@ __device__ void lasyf_device_upper(const rocblas_int tid,
         }
         __syncthreads();
 
-        if(max(absakk, colmax) == 0)
+        if(std::max(absakk, colmax) == 0)
         {
             // singularity found
             if(tid == 0 && _info == 0)
@@ -186,7 +186,7 @@ __device__ void lasyf_device_upper(const rocblas_int tid,
                 {
                     iamax<MAX_THDS>(tid, imax, W + (kw - 1) * ldw, 1, sval, sidx);
                     if(tid == 0)
-                        rowmax = max(rowmax, sval[0]);
+                        rowmax = std::max(rowmax, sval[0]);
                 }
                 __syncthreads();
 
@@ -294,7 +294,7 @@ __device__ void lasyf_device_upper(const rocblas_int tid,
     // update A from [0,0] to [k,k], nb columns at a time
     for(j = (k / nb) * nb; j >= 0; j -= nb)
     {
-        int jb = min(nb, k - j + 1);
+        int jb = std::min(nb, k - j + 1);
         for(i = j; i < j + jb; i++)
             lasyf_gemv<MAX_THDS>(tid, i - j + 1, n - k - 1, minone, A + j + (k + 1) * lda, lda,
                                  W + i + (kw + 1) * ldw, ldw, one, A + j + i * lda, 1);
@@ -381,7 +381,7 @@ __device__ void lasyf_device_lower(const rocblas_int tid,
         }
         __syncthreads();
 
-        if(max(absakk, colmax) == 0)
+        if(std::max(absakk, colmax) == 0)
         {
             // singularity found
             if(tid == 0 && _info == 0)
@@ -414,7 +414,7 @@ __device__ void lasyf_device_lower(const rocblas_int tid,
                 {
                     iamax<MAX_THDS>(tid, n - imax - 1, W + (imax + 1) + (k + 1) * ldw, 1, sval, sidx);
                     if(tid == 0)
-                        rowmax = max(rowmax, sval[0]);
+                        rowmax = std::max(rowmax, sval[0]);
                 }
                 __syncthreads();
 
@@ -520,7 +520,7 @@ __device__ void lasyf_device_lower(const rocblas_int tid,
     // update A from [k,k] to [n-1,n-1], nb columns at a time
     for(j = k; j < n; j += nb)
     {
-        int jb = min(nb, n - j);
+        int jb = std::min(nb, n - j);
         for(i = j; i < j + jb; i++)
             lasyf_gemv<MAX_THDS>(tid, j + jb - i, k, minone, A + i, lda, W + i, ldw, one,
                                  A + i + i * lda, 1);

--- a/library/src/auxiliary/rocauxiliary_latrd.hpp
+++ b/library/src/auxiliary/rocauxiliary_latrd.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     June 2017
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -103,7 +103,7 @@ rocblas_status rocsolver_latrd_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((n && !A) || (n && !E) || (n && !tau) || (n * k && !W))
+    if((n && !A) || (n && !E) || (n && !tau) || (n && k && !W))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;
@@ -191,7 +191,7 @@ rocblas_status rocsolver_latrd_template(rocblas_handle handle,
 
             // generate Householder reflector to work on column j
             rocsolver_larfg_template(handle, n - j - 1, A, shiftA + idx2D(j + 1, j, lda), A,
-                                     shiftA + idx2D(min(j + 2, n - 1), j, lda), 1, strideA,
+                                     shiftA + idx2D(std::min(j + 2, n - 1), j, lda), 1, strideA,
                                      (tau + j), strideP, batch_count, work, norms);
 
             // copy to E(j) the corresponding off-diagonal element of A, which is set to 1

--- a/library/src/auxiliary/rocauxiliary_org2l_ung2l.hpp
+++ b/library/src/auxiliary/rocauxiliary_org2l_ung2l.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -111,7 +111,7 @@ rocblas_status rocsolver_org2l_orgql_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((k && !ipiv) || (m * n && !A))
+    if((k && !ipiv) || (m && n && !A))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/auxiliary/rocauxiliary_org2r_ung2r.hpp
+++ b/library/src/auxiliary/rocauxiliary_org2r_ung2r.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -112,7 +112,7 @@ rocblas_status rocsolver_org2r_orgqr_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((k && !ipiv) || (m * n && !A))
+    if((k && !ipiv) || (m && n && !A))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/auxiliary/rocauxiliary_orgbr_ungbr.hpp
+++ b/library/src/auxiliary/rocauxiliary_orgbr_ungbr.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     April 2012
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -76,7 +76,7 @@ void rocsolver_orgbr_ungbr_getMemorySize(const rocblas_storev storev,
             rocsolver_orgqr_ungqr_getMemorySize<BATCHED, T>(m - 1, m - 1, m - 1, batch_count,
                                                             size_scalars, &s2, size_Abyx_tmptr,
                                                             size_trfact, size_workArr);
-            *size_work = max(s1, s2);
+            *size_work = std::max(s1, s2);
         }
     }
 
@@ -96,7 +96,7 @@ void rocsolver_orgbr_ungbr_getMemorySize(const rocblas_storev storev,
             rocsolver_orglq_unglq_getMemorySize<BATCHED, T>(n - 1, n - 1, n - 1, batch_count,
                                                             size_scalars, &s2, size_Abyx_tmptr,
                                                             size_trfact, size_workArr);
-            *size_work = max(s1, s2);
+            *size_work = std::max(s1, s2);
         }
     }
 }
@@ -121,9 +121,9 @@ rocblas_status rocsolver_orgbr_argCheck(rocblas_handle handle,
     // 2. invalid size
     if(m < 0 || n < 0 || k < 0 || lda < m)
         return rocblas_status_invalid_size;
-    if(!row && (n > m || n < min(m, k)))
+    if(!row && (n > m || n < std::min(m, k)))
         return rocblas_status_invalid_size;
-    if(row && (m > n || m < min(n, k)))
+    if(row && (m > n || m < std::min(n, k)))
         return rocblas_status_invalid_size;
 
     // skip pointer check if querying memory size
@@ -131,7 +131,8 @@ rocblas_status rocsolver_orgbr_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((m * n && !A) || (row && min(n, k) > 0 && !ipiv) || (!row && min(m, k) > 0 && !ipiv))
+    if((m && n && !A) || (row && std::min(n, k) > 0 && !ipiv)
+       || (!row && std::min(m, k) > 0 && !ipiv))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/auxiliary/rocauxiliary_orgl2_ungl2.hpp
+++ b/library/src/auxiliary/rocauxiliary_orgl2_ungl2.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -113,7 +113,7 @@ rocblas_status rocsolver_orgl2_orglq_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((k && !ipiv) || (m * n && !A))
+    if((k && !ipiv) || (m && n && !A))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/auxiliary/rocauxiliary_orglq_unglq.hpp
+++ b/library/src/auxiliary/rocauxiliary_orglq_unglq.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -74,7 +74,7 @@ void rocsolver_orglq_unglq_getMemorySize(const rocblas_int m,
     {
         rocblas_int jb = xxGxQ_BLOCKSIZE;
         rocblas_int j = ((k - xxGxQ_xxGxQ2_SWITCHSIZE - 1) / jb) * jb;
-        rocblas_int kk = min(k, j + jb);
+        rocblas_int kk = std::min(k, j + jb);
 
         // size of workspace is maximum of what is needed by larft and larfb.
         // size of Abyx_tmptr is maximum of what is needed by orgl2/ungl2 and larfb.
@@ -130,7 +130,7 @@ rocblas_status rocsolver_orglq_unglq_template(rocblas_handle handle,
     rocblas_int j = ((k - xxGxQ_xxGxQ2_SWITCHSIZE - 1) / jb) * jb;
 
     // start of the unblocked block
-    rocblas_int kk = min(k, j + jb);
+    rocblas_int kk = std::min(k, j + jb);
 
     rocblas_int blocksy, blocksx;
 

--- a/library/src/auxiliary/rocauxiliary_orgql_ungql.hpp
+++ b/library/src/auxiliary/rocauxiliary_orgql_ungql.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -74,7 +74,7 @@ void rocsolver_orgql_ungql_getMemorySize(const rocblas_int m,
     {
         rocblas_int jb = xxGQx_BLOCKSIZE;
         rocblas_int j = ((k - xxGQx_xxGQx2_SWITCHSIZE - 1) / jb) * jb;
-        rocblas_int kk = min(k, j + jb);
+        rocblas_int kk = std::min(k, j + jb);
 
         // size of workspace is maximum of what is needed by larft and larfb.
         // size of Abyx_tmptr is maximum of what is needed by org2r/ung2r and larfb.
@@ -127,7 +127,7 @@ rocblas_status rocsolver_orgql_ungql_template(rocblas_handle handle,
 
     // size of unblocked part
     rocblas_int jb = ldw;
-    rocblas_int kk = min(k, ((k - xxGQx_xxGQx2_SWITCHSIZE + jb - 1) / jb) * jb);
+    rocblas_int kk = std::min(k, ((k - xxGQx_xxGQx2_SWITCHSIZE + jb - 1) / jb) * jb);
 
     // start of first blocked block is j + n - k = n - kk
     rocblas_int j = k - kk;

--- a/library/src/auxiliary/rocauxiliary_orgqr_ungqr.hpp
+++ b/library/src/auxiliary/rocauxiliary_orgqr_ungqr.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -74,7 +74,7 @@ void rocsolver_orgqr_ungqr_getMemorySize(const rocblas_int m,
     {
         rocblas_int jb = xxGQx_BLOCKSIZE;
         rocblas_int j = ((k - xxGQx_xxGQx2_SWITCHSIZE - 1) / jb) * jb;
-        rocblas_int kk = min(k, j + jb);
+        rocblas_int kk = std::min(k, j + jb);
 
         // size of workspace is maximum of what is needed by larft and larfb.
         // size of Abyx_tmptr is maximum of what is needed by org2r/ung2r and larfb.
@@ -130,7 +130,7 @@ rocblas_status rocsolver_orgqr_ungqr_template(rocblas_handle handle,
     rocblas_int j = ((k - xxGQx_xxGQx2_SWITCHSIZE - 1) / jb) * jb;
 
     // start of the unblocked block
-    rocblas_int kk = min(k, j + jb);
+    rocblas_int kk = std::min(k, j + jb);
 
     rocblas_int blocksy, blocksx;
 

--- a/library/src/auxiliary/rocauxiliary_orgtr_ungtr.hpp
+++ b/library/src/auxiliary/rocauxiliary_orgtr_ungtr.hpp
@@ -75,7 +75,7 @@ void rocsolver_orgtr_ungtr_getMemorySize(const rocblas_fill uplo,
                                                         size_scalars, &w2, size_Abyx_tmptr,
                                                         size_trfact, size_workArr);
     }
-    *size_work = max(w1, w2);
+    *size_work = std::max(w1, w2);
 }
 
 template <typename T, typename U>

--- a/library/src/auxiliary/rocauxiliary_orgtr_ungtr.hpp
+++ b/library/src/auxiliary/rocauxiliary_orgtr_ungtr.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     April 2012
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -101,7 +101,7 @@ rocblas_status rocsolver_orgtr_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((n && !A) || (n && !ipiv))
+    if((n && !A) || (n > 1 && !ipiv))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/auxiliary/rocauxiliary_orm2l_unm2l.hpp
+++ b/library/src/auxiliary/rocauxiliary_orm2l_unm2l.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -105,7 +105,7 @@ rocblas_status rocsolver_orm2l_ormql_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((m * n && !C) || (k && !ipiv) || (left && m * k && !A) || (!left && n * k && !A))
+    if((m && n && !C) || (k && !ipiv) || (left && m && k && !A) || (!left && n && k && !A))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/auxiliary/rocauxiliary_orm2r_unm2r.hpp
+++ b/library/src/auxiliary/rocauxiliary_orm2r_unm2r.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -105,7 +105,7 @@ rocblas_status rocsolver_orm2r_ormqr_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((m * n && !C) || (k && !ipiv) || (left && m * k && !A) || (!left && n * k && !A))
+    if((m && n && !C) || (k && !ipiv) || (left && m && k && !A) || (!left && n && k && !A))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/auxiliary/rocauxiliary_ormbr_unmbr.hpp
+++ b/library/src/auxiliary/rocauxiliary_ormbr_unmbr.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -65,12 +65,12 @@ void rocsolver_ormbr_unmbr_getMemorySize(const rocblas_storev storev,
 
     // requirements for calling ORMQR/UNMQR or ORMLQ/UNMLQ
     if(storev == rocblas_column_wise)
-        rocsolver_ormqr_unmqr_getMemorySize<BATCHED, T>(side, m, n, min(nq, k), batch_count,
+        rocsolver_ormqr_unmqr_getMemorySize<BATCHED, T>(side, m, n, std::min(nq, k), batch_count,
                                                         size_scalars, size_AbyxORwork,
                                                         size_diagORtmptr, size_trfact, size_workArr);
 
     else
-        rocsolver_ormlq_unmlq_getMemorySize<BATCHED, T>(side, m, n, min(nq, k), batch_count,
+        rocsolver_ormlq_unmlq_getMemorySize<BATCHED, T>(side, m, n, std::min(nq, k), batch_count,
                                                         size_scalars, size_AbyxORwork,
                                                         size_diagORtmptr, size_trfact, size_workArr);
 }
@@ -111,7 +111,7 @@ rocblas_status rocsolver_ormbr_argCheck(rocblas_handle handle,
         return rocblas_status_invalid_size;
     if(!row && lda < nq)
         return rocblas_status_invalid_size;
-    if(row && lda < min(nq, k))
+    if(row && lda < std::min(nq, k))
         return rocblas_status_invalid_size;
 
     // skip pointer check if querying memory size
@@ -119,7 +119,7 @@ rocblas_status rocsolver_ormbr_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((min(nq, k) > 0 && !A) || (min(nq, k) > 0 && !ipiv) || (m * n && !C))
+    if((std::min(nq, k) > 0 && !A) || (std::min(nq, k) > 0 && !ipiv) || (m && n && !C))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/auxiliary/rocauxiliary_orml2_unml2.hpp
+++ b/library/src/auxiliary/rocauxiliary_orml2_unml2.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -105,7 +105,7 @@ rocblas_status rocsolver_orml2_ormlq_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((m * n && !C) || (k && !ipiv) || (left && m * k && !A) || (!left && n * k && !A))
+    if((m && n && !C) || (k && !ipiv) || (left && m && k && !A) || (!left && n && k && !A))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/auxiliary/rocauxiliary_ormlq_unmlq.hpp
+++ b/library/src/auxiliary/rocauxiliary_ormlq_unmlq.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -70,11 +70,11 @@ void rocsolver_ormlq_unmlq_getMemorySize(const rocblas_side side,
         rocblas_int jb = xxMxQ_BLOCKSIZE;
 
         // requirements for calling larft
-        rocsolver_larft_getMemorySize<BATCHED, T>(max(m, n), min(jb, k), batch_count, &unused,
-                                                  size_AbyxORwork, &unused);
+        rocsolver_larft_getMemorySize<BATCHED, T>(std::max(m, n), std::min(jb, k), batch_count,
+                                                  &unused, size_AbyxORwork, &unused);
 
         // requirements for calling larfb
-        rocsolver_larfb_getMemorySize<BATCHED, T>(side, m, n, min(jb, k), batch_count,
+        rocsolver_larfb_getMemorySize<BATCHED, T>(side, m, n, std::min(jb, k), batch_count,
                                                   size_diagORtmptr, &unused);
 
         // size of temporary array for triangular factor
@@ -176,7 +176,7 @@ rocblas_status rocsolver_ormlq_unmlq_template(rocblas_handle handle,
     for(rocblas_int j = 0; j < k; j += ldw)
     {
         i = start + step * j; // current householder block
-        ib = min(ldw, k - i);
+        ib = std::min(ldw, k - i);
         if(left)
         {
             nrow = m - i;

--- a/library/src/auxiliary/rocauxiliary_ormql_unmql.hpp
+++ b/library/src/auxiliary/rocauxiliary_ormql_unmql.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -70,11 +70,11 @@ void rocsolver_ormql_unmql_getMemorySize(const rocblas_side side,
         rocblas_int jb = xxMQx_BLOCKSIZE;
 
         // requirements for calling larft
-        rocsolver_larft_getMemorySize<BATCHED, T>(max(m, n), min(jb, k), batch_count, &unused,
-                                                  size_AbyxORwork, &unused);
+        rocsolver_larft_getMemorySize<BATCHED, T>(std::max(m, n), std::min(jb, k), batch_count,
+                                                  &unused, size_AbyxORwork, &unused);
 
         // requirements for calling larfb
-        rocsolver_larfb_getMemorySize<BATCHED, T>(side, m, n, min(jb, k), batch_count,
+        rocsolver_larfb_getMemorySize<BATCHED, T>(side, m, n, std::min(jb, k), batch_count,
                                                   size_diagORtmptr, &unused);
 
         // size of temporary array for triangular factor
@@ -167,7 +167,7 @@ rocblas_status rocsolver_ormql_unmql_template(rocblas_handle handle,
     for(rocblas_int j = 0; j < k; j += ldw)
     {
         i = start + step * j; // current householder block
-        ib = min(ldw, k - i);
+        ib = std::min(ldw, k - i);
         if(left)
         {
             nrow = m - k + i + ib;

--- a/library/src/auxiliary/rocauxiliary_ormqr_unmqr.hpp
+++ b/library/src/auxiliary/rocauxiliary_ormqr_unmqr.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -70,11 +70,11 @@ void rocsolver_ormqr_unmqr_getMemorySize(const rocblas_side side,
         rocblas_int jb = xxMQx_BLOCKSIZE;
 
         // requirements for calling larft
-        rocsolver_larft_getMemorySize<BATCHED, T>(max(m, n), min(jb, k), batch_count, &unused,
-                                                  size_AbyxORwork, &unused);
+        rocsolver_larft_getMemorySize<BATCHED, T>(std::max(m, n), std::min(jb, k), batch_count,
+                                                  &unused, size_AbyxORwork, &unused);
 
         // requirements for calling larfb
-        rocsolver_larfb_getMemorySize<BATCHED, T>(side, m, n, min(jb, k), batch_count,
+        rocsolver_larfb_getMemorySize<BATCHED, T>(side, m, n, std::min(jb, k), batch_count,
                                                   size_diagORtmptr, &unused);
 
         // size of temporary array for triangular factor
@@ -170,7 +170,7 @@ rocblas_status rocsolver_ormqr_unmqr_template(rocblas_handle handle,
     for(rocblas_int j = 0; j < k; j += ldw)
     {
         i = start + step * j; // current householder block
-        ib = min(ldw, k - i);
+        ib = std::min(ldw, k - i);
         if(left)
         {
             nrow = m - i;

--- a/library/src/auxiliary/rocauxiliary_ormtr_unmtr.hpp
+++ b/library/src/auxiliary/rocauxiliary_ormtr_unmtr.hpp
@@ -112,7 +112,7 @@ rocblas_status rocsolver_ormtr_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((nq > 0 && !A) || (nq > 1 && !ipiv) || (m * n && !C))
+    if((nq > 0 && !A) || (nq > 1 && !ipiv) || (m && n && !C))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/auxiliary/rocauxiliary_ormtr_unmtr.hpp
+++ b/library/src/auxiliary/rocauxiliary_ormtr_unmtr.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -112,7 +112,7 @@ rocblas_status rocsolver_ormtr_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((nq > 0 && !A) || (nq > 0 && !ipiv) || (m * n && !C))
+    if((nq > 0 && !A) || (nq > 1 && !ipiv) || (m * n && !C))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -257,8 +257,8 @@ __device__ rocblas_int seq_solve(const rocblas_int dd,
     else
     {
         // update bounds
-        lowb = (fx <= 0) ? max(lowb, tau) : lowb;
-        uppb = (fx > 0) ? min(uppb, tau) : uppb;
+        lowb = (fx <= 0) ? std::max(lowb, tau) : lowb;
+        uppb = (fx > 0) ? std::min(uppb, tau) : uppb;
 
         // calculate first step correction with fixed weight method
         ddk = D[k];
@@ -340,8 +340,8 @@ __device__ rocblas_int seq_solve(const rocblas_int dd,
             }
 
             // update bounds
-            lowb = (fx <= 0) ? max(lowb, tau) : lowb;
-            uppb = (fx > 0) ? min(uppb, tau) : uppb;
+            lowb = (fx <= 0) ? std::max(lowb, tau) : lowb;
+            uppb = (fx > 0) ? std::min(uppb, tau) : uppb;
 
             // calculate next step correction with either fixed weight method or
             // simple interpolation
@@ -522,8 +522,8 @@ __device__ rocblas_int seq_solve_ext(const rocblas_int dd,
     else
     {
         // update bounds
-        lowb = (fx <= 0) ? max(lowb, tau) : lowb;
-        uppb = (fx > 0) ? min(uppb, tau) : uppb;
+        lowb = (fx <= 0) ? std::max(lowb, tau) : lowb;
+        uppb = (fx > 0) ? std::min(uppb, tau) : uppb;
 
         // calculate first step correction with fixed weight method
         ddk = D[k];
@@ -583,8 +583,8 @@ __device__ rocblas_int seq_solve_ext(const rocblas_int dd,
             }
 
             // update bounds
-            lowb = (fx <= 0) ? max(lowb, tau) : lowb;
-            uppb = (fx > 0) ? min(uppb, tau) : uppb;
+            lowb = (fx <= 0) ? std::max(lowb, tau) : lowb;
+            uppb = (fx > 0) ? std::min(uppb, tau) : uppb;
 
             // calculate step correction
             ddk = D[k];
@@ -1799,7 +1799,7 @@ void rocsolver_stedc_getMemorySize(const rocblas_evect evect,
             *size_workArr = sizeof(S*) * batch_count;
         else
             *size_workArr = 0;
-        *size_work_stack = max(s1, s2);
+        *size_work_stack = std::max(s1, s2);
 
         // size for split blocks and sub-blocks positions
         *size_splits_map = sizeof(rocblas_int) * (5 * n + 2) * batch_count;

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1839,7 +1839,7 @@ rocblas_status rocsolver_stedc_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((n && !D) || (n && !E) || (evect != rocblas_evect_none && n && !C) || !info)
+    if((n && !D) || (n > 1 && !E) || (evect != rocblas_evect_none && n && !C) || !info)
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/auxiliary/rocauxiliary_stein.hpp
+++ b/library/src/auxiliary/rocauxiliary_stein.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -134,9 +134,9 @@ __device__ void run_stein(const int tid,
 
             // compute reorthogonalization criterion and stopping criterion
             onenrm = abs(D[b1]) + abs(E[b1]);
-            onenrm = max(onenrm, abs(D[bn]) + abs(E[bn - 1]));
+            onenrm = std::max(onenrm, abs(D[bn]) + abs(E[bn - 1]));
             for(j = b1 + 1; j <= bn - 1; j++)
-                onenrm = max(onenrm, abs(D[j]) + abs(E[j - 1]) + abs(E[j])); // <- parallelize?
+                onenrm = std::max(onenrm, abs(D[j]) + abs(E[j - 1]) + abs(E[j])); // <- parallelize?
             ortol = S(0.001) * onenrm;
             stpcrt = sqrt(0.1 / blksize);
         }
@@ -193,7 +193,7 @@ __device__ void run_stein(const int tid,
                     // normalize and scale righthand side vector
                     iamax<MAX_THDS, S>(tid, blksize, work, 1, sval1, sidx);
                     __syncthreads();
-                    scl = blksize * onenrm * max(eps, abs(work[3 * n + blksize - 1])) / sval1[0];
+                    scl = blksize * onenrm * std::max(eps, abs(work[3 * n + blksize - 1])) / sval1[0];
                     for(i = tid; i < blksize; i += MAX_THDS) // <- scal
                         work[i] = work[i] * scl;
                     __syncthreads();

--- a/library/src/auxiliary/rocauxiliary_steqr.hpp
+++ b/library/src/auxiliary/rocauxiliary_steqr.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -384,7 +384,7 @@ rocblas_status rocsolver_steqr_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((n && !D) || (n && !E) || (evect != rocblas_evect_none && n && !C) || !info)
+    if((n && !D) || (n > 1 && !E) || (evect != rocblas_evect_none && n && !C) || !info)
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/auxiliary/rocauxiliary_sterf.hpp
+++ b/library/src/auxiliary/rocauxiliary_sterf.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -338,7 +338,7 @@ rocblas_status
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((n && !D) || (n && !E) || !info)
+    if((n && !D) || (n > 1 && !E) || !info)
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/lapack/roclapack_gebd2.hpp
+++ b/library/src/lapack/roclapack_gebd2.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     June 2017
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -91,7 +91,8 @@ rocblas_status rocsolver_gebd2_gebrd_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((m * n && !A) || (m * n && !D) || (m * n && !E) || (m * n && !tauq) || (m * n && !taup))
+    if((m * n && !A) || (m * n && !D) || (min(m, n) > 1 && !E) || (m * n && !tauq)
+       || (m * n && !taup))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/lapack/roclapack_gebd2.hpp
+++ b/library/src/lapack/roclapack_gebd2.hpp
@@ -60,9 +60,9 @@ void rocsolver_gebd2_getMemorySize(const rocblas_int m,
     size_t s1, s2, w1, w2;
     rocsolver_larf_getMemorySize<BATCHED, T>(rocblas_side_both, m, n, batch_count, size_scalars,
                                              &s1, &w1);
-    rocsolver_larfg_getMemorySize<T>(max(m, n), batch_count, &w2, &s2);
-    *size_work_workArr = max(w1, w2);
-    *size_Abyx_norms = max(s1, s2);
+    rocsolver_larfg_getMemorySize<T>(std::max(m, n), batch_count, &w2, &s2);
+    *size_work_workArr = std::max(w1, w2);
+    *size_Abyx_norms = std::max(s1, s2);
 }
 
 template <typename T, typename S, typename U>
@@ -91,8 +91,7 @@ rocblas_status rocsolver_gebd2_gebrd_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((m * n && !A) || (m * n && !D) || (min(m, n) > 1 && !E) || (m * n && !tauq)
-       || (m * n && !taup))
+    if((m && n && (!A || !D || !tauq || !taup)) || (std::min(m, n) > 1 && !E))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;
@@ -128,7 +127,7 @@ rocblas_status rocsolver_gebd2_template(rocblas_handle handle,
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
 
-    rocblas_int dim = min(m, n); // total number of pivots
+    rocblas_int dim = std::min(m, n); // total number of pivots
 
     if(m >= n)
     {
@@ -137,7 +136,7 @@ rocblas_status rocsolver_gebd2_template(rocblas_handle handle,
         {
             // generate Householder reflector H(j)
             rocsolver_larfg_template(handle, m - j, A, shiftA + idx2D(j, j, lda), A,
-                                     shiftA + idx2D(min(j + 1, m - 1), j, lda), 1, strideA,
+                                     shiftA + idx2D(std::min(j + 1, m - 1), j, lda), 1, strideA,
                                      (tauq + j), strideQ, batch_count, (T*)work_workArr, Abyx_norms);
 
             // copy A(j,j) to D and insert one to build/apply the householder matrix
@@ -174,9 +173,9 @@ rocblas_status rocsolver_gebd2_template(rocblas_handle handle,
 
                 // generate Householder reflector G(j)
                 rocsolver_larfg_template(handle, n - j - 1, A, shiftA + idx2D(j, j + 1, lda), A,
-                                         shiftA + idx2D(j, min(j + 2, n - 1), lda), lda, strideA,
-                                         (taup + j), strideP, batch_count, (T*)work_workArr,
-                                         Abyx_norms);
+                                         shiftA + idx2D(j, std::min(j + 2, n - 1), lda), lda,
+                                         strideA, (taup + j), strideP, batch_count,
+                                         (T*)work_workArr, Abyx_norms);
 
                 // copy A(j,j+1) to E and insert one to build/apply the householder
                 // matrix
@@ -218,7 +217,7 @@ rocblas_status rocsolver_gebd2_template(rocblas_handle handle,
 
             // generate Householder reflector G(j)
             rocsolver_larfg_template(handle, n - j, A, shiftA + idx2D(j, j, lda), A,
-                                     shiftA + idx2D(j, min(j + 1, n - 1), lda), lda, strideA,
+                                     shiftA + idx2D(j, std::min(j + 1, n - 1), lda), lda, strideA,
                                      (taup + j), strideP, batch_count, (T*)work_workArr, Abyx_norms);
 
             // copy A(j,j) to D and insert one to build/apply the householder matrix
@@ -247,7 +246,7 @@ rocblas_status rocsolver_gebd2_template(rocblas_handle handle,
             {
                 // generate Householder reflector H(j)
                 rocsolver_larfg_template(handle, m - j - 1, A, shiftA + idx2D(j + 1, j, lda), A,
-                                         shiftA + idx2D(min(j + 2, m - 1), j, lda), 1, strideA,
+                                         shiftA + idx2D(std::min(j + 2, m - 1), j, lda), 1, strideA,
                                          (tauq + j), strideQ, batch_count, (T*)work_workArr,
                                          Abyx_norms);
 

--- a/library/src/lapack/roclapack_geblttrf_npvt.hpp
+++ b/library/src/lapack/roclapack_geblttrf_npvt.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -95,10 +95,10 @@ void rocsolver_geblttrf_npvt_getMemorySize(const rocblas_int nb,
     rocsolver_getrs_getMemorySize<BATCHED, STRIDED, T>(rocblas_operation_none, nb, nb, batch_count,
                                                        &a2, &b2, &c2, &d2, &unused, incb, incc);
 
-    *size_work1 = max(a1, a2);
-    *size_work2 = max(b1, b2);
-    *size_work3 = max(c1, c2);
-    *size_work4 = max(d1, d2);
+    *size_work1 = std::max(a1, a2);
+    *size_work2 = std::max(b1, b2);
+    *size_work3 = std::max(c1, c2);
+    *size_work4 = std::max(d1, d2);
 
     // size for temporary info storage
     *size_iinfo2 = sizeof(rocblas_int) * batch_count;

--- a/library/src/lapack/roclapack_gebrd.hpp
+++ b/library/src/lapack/roclapack_gebrd.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     November 2017
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -71,14 +71,14 @@ void rocsolver_gebrd_getMemorySize(const rocblas_int m,
     {
         size_t s1, s2, w1, w2, unused;
         rocblas_int k = GEBRD_GEBD2_SWITCHSIZE;
-        rocblas_int d = min(m / k, n / k);
+        rocblas_int d = std::min(m / k, n / k);
 
         // sizes are maximum of what is required by GEBD2 and LABRD
         rocsolver_gebd2_getMemorySize<BATCHED, T>(m - d * k, n - d * k, batch_count, &unused, &w1,
                                                   &s1);
         rocsolver_labrd_getMemorySize<BATCHED, T>(m, n, k, batch_count, size_scalars, &w2, &s2);
-        *size_work_workArr = max(w1, w2);
-        *size_Abyx_norms = max(s1, s2);
+        *size_work_workArr = std::max(w1, w2);
+        *size_Abyx_norms = std::max(s1, s2);
 
         // size of matrix X
         *size_X = m * k;
@@ -132,7 +132,7 @@ rocblas_status rocsolver_gebrd_template(rocblas_handle handle,
     T one = 1;
     rocblas_int nb = GEBRD_BLOCKSIZE;
     rocblas_int k = GEBRD_GEBD2_SWITCHSIZE;
-    rocblas_int dim = min(m, n); // total number of pivots
+    rocblas_int dim = std::min(m, n); // total number of pivots
     rocblas_int jb, j = 0;
     rocblas_int blocks;
 
@@ -150,7 +150,7 @@ rocblas_status rocsolver_gebrd_template(rocblas_handle handle,
     while(j < dim - k)
     {
         // Reduce block to bidiagonal form
-        jb = min(dim - j, nb); // number of rows and columns in the block
+        jb = std::min(dim - j, nb); // number of rows and columns in the block
         rocsolver_labrd_template<T>(handle, m - j, n - j, jb, A, shiftA + idx2D(j, j, lda), lda,
                                     strideA, D + j, strideD, E + j, strideE, tauq + j, strideQ,
                                     taup + j, strideP, X, shiftX, ldx, strideX, Y, shiftY, ldy,

--- a/library/src/lapack/roclapack_gelq2.hpp
+++ b/library/src/lapack/roclapack_gelq2.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     November 2019
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -63,8 +63,8 @@ void rocsolver_gelq2_getMemorySize(const rocblas_int m,
     rocsolver_larf_getMemorySize<BATCHED, T>(rocblas_side_right, m, n, batch_count, size_scalars,
                                              &s1, &w1);
     rocsolver_larfg_getMemorySize<T>(n, batch_count, &w2, &s2);
-    *size_work_workArr = max(w1, w2);
-    *size_Abyx_norms = max(s1, s2);
+    *size_work_workArr = std::max(w1, w2);
+    *size_Abyx_norms = std::max(s1, s2);
 
     // size of array to store temporary diagonal values
     *size_diag = sizeof(T) * batch_count;
@@ -93,7 +93,7 @@ rocblas_status rocsolver_gelq2_gelqf_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((m * n && !A) || (m * n && !ipiv))
+    if((m && n && !A) || (m && n && !ipiv))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;
@@ -124,7 +124,7 @@ rocblas_status rocsolver_gelq2_template(rocblas_handle handle,
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
 
-    rocblas_int dim = min(m, n); // total number of pivots
+    rocblas_int dim = std::min(m, n); // total number of pivots
 
     for(rocblas_int j = 0; j < dim; ++j)
     {
@@ -135,7 +135,7 @@ rocblas_status rocsolver_gelq2_template(rocblas_handle handle,
 
         // generate Householder reflector to work on row j
         rocsolver_larfg_template(handle, n - j, A, shiftA + idx2D(j, j, lda), A,
-                                 shiftA + idx2D(j, min(j + 1, n - 1), lda), lda, strideA,
+                                 shiftA + idx2D(j, std::min(j + 1, n - 1), lda), lda, strideA,
                                  (ipiv + j), strideP, batch_count, (T*)work_workArr, Abyx_norms);
 
         // insert one in A(j,j) tobuild/apply the householder matrix

--- a/library/src/lapack/roclapack_gelqf.hpp
+++ b/library/src/lapack/roclapack_gelqf.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     November 2019
- * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -76,7 +76,7 @@ void rocsolver_gelqf_getMemorySize(const rocblas_int m,
 
         // requirements for calling GELQ2 with sub blocks
         rocsolver_gelq2_getMemorySize<BATCHED, T>(jb, n, batch_count, size_scalars, &w1, &s2, &s1);
-        *size_Abyx_norms_trfact = max(s2, *size_Abyx_norms_trfact);
+        *size_Abyx_norms_trfact = std::max(s2, *size_Abyx_norms_trfact);
 
         // requirements for calling LARFT
         rocsolver_larft_getMemorySize<BATCHED, T>(n, jb, batch_count, &unused, &w2, size_workArr);
@@ -85,8 +85,8 @@ void rocsolver_gelqf_getMemorySize(const rocblas_int m,
         rocsolver_larfb_getMemorySize<BATCHED, T>(rocblas_side_right, m - jb, n, jb, batch_count,
                                                   &s2, &unused);
 
-        *size_work_workArr = max(w1, w2);
-        *size_diag_tmptr = max(s1, s2);
+        *size_work_workArr = std::max(w1, w2);
+        *size_diag_tmptr = std::max(s1, s2);
 
         // size of workArr is double to accommodate
         // LARFB's TRMM calls in the batched case
@@ -128,7 +128,7 @@ rocblas_status rocsolver_gelqf_template(rocblas_handle handle,
                                            batch_count, scalars, work_workArr, Abyx_norms_trfact,
                                            diag_tmptr);
 
-    rocblas_int dim = min(m, n); // total number of pivots
+    rocblas_int dim = std::min(m, n); // total number of pivots
     rocblas_int jb, j = 0;
 
     rocblas_int nb = GExQF_BLOCKSIZE;
@@ -138,7 +138,7 @@ rocblas_status rocsolver_gelqf_template(rocblas_handle handle,
     while(j < dim - GExQF_GExQ2_SWITCHSIZE)
     {
         // Factor diagonal and subdiagonal blocks
-        jb = min(dim - j, nb); // number of rows in the block
+        jb = std::min(dim - j, nb); // number of rows in the block
         rocsolver_gelq2_template<T>(handle, jb, n - j, A, shiftA + idx2D(j, j, lda), lda, strideA,
                                     (ipiv + j), strideP, batch_count, scalars, work_workArr,
                                     Abyx_norms_trfact, diag_tmptr);

--- a/library/src/lapack/roclapack_gels.hpp
+++ b/library/src/lapack/roclapack_gels.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -166,7 +166,7 @@ rocblas_status rocsolver_gels_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((m * n && !A) || ((m * nrhs || n * nrhs) && !B) || (batch_count && !info))
+    if((m && n && !A) || (((m && nrhs) || (n && nrhs)) && !B) || (batch_count && !info))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/lapack/roclapack_geql2.hpp
+++ b/library/src/lapack/roclapack_geql2.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     November 2019
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -63,8 +63,8 @@ void rocsolver_geql2_getMemorySize(const rocblas_int m,
     rocsolver_larf_getMemorySize<BATCHED, T>(rocblas_side_left, m, n, batch_count, size_scalars,
                                              &s1, &w1);
     rocsolver_larfg_getMemorySize<T>(m, batch_count, &w2, &s2);
-    *size_work_workArr = max(w1, w2);
-    *size_Abyx_norms = max(s1, s2);
+    *size_work_workArr = std::max(w1, w2);
+    *size_Abyx_norms = std::max(s1, s2);
 
     // size of array to store temporary diagonal values
     *size_diag = sizeof(T) * batch_count;
@@ -93,7 +93,7 @@ rocblas_status rocsolver_geql2_geqlf_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((m * n && !A) || (m * n && !ipiv))
+    if((m && n && !A) || (m && n && !ipiv))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;
@@ -124,7 +124,7 @@ rocblas_status rocsolver_geql2_template(rocblas_handle handle,
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
 
-    rocblas_int dim = min(m, n); // total number of pivots
+    rocblas_int dim = std::min(m, n); // total number of pivots
 
     for(rocblas_int j = 0; j < dim; j++)
     {

--- a/library/src/lapack/roclapack_geqlf.hpp
+++ b/library/src/lapack/roclapack_geqlf.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     November 2019
- * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -76,7 +76,7 @@ void rocsolver_geqlf_getMemorySize(const rocblas_int m,
 
         // requirements for calling GEQL2 with sub blocks
         rocsolver_geql2_getMemorySize<BATCHED, T>(m, jb, batch_count, size_scalars, &w1, &s2, &s1);
-        *size_Abyx_norms_trfact = max(s2, *size_Abyx_norms_trfact);
+        *size_Abyx_norms_trfact = std::max(s2, *size_Abyx_norms_trfact);
 
         // requirements for calling LARFT
         rocsolver_larft_getMemorySize<BATCHED, T>(m, jb, batch_count, &unused, &w2, size_workArr);
@@ -85,8 +85,8 @@ void rocsolver_geqlf_getMemorySize(const rocblas_int m,
         rocsolver_larfb_getMemorySize<BATCHED, T>(rocblas_side_left, m, n - jb, jb, batch_count,
                                                   &s2, &unused);
 
-        *size_work_workArr = max(w1, w2);
-        *size_diag_tmptr = max(s1, s2);
+        *size_work_workArr = std::max(w1, w2);
+        *size_diag_tmptr = std::max(s1, s2);
 
         // size of workArr is double to accommodate
         // LARFB's TRMM calls in the batched case
@@ -128,10 +128,10 @@ rocblas_status rocsolver_geqlf_template(rocblas_handle handle,
                                            batch_count, scalars, work_workArr, Abyx_norms_trfact,
                                            diag_tmptr);
 
-    rocblas_int k = min(m, n); // total number of pivots
+    rocblas_int k = std::min(m, n); // total number of pivots
     rocblas_int nb = GEQxF_BLOCKSIZE;
     rocblas_int ki = ((k - GEQxF_GEQx2_SWITCHSIZE - 1) / nb) * nb;
-    rocblas_int kk = min(k, ki + nb);
+    rocblas_int kk = std::min(k, ki + nb);
     rocblas_int jb, j = k - kk + ki;
     rocblas_int mu = m, nu = n;
 
@@ -141,7 +141,7 @@ rocblas_status rocsolver_geqlf_template(rocblas_handle handle,
     while(j >= k - kk)
     {
         // Factor diagonal and subdiagonal blocks
-        jb = min(k - j, nb); // number of columns in the block
+        jb = std::min(k - j, nb); // number of columns in the block
         rocsolver_geql2_template<T>(handle, m - k + j + jb, jb, A, shiftA + idx2D(0, n - k + j, lda),
                                     lda, strideA, (ipiv + j), strideP, batch_count, scalars,
                                     work_workArr, Abyx_norms_trfact, diag_tmptr);

--- a/library/src/lapack/roclapack_geqr2.hpp
+++ b/library/src/lapack/roclapack_geqr2.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     November 2019
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -63,8 +63,8 @@ void rocsolver_geqr2_getMemorySize(const rocblas_int m,
     rocsolver_larf_getMemorySize<BATCHED, T>(rocblas_side_left, m, n, batch_count, size_scalars,
                                              &s1, &w1);
     rocsolver_larfg_getMemorySize<T>(m, batch_count, &w2, &s2);
-    *size_work_workArr = max(w1, w2);
-    *size_Abyx_norms = max(s1, s2);
+    *size_work_workArr = std::max(w1, w2);
+    *size_Abyx_norms = std::max(s1, s2);
 
     // size of array to store temporary diagonal values
     *size_diag = sizeof(T) * batch_count;
@@ -93,7 +93,7 @@ rocblas_status rocsolver_geqr2_geqrf_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((m * n && !A) || (m * n && !ipiv))
+    if((m && n && !A) || (m && n && !ipiv))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;
@@ -124,14 +124,14 @@ rocblas_status rocsolver_geqr2_template(rocblas_handle handle,
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
 
-    rocblas_int dim = min(m, n); // total number of pivots
+    rocblas_int dim = std::min(m, n); // total number of pivots
 
     for(rocblas_int j = 0; j < dim; ++j)
     {
         // generate Householder reflector to work on column j
         rocsolver_larfg_template(handle, m - j, A, shiftA + idx2D(j, j, lda), A,
-                                 shiftA + idx2D(min(j + 1, m - 1), j, lda), 1, strideA, (ipiv + j),
-                                 strideP, batch_count, (T*)work_workArr, Abyx_norms);
+                                 shiftA + idx2D(std::min(j + 1, m - 1), j, lda), 1, strideA,
+                                 (ipiv + j), strideP, batch_count, (T*)work_workArr, Abyx_norms);
 
         // insert one in A(j,j) tobuild/apply the householder matrix
         ROCSOLVER_LAUNCH_KERNEL(set_diag<T>, dim3(batch_count, 1, 1), dim3(1, 1, 1), 0, stream,

--- a/library/src/lapack/roclapack_geqrf.hpp
+++ b/library/src/lapack/roclapack_geqrf.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     November 2019
- * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -76,7 +76,7 @@ void rocsolver_geqrf_getMemorySize(const rocblas_int m,
 
         // requirements for calling GEQR2 with sub blocks
         rocsolver_geqr2_getMemorySize<BATCHED, T>(m, jb, batch_count, size_scalars, &w1, &s2, &s1);
-        *size_Abyx_norms_trfact = max(s2, *size_Abyx_norms_trfact);
+        *size_Abyx_norms_trfact = std::max(s2, *size_Abyx_norms_trfact);
 
         // requirements for calling LARFT
         rocsolver_larft_getMemorySize<BATCHED, T>(m, jb, batch_count, &unused, &w2, size_workArr);
@@ -85,8 +85,8 @@ void rocsolver_geqrf_getMemorySize(const rocblas_int m,
         rocsolver_larfb_getMemorySize<BATCHED, T>(rocblas_side_left, m, n - jb, jb, batch_count,
                                                   &s2, &unused);
 
-        *size_work_workArr = max(w1, w2);
-        *size_diag_tmptr = max(s1, s2);
+        *size_work_workArr = std::max(w1, w2);
+        *size_diag_tmptr = std::max(s1, s2);
 
         // size of workArr is double to accommodate
         // LARFB's TRMM calls in the batched case
@@ -130,7 +130,7 @@ rocblas_status rocsolver_geqrf_template(rocblas_handle handle,
         return rocblas_status_success;
     }
 
-    rocblas_int dim = min(m, n); // total number of pivots
+    rocblas_int dim = std::min(m, n); // total number of pivots
     rocblas_int jb, j = 0;
 
     rocblas_int nb = GEQxF_BLOCKSIZE;
@@ -140,7 +140,7 @@ rocblas_status rocsolver_geqrf_template(rocblas_handle handle,
     while(j < dim - GEQxF_GEQx2_SWITCHSIZE)
     {
         // Factor diagonal and subdiagonal blocks
-        jb = min(dim - j, nb); // number of columns in the block
+        jb = std::min(dim - j, nb); // number of columns in the block
         rocsolver_geqr2_template<T>(handle, m - j, jb, A, shiftA + idx2D(j, j, lda), lda, strideA,
                                     (ipiv + j), strideP, batch_count, scalars, work_workArr,
                                     Abyx_norms_trfact, diag_tmptr);

--- a/library/src/lapack/roclapack_gerq2.hpp
+++ b/library/src/lapack/roclapack_gerq2.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     November 2019
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -63,8 +63,8 @@ void rocsolver_gerq2_getMemorySize(const rocblas_int m,
     rocsolver_larf_getMemorySize<BATCHED, T>(rocblas_side_right, m, n, batch_count, size_scalars,
                                              &s1, &w1);
     rocsolver_larfg_getMemorySize<T>(n, batch_count, &w2, &s2);
-    *size_work_workArr = max(w1, w2);
-    *size_Abyx_norms = max(s1, s2);
+    *size_work_workArr = std::max(w1, w2);
+    *size_Abyx_norms = std::max(s1, s2);
 
     // size of array to store temporary diagonal values
     *size_diag = sizeof(T) * batch_count;
@@ -93,7 +93,7 @@ rocblas_status rocsolver_gerq2_gerqf_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((m * n && !A) || (m * n && !ipiv))
+    if((m && n && !A) || (m && n && !ipiv))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;
@@ -123,7 +123,7 @@ rocblas_status rocsolver_gerq2_template(rocblas_handle handle,
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
 
-    rocblas_int dim = min(m, n); // total number of pivots
+    rocblas_int dim = std::min(m, n); // total number of pivots
 
     for(rocblas_int j = 0; j < dim; ++j)
     {

--- a/library/src/lapack/roclapack_gerqf.hpp
+++ b/library/src/lapack/roclapack_gerqf.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     November 2019
- * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -76,7 +76,7 @@ void rocsolver_gerqf_getMemorySize(const rocblas_int m,
 
         // requirements for calling GERQ2 with sub blocks
         rocsolver_gerq2_getMemorySize<BATCHED, T>(jb, n, batch_count, size_scalars, &w1, &s2, &s1);
-        *size_Abyx_norms_trfact = max(s2, *size_Abyx_norms_trfact);
+        *size_Abyx_norms_trfact = std::max(s2, *size_Abyx_norms_trfact);
 
         // requirements for calling LARFT
         rocsolver_larft_getMemorySize<BATCHED, T>(n, jb, batch_count, &unused, &w2, size_workArr);
@@ -85,8 +85,8 @@ void rocsolver_gerqf_getMemorySize(const rocblas_int m,
         rocsolver_larfb_getMemorySize<BATCHED, T>(rocblas_side_right, m - jb, n, jb, batch_count,
                                                   &s2, &unused);
 
-        *size_work_workArr = max(w1, w2);
-        *size_diag_tmptr = max(s1, s2);
+        *size_work_workArr = std::max(w1, w2);
+        *size_diag_tmptr = std::max(s1, s2);
 
         // size of workArr is double to accommodate
         // LARFB's TRMM calls in the batched case
@@ -128,10 +128,10 @@ rocblas_status rocsolver_gerqf_template(rocblas_handle handle,
                                            batch_count, scalars, work_workArr, Abyx_norms_trfact,
                                            diag_tmptr);
 
-    rocblas_int k = min(m, n); // total number of pivots
+    rocblas_int k = std::min(m, n); // total number of pivots
     rocblas_int nb = GExQF_BLOCKSIZE;
     rocblas_int ki = ((k - GExQF_GExQ2_SWITCHSIZE - 1) / nb) * nb;
-    rocblas_int kk = min(k, ki + nb);
+    rocblas_int kk = std::min(k, ki + nb);
     rocblas_int jb, j = k - kk + ki;
     rocblas_int mu = m, nu = n;
 
@@ -141,7 +141,7 @@ rocblas_status rocsolver_gerqf_template(rocblas_handle handle,
     while(j >= k - kk)
     {
         // Factor diagonal and subdiagonal blocks
-        jb = min(k - j, nb); // number of columns in the block
+        jb = std::min(k - j, nb); // number of columns in the block
         rocsolver_gerq2_template<T>(handle, jb, n - k + j + jb, A, shiftA + idx2D(m - k + j, 0, lda),
                                     lda, strideA, (ipiv + j), strideP, batch_count, scalars,
                                     work_workArr, Abyx_norms_trfact, diag_tmptr);

--- a/library/src/lapack/roclapack_gesv.hpp
+++ b/library/src/lapack/roclapack_gesv.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -63,7 +63,7 @@ rocblas_status rocsolver_gesv_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((n && !A) || (n && !ipiv) || (nrhs * n && !B) || (batch_count && !info))
+    if((n && !A) || (n && !ipiv) || (nrhs && n && !B) || (batch_count && !info))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/lapack/roclapack_gesvd.hpp
+++ b/library/src/lapack/roclapack_gesvd.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     April 2012
- * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -135,7 +135,7 @@ rocblas_status rocsolver_gesvd_argCheck(rocblas_handle handle,
     if((left_svect == rocblas_svect_all || left_svect == rocblas_svect_singular) && ldu < m)
         return rocblas_status_invalid_size;
     if((right_svect == rocblas_svect_all && ldv < n)
-       || (right_svect == rocblas_svect_singular && ldv < min(m, n)))
+       || (right_svect == rocblas_svect_singular && ldv < std::min(m, n)))
         return rocblas_status_invalid_size;
 
     // skip pointer check if querying memory size
@@ -143,10 +143,11 @@ rocblas_status rocsolver_gesvd_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((n * m && !A) || (min(m, n) > 1 && !E) || (min(m, n) && !S) || (batch_count && !info))
+    if((n && m && !A) || (std::min(m, n) > 1 && !E) || (std::min(m, n) && !S)
+       || (batch_count && !info))
         return rocblas_status_invalid_pointer;
     if((left_svect == rocblas_svect_all && m && !U)
-       || (left_svect == rocblas_svect_singular && min(m, n) && !U))
+       || (left_svect == rocblas_svect_singular && std::min(m, n) && !U))
         return rocblas_status_invalid_pointer;
     if((right_svect == rocblas_svect_all || right_svect == rocblas_svect_singular) && n && !V)
         return rocblas_status_invalid_pointer;
@@ -215,8 +216,8 @@ void rocsolver_gesvd_getMemorySize(const rocblas_svect left_svect,
     const bool fast_thinSVD = (thinSVD && fast_alg == rocblas_outofplace);
 
     // auxiliary sizes and variables
-    const rocblas_int k = min(m, n);
-    const rocblas_int kk = max(m, n);
+    const rocblas_int k = std::min(m, n);
+    const rocblas_int kk = std::max(m, n);
     const rocblas_int nu = leftvN ? 0 : ((fast_thinSVD || (thinSVD && leadvN)) ? k : m);
     const rocblas_int nv = rightvN ? 0 : ((fast_thinSVD || (thinSVD && leadvN)) ? k : n);
     const rocblas_storev storev_lead = row ? rocblas_column_wise : rocblas_row_wise;
@@ -249,7 +250,7 @@ void rocsolver_gesvd_getMemorySize(const rocblas_svect left_svect,
 
     // size of array tau to store householder scalars on intermediate
     // orthonormal/unitary matrices
-    *size_tau_splits = max(*size_tau_splits, 2 * sizeof(T) * min(m, n) * batch_count);
+    *size_tau_splits = std::max(*size_tau_splits, 2 * sizeof(T) * std::min(m, n) * batch_count);
 
     // extra requirements for QR/LQ factorization
     if(thinSVD)
@@ -403,8 +404,8 @@ rocblas_status rocsolver_gesvd_template(rocblas_handle handle,
     const bool fast_thinSVD = (thinSVD && fast_alg == rocblas_outofplace);
 
     // auxiliary sizes and variables
-    const rocblas_int k = min(m, n);
-    const rocblas_int kk = max(m, n);
+    const rocblas_int k = std::min(m, n);
+    const rocblas_int kk = std::max(m, n);
     const rocblas_int shiftX = 0;
     const rocblas_int shiftY = 0;
     const rocblas_int shiftUV = 0;

--- a/library/src/lapack/roclapack_gesvdx.hpp
+++ b/library/src/lapack/roclapack_gesvdx.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     April 2012
- * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -78,7 +78,7 @@ rocblas_status rocsolver_gesvdx_argCheck(rocblas_handle handle,
         return rocblas_status_invalid_value;
 
     // 2. invalid size
-    const rocblas_int nsv_max = (srange == rocblas_srange_index ? iu - il + 1 : min(m, n));
+    const rocblas_int nsv_max = (srange == rocblas_srange_index ? iu - il + 1 : std::min(m, n));
     if(n < 0 || m < 0 || lda < m || ldu < 1 || ldv < 1 || batch_count < 0)
         return rocblas_status_invalid_size;
     if(left_svect == rocblas_svect_singular && ldu < m)
@@ -89,7 +89,7 @@ rocblas_status rocsolver_gesvdx_argCheck(rocblas_handle handle,
         return rocblas_status_invalid_size;
     if(srange == rocblas_srange_index && (il < 1 || iu < 0))
         return rocblas_status_invalid_size;
-    if(srange == rocblas_srange_index && (iu > min(m, n) || (min(m, n) > 0 && il > iu)))
+    if(srange == rocblas_srange_index && (iu > std::min(m, n) || (std::min(m, n) > 0 && il > iu)))
         return rocblas_status_invalid_size;
 
     // skip pointer check if querying memory size
@@ -97,14 +97,14 @@ rocblas_status rocsolver_gesvdx_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((n * m && !A) || (nsv_max && !S) || (batch_count && !info) || (batch_count && !nsv))
+    if((n && m && !A) || (nsv_max && !S) || (batch_count && !info) || (batch_count && !nsv))
         return rocblas_status_invalid_pointer;
-    if((left_svect == rocblas_svect_singular || right_svect == rocblas_svect_singular) && min(m, n)
-       && !ifail)
+    if((left_svect == rocblas_svect_singular || right_svect == rocblas_svect_singular)
+       && std::min(m, n) && !ifail)
         return rocblas_status_invalid_pointer;
-    if(left_svect == rocblas_svect_singular && m * nsv_max && !U)
+    if(left_svect == rocblas_svect_singular && m && nsv_max && !U)
         return rocblas_status_invalid_pointer;
-    if(right_svect == rocblas_svect_singular && nsv_max * n && !V)
+    if(right_svect == rocblas_svect_singular && nsv_max && n && !V)
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;
@@ -171,7 +171,7 @@ void rocsolver_gesvdx_getMemorySize(const rocblas_svect left_svect,
     const bool leftvS = (left_svect == rocblas_svect_singular);
     const bool rightvS = (right_svect == rocblas_svect_singular);
     const bool thinSVD = (m >= THIN_SVD_SWITCH * n || n >= THIN_SVD_SWITCH * m);
-    const rocblas_int k = min(m, n);
+    const rocblas_int k = std::min(m, n);
     const rocblas_int nsv_max = (srange == rocblas_srange_index ? iu - il + 1 : k);
 
     // init sizes
@@ -365,7 +365,7 @@ rocblas_status rocsolver_gesvdx_template(rocblas_handle handle,
     rocblas_fill uplo = row ? rocblas_fill_upper : rocblas_fill_lower;
     const rocblas_svect svect = (leftvS || rightvS) ? rocblas_svect_singular : rocblas_svect_none;
     const rocblas_int thread_count = BS2;
-    const rocblas_int k = min(m, n);
+    const rocblas_int k = std::min(m, n);
     const rocblas_int nsv_max = (srange == rocblas_srange_index ? iu - il + 1 : k);
     const rocblas_int ldt = k;
     const rocblas_int ldx = thinSVD ? k : m;

--- a/library/src/lapack/roclapack_getf2.hpp
+++ b/library/src/lapack/roclapack_getf2.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -536,7 +536,7 @@ rocblas_status rocsolver_getf2_getrf_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((m * n && !A) || (m * n && pivot && !ipiv) || (batch_count && !info))
+    if((m && n && !A) || (m && n && pivot && !ipiv) || (batch_count && !info))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;
@@ -577,7 +577,7 @@ rocblas_status rocsolver_getf2_template(rocblas_handle handle,
     rocblas_int blocks = (batch_count - 1) / 256 + 1;
     dim3 grid(blocks, 1, 1);
     dim3 threads(256, 1, 1);
-    rocblas_int dim = min(m, n); // total number of pivots
+    rocblas_int dim = std::min(m, n); // total number of pivots
 
     // info=0 (starting with a nonsingular matrix)
     if(offset == 0)

--- a/library/src/lapack/roclapack_getrf.hpp
+++ b/library/src/lapack/roclapack_getrf.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -493,7 +493,7 @@ rocblas_status getrf_panelLU(rocblas_handle handle,
     // Main loop
     for(rocblas_int k = 0; k < nn; k += blk)
     {
-        jb = min(nn - k, blk); // number of columns/pivots in the inner block
+        jb = std::min(nn - k, blk); // number of columns/pivots in the inner block
 
         // factorize inner panel block
         rocsolver_getf2_template<ISBATCHED, T>(handle, mm - k, jb, A, shiftA + idx2D(k, k, inca, lda),
@@ -573,7 +573,7 @@ void rocsolver_getrf_getMemorySize(const rocblas_int m,
         return;
     }
 
-    rocblas_int dim = min(m, n);
+    rocblas_int dim = std::min(m, n);
     rocblas_int blk = getrf_get_blksize<ISBATCHED, T>(dim, pivot);
 
     if(blk == 0)
@@ -594,7 +594,7 @@ void rocsolver_getrf_getMemorySize(const rocblas_int m,
     {
         // requirements for largest possible GETF2 for the sub blocks
         // (largest block panel dimension is 512)
-        rocsolver_getf2_getMemorySize<ISBATCHED, T>(m, min(dim, 512), pivot, batch_count,
+        rocsolver_getf2_getMemorySize<ISBATCHED, T>(m, std::min(dim, 512), pivot, batch_count,
                                                     size_scalars, size_pivotval, size_pivotidx,
                                                     true, inca);
 
@@ -604,14 +604,14 @@ void rocsolver_getrf_getMemorySize(const rocblas_int m,
 
         // extra workspace for calling largest possible TRSM
         rocsolver_trsm_mem<BATCHED, STRIDED, T>(
-            rocblas_side_left, rocblas_operation_none, min(dim, 512), n, batch_count, size_work1,
-            size_work2, size_work3, size_work4, optim_mem, true, inca, inca);
+            rocblas_side_left, rocblas_operation_none, std::min(dim, 512), n, batch_count,
+            size_work1, size_work2, size_work3, size_work4, optim_mem, true, inca, inca);
         if(!pivot)
         {
             size_t w1, w2, w3, w4;
             rocsolver_trsm_mem<BATCHED, STRIDED, T>(rocblas_side_right, rocblas_operation_none, m,
-                                                    min(dim, 512), batch_count, &w1, &w2, &w3, &w4,
-                                                    optim_mem, true, inca, inca);
+                                                    std::min(dim, 512), batch_count, &w1, &w2, &w3,
+                                                    &w4, optim_mem, true, inca, inca);
             *size_work1 = std::max(*size_work1, w1);
             *size_work2 = std::max(*size_work2, w2);
             *size_work3 = std::max(*size_work3, w3);
@@ -656,7 +656,7 @@ rocblas_status rocsolver_getrf_template(rocblas_handle handle,
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
     static constexpr bool ISBATCHED = BATCHED || STRIDED;
-    rocblas_int dim = min(m, n);
+    rocblas_int dim = std::min(m, n);
     rocblas_int blocks, blocksy;
     dim3 grid, threads;
 
@@ -702,7 +702,7 @@ rocblas_status rocsolver_getrf_template(rocblas_handle handle,
     // MAIN LOOP
     for(rocblas_int j = 0; j < dim; j += blk)
     {
-        jb = min(dim - j, blk);
+        jb = std::min(dim - j, blk);
 
         if(pivot || panel)
         {

--- a/library/src/lapack/roclapack_getri.hpp
+++ b/library/src/lapack/roclapack_getri.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -242,11 +242,11 @@ void rocsolver_getri_getMemorySize(const rocblas_int n,
     rocblasCall_trsm_mem<BATCHED, T>(rocblas_side_right, rocblas_operation_none, n, blk + 1,
                                      batch_count, &w1a, &w2a, &w3a, &w4a);
 
-    *size_work1 = max(w1a, w1b);
-    *size_work2 = max(w2a, w2b);
-    *size_work3 = max(w3a, w3b);
-    *size_work4 = max(w4a, w4b);
-    *size_tmpcopy = max(t1, t2);
+    *size_work1 = std::max(w1a, w1b);
+    *size_work2 = std::max(w2a, w2b);
+    *size_work3 = std::max(w3a, w3b);
+    *size_work4 = std::max(w4a, w4b);
+    *size_tmpcopy = std::max(t1, t2);
 
     // always allocate all required memory for TRSM optimal performance
     opt2 = true;
@@ -351,7 +351,7 @@ rocblas_status rocsolver_getri_template(rocblas_handle handle,
     }
 #endif
 
-    rocblas_int threads = min(((n - 1) / 64 + 1) * 64, BS1);
+    rocblas_int threads = std::min(((n - 1) / 64 + 1) * 64, BS1);
     rocblas_int ldw = n;
     rocblas_stride strideW = n * n;
 
@@ -372,7 +372,7 @@ rocblas_status rocsolver_getri_template(rocblas_handle handle,
     rocblas_int nn = ((n - 1) / blk) * blk + 1;
     for(rocblas_int j = nn - 1; j >= 0; j -= blk)
     {
-        jb = min(n - j, blk);
+        jb = std::min(n - j, blk);
 
         // copy and zero entries in case info is nonzero
         ROCSOLVER_LAUNCH_KERNEL(getri_kernel_large1<T>, dim3(batch_count, 1, 1), dim3(1, threads, 1),

--- a/library/src/lapack/roclapack_getrs.hpp
+++ b/library/src/lapack/roclapack_getrs.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -65,7 +65,7 @@ rocblas_status rocsolver_getrs_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((n && !A) || (n && !ipiv) || (nrhs * n && !B))
+    if((n && !A) || (n && !ipiv) || (nrhs && n && !B))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/lapack/roclapack_posv.hpp
+++ b/library/src/lapack/roclapack_posv.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2021-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -63,7 +63,7 @@ rocblas_status rocsolver_posv_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((n && !A) || (nrhs * n && !B) || (batch_count && !info))
+    if((n && !A) || (nrhs && n && !B) || (batch_count && !info))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/lapack/roclapack_potrf.hpp
+++ b/library/src/lapack/roclapack_potrf.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -105,7 +105,7 @@ void rocsolver_potrf_getMemorySize(const rocblas_int n,
                 rocblas_side_right, rocblas_operation_conjugate_transpose, n - jb, jb, batch_count,
                 &s2, size_work2, size_work3, size_work4, optim_mem);
 
-        *size_work1 = max(s1, s2);
+        *size_work1 = std::max(s1, s2);
     }
 }
 
@@ -178,7 +178,7 @@ rocblas_status rocsolver_potrf_template(rocblas_handle handle,
         while(j < n - POTRF_POTF2_SWITCHSIZE)
         {
             // Factor diagonal and subdiagonal blocks
-            jb = min(n - j, nb); // number of columns in the block
+            jb = std::min(n - j, nb); // number of columns in the block
             ROCSOLVER_LAUNCH_KERNEL(reset_info, gridReset, threads, 0, stream, iinfo, batch_count, 0);
             rocsolver_potf2_template<T>(handle, uplo, jb, A, shiftA + idx2D(j, j, lda), lda,
                                         strideA, iinfo, batch_count, scalars, (T*)work1, pivots);
@@ -210,7 +210,7 @@ rocblas_status rocsolver_potrf_template(rocblas_handle handle,
         while(j < n - POTRF_POTF2_SWITCHSIZE)
         {
             // Factor diagonal and subdiagonal blocks
-            jb = min(n - j, nb); // number of columns in the block
+            jb = std::min(n - j, nb); // number of columns in the block
             ROCSOLVER_LAUNCH_KERNEL(reset_info, gridReset, threads, 0, stream, iinfo, batch_count, 0);
             rocsolver_potf2_template<T>(handle, uplo, jb, A, shiftA + idx2D(j, j, lda), lda,
                                         strideA, iinfo, batch_count, scalars, (T*)work1, pivots);

--- a/library/src/lapack/roclapack_potrs.hpp
+++ b/library/src/lapack/roclapack_potrs.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2021-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -61,7 +61,7 @@ rocblas_status rocsolver_potrs_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((n && !A) || (nrhs * n && !B))
+    if((n && !A) || (nrhs && n && !B))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/lapack/roclapack_sygs2_hegs2.hpp
+++ b/library/src/lapack/roclapack_sygs2_hegs2.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2021-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -156,7 +156,7 @@ void rocsolver_sygs2_hegs2_getMemorySize(const rocblas_eform itype,
     if(itype == rocblas_eform_ax)
     {
         // extra workspace (for calling TRSV)
-        *size_store_wcs = max(*size_store_wcs, sizeof(rocblas_int) * batch_count);
+        *size_store_wcs = std::max(*size_store_wcs, sizeof(rocblas_int) * batch_count);
         *size_work = 0;
     }
     else
@@ -237,7 +237,7 @@ rocblas_status rocsolver_sygs2_hegs2_template(rocblas_handle handle,
     rocblas_int blocks_batch = (batch_count - 1) / BS1 + 1;
     rocblas_int waves_batch = (batch_count - 1) / warpSize + 1;
     dim3 blocks(blocks_batch, 1, 1);
-    dim3 threads(min(BS1, warpSize * waves_batch), 1, 1);
+    dim3 threads(std::min(BS1, warpSize * waves_batch), 1, 1);
 
     if(itype == rocblas_eform_ax)
     {

--- a/library/src/lapack/roclapack_sygst_hegst.hpp
+++ b/library/src/lapack/roclapack_sygst_hegst.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2021-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -103,10 +103,10 @@ void rocsolver_sygst_hegst_getMemorySize(const rocblas_fill uplo,
                     batch_count, &temp5, &temp6, &temp7, &temp8, optim_mem);
             }
 
-            *size_work_x_temp = max(*size_work_x_temp, max(temp1, temp5));
-            *size_workArr_temp_arr = max(*size_workArr_temp_arr, max(temp2, temp6));
-            *size_store_wcs_invA = max(*size_store_wcs_invA, max(temp3, temp7));
-            *size_invA_arr = max(*size_invA_arr, max(temp4, temp8));
+            *size_work_x_temp = std::max(*size_work_x_temp, std::max(temp1, temp5));
+            *size_workArr_temp_arr = std::max(*size_workArr_temp_arr, std::max(temp2, temp6));
+            *size_store_wcs_invA = std::max(*size_store_wcs_invA, std::max(temp3, temp7));
+            *size_invA_arr = std::max(*size_invA_arr, std::max(temp4, temp8));
         }
         else
             *optim_mem = true;
@@ -170,7 +170,7 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
             // Compute inv(U')*A*inv(U)
             for(rocblas_int k = 0; k < n; k += nb)
             {
-                rocblas_int kb = min(n - k, nb);
+                rocblas_int kb = std::min(n - k, nb);
 
                 rocsolver_sygs2_hegs2_template<BATCHED, T>(
                     handle, itype, uplo, kb, A, shiftA + idx2D(k, k, lda), lda, strideA, B,
@@ -214,7 +214,7 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
             // Compute inv(L)*A*inv(L')
             for(rocblas_int k = 0; k < n; k += nb)
             {
-                rocblas_int kb = min(n - k, nb);
+                rocblas_int kb = std::min(n - k, nb);
 
                 rocsolver_sygs2_hegs2_template<BATCHED, T>(
                     handle, itype, uplo, kb, A, shiftA + idx2D(k, k, lda), lda, strideA, B,
@@ -261,7 +261,7 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
             // Compute U*A*U'
             for(rocblas_int k = 0; k < n; k += nb)
             {
-                rocblas_int kb = min(n - k, nb);
+                rocblas_int kb = std::min(n - k, nb);
 
                 rocblasCall_trmm(handle, rocblas_side_left, uplo, rocblas_operation_none,
                                  rocblas_diagonal_non_unit, k, kb, &t_one, 0, B, shiftB, ldb,
@@ -300,7 +300,7 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
             // Compute L'*A*L
             for(rocblas_int k = 0; k < n; k += nb)
             {
-                rocblas_int kb = min(n - k, nb);
+                rocblas_int kb = std::min(n - k, nb);
 
                 rocblasCall_trmm(handle, rocblas_side_right, uplo, rocblas_operation_none,
                                  rocblas_diagonal_non_unit, kb, k, &t_one, 0, B, shiftB, ldb,

--- a/library/src/lapack/roclapack_sygv_hegv.hpp
+++ b/library/src/lapack/roclapack_sygv_hegv.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2021-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -88,24 +88,24 @@ void rocsolver_sygv_hegv_getMemorySize(const rocblas_eform itype,
     rocsolver_potrf_getMemorySize<BATCHED, STRIDED, T>(n, uplo, batch_count, size_scalars,
                                                        size_work1, size_work2, size_work3, size_work4,
                                                        size_pivots_workArr, size_iinfo, &opt1);
-    *size_iinfo = max(*size_iinfo, sizeof(rocblas_int) * batch_count);
+    *size_iinfo = std::max(*size_iinfo, sizeof(rocblas_int) * batch_count);
 
     // requirements for calling SYGST/HEGST
     rocsolver_sygst_hegst_getMemorySize<BATCHED, STRIDED, T>(uplo, itype, n, batch_count, &unused,
                                                              &temp1, &temp2, &temp3, &temp4, &opt2);
-    *size_work1 = max(*size_work1, temp1);
-    *size_work2 = max(*size_work2, temp2);
-    *size_work3 = max(*size_work3, temp3);
-    *size_work4 = max(*size_work4, temp4);
+    *size_work1 = std::max(*size_work1, temp1);
+    *size_work2 = std::max(*size_work2, temp2);
+    *size_work3 = std::max(*size_work3, temp3);
+    *size_work4 = std::max(*size_work4, temp4);
 
     // requirements for calling SYEV/HEEV
     rocsolver_syev_heev_getMemorySize<BATCHED, T, S>(evect, uplo, n, batch_count, &unused, &temp1,
                                                      &temp2, &temp3, &temp4, &temp5);
-    *size_work1 = max(*size_work1, temp1);
-    *size_work2 = max(*size_work2, temp2);
-    *size_work3 = max(*size_work3, temp3);
-    *size_work4 = max(*size_work4, temp4);
-    *size_pivots_workArr = max(*size_pivots_workArr, temp5);
+    *size_work1 = std::max(*size_work1, temp1);
+    *size_work2 = std::max(*size_work2, temp2);
+    *size_work3 = std::max(*size_work3, temp3);
+    *size_work4 = std::max(*size_work4, temp4);
+    *size_pivots_workArr = std::max(*size_pivots_workArr, temp5);
 
     if(evect == rocblas_evect_original)
     {
@@ -117,10 +117,10 @@ void rocsolver_sygv_hegv_getMemorySize(const rocblas_eform itype,
             // requirements for calling TRSM
             rocsolver_trsm_mem<BATCHED, STRIDED, T>(rocblas_side_left, trans, n, n, batch_count,
                                                     &temp1, &temp2, &temp3, &temp4, &opt3);
-            *size_work1 = max(*size_work1, temp1);
-            *size_work2 = max(*size_work2, temp2);
-            *size_work3 = max(*size_work3, temp3);
-            *size_work4 = max(*size_work4, temp4);
+            *size_work1 = std::max(*size_work1, temp1);
+            *size_work2 = std::max(*size_work2, temp2);
+            *size_work3 = std::max(*size_work3, temp3);
+            *size_work4 = std::max(*size_work4, temp4);
         }
     }
 

--- a/library/src/lapack/roclapack_sygvd_hegvd.hpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -81,25 +81,25 @@ void rocsolver_sygvd_hegvd_getMemorySize(const rocblas_eform itype,
     rocsolver_potrf_getMemorySize<BATCHED, STRIDED, T>(n, uplo, batch_count, size_scalars,
                                                        size_work1, size_work2, size_work3, size_work4,
                                                        size_pivots_workArr, size_iinfo, &opt1);
-    *size_iinfo = max(*size_iinfo, sizeof(rocblas_int) * batch_count);
+    *size_iinfo = std::max(*size_iinfo, sizeof(rocblas_int) * batch_count);
 
     // requirements for calling SYGST/HEGST
     rocsolver_sygst_hegst_getMemorySize<BATCHED, STRIDED, T>(uplo, itype, n, batch_count, &unused,
                                                              &temp1, &temp2, &temp3, &temp4, &opt2);
-    *size_work1 = max(*size_work1, temp1);
-    *size_work2 = max(*size_work2, temp2);
-    *size_work3 = max(*size_work3, temp3);
-    *size_work4 = max(*size_work4, temp4);
+    *size_work1 = std::max(*size_work1, temp1);
+    *size_work2 = std::max(*size_work2, temp2);
+    *size_work3 = std::max(*size_work3, temp3);
+    *size_work4 = std::max(*size_work4, temp4);
 
     // requirements for calling SYEV/HEEV
     rocsolver_syevd_heevd_getMemorySize<BATCHED, T, S>(evect, uplo, n, batch_count, &unused, &temp1,
                                                        &temp2, &temp3, size_tmpz, size_splits,
                                                        &temp4, size_tau, &temp5);
-    *size_work1 = max(*size_work1, temp1);
-    *size_work2 = max(*size_work2, temp2);
-    *size_work3 = max(*size_work3, temp3);
-    *size_work4 = max(*size_work4, temp4);
-    *size_pivots_workArr = max(*size_pivots_workArr, temp5);
+    *size_work1 = std::max(*size_work1, temp1);
+    *size_work2 = std::max(*size_work2, temp2);
+    *size_work3 = std::max(*size_work3, temp3);
+    *size_work4 = std::max(*size_work4, temp4);
+    *size_pivots_workArr = std::max(*size_pivots_workArr, temp5);
 
     if(evect == rocblas_evect_original)
     {
@@ -111,10 +111,10 @@ void rocsolver_sygvd_hegvd_getMemorySize(const rocblas_eform itype,
                                               : rocblas_operation_conjugate_transpose);
             rocsolver_trsm_mem<BATCHED, STRIDED, T>(rocblas_side_left, trans, n, n, batch_count,
                                                     &temp1, &temp2, &temp3, &temp4, &opt3);
-            *size_work1 = max(*size_work1, temp1);
-            *size_work2 = max(*size_work2, temp2);
-            *size_work3 = max(*size_work3, temp3);
-            *size_work4 = max(*size_work4, temp4);
+            *size_work1 = std::max(*size_work1, temp1);
+            *size_work2 = std::max(*size_work2, temp2);
+            *size_work3 = std::max(*size_work3, temp3);
+            *size_work4 = std::max(*size_work4, temp4);
         }
     }
 

--- a/library/src/lapack/roclapack_sygvdj_hegvdj.hpp
+++ b/library/src/lapack/roclapack_sygvdj_hegvdj.hpp
@@ -117,25 +117,25 @@ void rocsolver_sygvdj_hegvdj_getMemorySize(const rocblas_eform itype,
     rocsolver_potrf_getMemorySize<BATCHED, STRIDED, T>(n, uplo, batch_count, size_scalars,
                                                        size_work1, size_work2, size_work3,
                                                        size_work4, size_workArr, size_iinfo, &opt1);
-    *size_iinfo = max(*size_iinfo, sizeof(rocblas_int) * batch_count);
+    *size_iinfo = std::max(*size_iinfo, sizeof(rocblas_int) * batch_count);
 
     // requirements for calling SYGST/HEGST
     rocsolver_sygst_hegst_getMemorySize<BATCHED, STRIDED, T>(uplo, itype, n, batch_count, &unused,
                                                              &temp1, &temp2, &temp3, &temp4, &opt2);
-    *size_work1 = max(*size_work1, temp1);
-    *size_work2 = max(*size_work2, temp2);
-    *size_work3 = max(*size_work3, temp3);
-    *size_work4 = max(*size_work4, temp4);
+    *size_work1 = std::max(*size_work1, temp1);
+    *size_work2 = std::max(*size_work2, temp2);
+    *size_work3 = std::max(*size_work3, temp3);
+    *size_work4 = std::max(*size_work4, temp4);
 
     // requirements for calling SYEVDJ/HEEVDJ
     rocsolver_syevdj_heevdj_getMemorySize<BATCHED, T, S>(
         evect, uplo, n, batch_count, &unused, size_workE, size_workTau, size_workVec,
         size_workSplits, &temp1, &temp2, &temp3, &temp4, &temp5);
-    *size_work1 = max(*size_work1, temp1);
-    *size_work2 = max(*size_work2, temp2);
-    *size_work3 = max(*size_work3, temp3);
-    *size_work4 = max(*size_work4, temp4);
-    *size_workArr = max(*size_workArr, temp5);
+    *size_work1 = std::max(*size_work1, temp1);
+    *size_work2 = std::max(*size_work2, temp2);
+    *size_work3 = std::max(*size_work3, temp3);
+    *size_work4 = std::max(*size_work4, temp4);
+    *size_workArr = std::max(*size_workArr, temp5);
 
     if(evect == rocblas_evect_original)
     {
@@ -147,10 +147,10 @@ void rocsolver_sygvdj_hegvdj_getMemorySize(const rocblas_eform itype,
                                               : rocblas_operation_conjugate_transpose);
             rocsolver_trsm_mem<BATCHED, STRIDED, T>(rocblas_side_left, trans, n, n, batch_count,
                                                     &temp1, &temp2, &temp3, &temp4, &opt3);
-            *size_work1 = max(*size_work1, temp1);
-            *size_work2 = max(*size_work2, temp2);
-            *size_work3 = max(*size_work3, temp3);
-            *size_work4 = max(*size_work4, temp4);
+            *size_work1 = std::max(*size_work1, temp1);
+            *size_work2 = std::max(*size_work2, temp2);
+            *size_work3 = std::max(*size_work3, temp3);
+            *size_work4 = std::max(*size_work4, temp4);
         }
     }
 

--- a/library/src/lapack/roclapack_sygvj_hegvj.hpp
+++ b/library/src/lapack/roclapack_sygvj_hegvj.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2021-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -77,24 +77,24 @@ void rocsolver_sygvj_hegvj_getMemorySize(const rocblas_eform itype,
     rocsolver_potrf_getMemorySize<BATCHED, STRIDED, T>(n, uplo, batch_count, size_scalars,
                                                        size_work1, size_work2, size_work3,
                                                        size_work4, size_work5, size_iinfo, &opt1);
-    *size_iinfo = max(*size_iinfo, sizeof(rocblas_int) * batch_count);
+    *size_iinfo = std::max(*size_iinfo, sizeof(rocblas_int) * batch_count);
 
     // requirements for calling SYGST/HEGST
     rocsolver_sygst_hegst_getMemorySize<BATCHED, STRIDED, T>(uplo, itype, n, batch_count, &unused,
                                                              &temp1, &temp2, &temp3, &temp4, &opt2);
-    *size_work1 = max(*size_work1, temp1);
-    *size_work2 = max(*size_work2, temp2);
-    *size_work3 = max(*size_work3, temp3);
-    *size_work4 = max(*size_work4, temp4);
+    *size_work1 = std::max(*size_work1, temp1);
+    *size_work2 = std::max(*size_work2, temp2);
+    *size_work3 = std::max(*size_work3, temp3);
+    *size_work4 = std::max(*size_work4, temp4);
 
     // requirements for calling SYEVJ/HEEVJ
     rocsolver_syevj_heevj_getMemorySize<BATCHED, T, S>(evect, uplo, n, batch_count, &temp1, &temp2,
                                                        &temp3, &temp4, &temp5, size_work6);
-    *size_work1 = max(*size_work1, temp1);
-    *size_work2 = max(*size_work2, temp2);
-    *size_work3 = max(*size_work3, temp3);
-    *size_work4 = max(*size_work4, temp4);
-    *size_work5 = max(*size_work5, temp5);
+    *size_work1 = std::max(*size_work1, temp1);
+    *size_work2 = std::max(*size_work2, temp2);
+    *size_work3 = std::max(*size_work3, temp3);
+    *size_work4 = std::max(*size_work4, temp4);
+    *size_work5 = std::max(*size_work5, temp5);
 
     if(evect == rocblas_evect_original)
     {
@@ -106,10 +106,10 @@ void rocsolver_sygvj_hegvj_getMemorySize(const rocblas_eform itype,
                                               : rocblas_operation_conjugate_transpose);
             rocsolver_trsm_mem<BATCHED, STRIDED, T>(rocblas_side_left, trans, n, n, batch_count,
                                                     &temp1, &temp2, &temp3, &temp4, &opt3);
-            *size_work1 = max(*size_work1, temp1);
-            *size_work2 = max(*size_work2, temp2);
-            *size_work3 = max(*size_work3, temp3);
-            *size_work4 = max(*size_work4, temp4);
+            *size_work1 = std::max(*size_work1, temp1);
+            *size_work2 = std::max(*size_work2, temp2);
+            *size_work3 = std::max(*size_work3, temp3);
+            *size_work4 = std::max(*size_work4, temp4);
         }
         else
         {
@@ -118,7 +118,7 @@ void rocsolver_sygvj_hegvj_getMemorySize(const rocblas_eform itype,
                 temp1 = sizeof(T*) * batch_count;
             else
                 temp1 = 0;
-            *size_work5 = max(*size_work5, temp1);
+            *size_work5 = std::max(*size_work5, temp1);
         }
     }
 

--- a/library/src/lapack/roclapack_sygvx_hegvx.hpp
+++ b/library/src/lapack/roclapack_sygvx_hegvx.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2021-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -165,25 +165,25 @@ void rocsolver_sygvx_hegvx_getMemorySize(const rocblas_eform itype,
     rocsolver_potrf_getMemorySize<BATCHED, STRIDED, T>(n, uplo, batch_count, size_scalars,
                                                        size_work1, size_work2, size_work3, size_work4,
                                                        size_work7_workArr, size_iinfo, &opt1);
-    *size_iinfo = max(*size_iinfo, sizeof(rocblas_int) * batch_count);
+    *size_iinfo = std::max(*size_iinfo, sizeof(rocblas_int) * batch_count);
 
     // requirements for calling SYGST/HEGST
     rocsolver_sygst_hegst_getMemorySize<BATCHED, STRIDED, T>(uplo, itype, n, batch_count, &unused,
                                                              &temp1, &temp2, &temp3, &temp4, &opt2);
-    *size_work1 = max(*size_work1, temp1);
-    *size_work2 = max(*size_work2, temp2);
-    *size_work3 = max(*size_work3, temp3);
-    *size_work4 = max(*size_work4, temp4);
+    *size_work1 = std::max(*size_work1, temp1);
+    *size_work2 = std::max(*size_work2, temp2);
+    *size_work3 = std::max(*size_work3, temp3);
+    *size_work4 = std::max(*size_work4, temp4);
 
     // requirements for calling SYEVX/HEEVX
     rocsolver_syevx_heevx_getMemorySize<BATCHED, T, S>(
         evect, uplo, n, batch_count, &unused, &temp1, &temp2, &temp3, &temp4, size_work5,
         size_work6, size_D, size_E, size_iblock, size_isplit, size_tau, &temp5);
-    *size_work1 = max(*size_work1, temp1);
-    *size_work2 = max(*size_work2, temp2);
-    *size_work3 = max(*size_work3, temp3);
-    *size_work4 = max(*size_work4, temp4);
-    *size_work7_workArr = max(*size_work7_workArr, temp5);
+    *size_work1 = std::max(*size_work1, temp1);
+    *size_work2 = std::max(*size_work2, temp2);
+    *size_work3 = std::max(*size_work3, temp3);
+    *size_work4 = std::max(*size_work4, temp4);
+    *size_work7_workArr = std::max(*size_work7_workArr, temp5);
 
     if(evect == rocblas_evect_original)
     {
@@ -195,10 +195,10 @@ void rocsolver_sygvx_hegvx_getMemorySize(const rocblas_eform itype,
             // requirements for calling TRSM
             rocsolver_trsm_mem<BATCHED, STRIDED, T>(rocblas_side_left, trans, n, n, batch_count,
                                                     &temp1, &temp2, &temp3, &temp4, &opt3);
-            *size_work1 = max(*size_work1, temp1);
-            *size_work2 = max(*size_work2, temp2);
-            *size_work3 = max(*size_work3, temp3);
-            *size_work4 = max(*size_work4, temp4);
+            *size_work1 = std::max(*size_work1, temp1);
+            *size_work2 = std::max(*size_work2, temp2);
+            *size_work3 = std::max(*size_work3, temp3);
+            *size_work4 = std::max(*size_work4, temp4);
         }
     }
 

--- a/library/src/lapack/roclapack_sytd2_hetd2.hpp
+++ b/library/src/lapack/roclapack_sytd2_hetd2.hpp
@@ -260,7 +260,7 @@ rocblas_status rocsolver_sytd2_hetd2_template(rocblas_handle handle,
         {
             // 1. generate Householder reflector to annihilate A(j+2:n-1,j)
             rocsolver_larfg_template<T>(handle, n - 1 - j, A, shiftA + idx2D(j + 1, j, lda), A,
-                                        shiftA + idx2D(min(j + 2, n - 1), j, lda), 1, strideA,
+                                        shiftA + idx2D(std::min(j + 2, n - 1), j, lda), 1, strideA,
                                         tmptau, stridet, batch_count, work, norms);
 
             // 2. copy to E(j) the corresponding off-diagonal element of A, which is set to 1

--- a/library/src/lapack/roclapack_sytd2_hetd2.hpp
+++ b/library/src/lapack/roclapack_sytd2_hetd2.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -201,7 +201,7 @@ rocblas_status rocsolver_sytd2_hetd2_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((n && !A) || (n && !D) || (n && !E) || (n && !tau))
+    if((n && !A) || (n && !D) || (n > 1 && !E) || (n > 1 && !tau))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/lapack/roclapack_sytf2.hpp
+++ b/library/src/lapack/roclapack_sytf2.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -81,7 +81,7 @@ __device__ void sytf2_device_upper(const rocblas_int tid,
         }
         __syncthreads();
 
-        if(max(absakk, colmax) == 0)
+        if(std::max(absakk, colmax) == 0)
         {
             // singularity found
             if(tid == 0 && _info == 0)
@@ -104,7 +104,7 @@ __device__ void sytf2_device_upper(const rocblas_int tid,
                 {
                     iamax<MAX_THDS>(tid, imax, A + imax * lda, 1, sval, sidx);
                     if(tid == 0)
-                        rowmax = max(rowmax, sval[0]);
+                        rowmax = std::max(rowmax, sval[0]);
                 }
                 __syncthreads();
 
@@ -252,7 +252,7 @@ __device__ void sytf2_device_lower(const rocblas_int tid,
         }
         __syncthreads();
 
-        if(max(absakk, colmax) == 0)
+        if(std::max(absakk, colmax) == 0)
         {
             // singularity found
             if(tid == 0 && _info == 0)
@@ -275,7 +275,7 @@ __device__ void sytf2_device_lower(const rocblas_int tid,
                 {
                     iamax<MAX_THDS>(tid, n - imax - 1, A + (imax + 1) + imax * lda, 1, sval, sidx);
                     if(tid == 0)
-                        rowmax = max(rowmax, sval[0]);
+                        rowmax = std::max(rowmax, sval[0]);
                 }
                 __syncthreads();
 

--- a/library/src/lapack/roclapack_sytrd_hetrd.hpp
+++ b/library/src/lapack/roclapack_sytrd_hetrd.hpp
@@ -70,7 +70,7 @@ void rocsolver_sytrd_hetrd_getMemorySize(const rocblas_int n,
     rocsolver_sytd2_hetd2_getMemorySize<BATCHED, T>(n, batch_count, size_scalars, size_work,
                                                     size_norms, &s2, size_workArr);
 
-    *size_tmptau_W = max(s1, s2);
+    *size_tmptau_W = std::max(s1, s2);
 }
 
 template <typename T, typename S, typename U>

--- a/library/src/lapack/roclapack_sytrd_hetrd.hpp
+++ b/library/src/lapack/roclapack_sytrd_hetrd.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -99,7 +99,7 @@ rocblas_status rocsolver_sytrd_hetrd_argCheck(rocblas_handle handle,
         return rocblas_status_continue;
 
     // 3. invalid pointers
-    if((n && !A) || (n && !D) || (n && !E) || (n && !tau))
+    if((n && !A) || (n && !D) || (n > 1 && !E) || (n > 1 && !tau))
         return rocblas_status_invalid_pointer;
 
     return rocblas_status_continue;

--- a/library/src/lapack/roclapack_trtri.hpp
+++ b/library/src/lapack/roclapack_trtri.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -174,8 +174,8 @@ void rocsolver_trtri_getMemorySize(const rocblas_diagonal diag,
     {
         rocblasCall_trsm_mem<BATCHED, T>(rocblas_side_right, rocblas_operation_none, n, blk,
                                          batch_count, &w1b, size_work2, &w3b, size_work4);
-        *size_work1 = max(w1a, w1b);
-        *size_work3 = max(w3a, w3b);
+        *size_work1 = std::max(w1a, w1b);
+        *size_work3 = std::max(w3a, w3b);
 
         // always allocate all required memory for TRSM optimal performance
         *optim_mem = true;
@@ -373,7 +373,7 @@ rocblas_status rocsolver_trtri_template(rocblas_handle handle,
         {
             for(rocblas_int j = 0; j < n; j += blk)
             {
-                jb = min(n - j, blk);
+                jb = std::min(n - j, blk);
 
                 // update current block column
                 rocblasCall_trmm(handle, rocblas_side_left, uplo, rocblas_operation_none, diag, j,
@@ -394,7 +394,7 @@ rocblas_status rocsolver_trtri_template(rocblas_handle handle,
             rocblas_int nn = ((n - 1) / blk) * blk + 1;
             for(rocblas_int j = nn - 1; j >= 0; j -= blk)
             {
-                jb = min(n - j, blk);
+                jb = std::min(n - j, blk);
 
                 // update current block column
                 rocblasCall_trmm(handle, rocblas_side_left, uplo, rocblas_operation_none, diag,

--- a/library/src/refact/rocrefact_csrrf_analysis.hpp
+++ b/library/src/refact/rocrefact_csrrf_analysis.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -65,7 +65,7 @@ rocblas_status rocsolver_csrrf_analysis_argCheck(rocblas_handle handle,
 
     // 3. invalid pointers
     if(!rfinfo || !ptrM || !ptrT || (nnzM && (!indM || !valM)) || (nnzT && (!indT || !valT))
-       || (n * nrhs && !B))
+       || (n && nrhs && !B))
         return rocblas_status_invalid_pointer;
     if(n && ((rfinfo->mode == rocsolver_rfinfo_mode_lu && !pivP) || !pivQ))
         return rocblas_status_invalid_pointer;


### PR DESCRIPTION
The documentation of several functions indicates that some of their argument arrays are size n-1. Within the argument-checking methods, however, we return invalid pointer status if n > 0 and the pointer is null. 

This PR fixes this discrepancy and addresses the error in [SWDEV-445494](https://ontrack-internal.amd.com/browse/SWDEV-445494) 

Also changed min and max to std::min and std::max everywhere in the library code