### PR TITLE
Use TARGET_RUNTIME_DLLS generator expression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@
 # SUCH DAMAGE.
 # ##########################################################################
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.21)
 
 # This has to be initialized before the project() command appears
 # Set the default build type to Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@
 # SUCH DAMAGE.
 # ##########################################################################
 
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.13)
 
 # This has to be initialized before the project() command appears
 # Set the default build type to Release
@@ -136,6 +136,7 @@ option(BUILD_ADDRESS_SANITIZER "Build with address sanitizer enabled" OFF)
 option(BUILD_CODE_COVERAGE "Build rocSOLVER with code coverage enabled" OFF)
 option(WERROR "Treat warnings as errors" OFF)
 option(BUILD_COMPRESSED_DBG "Enable compressed debug symbols" ON)
+cmake_dependent_option(BUILD_COPY_TEST_DEPS "Copy test dependencies to the clients build directory" ON "WIN32;CMAKE_VERSION VERSION_GREATER_EQUAL 3.21" OFF)
 
 cmake_dependent_option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY
   "Build with file/folder reorg backward compatibility enabled" OFF "NOT WIN32" OFF)

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -152,7 +152,7 @@ add_armor_flags(rocsolver-test "${ARMOR_LEVEL}")
 
 if(WIN32)
   add_custom_command(TARGET rocsolver-test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE_DIR:rocsolver-test> $<TARGET_RUNTIME_DLLS:rocsolver-test>
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:rocsolver-test> $<TARGET_FILE_DIR:rocsolver-test>
   )
 
   get_target_property(rocblas_location roc::rocblas LOCATION)

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -153,6 +153,7 @@ add_armor_flags(rocsolver-test "${ARMOR_LEVEL}")
 if(WIN32)
   add_custom_command(TARGET rocsolver-test POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:rocsolver-test> $<TARGET_FILE_DIR:rocsolver-test>
+    COMMAND_EXPAND_LISTS
   )
 
   get_target_property(rocblas_location roc::rocblas LOCATION)
@@ -167,11 +168,10 @@ if(WIN32)
     ${CMAKE_CURRENT_SOURCE_DIR}/../../rtest.py
     ${CMAKE_CURRENT_SOURCE_DIR}/../../rtest.xml
   )
-  foreach(file_i ${runtime_files})
-    add_custom_command(TARGET rocsolver-test POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy ${file_i} $<TARGET_FILE_DIR:rocsolver-test>
-    )
-  endforeach()
+  add_custom_command(TARGET rocsolver-test POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy "${runtime_files}" $<TARGET_FILE_DIR:rocsolver-test>
+    COMMAND_EXPAND_LISTS
+  )
 endif()
 
 target_link_libraries(rocsolver-test PRIVATE

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -156,8 +156,9 @@ if(WIN32)
   )
 
   get_target_property(rocblas_location roc::rocblas LOCATION)
+  get_filename_component(rocblas_directory ${rocblas_location} DIRECTORY)
   add_custom_command(TARGET rocsolver-test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory $<TARGET_FILE_DIR:rocsolver-test>/library ${rocblas_location}/library
+    COMMAND ${CMAKE_COMMAND} -E copy_directory $<TARGET_FILE_DIR:rocsolver-test>/library ${rocblas_directory}/library
   )
 
   find_program(HIPINFO_EXECUTABLE hipinfo PATHS $ENV{HIP_DIR}/bin)

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -151,28 +151,26 @@ add_executable(rocsolver-test
 add_armor_flags(rocsolver-test "${ARMOR_LEVEL}")
 
 if(WIN32)
-  file(GLOB third_party_dlls
-    LIST_DIRECTORIES OFF
-    CONFIGURE_DEPENDS
-    ${ROCSOLVER_LAPACK_PATH}/bin/*.dll
-    ${GTest_DIR}/bin/*.dll
-    $ENV{rocblas_DIR}/bin/*.dll
-    $ENV{HIP_DIR}/bin/*.dll
-    $ENV{HIP_DIR}/bin/hipinfo.exe
-    ${CMAKE_SOURCE_DIR}/rtest.*
+  add_custom_command(TARGET rocsolver-test POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE_DIR:rocsolver-test> $<TARGET_RUNTIME_DLLS:rocsolver-test>
   )
-  foreach(file_i ${third_party_dlls})
-    add_custom_command(TARGET rocsolver-test
-      POST_BUILD
-      COMMAND ${CMAKE_COMMAND}
-      ARGS -E copy ${file_i} ${PROJECT_BINARY_DIR}/staging/
+
+  get_target_property(rocblas_location roc::rocblas LOCATION)
+  add_custom_command(TARGET rocsolver-test POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory $<TARGET_FILE_DIR:rocsolver-test>/library ${rocblas_location}/library
+  )
+
+  find_program(HIPINFO_EXECUTABLE hipinfo PATHS $ENV{HIP_DIR}/bin)
+  set(test_files
+    ${HIPINFO_EXECUTABLE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../rtest.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../rtest.xml
+  )
+  foreach(file_i ${runtime_files})
+    add_custom_command(TARGET rocsolver-test POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy ${file_i} $<TARGET_FILE_DIR:rocsolver-test>
     )
   endforeach()
-  add_custom_command(TARGET rocsolver-test
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND}
-    ARGS -E copy_directory $ENV{rocblas_DIR}/bin/rocblas/library ${PROJECT_BINARY_DIR}/staging/library
-  )
 endif()
 
 target_link_libraries(rocsolver-test PRIVATE

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -150,7 +150,7 @@ add_executable(rocsolver-test
 
 add_armor_flags(rocsolver-test "${ARMOR_LEVEL}")
 
-if(WIN32)
+if(BUILD_COPY_TEST_DEPS)
   add_custom_command(TARGET rocsolver-test POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:rocsolver-test> $<TARGET_FILE_DIR:rocsolver-test>
     COMMAND_EXPAND_LISTS

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -159,7 +159,7 @@ if(WIN32)
   get_target_property(rocblas_location roc::rocblas LOCATION)
   get_filename_component(rocblas_directory ${rocblas_location} DIRECTORY)
   add_custom_command(TARGET rocsolver-test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory $<TARGET_FILE_DIR:rocsolver-test>/library ${rocblas_directory}/library
+    COMMAND ${CMAKE_COMMAND} -E copy_directory  ${rocblas_directory}/library $<TARGET_FILE_DIR:rocsolver-test>/library
   )
 
   find_program(HIPINFO_EXECUTABLE hipinfo PATHS $ENV{HIP_DIR}/bin)

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -168,10 +168,11 @@ if(WIN32)
     ${CMAKE_CURRENT_SOURCE_DIR}/../../rtest.py
     ${CMAKE_CURRENT_SOURCE_DIR}/../../rtest.xml
   )
-  add_custom_command(TARGET rocsolver-test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy "${runtime_files}" $<TARGET_FILE_DIR:rocsolver-test>
-    COMMAND_EXPAND_LISTS
-  )
+  foreach(file_i ${runtime_files})
+    add_custom_command(TARGET rocsolver-test POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy ${file_i} $<TARGET_FILE_DIR:rocsolver-test>
+    )
+  endforeach()
 endif()
 
 target_link_libraries(rocsolver-test PRIVATE

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -159,7 +159,7 @@ if(WIN32)
   get_target_property(rocblas_location roc::rocblas LOCATION)
   get_filename_component(rocblas_directory ${rocblas_location} DIRECTORY)
   add_custom_command(TARGET rocsolver-test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory  ${rocblas_directory}/library $<TARGET_FILE_DIR:rocsolver-test>/library
+    COMMAND ${CMAKE_COMMAND} -E copy_directory  ${rocblas_directory}/rocblas/library $<TARGET_FILE_DIR:rocsolver-test>/library
   )
 
   find_program(HIPINFO_EXECUTABLE hipinfo PATHS $ENV{HIP_DIR}/bin)


### PR DESCRIPTION
The TARGET_RUNTIME_DLLS generator expression added in CMake 3.21 provides exactly the functionality that is desired on Windows for copying the DLLs, and it is more robust than the existing glob.