### PR TITLE
Fix stebz pivots lower bound

### DIFF
--- a/library/src/auxiliary/rocauxiliary_stebz.hpp
+++ b/library/src/auxiliary/rocauxiliary_stebz.hpp
@@ -300,7 +300,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(SPLIT_THDS)
     iamax<SPLIT_THDS>(tid, n - 1, Esqr, 1, sval, sidx);
     __syncthreads();
 
-    T pmin = sval[0] * sfmin;
+    // `pmin` is a numerically stable lower bound for pivots
+    T pmin = std::max(sval[0] * sfmin, sfmin);
     vl = vlow;
     vu = vup;
 


### PR DESCRIPTION
This PR fixes a bug in which `stebz` can fail when the lower bound for pivots is too small.

For example, the following input matrix:
```.cpp
  double A[9] = {
      1.000000105,  0.000000005, 0.0,
      0.000000005,  1.000000105, 0.0,
      0.0, 0.0,     1.000000111
  };
```
will cause an underflow in line:
https://github.com/ROCm/rocSOLVER/blob/9e10562c3c226b11a04b9bf6a6afc01029353d14/library/src/auxiliary/rocauxiliary_stebz.hpp#L305
which yields `pmin = 0`.

For this input matrix, `stebz` crashes with a segmentation fault because many variables are not initialized correctly, for instance, see `lc_maxite`:
https://github.com/ROCm/rocSOLVER/blob/9e10562c3c226b11a04b9bf6a6afc01029353d14/library/src/auxiliary/rocauxiliary_stebz.hpp#L552