### PR TITLE
Docs: fix links in installation and types guides

### DIFF
--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -5,7 +5,7 @@
 .. _user-guide:
 
 ********************************************************************
-How-To
+How to
 ********************************************************************
 
 This section provides guides on how to use the rocSOLVER library and its

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,11 +9,11 @@ rocSOLVER documentation
 ********************************************************************
 
 rocSOLVER is an implementation of `LAPACK routines <https://www.netlib.org/lapack/explore-html/modules.html>`_ 
-on top of `AMD's open source ROCm platform <https://rocm.docs.amd.com/>`_. rocSOLVER is implemented in the
-`HIP programming language <https://rocm.docs.amd.com/projects/HIP/>`_ and optimized for AMD's
+on top of :doc:`AMD's open source ROCm platform <rocm:index>`. rocSOLVER is implemented in the
+:doc:`HIP programming language <hip:index>` and optimized for AMD's
 latest discrete GPUs.
 
-The code is open and hosted at: https://github.com/ROCm/rocSOLVER
+The code is open and hosted at: `<https://github.com/ROCm/rocSOLVER>`__
 
 The rocSOLVER documentation is structured as follows:
 
@@ -24,7 +24,7 @@ The rocSOLVER documentation is structured as follows:
 
     * :ref:`install-linux`
 
-  .. grid-item-card:: How-to
+  .. grid-item-card:: How to
 
     * :ref:`using`
     * :ref:`memory`
@@ -44,7 +44,7 @@ The rocSOLVER documentation is structured as follows:
     * :ref:`tuning_label`
     * :ref:`deprecated`
 
-To contribute to the documentation refer to `Contributing to ROCm  <https://rocm.docs.amd.com/en/latest/contribute/index.html>`_.
+To contribute to the documentation refer to :doc:`Contributing to ROCm <rocm:contribute/contributing>`.
 
-You can find licensing information on the `Licensing <https://rocm.docs.amd.com/en/latest/about/license.html>`_ page.
+You can find licensing information on the :doc:`Licensing <rocm:about/license>` page.
 

--- a/docs/installation/installlinux.rst
+++ b/docs/installation/installlinux.rst
@@ -12,11 +12,11 @@ Prerequisites
 =================
 
 rocSOLVER requires a ROCm-enabled platform. For more information, see the
-`ROCm install guide <https://rocm.docs.amd.com/en/latest/deploy/linux/index.html>`_.
+:doc:`ROCm install guide <rocm-install-on-linux:index>`.
 
 rocSOLVER also requires compatible versions of rocBLAS and rocSPARSE installed on the system.
-For more information, see the `rocBLAS install guide <https://rocm.docs.amd.com/projects/rocBLAS/en/latest/Linux_Install_Guide.html>`_
-and `rocSPARSE install guide <https://rocm.docs.amd.com/projects/rocSPARSE/en/latest/install.html>`_.
+For more information, see the :doc:`rocBLAS install guide <rocblas:install/Linux_Install_Guide>`
+and :doc:`rocSPARSE install guide <rocsparse:install/install>`.
 
 rocBLAS, rocSPARSE, and rocSOLVER are still under active development, and it is hard to define minimal
 compatibility versions. For now, a good rule of thumb is to always use rocSOLVER together with the
@@ -43,7 +43,7 @@ rocSOLVER can be installed using a package manager. On Ubuntu, for example, use 
 Building & installing from source
 =====================================
 
-The `rocSOLVER source code <https://github.com/ROCmSoftwarePlatform/rocSOLVER.git>`_ is hosted
+The `rocSOLVER source code <https://github.com/ROCm/rocSOLVER.git>`_ is hosted
 on GitHub. Download the code and checkout the desired branch using:
 
 .. code-block:: bash

--- a/docs/reference/types.rst
+++ b/docs/reference/types.rst
@@ -10,8 +10,8 @@ rocSOLVER Types
 
 rocSOLVER uses most types and enumerations defined in rocBLAS for the general operation and
 dense matrix computations, and some defined in rocSPARSE for sparse matrix computations (direct solvers).
-For more information, see the `rocBLAS types <https://rocm.docs.amd.com/projects/rocBLAS/en/latest/API_Reference_Guide.html#rocblas-datatypes>`_ and
-`rocSPARSE types <https://rocm.docs.amd.com/projects/rocSPARSE/en/latest/types.html>`_ documentation.
+For more information, see the :doc:`rocBLAS types <rocblas:reference/datatypes>` and
+:doc:`rocSPARSE types <rocsparse:reference/types>` documentation.
 Next we present additional types, only used in rocSOLVER, that extend the rocBLAS and rocSPARSE APIs.
 
 

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -9,7 +9,7 @@ subtrees:
     - entries:
       - file: installation/installlinux.rst
   - file: howto/index.rst
-    title: How To
+    title: How to
     subtrees:
     - entries:
       - file: howto/using.rst


### PR DESCRIPTION
This PR fixes dead links in `installlinux.rst` and `types.rst`.