### PR TITLE
Update package dependencies for static compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,16 +187,24 @@ find_package(hip REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm)
 find_package(rocblas REQUIRED CONFIG PATHS ${ROCM_PATH})
 get_imported_target_location(location roc::rocblas)
 message(STATUS "Found rocBLAS: ${location}")
-set(rocsolver_pkgdeps "rocblas >= 4.2")
+set(rocblas_minimum 4.2)
+rocm_package_add_dependencies(SHARED_DEPENDS "rocblas >= ${rocblas_minimum}")
+rocm_package_add_rpm_dependencies(STATIC_DEPENDS "rocblas-static-devel >= ${rocblas_minimum}")
+rocm_package_add_deb_dependencies(STATIC_DEPENDS "rocblas-static-dev >= ${rocblas_minimum}")
 
 if(BUILD_WITH_SPARSE)
   find_package(rocsparse REQUIRED CONFIG PATHS ${ROCM_PATH})
   get_imported_target_location(location roc::rocsparse)
   message(STATUS "Found rocSPARSE: ${location}")
-  list(APPEND rocsolver_pkgdeps "rocsparse >= 2.2")
+  set(rocsparse_minimum 2.2)
+  rocm_package_add_dependencies(SHARED_DEPENDS "rocsparse >= ${rocsparse_minimum}")
+  rocm_package_add_rpm_dependencies(STATIC_DEPENDS "rocsparse-static-devel >= ${rocsparse_minimum}")
+  rocm_package_add_deb_dependencies(STATIC_DEPENDS "rocsparse-static-dev >= ${rocsparse_minimum}")
 endif()
 
 find_package(rocprim REQUIRED CONFIG PATHS ${ROCM_PATH})
+rocm_package_add_rpm_dependencies(STATIC_DEPENDS "rocprim-devel")
+rocm_package_add_deb_dependencies(STATIC_DEPENDS "rocprim-dev")
 
 add_subdirectory(common)
 
@@ -228,9 +236,6 @@ if(BUILD_CLIENTS_TESTS OR BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_SAMPLES)
   endif()
   add_subdirectory(clients)
 endif()
-
-# Package-specific CPACK vars
-rocm_package_add_dependencies(DEPENDS ${rocsolver_pkgdeps})
 
 if(OS_ID_sles)
   rocm_package_add_rpm_dependencies("libLLVM >= 7.0.1")


### PR DESCRIPTION
* Update package dependencies for static compilation

* add rocPRIM dependency for static packages

This picks c883a04488cfd61c0a8fc11b082babd2094d2e63 from topic/init-static-libs-support, which was written after release-staging/rocm-rel-6.2 was created.

Do we need an additional PR to target develop, or can we just let the 6.2 mergeback take care of it?