### PR TITLE
Disable `user_owned` memory test for 6.2 release. (#705)

### DIFF
--- a/clients/gtest/memory_model_gtest.cpp
+++ b/clients/gtest/memory_model_gtest.cpp
@@ -279,7 +279,7 @@ TEST_F(checkin_misc_MEMORY_MODEL, user_managed)
 /*************************************/
 /******** user owned workspace *******/
 /*************************************/
-TEST_F(checkin_misc_MEMORY_MODEL, user_owned)
+TEST_F(checkin_misc_MEMORY_MODEL, DISABLED_user_owned)
 {
     size_t size;
     rocblas_status status;


### PR DESCRIPTION
Merge back 6.2 into develop