### PR TITLE
Added larf_64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
 ## (Unreleased) rocSOLVER
 ### Added
 - 64-bit APIs for existing functions:
-    - LARF
+    - LARF_64
 
 ### Optimized
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
 
 ## (Unreleased) rocSOLVER
 ### Added
+- 64-bit APIs for existing functions:
+    - LARF
+
 ### Optimized
 ### Changed
 - Renamed install script arguments of the form *_dir to *-path. Arguments of the form *_dir remain functional for

--- a/clients/common/testing_larf.cpp
+++ b/clients/common/testing_larf.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,4 +29,4 @@
 
 #define TESTING_LARF(...) template void testing_larf<__VA_ARGS__>(Arguments&);
 
-INSTANTIATE(TESTING_LARF, FOREACH_SCALAR_TYPE, APPLY_STAMP)
+INSTANTIATE(TESTING_LARF, FOREACH_BIT_VARIANT, FOREACH_SCALAR_TYPE, APPLY_STAMP)

--- a/clients/gtest/larf_gtest.cpp
+++ b/clients/gtest/larf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -92,7 +92,8 @@ Arguments larf_setup_arguments(larf_tuple tup)
     return arg;
 }
 
-class LARF : public ::TestWithParam<larf_tuple>
+template <bool API64>
+class LARF_BASE : public ::TestWithParam<larf_tuple>
 {
 protected:
     void TearDown() override
@@ -106,10 +107,18 @@ protected:
         Arguments arg = larf_setup_arguments(GetParam());
 
         if(arg.peek<rocblas_int>("m") == 0 && arg.peek<rocblas_int>("incx") == 0)
-            testing_larf_bad_arg<T>();
+            testing_larf_bad_arg<API64, T>();
 
-        testing_larf<T>(arg);
+        testing_larf<API64, T>(arg);
     }
+};
+
+class LARF : public LARF_BASE<false>
+{
+};
+
+class LARF_64 : public LARF_BASE<true>
+{
 };
 
 // non-batch tests
@@ -134,10 +143,38 @@ TEST_P(LARF, __double_complex)
     run_tests<rocblas_double_complex>();
 }
 
+TEST_P(LARF_64, __float)
+{
+    run_tests<float>();
+}
+
+TEST_P(LARF_64, __double)
+{
+    run_tests<double>();
+}
+
+TEST_P(LARF_64, __float_complex)
+{
+    run_tests<rocblas_float_complex>();
+}
+
+TEST_P(LARF_64, __double_complex)
+{
+    run_tests<rocblas_double_complex>();
+}
+
 INSTANTIATE_TEST_SUITE_P(daily_lapack,
                          LARF,
                          Combine(ValuesIn(large_matrix_size_range), ValuesIn(incx_range)));
 
 INSTANTIATE_TEST_SUITE_P(checkin_lapack,
                          LARF,
+                         Combine(ValuesIn(matrix_size_range), ValuesIn(incx_range)));
+
+INSTANTIATE_TEST_SUITE_P(daily_lapack,
+                         LARF_64,
+                         Combine(ValuesIn(large_matrix_size_range), ValuesIn(incx_range)));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+                         LARF_64,
                          Combine(ValuesIn(matrix_size_range), ValuesIn(incx_range)));

--- a/clients/include/client_util.hpp
+++ b/clients/include/client_util.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -53,6 +53,9 @@
    wants to add. By calling the next function twice, it can double the number of times the stamp
    is instantiated. By appending different values in each call to the next function, it can
    instantiate the stamp with multiple different values. */
+#define FOREACH_BIT_VARIANT(STAMP, F, ...) \
+    F(STAMP, ##__VA_ARGS__, false)         \
+    F(STAMP, ##__VA_ARGS__, true)
 #define FOREACH_BLOCKED_VARIANT(STAMP, F, ...) \
     F(STAMP, ##__VA_ARGS__, false)             \
     F(STAMP, ##__VA_ARGS__, true)

--- a/clients/include/rocsolver.hpp
+++ b/clients/include/rocsolver.hpp
@@ -946,7 +946,8 @@ inline rocblas_status rocsolver_larfg(rocblas_handle handle,
 /*****************************************************/
 
 /******************** LARF ********************/
-inline rocblas_status rocsolver_larf(rocblas_handle handle,
+inline rocblas_status rocsolver_larf(bool API64,
+                                     rocblas_handle handle,
                                      rocblas_side side,
                                      rocblas_int m,
                                      rocblas_int n,
@@ -956,10 +957,14 @@ inline rocblas_status rocsolver_larf(rocblas_handle handle,
                                      float* A,
                                      rocblas_int lda)
 {
-    return rocsolver_slarf(handle, side, m, n, x, incx, alpha, A, lda);
+    if(!API64)
+        return rocsolver_slarf(handle, side, m, n, x, incx, alpha, A, lda);
+    else
+        return rocsolver_slarf_64(handle, side, m, n, x, incx, alpha, A, lda);
 }
 
-inline rocblas_status rocsolver_larf(rocblas_handle handle,
+inline rocblas_status rocsolver_larf(bool API64,
+                                     rocblas_handle handle,
                                      rocblas_side side,
                                      rocblas_int m,
                                      rocblas_int n,
@@ -969,10 +974,14 @@ inline rocblas_status rocsolver_larf(rocblas_handle handle,
                                      double* A,
                                      rocblas_int lda)
 {
-    return rocsolver_dlarf(handle, side, m, n, x, incx, alpha, A, lda);
+    if(!API64)
+        return rocsolver_dlarf(handle, side, m, n, x, incx, alpha, A, lda);
+    else
+        return rocsolver_dlarf_64(handle, side, m, n, x, incx, alpha, A, lda);
 }
 
-inline rocblas_status rocsolver_larf(rocblas_handle handle,
+inline rocblas_status rocsolver_larf(bool API64,
+                                     rocblas_handle handle,
                                      rocblas_side side,
                                      rocblas_int m,
                                      rocblas_int n,
@@ -982,10 +991,14 @@ inline rocblas_status rocsolver_larf(rocblas_handle handle,
                                      rocblas_float_complex* A,
                                      rocblas_int lda)
 {
-    return rocsolver_clarf(handle, side, m, n, x, incx, alpha, A, lda);
+    if(!API64)
+        return rocsolver_clarf(handle, side, m, n, x, incx, alpha, A, lda);
+    else
+        return rocsolver_clarf_64(handle, side, m, n, x, incx, alpha, A, lda);
 }
 
-inline rocblas_status rocsolver_larf(rocblas_handle handle,
+inline rocblas_status rocsolver_larf(bool API64,
+                                     rocblas_handle handle,
                                      rocblas_side side,
                                      rocblas_int m,
                                      rocblas_int n,
@@ -995,7 +1008,10 @@ inline rocblas_status rocsolver_larf(rocblas_handle handle,
                                      rocblas_double_complex* A,
                                      rocblas_int lda)
 {
-    return rocsolver_zlarf(handle, side, m, n, x, incx, alpha, A, lda);
+    if(!API64)
+        return rocsolver_zlarf(handle, side, m, n, x, incx, alpha, A, lda);
+    else
+        return rocsolver_zlarf_64(handle, side, m, n, x, incx, alpha, A, lda);
 }
 /*****************************************************/
 

--- a/clients/include/rocsolver_dispatcher.hpp
+++ b/clients/include/rocsolver_dispatcher.hpp
@@ -125,7 +125,8 @@ class rocsolver_dispatcher
         static const func_map map = {
             {"laswp", testing_laswp<T>},
             {"larfg", testing_larfg<T>},
-            {"larf", testing_larf<T>},
+            {"larf", testing_larf<false, T>},
+            {"larf_64", testing_larf<true, T>},
             {"larft", testing_larft<T>},
             {"larfb", testing_larfb<T>},
             {"latrd", testing_latrd<T>},

--- a/docs/reference/auxiliary.rst
+++ b/docs/reference/auxiliary.rst
@@ -24,13 +24,13 @@ The auxiliary functions are divided into the following categories:
 
     * i, j, and k are used as general purpose indices. In some legacy LAPACK APIs, k could be
       a parameter indicating some problem/matrix dimension.
-    * Depending on the context, when it is necessary to index rows, columns and blocks or submatrices, 
-      i is assigned to rows, j to columns and k to blocks. l is always used to index 
-      matrices/problems in a batch. 
+    * Depending on the context, when it is necessary to index rows, columns and blocks or submatrices,
+      i is assigned to rows, j to columns and k to blocks. l is always used to index
+      matrices/problems in a batch.
     * x[i] stands for the i-th element of vector x, while A[i,j] represents the element
       in the i-th row and j-th column of matrix A. Indices are 1-based, i.e. x[1] is the first
       element of x.
-    * To identify a block in a matrix or a matrix in the batch, k and l are used as sub-indices 
+    * To identify a block in a matrix or a matrix in the batch, k and l are used as sub-indices
     * x_i :math:`=x_i`; we sometimes use both notations, :math:`x_i` when displaying mathematical
       equations, and x_i in the text describing the function parameters.
     * If X is a real vector or matrix, :math:`X^T` indicates its transpose; if X is complex, then
@@ -121,6 +121,14 @@ rocsolver_<type>larft()
 
 rocsolver_<type>larf()
 ---------------------------------------
+.. doxygenfunction:: rocsolver_zlarf_64
+   :outline:
+.. doxygenfunction:: rocsolver_clarf_64
+   :outline:
+.. doxygenfunction:: rocsolver_dlarf_64
+   :outline:
+.. doxygenfunction:: rocsolver_slarf_64
+   :outline:
 .. doxygenfunction:: rocsolver_zlarf
    :outline:
 .. doxygenfunction:: rocsolver_clarf

--- a/library/include/rocsolver/rocsolver-functions.h
+++ b/library/include/rocsolver/rocsolver-functions.h
@@ -537,6 +537,46 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zlarf(rocblas_handle handle,
                                                 const rocblas_double_complex* alpha,
                                                 rocblas_double_complex* A,
                                                 const rocblas_int lda);
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_slarf_64(rocblas_handle handle,
+                                                   const rocblas_side side,
+                                                   const int64_t m,
+                                                   const int64_t n,
+                                                   float* x,
+                                                   const int64_t incx,
+                                                   const float* alpha,
+                                                   float* A,
+                                                   const int64_t lda);
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_dlarf_64(rocblas_handle handle,
+                                                   const rocblas_side side,
+                                                   const int64_t m,
+                                                   const int64_t n,
+                                                   double* x,
+                                                   const int64_t incx,
+                                                   const double* alpha,
+                                                   double* A,
+                                                   const int64_t lda);
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_clarf_64(rocblas_handle handle,
+                                                   const rocblas_side side,
+                                                   const int64_t m,
+                                                   const int64_t n,
+                                                   rocblas_float_complex* x,
+                                                   const int64_t incx,
+                                                   const rocblas_float_complex* alpha,
+                                                   rocblas_float_complex* A,
+                                                   const int64_t lda);
+
+ROCSOLVER_EXPORT rocblas_status rocsolver_zlarf_64(rocblas_handle handle,
+                                                   const rocblas_side side,
+                                                   const int64_t m,
+                                                   const int64_t n,
+                                                   rocblas_double_complex* x,
+                                                   const int64_t incx,
+                                                   const rocblas_double_complex* alpha,
+                                                   rocblas_double_complex* A,
+                                                   const int64_t lda);
 //! @}
 
 /*! @{

--- a/library/src/auxiliary/rocauxiliary_labrd.hpp
+++ b/library/src/auxiliary/rocauxiliary_labrd.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     June 2017
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -167,20 +167,20 @@ rocblas_status rocsolver_labrd_template(rocblas_handle handle,
                 rocsolver_lacgv_template<T>(handle, j, Y, shiftY + idx2D(j, 0, ldy), ldy, strideY,
                                             batch_count);
 
-            rocblasCall_gemv<T>(handle, rocblas_operation_none, m - j, j,
-                                cast2constType<T>(scalars), 0, A, shiftA + idx2D(j, 0, lda), lda,
-                                strideA, Y, shiftY + idx2D(j, 0, ldy), ldy, strideY,
-                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j, lda), 1,
-                                strideA, batch_count, (T**)work_workArr);
+            rocblasCall_gemv<T, rocblas_int>(
+                handle, rocblas_operation_none, m - j, j, cast2constType<T>(scalars), 0, A,
+                shiftA + idx2D(j, 0, lda), lda, strideA, Y, shiftY + idx2D(j, 0, ldy), ldy, strideY,
+                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j, lda), 1, strideA,
+                batch_count, (T**)work_workArr);
 
             if(COMPLEX)
                 rocsolver_lacgv_template<T>(handle, j, Y, shiftY + idx2D(j, 0, ldy), ldy, strideY,
                                             batch_count);
-            rocblasCall_gemv<T>(handle, rocblas_operation_none, m - j, j,
-                                cast2constType<T>(scalars), 0, X, shiftX + idx2D(j, 0, lda), ldx,
-                                strideX, A, shiftA + idx2D(0, j, lda), 1, strideA,
-                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j, lda), 1,
-                                strideA, batch_count, (T**)work_workArr);
+            rocblasCall_gemv<T, rocblas_int>(
+                handle, rocblas_operation_none, m - j, j, cast2constType<T>(scalars), 0, X,
+                shiftX + idx2D(j, 0, lda), ldx, strideX, A, shiftA + idx2D(0, j, lda), 1, strideA,
+                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j, lda), 1, strideA,
+                batch_count, (T**)work_workArr);
 
             // generate Householder reflector to work on column j
             rocsolver_larfg_template(handle,
@@ -198,27 +198,27 @@ rocblas_status rocsolver_labrd_template(rocblas_handle handle,
             if(j < n - 1)
             {
                 // compute column j of Y
-                rocblasCall_gemv<T>(
+                rocblasCall_gemv<T, rocblas_int>(
                     handle, rocblas_operation_conjugate_transpose, m - j, n - j - 1,
                     cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j + 1, lda), lda, strideA,
                     A, shiftA + idx2D(j, j, lda), 1, strideA, cast2constType<T>(scalars + 1), 0, Y,
                     shiftY + idx2D(j + 1, j, ldy), 1, strideY, batch_count, (T**)work_workArr);
-                rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, m - j, j,
-                                    cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, 0, lda),
-                                    lda, strideA, A, shiftA + idx2D(j, j, lda), 1, strideA,
-                                    cast2constType<T>(scalars + 1), 0, Y, shiftY + idx2D(0, j, ldy),
-                                    1, strideY, batch_count, (T**)work_workArr);
-                rocblasCall_gemv<T>(
+                rocblasCall_gemv<T, rocblas_int>(
+                    handle, rocblas_operation_conjugate_transpose, m - j, j,
+                    cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, 0, lda), lda, strideA,
+                    A, shiftA + idx2D(j, j, lda), 1, strideA, cast2constType<T>(scalars + 1), 0, Y,
+                    shiftY + idx2D(0, j, ldy), 1, strideY, batch_count, (T**)work_workArr);
+                rocblasCall_gemv<T, rocblas_int>(
                     handle, rocblas_operation_none, n - j - 1, j, cast2constType<T>(scalars), 0, Y,
                     shiftY + idx2D(j + 1, 0, ldy), ldy, strideY, Y, shiftY + idx2D(0, j, ldy), 1,
                     strideY, cast2constType<T>(scalars + 2), 0, Y, shiftY + idx2D(j + 1, j, ldy), 1,
                     strideY, batch_count, (T**)work_workArr);
-                rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, m - j, j,
-                                    cast2constType<T>(scalars + 2), 0, X, shiftX + idx2D(j, 0, ldx),
-                                    ldx, strideX, A, shiftA + idx2D(j, j, lda), 1, strideA,
-                                    cast2constType<T>(scalars + 1), 0, Y, shiftY + idx2D(0, j, ldy),
-                                    1, strideY, batch_count, (T**)work_workArr);
-                rocblasCall_gemv<T>(
+                rocblasCall_gemv<T, rocblas_int>(
+                    handle, rocblas_operation_conjugate_transpose, m - j, j,
+                    cast2constType<T>(scalars + 2), 0, X, shiftX + idx2D(j, 0, ldx), ldx, strideX,
+                    A, shiftA + idx2D(j, j, lda), 1, strideA, cast2constType<T>(scalars + 1), 0, Y,
+                    shiftY + idx2D(0, j, ldy), 1, strideY, batch_count, (T**)work_workArr);
+                rocblasCall_gemv<T, rocblas_int>(
                     handle, rocblas_operation_conjugate_transpose, j, n - j - 1,
                     cast2constType<T>(scalars), 0, A, shiftA + idx2D(0, j + 1, lda), lda, strideA,
                     Y, shiftY + idx2D(0, j, ldy), 1, strideY, cast2constType<T>(scalars + 2), 0, Y,
@@ -230,7 +230,7 @@ rocblas_status rocsolver_labrd_template(rocblas_handle handle,
                 if(COMPLEX)
                     rocsolver_lacgv_template<T>(handle, n, A, shiftA + idx2D(j, 0, lda), lda,
                                                 strideA, batch_count);
-                rocblasCall_gemv<T>(
+                rocblasCall_gemv<T, rocblas_int>(
                     handle, rocblas_operation_none, n - j - 1, j + 1, cast2constType<T>(scalars), 0,
                     Y, shiftY + idx2D(j + 1, 0, ldy), ldy, strideY, A, shiftA + idx2D(j, 0, lda),
                     lda, strideA, cast2constType<T>(scalars + 2), 0, A,
@@ -244,7 +244,7 @@ rocblas_status rocsolver_labrd_template(rocblas_handle handle,
                                                 strideX, batch_count);
                 }
 
-                rocblasCall_gemv<T>(
+                rocblasCall_gemv<T, rocblas_int>(
                     handle, rocblas_operation_conjugate_transpose, j, n - j - 1,
                     cast2constType<T>(scalars), 0, A, shiftA + idx2D(0, j + 1, lda), lda, strideA,
                     X, shiftX + idx2D(j, 0, ldx), ldx, strideX, cast2constType<T>(scalars + 2), 0,
@@ -269,29 +269,28 @@ rocblas_status rocsolver_labrd_template(rocblas_handle handle,
                                         lda, strideA, 1, true);
 
                 // compute column j of X
-                rocblasCall_gemv<T>(
+                rocblasCall_gemv<T, rocblas_int>(
                     handle, rocblas_operation_none, m - j - 1, n - j - 1,
                     cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j + 1, j + 1, lda), lda,
                     strideA, A, shiftA + idx2D(j, j + 1, lda), lda, strideA,
                     cast2constType<T>(scalars + 1), 0, X, shiftX + idx2D(j + 1, j, ldx), 1, strideX,
                     batch_count, (T**)work_workArr);
-                rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, n - j - 1, j + 1,
-                                    cast2constType<T>(scalars + 2), 0, Y,
-                                    shiftY + idx2D(j + 1, 0, ldy), ldy, strideY, A,
-                                    shiftA + idx2D(j, j + 1, lda), lda, strideA,
-                                    cast2constType<T>(scalars + 1), 0, X, shiftX + idx2D(0, j, ldx),
-                                    1, strideX, batch_count, (T**)work_workArr);
-                rocblasCall_gemv<T>(
+                rocblasCall_gemv<T, rocblas_int>(
+                    handle, rocblas_operation_conjugate_transpose, n - j - 1, j + 1,
+                    cast2constType<T>(scalars + 2), 0, Y, shiftY + idx2D(j + 1, 0, ldy), ldy, strideY,
+                    A, shiftA + idx2D(j, j + 1, lda), lda, strideA, cast2constType<T>(scalars + 1),
+                    0, X, shiftX + idx2D(0, j, ldx), 1, strideX, batch_count, (T**)work_workArr);
+                rocblasCall_gemv<T, rocblas_int>(
                     handle, rocblas_operation_none, m - j - 1, j + 1, cast2constType<T>(scalars), 0,
                     A, shiftA + idx2D(j + 1, 0, lda), lda, strideA, X, shiftX + idx2D(0, j, ldx), 1,
                     strideX, cast2constType<T>(scalars + 2), 0, X, shiftX + idx2D(j + 1, j, ldx), 1,
                     strideX, batch_count, (T**)work_workArr);
-                rocblasCall_gemv<T>(
+                rocblasCall_gemv<T, rocblas_int>(
                     handle, rocblas_operation_none, j, n - j - 1, cast2constType<T>(scalars + 2), 0,
                     A, shiftA + idx2D(0, j + 1, lda), lda, strideA, A,
                     shiftA + idx2D(j, j + 1, lda), lda, strideA, cast2constType<T>(scalars + 1), 0,
                     X, shiftX + idx2D(0, j, ldx), 1, strideX, batch_count, (T**)work_workArr);
-                rocblasCall_gemv<T>(
+                rocblasCall_gemv<T, rocblas_int>(
                     handle, rocblas_operation_none, m - j - 1, j, cast2constType<T>(scalars), 0, X,
                     shiftX + idx2D(j + 1, 0, ldx), ldx, strideX, X, shiftX + idx2D(0, j, ldx), 1,
                     strideX, cast2constType<T>(scalars + 2), 0, X, shiftX + idx2D(j + 1, j, ldx), 1,
@@ -316,11 +315,11 @@ rocblas_status rocsolver_labrd_template(rocblas_handle handle,
                 rocsolver_lacgv_template<T>(handle, n, A, shiftA + idx2D(j, 0, lda), lda, strideA,
                                             batch_count);
 
-            rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j, j,
-                                cast2constType<T>(scalars), 0, Y, shiftY + idx2D(j, 0, ldy), ldy,
-                                strideY, A, shiftA + idx2D(j, 0, lda), lda, strideA,
-                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j, lda),
-                                lda, strideA, batch_count, (T**)work_workArr);
+            rocblasCall_gemv<T, rocblas_int>(
+                handle, rocblas_operation_none, n - j, j, cast2constType<T>(scalars), 0, Y,
+                shiftY + idx2D(j, 0, ldy), ldy, strideY, A, shiftA + idx2D(j, 0, lda), lda, strideA,
+                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j, lda), lda, strideA,
+                batch_count, (T**)work_workArr);
 
             if(COMPLEX)
             {
@@ -329,11 +328,11 @@ rocblas_status rocsolver_labrd_template(rocblas_handle handle,
                 rocsolver_lacgv_template<T>(handle, j, X, shiftX + idx2D(j, 0, ldx), ldx, strideX,
                                             batch_count);
             }
-            rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, j, n - j,
-                                cast2constType<T>(scalars), 0, A, shiftA + idx2D(0, j, lda), lda,
-                                strideA, X, shiftX + idx2D(j, 0, ldx), ldx, strideX,
-                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j, lda),
-                                lda, strideA, batch_count, (T**)work_workArr);
+            rocblasCall_gemv<T, rocblas_int>(
+                handle, rocblas_operation_conjugate_transpose, j, n - j, cast2constType<T>(scalars),
+                0, A, shiftA + idx2D(0, j, lda), lda, strideA, X, shiftX + idx2D(j, 0, ldx), ldx,
+                strideX, cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j, lda), lda,
+                strideA, batch_count, (T**)work_workArr);
 
             if(COMPLEX)
                 rocsolver_lacgv_template<T>(handle, j, X, shiftX + idx2D(j, 0, ldx), ldx, strideX,
@@ -355,27 +354,27 @@ rocblas_status rocsolver_labrd_template(rocblas_handle handle,
             if(j < m - 1)
             {
                 // compute column j of X
-                rocblasCall_gemv<T>(
+                rocblasCall_gemv<T, rocblas_int>(
                     handle, rocblas_operation_none, m - j - 1, n - j, cast2constType<T>(scalars + 2),
                     0, A, shiftA + idx2D(j + 1, j, lda), lda, strideA, A, shiftA + idx2D(j, j, lda),
                     lda, strideA, cast2constType<T>(scalars + 1), 0, X,
                     shiftX + idx2D(j + 1, j, ldx), 1, strideX, batch_count, (T**)work_workArr);
-                rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, n - j, j,
-                                    cast2constType<T>(scalars + 2), 0, Y, shiftY + idx2D(j, 0, ldy),
-                                    ldy, strideY, A, shiftA + idx2D(j, j, lda), lda, strideA,
-                                    cast2constType<T>(scalars + 1), 0, X, shiftX + idx2D(0, j, ldx),
-                                    1, strideX, batch_count, (T**)work_workArr);
-                rocblasCall_gemv<T>(
+                rocblasCall_gemv<T, rocblas_int>(
+                    handle, rocblas_operation_conjugate_transpose, n - j, j,
+                    cast2constType<T>(scalars + 2), 0, Y, shiftY + idx2D(j, 0, ldy), ldy, strideY,
+                    A, shiftA + idx2D(j, j, lda), lda, strideA, cast2constType<T>(scalars + 1), 0,
+                    X, shiftX + idx2D(0, j, ldx), 1, strideX, batch_count, (T**)work_workArr);
+                rocblasCall_gemv<T, rocblas_int>(
                     handle, rocblas_operation_none, m - j - 1, j, cast2constType<T>(scalars), 0, A,
                     shiftA + idx2D(j + 1, 0, lda), lda, strideA, X, shiftX + idx2D(0, j, ldx), 1,
                     strideX, cast2constType<T>(scalars + 2), 0, X, shiftX + idx2D(j + 1, j, ldx), 1,
                     strideX, batch_count, (T**)work_workArr);
-                rocblasCall_gemv<T>(handle, rocblas_operation_none, j, n - j,
-                                    cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(0, j, lda),
-                                    lda, strideA, A, shiftA + idx2D(j, j, lda), lda, strideA,
-                                    cast2constType<T>(scalars + 1), 0, X, shiftX + idx2D(0, j, ldx),
-                                    1, strideX, batch_count, (T**)work_workArr);
-                rocblasCall_gemv<T>(
+                rocblasCall_gemv<T, rocblas_int>(
+                    handle, rocblas_operation_none, j, n - j, cast2constType<T>(scalars + 2), 0, A,
+                    shiftA + idx2D(0, j, lda), lda, strideA, A, shiftA + idx2D(j, j, lda), lda,
+                    strideA, cast2constType<T>(scalars + 1), 0, X, shiftX + idx2D(0, j, ldx), 1,
+                    strideX, batch_count, (T**)work_workArr);
+                rocblasCall_gemv<T, rocblas_int>(
                     handle, rocblas_operation_none, m - j - 1, j, cast2constType<T>(scalars), 0, X,
                     shiftX + idx2D(j + 1, 0, ldx), ldx, strideX, X, shiftX + idx2D(0, j, ldx), 1,
                     strideX, cast2constType<T>(scalars + 2), 0, X, shiftX + idx2D(j + 1, j, ldx), 1,
@@ -392,7 +391,7 @@ rocblas_status rocsolver_labrd_template(rocblas_handle handle,
                                                 strideY, batch_count);
                 }
 
-                rocblasCall_gemv<T>(
+                rocblasCall_gemv<T, rocblas_int>(
                     handle, rocblas_operation_none, m - j - 1, j, cast2constType<T>(scalars), 0, A,
                     shiftA + idx2D(j + 1, 0, lda), lda, strideA, Y, shiftY + idx2D(j, 0, ldy), ldy,
                     strideY, cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j + 1, j, lda), 1,
@@ -402,7 +401,7 @@ rocblas_status rocsolver_labrd_template(rocblas_handle handle,
                     rocsolver_lacgv_template<T>(handle, j, Y, shiftY + idx2D(j, 0, ldy), ldy,
                                                 strideY, batch_count);
 
-                rocblasCall_gemv<T>(
+                rocblasCall_gemv<T, rocblas_int>(
                     handle, rocblas_operation_none, m - j - 1, j + 1, cast2constType<T>(scalars), 0,
                     X, shiftX + idx2D(j + 1, 0, lda), ldx, strideX, A, shiftA + idx2D(0, j, lda), 1,
                     strideA, cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j + 1, j, lda), 1,
@@ -423,30 +422,28 @@ rocblas_status rocsolver_labrd_template(rocblas_handle handle,
                                         lda, strideA, 1, true);
 
                 // compute column j of Y
-                rocblasCall_gemv<T>(
+                rocblasCall_gemv<T, rocblas_int>(
                     handle, rocblas_operation_conjugate_transpose, m - j - 1, n - j - 1,
                     cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j + 1, j + 1, lda), lda,
                     strideA, A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
                     cast2constType<T>(scalars + 1), 0, Y, shiftY + idx2D(j + 1, j, ldy), 1, strideY,
                     batch_count, (T**)work_workArr);
-                rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, m - j - 1, j,
-                                    cast2constType<T>(scalars + 2), 0, A,
-                                    shiftA + idx2D(j + 1, 0, lda), lda, strideA, A,
-                                    shiftA + idx2D(j + 1, j, lda), 1, strideA,
-                                    cast2constType<T>(scalars + 1), 0, Y, shiftY + idx2D(0, j, ldy),
-                                    1, strideY, batch_count, (T**)work_workArr);
-                rocblasCall_gemv<T>(
+                rocblasCall_gemv<T, rocblas_int>(
+                    handle, rocblas_operation_conjugate_transpose, m - j - 1, j,
+                    cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j + 1, 0, lda), lda, strideA,
+                    A, shiftA + idx2D(j + 1, j, lda), 1, strideA, cast2constType<T>(scalars + 1), 0,
+                    Y, shiftY + idx2D(0, j, ldy), 1, strideY, batch_count, (T**)work_workArr);
+                rocblasCall_gemv<T, rocblas_int>(
                     handle, rocblas_operation_none, n - j - 1, j, cast2constType<T>(scalars), 0, Y,
                     shiftY + idx2D(j + 1, 0, ldy), ldy, strideY, Y, shiftY + idx2D(0, j, ldy), 1,
                     strideY, cast2constType<T>(scalars + 2), 0, Y, shiftY + idx2D(j + 1, j, ldy), 1,
                     strideY, batch_count, (T**)work_workArr);
-                rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, m - j - 1, j + 1,
-                                    cast2constType<T>(scalars + 2), 0, X,
-                                    shiftX + idx2D(j + 1, 0, ldx), ldx, strideX, A,
-                                    shiftA + idx2D(j + 1, j, lda), 1, strideA,
-                                    cast2constType<T>(scalars + 1), 0, Y, shiftY + idx2D(0, j, ldy),
-                                    1, strideY, batch_count, (T**)work_workArr);
-                rocblasCall_gemv<T>(
+                rocblasCall_gemv<T, rocblas_int>(
+                    handle, rocblas_operation_conjugate_transpose, m - j - 1, j + 1,
+                    cast2constType<T>(scalars + 2), 0, X, shiftX + idx2D(j + 1, 0, ldx), ldx, strideX,
+                    A, shiftA + idx2D(j + 1, j, lda), 1, strideA, cast2constType<T>(scalars + 1), 0,
+                    Y, shiftY + idx2D(0, j, ldy), 1, strideY, batch_count, (T**)work_workArr);
+                rocblasCall_gemv<T, rocblas_int>(
                     handle, rocblas_operation_conjugate_transpose, j + 1, n - j - 1,
                     cast2constType<T>(scalars), 0, A, shiftA + idx2D(0, j + 1, lda), lda, strideA,
                     Y, shiftY + idx2D(0, j, ldy), 1, strideY, cast2constType<T>(scalars + 2), 0, Y,

--- a/library/src/auxiliary/rocauxiliary_larf.cpp
+++ b/library/src/auxiliary/rocauxiliary_larf.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,16 +27,16 @@
 
 #include "rocauxiliary_larf.hpp"
 
-template <typename T>
+template <typename T, typename I>
 rocblas_status rocsolver_larf_impl(rocblas_handle handle,
                                    const rocblas_side side,
-                                   const rocblas_int m,
-                                   const rocblas_int n,
+                                   const I m,
+                                   const I n,
                                    T* x,
-                                   const rocblas_int incx,
+                                   const I incx,
                                    const T* alpha,
                                    T* A,
-                                   const rocblas_int lda)
+                                   const I lda)
 {
     ROCSOLVER_ENTER_TOP("larf", "--side", side, "-m", m, "-n", n, "--incx", incx, "--lda", lda);
 
@@ -49,14 +49,14 @@ rocblas_status rocsolver_larf_impl(rocblas_handle handle,
         return st;
 
     // working with unshifted arrays
-    rocblas_int shiftA = 0;
-    rocblas_int shiftx = 0;
+    rocblas_stride shiftA = 0;
+    rocblas_stride shiftx = 0;
 
     // normal (non-batched non-strided) execution
     rocblas_stride stridex = 0;
     rocblas_stride stridea = 0;
     rocblas_stride stridep = 0;
-    rocblas_int batch_count = 1;
+    I batch_count = 1;
 
     // memory workspace sizes:
     // size for constants in rocblas calls
@@ -145,6 +145,58 @@ rocblas_status rocsolver_zlarf(rocblas_handle handle,
                                const rocblas_double_complex* alpha,
                                rocblas_double_complex* A,
                                const rocblas_int lda)
+{
+    return rocsolver_larf_impl<rocblas_double_complex>(handle, side, m, n, x, incx, alpha, A, lda);
+}
+
+rocblas_status rocsolver_slarf_64(rocblas_handle handle,
+                                  const rocblas_side side,
+                                  const int64_t m,
+                                  const int64_t n,
+                                  float* x,
+                                  const int64_t incx,
+                                  const float* alpha,
+                                  float* A,
+                                  const int64_t lda)
+{
+    return rocsolver_larf_impl<float>(handle, side, m, n, x, incx, alpha, A, lda);
+}
+
+rocblas_status rocsolver_dlarf_64(rocblas_handle handle,
+                                  const rocblas_side side,
+                                  const int64_t m,
+                                  const int64_t n,
+                                  double* x,
+                                  const int64_t incx,
+                                  const double* alpha,
+                                  double* A,
+                                  const int64_t lda)
+{
+    return rocsolver_larf_impl<double>(handle, side, m, n, x, incx, alpha, A, lda);
+}
+
+rocblas_status rocsolver_clarf_64(rocblas_handle handle,
+                                  const rocblas_side side,
+                                  const int64_t m,
+                                  const int64_t n,
+                                  rocblas_float_complex* x,
+                                  const int64_t incx,
+                                  const rocblas_float_complex* alpha,
+                                  rocblas_float_complex* A,
+                                  const int64_t lda)
+{
+    return rocsolver_larf_impl<rocblas_float_complex>(handle, side, m, n, x, incx, alpha, A, lda);
+}
+
+rocblas_status rocsolver_zlarf_64(rocblas_handle handle,
+                                  const rocblas_side side,
+                                  const int64_t m,
+                                  const int64_t n,
+                                  rocblas_double_complex* x,
+                                  const int64_t incx,
+                                  const rocblas_double_complex* alpha,
+                                  rocblas_double_complex* A,
+                                  const int64_t lda)
 {
     return rocsolver_larf_impl<rocblas_double_complex>(handle, side, m, n, x, incx, alpha, A, lda);
 }

--- a/library/src/auxiliary/rocauxiliary_larf.hpp
+++ b/library/src/auxiliary/rocauxiliary_larf.hpp
@@ -35,11 +35,11 @@
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
 
-template <bool BATCHED, typename T>
+template <bool BATCHED, typename T, typename I>
 void rocsolver_larf_getMemorySize(const rocblas_side side,
-                                  const rocblas_int m,
-                                  const rocblas_int n,
-                                  const rocblas_int batch_count,
+                                  const I m,
+                                  const I n,
+                                  const I batch_count,
                                   size_t* size_scalars,
                                   size_t* size_Abyx,
                                   size_t* size_workArr)
@@ -72,13 +72,13 @@ void rocsolver_larf_getMemorySize(const rocblas_side side,
         *size_workArr = 0;
 }
 
-template <typename T, typename U>
+template <typename T, typename I, typename U>
 rocblas_status rocsolver_larf_argCheck(rocblas_handle handle,
                                        const rocblas_side side,
-                                       const rocblas_int m,
-                                       const rocblas_int n,
-                                       const rocblas_int lda,
-                                       const rocblas_int incx,
+                                       const I m,
+                                       const I n,
+                                       const I lda,
+                                       const I incx,
                                        T x,
                                        T A,
                                        U alpha)
@@ -105,22 +105,22 @@ rocblas_status rocsolver_larf_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
+template <typename T, typename I, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_larf_template(rocblas_handle handle,
                                        const rocblas_side side,
-                                       const rocblas_int m,
-                                       const rocblas_int n,
+                                       const I m,
+                                       const I n,
                                        U x,
-                                       const rocblas_int shiftx,
-                                       const rocblas_int incx,
+                                       const rocblas_stride shiftx,
+                                       const I incx,
                                        const rocblas_stride stridex,
                                        const T* alpha,
                                        const rocblas_stride stridep,
                                        U A,
-                                       const rocblas_int shiftA,
-                                       const rocblas_int lda,
+                                       const rocblas_stride shiftA,
+                                       const I lda,
                                        const rocblas_stride stridea,
-                                       const rocblas_int batch_count,
+                                       const I batch_count,
                                        T* scalars,
                                        T* Abyx,
                                        T** workArr)
@@ -142,7 +142,7 @@ rocblas_status rocsolver_larf_template(rocblas_handle handle,
 
     // determine side and order of H
     bool leftside = (side == rocblas_side_left);
-    rocblas_int order = m;
+    I order = m;
     rocblas_operation trans = rocblas_operation_none;
     if(leftside)
     {
@@ -156,20 +156,20 @@ rocblas_status rocsolver_larf_template(rocblas_handle handle,
     //      ZERO ENTRIES ****
 
     // compute the matrix vector product  (W=-A'*X or W=-A*X)
-    rocblasCall_gemv<T, rocblas_int>(
-        handle, trans, m, n, cast2constType<T>(scalars), 0, A, shiftA, lda, stridea, x, shiftx,
-        incx, stridex, cast2constType<T>(scalars + 1), 0, Abyx, 0, 1, order, batch_count, workArr);
+    rocblasCall_gemv<T, I>(handle, trans, m, n, cast2constType<T>(scalars), 0, A, shiftA, lda,
+                           stridea, x, shiftx, incx, stridex, cast2constType<T>(scalars + 1), 0,
+                           Abyx, 0, 1, order, batch_count, workArr);
 
     // compute the rank-1 update  (A + tau*X*W'  or A + tau*W*X')
     if(leftside)
     {
-        rocblasCall_ger<COMPLEX, T>(handle, m, n, alpha, stridep, x, shiftx, incx, stridex, Abyx, 0,
-                                    1, order, A, shiftA, lda, stridea, batch_count, workArr);
+        rocblasCall_ger<COMPLEX, T, I>(handle, m, n, alpha, stridep, x, shiftx, incx, stridex, Abyx,
+                                       0, 1, order, A, shiftA, lda, stridea, batch_count, workArr);
     }
     else
     {
-        rocblasCall_ger<COMPLEX, T>(handle, m, n, alpha, stridep, Abyx, 0, 1, order, x, shiftx,
-                                    incx, stridex, A, shiftA, lda, stridea, batch_count, workArr);
+        rocblasCall_ger<COMPLEX, T, I>(handle, m, n, alpha, stridep, Abyx, 0, 1, order, x, shiftx,
+                                       incx, stridex, A, shiftA, lda, stridea, batch_count, workArr);
     }
 
     rocblas_set_pointer_mode(handle, old_mode);

--- a/library/src/auxiliary/rocauxiliary_larf.hpp
+++ b/library/src/auxiliary/rocauxiliary_larf.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -156,9 +156,9 @@ rocblas_status rocsolver_larf_template(rocblas_handle handle,
     //      ZERO ENTRIES ****
 
     // compute the matrix vector product  (W=-A'*X or W=-A*X)
-    rocblasCall_gemv<T>(handle, trans, m, n, cast2constType<T>(scalars), 0, A, shiftA, lda, stridea,
-                        x, shiftx, incx, stridex, cast2constType<T>(scalars + 1), 0, Abyx, 0, 1,
-                        order, batch_count, workArr);
+    rocblasCall_gemv<T, rocblas_int>(
+        handle, trans, m, n, cast2constType<T>(scalars), 0, A, shiftA, lda, stridea, x, shiftx,
+        incx, stridex, cast2constType<T>(scalars + 1), 0, Abyx, 0, 1, order, batch_count, workArr);
 
     // compute the rank-1 update  (A + tau*X*W'  or A + tau*W*X')
     if(leftside)

--- a/library/src/auxiliary/rocauxiliary_larft.hpp
+++ b/library/src/auxiliary/rocauxiliary_larft.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -292,10 +292,10 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
             if(storev == rocblas_column_wise)
             {
                 trans = rocblas_operation_conjugate_transpose;
-                rocblasCall_gemv<T>(handle, trans, n - 1 - i, i, tau + i, strideT, V,
-                                    shiftV + idx2D(i + 1, 0, ldv), ldv, strideV, V,
-                                    shiftV + idx2D(i + 1, i, ldv), 1, strideV, scalars + 2, 0, F,
-                                    idx2D(0, i, ldf), 1, strideF, batch_count, workArr);
+                rocblasCall_gemv<T, rocblas_int>(
+                    handle, trans, n - 1 - i, i, tau + i, strideT, V, shiftV + idx2D(i + 1, 0, ldv),
+                    ldv, strideV, V, shiftV + idx2D(i + 1, i, ldv), 1, strideV, scalars + 2, 0, F,
+                    idx2D(0, i, ldf), 1, strideF, batch_count, workArr);
             }
             else
             {
@@ -304,10 +304,10 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
                                                 ldv, strideV, batch_count);
 
                 trans = rocblas_operation_none;
-                rocblasCall_gemv<T>(handle, trans, i, n - 1 - i, tau + i, strideT, V,
-                                    shiftV + idx2D(0, i + 1, ldv), ldv, strideV, V,
-                                    shiftV + idx2D(i, i + 1, ldv), ldv, strideV, scalars + 2, 0, F,
-                                    idx2D(0, i, ldf), 1, strideF, batch_count, workArr);
+                rocblasCall_gemv<T, rocblas_int>(
+                    handle, trans, i, n - 1 - i, tau + i, strideT, V, shiftV + idx2D(0, i + 1, ldv),
+                    ldv, strideV, V, shiftV + idx2D(i, i + 1, ldv), ldv, strideV, scalars + 2, 0, F,
+                    idx2D(0, i, ldf), 1, strideF, batch_count, workArr);
 
                 if(COMPLEX)
                     rocsolver_lacgv_template<T>(handle, n - i - 1, V, shiftV + idx2D(i, i + 1, ldv),
@@ -335,10 +335,11 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
             if(storev == rocblas_column_wise)
             {
                 trans = rocblas_operation_conjugate_transpose;
-                rocblasCall_gemv<T>(handle, trans, n - k + i, k - i - 1, tau + i, strideT, V,
-                                    shiftV + idx2D(0, i + 1, ldv), ldv, strideV, V,
-                                    shiftV + idx2D(0, i, ldv), 1, strideV, scalars + 2, 0, F,
-                                    idx2D(i + 1, i, ldf), 1, strideF, batch_count, workArr);
+                rocblasCall_gemv<T, rocblas_int>(handle, trans, n - k + i, k - i - 1, tau + i,
+                                                 strideT, V, shiftV + idx2D(0, i + 1, ldv), ldv,
+                                                 strideV, V, shiftV + idx2D(0, i, ldv), 1, strideV,
+                                                 scalars + 2, 0, F, idx2D(i + 1, i, ldf), 1,
+                                                 strideF, batch_count, workArr);
             }
             else
             {
@@ -347,10 +348,11 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
                                                 ldv, strideV, batch_count);
 
                 trans = rocblas_operation_none;
-                rocblasCall_gemv<T>(handle, trans, k - i - 1, n - k + i, tau + i, strideT, V,
-                                    shiftV + idx2D(i + 1, 0, ldv), ldv, strideV, V,
-                                    shiftV + idx2D(i, 0, ldv), ldv, strideV, scalars + 2, 0, F,
-                                    idx2D(i + 1, i, ldf), 1, strideF, batch_count, workArr);
+                rocblasCall_gemv<T, rocblas_int>(handle, trans, k - i - 1, n - k + i, tau + i,
+                                                 strideT, V, shiftV + idx2D(i + 1, 0, ldv), ldv,
+                                                 strideV, V, shiftV + idx2D(i, 0, ldv), ldv,
+                                                 strideV, scalars + 2, 0, F, idx2D(i + 1, i, ldf),
+                                                 1, strideF, batch_count, workArr);
 
                 if(COMPLEX)
                     rocsolver_lacgv_template<T>(handle, n - k + i, V, shiftV + idx2D(i, 0, ldv),

--- a/library/src/auxiliary/rocauxiliary_latrd.hpp
+++ b/library/src/auxiliary/rocauxiliary_latrd.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     June 2017
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -165,11 +165,11 @@ rocblas_status rocsolver_latrd_template(rocblas_handle handle,
                 rocsolver_lacgv_template<T>(handle, j, W, shiftW + idx2D(j, 0, ldw), ldw, strideW,
                                             batch_count);
 
-            rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j, j,
-                                cast2constType<T>(scalars), 0, A, shiftA + idx2D(j, 0, lda), lda,
-                                strideA, W, shiftW + idx2D(j, 0, ldw), ldw, strideW,
-                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j, lda), 1,
-                                strideA, batch_count, workArr);
+            rocblasCall_gemv<T, rocblas_int>(
+                handle, rocblas_operation_none, n - j, j, cast2constType<T>(scalars), 0, A,
+                shiftA + idx2D(j, 0, lda), lda, strideA, W, shiftW + idx2D(j, 0, ldw), ldw, strideW,
+                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j, lda), 1, strideA,
+                batch_count, workArr);
 
             if(COMPLEX)
             {
@@ -179,11 +179,11 @@ rocblas_status rocsolver_latrd_template(rocblas_handle handle,
                                             batch_count);
             }
 
-            rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j, j,
-                                cast2constType<T>(scalars), 0, W, shiftW + idx2D(j, 0, ldw), ldw,
-                                strideW, A, shiftA + idx2D(j, 0, lda), lda, strideA,
-                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j, lda), 1,
-                                strideA, batch_count, workArr);
+            rocblasCall_gemv<T, rocblas_int>(
+                handle, rocblas_operation_none, n - j, j, cast2constType<T>(scalars), 0, W,
+                shiftW + idx2D(j, 0, ldw), ldw, strideW, A, shiftA + idx2D(j, 0, lda), lda, strideA,
+                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j, lda), 1, strideA,
+                batch_count, workArr);
 
             if(COMPLEX)
                 rocsolver_lacgv_template<T>(handle, j, A, shiftA + idx2D(j, 0, lda), lda, strideA,
@@ -204,29 +204,29 @@ rocblas_status rocsolver_latrd_template(rocblas_handle handle,
                 lda, strideA, A, shiftA + idx2D(j + 1, j, lda), 1, strideA, (scalars + 1), 0, W,
                 shiftW + idx2D(j + 1, j, ldw), 1, strideW, batch_count, work, workArr);
 
-            rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, n - j - 1, j,
-                                cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(j + 1, 0, ldw),
-                                ldw, strideW, A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
-                                cast2constType<T>(scalars + 1), 0, W, shiftW + idx2D(0, j, ldw), 1,
-                                strideW, batch_count, workArr);
+            rocblasCall_gemv<T, rocblas_int>(
+                handle, rocblas_operation_conjugate_transpose, n - j - 1, j,
+                cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(j + 1, 0, ldw), ldw, strideW,
+                A, shiftA + idx2D(j + 1, j, lda), 1, strideA, cast2constType<T>(scalars + 1), 0, W,
+                shiftW + idx2D(0, j, ldw), 1, strideW, batch_count, workArr);
 
-            rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j - 1, j,
-                                cast2constType<T>(scalars), 0, A, shiftA + idx2D(j + 1, 0, lda),
-                                lda, strideA, W, shiftW + idx2D(0, j, ldw), 1, strideW,
-                                cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(j + 1, j, ldw),
-                                1, strideW, batch_count, workArr);
+            rocblasCall_gemv<T, rocblas_int>(
+                handle, rocblas_operation_none, n - j - 1, j, cast2constType<T>(scalars), 0, A,
+                shiftA + idx2D(j + 1, 0, lda), lda, strideA, W, shiftW + idx2D(0, j, ldw), 1,
+                strideW, cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(j + 1, j, ldw), 1,
+                strideW, batch_count, workArr);
 
-            rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, n - j - 1, j,
-                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j + 1, 0, lda),
-                                lda, strideA, A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
-                                cast2constType<T>(scalars + 1), 0, W, shiftW + idx2D(0, j, ldw), 1,
-                                strideW, batch_count, workArr);
+            rocblasCall_gemv<T, rocblas_int>(
+                handle, rocblas_operation_conjugate_transpose, n - j - 1, j,
+                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j + 1, 0, lda), lda, strideA,
+                A, shiftA + idx2D(j + 1, j, lda), 1, strideA, cast2constType<T>(scalars + 1), 0, W,
+                shiftW + idx2D(0, j, ldw), 1, strideW, batch_count, workArr);
 
-            rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j - 1, j,
-                                cast2constType<T>(scalars), 0, W, shiftW + idx2D(j + 1, 0, ldw),
-                                ldw, strideW, W, shiftW + idx2D(0, j, ldw), 1, strideW,
-                                cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(j + 1, j, ldw),
-                                1, strideW, batch_count, workArr);
+            rocblasCall_gemv<T, rocblas_int>(
+                handle, rocblas_operation_none, n - j - 1, j, cast2constType<T>(scalars), 0, W,
+                shiftW + idx2D(j + 1, 0, ldw), ldw, strideW, W, shiftW + idx2D(0, j, ldw), 1,
+                strideW, cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(j + 1, j, ldw), 1,
+                strideW, batch_count, workArr);
 
             rocblasCall_scal<T>(handle, n - j - 1, (tau + j), strideP, W,
                                 shiftW + idx2D(j + 1, j, ldw), 1, strideW, batch_count);
@@ -257,11 +257,11 @@ rocblas_status rocsolver_latrd_template(rocblas_handle handle,
                 rocsolver_lacgv_template<T>(handle, n - 1 - j, W, shiftW + idx2D(j, jw + 1, ldw),
                                             ldw, strideW, batch_count);
 
-            rocblasCall_gemv<T>(handle, rocblas_operation_none, j + 1, n - 1 - j,
-                                cast2constType<T>(scalars), 0, A, shiftA + idx2D(0, j + 1, lda),
-                                lda, strideA, W, shiftW + idx2D(j, jw + 1, ldw), ldw, strideW,
-                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(0, j, lda), 1,
-                                strideA, batch_count, workArr);
+            rocblasCall_gemv<T, rocblas_int>(
+                handle, rocblas_operation_none, j + 1, n - 1 - j, cast2constType<T>(scalars), 0, A,
+                shiftA + idx2D(0, j + 1, lda), lda, strideA, W, shiftW + idx2D(j, jw + 1, ldw), ldw,
+                strideW, cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(0, j, lda), 1,
+                strideA, batch_count, workArr);
 
             if(COMPLEX)
             {
@@ -271,11 +271,11 @@ rocblas_status rocsolver_latrd_template(rocblas_handle handle,
                                             lda, strideA, batch_count);
             }
 
-            rocblasCall_gemv<T>(handle, rocblas_operation_none, j + 1, n - 1 - j,
-                                cast2constType<T>(scalars), 0, W, shiftW + idx2D(0, jw + 1, ldw),
-                                ldw, strideW, A, shiftA + idx2D(j, j + 1, lda), lda, strideA,
-                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(0, j, lda), 1,
-                                strideA, batch_count, workArr);
+            rocblasCall_gemv<T, rocblas_int>(
+                handle, rocblas_operation_none, j + 1, n - 1 - j, cast2constType<T>(scalars), 0, W,
+                shiftW + idx2D(0, jw + 1, ldw), ldw, strideW, A, shiftA + idx2D(j, j + 1, lda), lda,
+                strideA, cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(0, j, lda), 1,
+                strideA, batch_count, workArr);
 
             if(COMPLEX)
                 rocsolver_lacgv_template<T>(handle, n - 1 - j, A, shiftA + idx2D(j, j + 1, lda),
@@ -296,29 +296,29 @@ rocblas_status rocsolver_latrd_template(rocblas_handle handle,
                                      shiftW + idx2D(0, jw, ldw), 1, strideW, batch_count, work,
                                      workArr);
 
-            rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, j, n - 1 - j,
-                                cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(0, jw + 1, ldw),
-                                ldw, strideW, A, shiftA + idx2D(0, j, lda), 1, strideA,
-                                cast2constType<T>(scalars + 1), 0, W,
-                                shiftW + idx2D(j + 1, jw, ldw), 1, strideW, batch_count, workArr);
+            rocblasCall_gemv<T, rocblas_int>(
+                handle, rocblas_operation_conjugate_transpose, j, n - 1 - j,
+                cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(0, jw + 1, ldw), ldw, strideW,
+                A, shiftA + idx2D(0, j, lda), 1, strideA, cast2constType<T>(scalars + 1), 0, W,
+                shiftW + idx2D(j + 1, jw, ldw), 1, strideW, batch_count, workArr);
 
-            rocblasCall_gemv<T>(handle, rocblas_operation_none, j, n - 1 - j,
-                                cast2constType<T>(scalars), 0, A, shiftA + idx2D(0, j + 1, lda),
-                                lda, strideA, W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW,
-                                cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(0, jw, ldw), 1,
-                                strideW, batch_count, workArr);
+            rocblasCall_gemv<T, rocblas_int>(
+                handle, rocblas_operation_none, j, n - 1 - j, cast2constType<T>(scalars), 0, A,
+                shiftA + idx2D(0, j + 1, lda), lda, strideA, W, shiftW + idx2D(j + 1, jw, ldw), 1,
+                strideW, cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(0, jw, ldw), 1,
+                strideW, batch_count, workArr);
 
-            rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, j, n - 1 - j,
-                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(0, j + 1, lda),
-                                lda, strideA, A, shiftA + idx2D(0, j, lda), 1, strideA,
-                                cast2constType<T>(scalars + 1), 0, W,
-                                shiftW + idx2D(j + 1, jw, ldw), 1, strideW, batch_count, workArr);
+            rocblasCall_gemv<T, rocblas_int>(
+                handle, rocblas_operation_conjugate_transpose, j, n - 1 - j,
+                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(0, j + 1, lda), lda, strideA,
+                A, shiftA + idx2D(0, j, lda), 1, strideA, cast2constType<T>(scalars + 1), 0, W,
+                shiftW + idx2D(j + 1, jw, ldw), 1, strideW, batch_count, workArr);
 
-            rocblasCall_gemv<T>(handle, rocblas_operation_none, j, n - 1 - j,
-                                cast2constType<T>(scalars), 0, W, shiftW + idx2D(0, jw + 1, ldw),
-                                ldw, strideW, W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW,
-                                cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(0, jw, ldw), 1,
-                                strideW, batch_count, workArr);
+            rocblasCall_gemv<T, rocblas_int>(
+                handle, rocblas_operation_none, j, n - 1 - j, cast2constType<T>(scalars), 0, W,
+                shiftW + idx2D(0, jw + 1, ldw), ldw, strideW, W, shiftW + idx2D(j + 1, jw, ldw), 1,
+                strideW, cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(0, jw, ldw), 1,
+                strideW, batch_count, workArr);
 
             rocblasCall_scal<T>(handle, j, (tau + j - 1), strideP, W, shiftW + idx2D(0, jw, ldw), 1,
                                 strideW, batch_count);

--- a/library/src/include/lib_device_helpers.hpp
+++ b/library/src/include/lib_device_helpers.hpp
@@ -392,7 +392,7 @@ ROCSOLVER_KERNEL void reset_batch_info(U info, const rocblas_stride stride, cons
 template <typename T, typename I>
 ROCSOLVER_KERNEL void get_array(T** out, T* in, rocblas_stride stride, I batch)
 {
-    I b = static_cast<I>(hipBlockIdx_x) * hipBlockDim_x + hipThreadIdx_x;
+    I b = hipBlockIdx_x * static_cast<I>(hipBlockDim_x) + hipThreadIdx_x;
 
     if(b < batch)
         out[b] = in + b * stride;

--- a/library/src/include/lib_device_helpers.hpp
+++ b/library/src/include/lib_device_helpers.hpp
@@ -389,10 +389,10 @@ ROCSOLVER_KERNEL void reset_batch_info(U info, const rocblas_stride stride, cons
         inf[idx] = T(val);
 }
 
-template <typename T>
-ROCSOLVER_KERNEL void get_array(T** out, T* in, rocblas_stride stride, rocblas_int batch)
+template <typename T, typename I>
+ROCSOLVER_KERNEL void get_array(T** out, T* in, rocblas_stride stride, I batch)
 {
-    int b = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    I b = static_cast<I>(hipBlockIdx_x) * hipBlockDim_x + hipThreadIdx_x;
 
     if(b < batch)
         out[b] = in + b * stride;

--- a/library/src/include/lib_host_helpers.hpp
+++ b/library/src/include/lib_host_helpers.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,12 +41,15 @@
  * ===========================================================================
  */
 
-inline size_t idx2D(const size_t i, const size_t j, const size_t lda)
+inline rocblas_stride idx2D(const rocblas_stride i, const rocblas_stride j, const rocblas_stride lda)
 {
     return j * lda + i;
 }
 
-inline size_t idx2D(const size_t i, const size_t j, const size_t inca, const size_t lda)
+inline rocblas_stride idx2D(const rocblas_stride i,
+                            const rocblas_stride j,
+                            const rocblas_stride inca,
+                            const rocblas_stride lda)
 {
     return j * lda + i * inca;
 }

--- a/library/src/include/lib_host_helpers.hpp
+++ b/library/src/include/lib_host_helpers.hpp
@@ -41,17 +41,16 @@
  * ===========================================================================
  */
 
-inline rocblas_stride idx2D(const rocblas_stride i, const rocblas_stride j, const rocblas_stride lda)
+template <typename I>
+inline rocblas_stride idx2D(const I i, const I j, const I lda)
 {
-    return j * lda + i;
+    return j * static_cast<rocblas_stride>(lda) + i;
 }
 
-inline rocblas_stride idx2D(const rocblas_stride i,
-                            const rocblas_stride j,
-                            const rocblas_stride inca,
-                            const rocblas_stride lda)
+template <typename I>
+inline rocblas_stride idx2D(const I i, const I j, const I inca, const I lda)
 {
-    return j * lda + i * inca;
+    return j * static_cast<rocblas_stride>(lda) + i * inca;
 }
 
 template <typename T>

--- a/library/src/include/rocblas.hpp
+++ b/library/src/include/rocblas.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -299,97 +299,125 @@ rocblas_status rocblasCall_dot(rocblas_handle handle,
 }
 
 // ger - non batched
-template <bool CONJ, typename T>
+template <bool CONJ, typename T, typename I>
 rocblas_status rocblasCall_ger(rocblas_handle handle,
-                               rocblas_int m,
-                               rocblas_int n,
+                               I m,
+                               I n,
                                const T* alpha,
                                rocblas_stride stridea,
                                const T* x,
                                rocblas_stride offsetx,
-                               rocblas_int incx,
+                               I incx,
                                rocblas_stride stridex,
                                const T* y,
                                rocblas_stride offsety,
-                               rocblas_int incy,
+                               I incy,
                                rocblas_stride stridey,
                                T* A,
                                rocblas_stride offsetA,
-                               rocblas_int lda,
+                               I lda,
                                rocblas_stride strideA,
-                               rocblas_int batch_count,
+                               I batch_count,
                                T** work)
 {
     // TODO: How to get alpha for trace logging
     ROCBLAS_ENTER("ger", "m:", m, "n:", n, "shiftX:", offsetx, "incx:", incx, "shiftY:", offsety,
                   "incy:", incy, "shiftA:", offsetA, "lda:", lda, "bc:", batch_count);
 
-    if constexpr(CONJ)
-        return rocblas_internal_gerc_template(handle, m, n, alpha, stridea, x, offsetx, incx,
-                                              stridex, y, offsety, incy, stridey, A, offsetA, lda,
-                                              strideA, batch_count);
+    if(std::is_same<I, rocblas_int>::value)
+    {
+        if constexpr(CONJ)
+            return rocblas_internal_gerc_template(handle, m, n, alpha, stridea, x, offsetx, incx,
+                                                  stridex, y, offsety, incy, stridey, A, offsetA,
+                                                  lda, strideA, batch_count);
+        else
+            return rocblas_internal_ger_template(handle, m, n, alpha, stridea, x, offsetx, incx,
+                                                 stridex, y, offsety, incy, stridey, A, offsetA,
+                                                 lda, strideA, batch_count);
+    }
     else
-        return rocblas_internal_ger_template(handle, m, n, alpha, stridea, x, offsetx, incx,
-                                             stridex, y, offsety, incy, stridey, A, offsetA, lda,
-                                             strideA, batch_count);
+    {
+        if constexpr(CONJ)
+            return rocblas_internal_gerc_template_64(handle, m, n, alpha, stridea, x, offsetx, incx,
+                                                     stridex, y, offsety, incy, stridey, A, offsetA,
+                                                     lda, strideA, batch_count);
+        else
+            return rocblas_internal_ger_template_64(handle, m, n, alpha, stridea, x, offsetx, incx,
+                                                    stridex, y, offsety, incy, stridey, A, offsetA,
+                                                    lda, strideA, batch_count);
+    }
 }
 
 // ger batched
-template <bool CONJ, typename T>
+template <bool CONJ, typename T, typename I>
 rocblas_status rocblasCall_ger(rocblas_handle handle,
-                               rocblas_int m,
-                               rocblas_int n,
+                               I m,
+                               I n,
                                const T* alpha,
                                rocblas_stride stridea,
                                const T* const* x,
                                rocblas_stride offsetx,
-                               rocblas_int incx,
+                               I incx,
                                rocblas_stride stridex,
                                const T* const* y,
                                rocblas_stride offsety,
-                               rocblas_int incy,
+                               I incy,
                                rocblas_stride stridey,
                                T* const* A,
                                rocblas_stride offsetA,
-                               rocblas_int lda,
+                               I lda,
                                rocblas_stride strideA,
-                               rocblas_int batch_count,
+                               I batch_count,
                                T** work)
 {
     // TODO: How to get alpha for trace logging
     ROCBLAS_ENTER("ger", "m:", m, "n:", n, "shiftX:", offsetx, "incx:", incx, "shiftY:", offsety,
                   "incy:", incy, "shiftA:", offsetA, "lda:", lda, "bc:", batch_count);
 
-    if constexpr(CONJ)
-        return rocblas_internal_gerc_batched_template(handle, m, n, alpha, stridea, x, offsetx,
-                                                      incx, stridex, y, offsety, incy, stridey, A,
-                                                      offsetA, lda, strideA, batch_count);
+    if(std::is_same<I, rocblas_int>::value)
+    {
+        if constexpr(CONJ)
+            return rocblas_internal_gerc_batched_template(handle, m, n, alpha, stridea, x, offsetx,
+                                                          incx, stridex, y, offsety, incy, stridey,
+                                                          A, offsetA, lda, strideA, batch_count);
+        else
+            return rocblas_internal_ger_batched_template(handle, m, n, alpha, stridea, x, offsetx,
+                                                         incx, stridex, y, offsety, incy, stridey,
+                                                         A, offsetA, lda, strideA, batch_count);
+    }
     else
-        return rocblas_internal_ger_batched_template(handle, m, n, alpha, stridea, x, offsetx, incx,
-                                                     stridex, y, offsety, incy, stridey, A, offsetA,
-                                                     lda, strideA, batch_count);
+    {
+        if constexpr(CONJ)
+            return rocblas_internal_gerc_batched_template_64(
+                handle, m, n, alpha, stridea, x, offsetx, incx, stridex, y, offsety, incy, stridey,
+                A, offsetA, lda, strideA, batch_count);
+        else
+            return rocblas_internal_ger_batched_template_64(handle, m, n, alpha, stridea, x, offsetx,
+                                                            incx, stridex, y, offsety, incy, stridey,
+                                                            A, offsetA, lda, strideA, batch_count);
+    }
 }
 
 // ger overload - batched with strided y
-template <bool CONJ, typename T>
+template <bool CONJ, typename T, typename I>
 rocblas_status rocblasCall_ger(rocblas_handle handle,
-                               rocblas_int m,
-                               rocblas_int n,
+                               I m,
+                               I n,
                                const T* alpha,
                                rocblas_stride stridea,
                                const T* const* x,
                                rocblas_stride offsetx,
-                               rocblas_int incx,
+                               I incx,
                                rocblas_stride stridex,
                                T* y,
                                rocblas_stride offsety,
-                               rocblas_int incy,
+                               I incy,
                                rocblas_stride stridey,
                                T* const* A,
                                rocblas_stride offsetA,
-                               rocblas_int lda,
+                               I lda,
                                rocblas_stride strideA,
-                               rocblas_int batch_count,
+                               I batch_count,
                                T** work)
 {
     // TODO: How to get alpha for trace logging
@@ -403,36 +431,50 @@ rocblas_status rocblasCall_ger(rocblas_handle handle,
     ROCSOLVER_LAUNCH_KERNEL(get_array, dim3(blocks), dim3(256), 0, stream, work, y, stridey,
                             batch_count);
 
-    if constexpr(CONJ)
-        return rocblas_internal_gerc_batched_template(
-            handle, m, n, alpha, stridea, x, offsetx, incx, stridex, cast2constType<T>(work),
-            offsety, incy, stridey, A, offsetA, lda, strideA, batch_count);
+    if(std::is_same<I, rocblas_int>::value)
+    {
+        if constexpr(CONJ)
+            return rocblas_internal_gerc_batched_template(
+                handle, m, n, alpha, stridea, x, offsetx, incx, stridex, cast2constType<T>(work),
+                offsety, incy, stridey, A, offsetA, lda, strideA, batch_count);
+        else
+            return rocblas_internal_ger_batched_template(
+                handle, m, n, alpha, stridea, x, offsetx, incx, stridex, cast2constType<T>(work),
+                offsety, incy, stridey, A, offsetA, lda, strideA, batch_count);
+    }
     else
-        return rocblas_internal_ger_batched_template(handle, m, n, alpha, stridea, x, offsetx, incx,
-                                                     stridex, cast2constType<T>(work), offsety, incy,
-                                                     stridey, A, offsetA, lda, strideA, batch_count);
+    {
+        if constexpr(CONJ)
+            return rocblas_internal_gerc_batched_template_64(
+                handle, m, n, alpha, stridea, x, offsetx, incx, stridex, cast2constType<T>(work),
+                offsety, incy, stridey, A, offsetA, lda, strideA, batch_count);
+        else
+            return rocblas_internal_ger_batched_template_64(
+                handle, m, n, alpha, stridea, x, offsetx, incx, stridex, cast2constType<T>(work),
+                offsety, incy, stridey, A, offsetA, lda, strideA, batch_count);
+    }
 }
 
 // ger overload - batched with strided x
-template <bool CONJ, typename T>
+template <bool CONJ, typename T, typename I>
 rocblas_status rocblasCall_ger(rocblas_handle handle,
-                               rocblas_int m,
-                               rocblas_int n,
+                               I m,
+                               I n,
                                const T* alpha,
                                rocblas_stride stridea,
                                T* x,
                                rocblas_stride offsetx,
-                               rocblas_int incx,
+                               I incx,
                                rocblas_stride stridex,
                                const T* const* y,
                                rocblas_stride offsety,
-                               rocblas_int incy,
+                               I incy,
                                rocblas_stride stridey,
                                T* const* A,
                                rocblas_stride offsetA,
-                               rocblas_int lda,
+                               I lda,
                                rocblas_stride strideA,
-                               rocblas_int batch_count,
+                               I batch_count,
                                T** work)
 {
     // TODO: How to get alpha for trace logging
@@ -446,39 +488,53 @@ rocblas_status rocblasCall_ger(rocblas_handle handle,
     ROCSOLVER_LAUNCH_KERNEL(get_array, dim3(blocks), dim3(256), 0, stream, work, x, stridex,
                             batch_count);
 
-    if constexpr(CONJ)
-        return rocblas_internal_gerc_batched_template(
-            handle, m, n, alpha, stridea, cast2constType<T>(work), offsetx, incx, stridex, y,
-            offsety, incy, stridey, A, offsetA, lda, strideA, batch_count);
+    if(std::is_same<I, rocblas_int>::value)
+    {
+        if constexpr(CONJ)
+            return rocblas_internal_gerc_batched_template(
+                handle, m, n, alpha, stridea, cast2constType<T>(work), offsetx, incx, stridex, y,
+                offsety, incy, stridey, A, offsetA, lda, strideA, batch_count);
+        else
+            return rocblas_internal_ger_batched_template(
+                handle, m, n, alpha, stridea, cast2constType<T>(work), offsetx, incx, stridex, y,
+                offsety, incy, stridey, A, offsetA, lda, strideA, batch_count);
+    }
     else
-        return rocblas_internal_ger_batched_template(
-            handle, m, n, alpha, stridea, cast2constType<T>(work), offsetx, incx, stridex, y,
-            offsety, incy, stridey, A, offsetA, lda, strideA, batch_count);
+    {
+        if constexpr(CONJ)
+            return rocblas_internal_gerc_batched_template_64(
+                handle, m, n, alpha, stridea, cast2constType<T>(work), offsetx, incx, stridex, y,
+                offsety, incy, stridey, A, offsetA, lda, strideA, batch_count);
+        else
+            return rocblas_internal_ger_batched_template_64(
+                handle, m, n, alpha, stridea, cast2constType<T>(work), offsetx, incx, stridex, y,
+                offsety, incy, stridey, A, offsetA, lda, strideA, batch_count);
+    }
 }
 
 // gemv - non batched
-template <typename T>
+template <typename T, typename I>
 rocblas_status rocblasCall_gemv(rocblas_handle handle,
                                 rocblas_operation transA,
-                                rocblas_int m,
-                                rocblas_int n,
+                                I m,
+                                I n,
                                 const T* alpha,
                                 rocblas_stride stride_alpha,
                                 const T* A,
                                 rocblas_stride offseta,
-                                rocblas_int lda,
+                                I lda,
                                 rocblas_stride strideA,
                                 const T* x,
                                 rocblas_stride offsetx,
-                                rocblas_int incx,
+                                I incx,
                                 rocblas_stride stridex,
                                 const T* beta,
                                 rocblas_stride stride_beta,
                                 T* y,
                                 rocblas_stride offsety,
-                                rocblas_int incy,
+                                I incy,
                                 rocblas_stride stridey,
-                                rocblas_int batch_count,
+                                I batch_count,
                                 T** work)
 {
     // TODO: How to get alpha and beta for trace logging
@@ -486,34 +542,39 @@ rocblas_status rocblasCall_gemv(rocblas_handle handle,
                   "shiftX:", offsetx, "incx:", incx, "shiftY:", offsety, "incy:", incy,
                   "bc:", batch_count);
 
-    return rocblas_internal_gemv_template(handle, transA, m, n, alpha, stride_alpha, A, offseta,
-                                          lda, strideA, x, offsetx, incx, stridex, beta,
-                                          stride_beta, y, offsety, incy, stridey, batch_count);
+    if(std::is_same<I, rocblas_int>::value)
+        return rocblas_internal_gemv_template(handle, transA, m, n, alpha, stride_alpha, A, offseta,
+                                              lda, strideA, x, offsetx, incx, stridex, beta,
+                                              stride_beta, y, offsety, incy, stridey, batch_count);
+    else
+        return rocblas_internal_gemv_template_64(
+            handle, transA, m, n, alpha, stride_alpha, A, offseta, lda, strideA, x, offsetx, incx,
+            stridex, beta, stride_beta, y, offsety, incy, stridey, batch_count);
 }
 
 // gemv - batched
-template <typename T>
+template <typename T, typename I>
 rocblas_status rocblasCall_gemv(rocblas_handle handle,
                                 rocblas_operation transA,
-                                rocblas_int m,
-                                rocblas_int n,
+                                I m,
+                                I n,
                                 const T* alpha,
                                 rocblas_stride stride_alpha,
                                 const T* const* A,
                                 rocblas_stride offseta,
-                                rocblas_int lda,
+                                I lda,
                                 rocblas_stride strideA,
                                 const T* const* x,
                                 rocblas_stride offsetx,
-                                rocblas_int incx,
+                                I incx,
                                 rocblas_stride stridex,
                                 const T* beta,
                                 rocblas_stride stride_beta,
                                 T* const* y,
                                 rocblas_stride offsety,
-                                rocblas_int incy,
+                                I incy,
                                 rocblas_stride stridey,
-                                rocblas_int batch_count,
+                                I batch_count,
                                 T** work)
 {
     // TODO: How to get alpha and beta for trace logging
@@ -521,34 +582,39 @@ rocblas_status rocblasCall_gemv(rocblas_handle handle,
                   "shiftX:", offsetx, "incx:", incx, "shiftY:", offsety, "incy:", incy,
                   "bc:", batch_count);
 
-    return rocblas_internal_gemv_batched_template(
-        handle, transA, m, n, alpha, stride_alpha, A, offseta, lda, strideA, x, offsetx, incx,
-        stridex, beta, stride_beta, y, offsety, incy, stridey, batch_count);
+    if(std::is_same<I, rocblas_int>::value)
+        return rocblas_internal_gemv_batched_template(
+            handle, transA, m, n, alpha, stride_alpha, A, offseta, lda, strideA, x, offsetx, incx,
+            stridex, beta, stride_beta, y, offsety, incy, stridey, batch_count);
+    else
+        return rocblas_internal_gemv_batched_template_64(
+            handle, transA, m, n, alpha, stride_alpha, A, offseta, lda, strideA, x, offsetx, incx,
+            stridex, beta, stride_beta, y, offsety, incy, stridey, batch_count);
 }
 
 // gemv overload - batched with strided A
-template <typename T>
+template <typename T, typename I>
 rocblas_status rocblasCall_gemv(rocblas_handle handle,
                                 rocblas_operation transA,
-                                rocblas_int m,
-                                rocblas_int n,
+                                I m,
+                                I n,
                                 const T* alpha,
                                 rocblas_stride stride_alpha,
                                 T* A,
                                 rocblas_stride offseta,
-                                rocblas_int lda,
+                                I lda,
                                 rocblas_stride strideA,
                                 const T* const* x,
                                 rocblas_stride offsetx,
-                                rocblas_int incx,
+                                I incx,
                                 rocblas_stride stridex,
                                 const T* beta,
                                 rocblas_stride stride_beta,
                                 T* const* y,
                                 rocblas_stride offsety,
-                                rocblas_int incy,
+                                I incy,
                                 rocblas_stride stridey,
-                                rocblas_int batch_count,
+                                I batch_count,
                                 T** work)
 {
     // TODO: How to get alpha and beta for trace logging
@@ -563,34 +629,40 @@ rocblas_status rocblasCall_gemv(rocblas_handle handle,
     ROCSOLVER_LAUNCH_KERNEL(get_array, dim3(blocks), dim3(256), 0, stream, work, A, strideA,
                             batch_count);
 
-    return rocblas_internal_gemv_batched_template(
-        handle, transA, m, n, alpha, stride_alpha, cast2constType<T>(work), offseta, lda, strideA,
-        x, offsetx, incx, stridex, beta, stride_beta, y, offsety, incy, stridey, batch_count);
+    if(std::is_same<I, rocblas_int>::value)
+        return rocblas_internal_gemv_batched_template(handle, transA, m, n, alpha, stride_alpha,
+                                                      cast2constType<T>(work), offseta, lda, strideA,
+                                                      x, offsetx, incx, stridex, beta, stride_beta,
+                                                      y, offsety, incy, stridey, batch_count);
+    else
+        return rocblas_internal_gemv_batched_template_64(
+            handle, transA, m, n, alpha, stride_alpha, cast2constType<T>(work), offseta, lda, strideA,
+            x, offsetx, incx, stridex, beta, stride_beta, y, offsety, incy, stridey, batch_count);
 }
 
 // gemv overload - batched with strided x
-template <typename T>
+template <typename T, typename I>
 rocblas_status rocblasCall_gemv(rocblas_handle handle,
                                 rocblas_operation transA,
-                                rocblas_int m,
-                                rocblas_int n,
+                                I m,
+                                I n,
                                 const T* alpha,
                                 rocblas_stride stride_alpha,
                                 const T* const* A,
                                 rocblas_stride offseta,
-                                rocblas_int lda,
+                                I lda,
                                 rocblas_stride strideA,
                                 T* x,
                                 rocblas_stride offsetx,
-                                rocblas_int incx,
+                                I incx,
                                 rocblas_stride stridex,
                                 const T* beta,
                                 rocblas_stride stride_beta,
                                 T* const* y,
                                 rocblas_stride offsety,
-                                rocblas_int incy,
+                                I incy,
                                 rocblas_stride stridey,
-                                rocblas_int batch_count,
+                                I batch_count,
                                 T** work)
 {
     // TODO: How to get alpha and beta for trace logging
@@ -605,35 +677,41 @@ rocblas_status rocblasCall_gemv(rocblas_handle handle,
     ROCSOLVER_LAUNCH_KERNEL(get_array, dim3(blocks), dim3(256), 0, stream, work, x, stridex,
                             batch_count);
 
-    return rocblas_internal_gemv_batched_template(handle, transA, m, n, alpha, stride_alpha, A,
-                                                  offseta, lda, strideA, cast2constType<T>(work),
-                                                  offsetx, incx, stridex, beta, stride_beta, y,
-                                                  offsety, incy, stridey, batch_count);
+    if(std::is_same<I, rocblas_int>::value)
+        return rocblas_internal_gemv_batched_template(handle, transA, m, n, alpha, stride_alpha, A,
+                                                      offseta, lda, strideA, cast2constType<T>(work),
+                                                      offsetx, incx, stridex, beta, stride_beta, y,
+                                                      offsety, incy, stridey, batch_count);
+    else
+        return rocblas_internal_gemv_batched_template_64(
+            handle, transA, m, n, alpha, stride_alpha, A, offseta, lda, strideA,
+            cast2constType<T>(work), offsetx, incx, stridex, beta, stride_beta, y, offsety, incy,
+            stridey, batch_count);
 }
 
 // gemv overload - batched with strided y
-template <typename T>
+template <typename T, typename I>
 rocblas_status rocblasCall_gemv(rocblas_handle handle,
                                 rocblas_operation transA,
-                                rocblas_int m,
-                                rocblas_int n,
+                                I m,
+                                I n,
                                 const T* alpha,
                                 rocblas_stride stride_alpha,
                                 const T* const* A,
                                 rocblas_stride offseta,
-                                rocblas_int lda,
+                                I lda,
                                 rocblas_stride strideA,
                                 const T* const* x,
                                 rocblas_stride offsetx,
-                                rocblas_int incx,
+                                I incx,
                                 rocblas_stride stridex,
                                 const T* beta,
                                 rocblas_stride stride_beta,
                                 T* y,
                                 rocblas_stride offsety,
-                                rocblas_int incy,
+                                I incy,
                                 rocblas_stride stridey,
-                                rocblas_int batch_count,
+                                I batch_count,
                                 T** work)
 {
     // TODO: How to get alpha and beta for trace logging
@@ -648,35 +726,41 @@ rocblas_status rocblasCall_gemv(rocblas_handle handle,
     ROCSOLVER_LAUNCH_KERNEL(get_array, dim3(blocks), dim3(256), 0, stream, work, y, stridey,
                             batch_count);
 
-    return rocblas_internal_gemv_batched_template(handle, transA, m, n, alpha, stride_alpha, A,
-                                                  offseta, lda, strideA, x, offsetx, incx, stridex,
-                                                  beta, stride_beta, cast2constPointer<T>(work),
-                                                  offsety, incy, stridey, batch_count);
+    if(std::is_same<I, rocblas_int>::value)
+        return rocblas_internal_gemv_batched_template(
+            handle, transA, m, n, alpha, stride_alpha, A, offseta, lda, strideA, x, offsetx, incx,
+            stridex, beta, stride_beta, cast2constPointer<T>(work), offsety, incy, stridey,
+            batch_count);
+    else
+        return rocblas_internal_gemv_batched_template_64(
+            handle, transA, m, n, alpha, stride_alpha, A, offseta, lda, strideA, x, offsetx, incx,
+            stridex, beta, stride_beta, cast2constPointer<T>(work), offsety, incy, stridey,
+            batch_count);
 }
 
 // gemv overload - batched with strided x and y
-template <typename T>
+template <typename T, typename I>
 rocblas_status rocblasCall_gemv(rocblas_handle handle,
                                 rocblas_operation transA,
-                                rocblas_int m,
-                                rocblas_int n,
+                                I m,
+                                I n,
                                 const T* alpha,
                                 rocblas_stride stride_alpha,
                                 const T* const* A,
                                 rocblas_stride offseta,
-                                rocblas_int lda,
+                                I lda,
                                 rocblas_stride strideA,
                                 T* x,
                                 rocblas_stride offsetx,
-                                rocblas_int incx,
+                                I incx,
                                 rocblas_stride stridex,
                                 const T* beta,
                                 rocblas_stride stride_beta,
                                 T* y,
                                 rocblas_stride offsety,
-                                rocblas_int incy,
+                                I incy,
                                 rocblas_stride stridey,
-                                rocblas_int batch_count,
+                                I batch_count,
                                 T** work)
 {
     // TODO: How to get alpha and beta for trace logging
@@ -693,14 +777,20 @@ rocblas_status rocblasCall_gemv(rocblas_handle handle,
     ROCSOLVER_LAUNCH_KERNEL(get_array, dim3(blocks), dim3(256), 0, stream, (work + batch_count), y,
                             stridey, batch_count);
 
-    return rocblas_internal_gemv_batched_template(
-        handle, transA, m, n, alpha, stride_alpha, A, offseta, lda, strideA,
-        cast2constType<T>(work), offsetx, incx, stridex, beta, stride_beta,
-        cast2constPointer<T>(work + batch_count), offsety, incy, stridey, batch_count);
+    if(std::is_same<I, rocblas_int>::value)
+        return rocblas_internal_gemv_batched_template(
+            handle, transA, m, n, alpha, stride_alpha, A, offseta, lda, strideA,
+            cast2constType<T>(work), offsetx, incx, stridex, beta, stride_beta,
+            cast2constPointer<T>(work + batch_count), offsety, incy, stridey, batch_count);
+    else
+        return rocblas_internal_gemv_batched_template_64(
+            handle, transA, m, n, alpha, stride_alpha, A, offseta, lda, strideA,
+            cast2constType<T>(work), offsetx, incx, stridex, beta, stride_beta,
+            cast2constPointer<T>(work + batch_count), offsety, incy, stridey, batch_count);
 }
 
 // gemv overload - batched with strided A and y
-template <typename T>
+template <typename T, typename I>
 rocblas_status rocblasCall_gemv(rocblas_handle handle,
                                 rocblas_operation transA,
                                 rocblas_int m,
@@ -738,10 +828,16 @@ rocblas_status rocblasCall_gemv(rocblas_handle handle,
     ROCSOLVER_LAUNCH_KERNEL(get_array, dim3(blocks), dim3(256), 0, stream, (work + batch_count), y,
                             stridey, batch_count);
 
-    return rocblas_internal_gemv_batched_template(
-        handle, transA, m, n, alpha, stride_alpha, cast2constType<T>(work), offseta, lda, strideA,
-        x, offsetx, incx, stridex, beta, stride_beta, cast2constPointer<T>(work + batch_count),
-        offsety, incy, stridey, batch_count);
+    if(std::is_same<I, rocblas_int>::value)
+        return rocblas_internal_gemv_batched_template(
+            handle, transA, m, n, alpha, stride_alpha, cast2constType<T>(work), offseta, lda,
+            strideA, x, offsetx, incx, stridex, beta, stride_beta,
+            cast2constPointer<T>(work + batch_count), offsety, incy, stridey, batch_count);
+    else
+        return rocblas_internal_gemv_batched_template_64(
+            handle, transA, m, n, alpha, stride_alpha, cast2constType<T>(work), offseta, lda,
+            strideA, x, offsetx, incx, stridex, beta, stride_beta,
+            cast2constPointer<T>(work + batch_count), offsety, incy, stridey, batch_count);
 }
 
 // trmv

--- a/library/src/lapack/roclapack_potf2.hpp
+++ b/library/src/lapack/roclapack_potf2.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -220,11 +220,11 @@ rocblas_status rocsolver_potf2_template(rocblas_handle handle,
                     rocsolver_lacgv_template<T>(handle, j, A, shiftA + idx2D(0, j, lda), 1, strideA,
                                                 batch_count);
 
-                rocblasCall_gemv<T>(handle, rocblas_operation_transpose, j, n - j - 1, scalars, 0,
-                                    A, shiftA + idx2D(0, j + 1, lda), lda, strideA, A,
-                                    shiftA + idx2D(0, j, lda), 1, strideA, scalars + 2, 0, A,
-                                    shiftA + idx2D(j, j + 1, lda), lda, strideA, batch_count,
-                                    nullptr);
+                rocblasCall_gemv<T, rocblas_int>(handle, rocblas_operation_transpose, j, n - j - 1,
+                                                 scalars, 0, A, shiftA + idx2D(0, j + 1, lda), lda,
+                                                 strideA, A, shiftA + idx2D(0, j, lda), 1, strideA,
+                                                 scalars + 2, 0, A, shiftA + idx2D(j, j + 1, lda),
+                                                 lda, strideA, batch_count, nullptr);
 
                 if(COMPLEX)
                     rocsolver_lacgv_template<T>(handle, j, A, shiftA + idx2D(0, j, lda), 1, strideA,
@@ -256,10 +256,11 @@ rocblas_status rocsolver_potf2_template(rocblas_handle handle,
                     rocsolver_lacgv_template<T>(handle, j, A, shiftA + idx2D(j, 0, lda), lda,
                                                 strideA, batch_count);
 
-                rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j - 1, j, scalars, 0, A,
-                                    shiftA + idx2D(j + 1, 0, lda), lda, strideA, A,
-                                    shiftA + idx2D(j, 0, lda), lda, strideA, scalars + 2, 0, A,
-                                    shiftA + idx2D(j + 1, j, lda), 1, strideA, batch_count, nullptr);
+                rocblasCall_gemv<T, rocblas_int>(handle, rocblas_operation_none, n - j - 1, j,
+                                                 scalars, 0, A, shiftA + idx2D(j + 1, 0, lda), lda,
+                                                 strideA, A, shiftA + idx2D(j, 0, lda), lda, strideA,
+                                                 scalars + 2, 0, A, shiftA + idx2D(j + 1, j, lda),
+                                                 1, strideA, batch_count, nullptr);
 
                 if(COMPLEX)
                     rocsolver_lacgv_template<T>(handle, j, A, shiftA + idx2D(j, 0, lda), lda,


### PR DESCRIPTION
This PR adds 64-bit APIs for LARF. I intend to follow the same general structure for future 64-bit APIs, so let me know what you think as soon as you're able.

One of the important questions we need to address with the 64-bit APIs is how to test them. For now, I'm using the same test cases as for the 32-bit API. We can probably stick with this approach as long as we ensure there's no downcasting happening within LARF or future 64-bit APIs, e.g. by reenabling some of the warnings we've disabled and flagging them as failures on CI.