### PR TITLE
Remove loop unrolls from getri and trtri

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -300,6 +300,16 @@ set(rocsolver_specialized_source
   specialized/roclapack_potf2_specialized_kernels_d.cpp
   specialized/roclapack_potf2_specialized_kernels_c.cpp
   specialized/roclapack_potf2_specialized_kernels_z.cpp
+  # getri
+  specialized/roclapack_getri_specialized_kernels_s.cpp
+  specialized/roclapack_getri_specialized_kernels_d.cpp
+  specialized/roclapack_getri_specialized_kernels_c.cpp
+  specialized/roclapack_getri_specialized_kernels_z.cpp
+  # trtri
+  specialized/roclapack_trtri_specialized_kernels_s.cpp
+  specialized/roclapack_trtri_specialized_kernels_d.cpp
+  specialized/roclapack_trtri_specialized_kernels_c.cpp
+  specialized/roclapack_trtri_specialized_kernels_z.cpp
 )
 
 if(OPTIMAL)
@@ -317,16 +327,6 @@ if(OPTIMAL)
     specialized/roclapack_getf2_small_db.cpp
     specialized/roclapack_getf2_small_cb.cpp
     specialized/roclapack_getf2_small_zb.cpp
-    # getri
-    specialized/roclapack_getri_specialized_kernels_s.cpp
-    specialized/roclapack_getri_specialized_kernels_d.cpp
-    specialized/roclapack_getri_specialized_kernels_c.cpp
-    specialized/roclapack_getri_specialized_kernels_z.cpp
-    # trtri
-    specialized/roclapack_trtri_specialized_kernels_s.cpp
-    specialized/roclapack_trtri_specialized_kernels_d.cpp
-    specialized/roclapack_trtri_specialized_kernels_c.cpp
-    specialized/roclapack_trtri_specialized_kernels_z.cpp
   )
 endif()
 

--- a/library/src/include/rocsolver_run_specialized_kernels.hpp
+++ b/library/src/include/rocsolver_run_specialized_kernels.hpp
@@ -309,6 +309,8 @@ rocblas_status getf2_run_small(rocblas_handle handle,
                                I* permut_idx,
                                const rocblas_stride stride);
 
+#endif // OPTIMAL
+
 template <typename T, typename U>
 rocblas_status getri_run_small(rocblas_handle handle,
                                const rocblas_int n,
@@ -335,7 +337,5 @@ void trti2_run_small(rocblas_handle handle,
                      const rocblas_int lda,
                      const rocblas_stride strideA,
                      const rocblas_int batch_count);
-
-#endif // OPTIMAL
 
 ROCSOLVER_END_NAMESPACE

--- a/library/src/lapack/roclapack_getri.hpp
+++ b/library/src/lapack/roclapack_getri.hpp
@@ -191,7 +191,6 @@ void rocsolver_getri_getMemorySize(const rocblas_int n,
 
     static constexpr bool ISBATCHED = BATCHED || STRIDED;
 
-#ifdef OPTIMAL
     // if tiny size, no workspace needed
     if((n <= GETRI_TINY_SIZE && !ISBATCHED) || (n <= GETRI_BATCH_TINY_SIZE && ISBATCHED))
     {
@@ -204,7 +203,6 @@ void rocsolver_getri_getMemorySize(const rocblas_int n,
         *optim_mem = true;
         return;
     }
-#endif
 
     bool opt1, opt2;
     size_t unused, w1a = 0, w1b = 0, w2a = 0, w2b = 0, w3a = 0, w3b = 0, w4a = 0, w4b = 0, t1, t2;
@@ -219,7 +217,6 @@ void rocsolver_getri_getMemorySize(const rocblas_int n,
     else
         *size_workArr = 0;
 
-#ifdef OPTIMAL
     // if small size nothing else is needed
     if(n <= TRTRI_MAX_COLS)
     {
@@ -230,7 +227,6 @@ void rocsolver_getri_getMemorySize(const rocblas_int n,
         *size_tmpcopy = t2;
         return;
     }
-#endif
 
     // get block size
     rocblas_int blk = getri_get_blksize<ISBATCHED>(n);
@@ -329,13 +325,11 @@ rocblas_status rocsolver_getri_template(rocblas_handle handle,
 
     static constexpr bool ISBATCHED = BATCHED || STRIDED;
 
-#ifdef OPTIMAL
     if((n <= GETRI_TINY_SIZE && !ISBATCHED) || (n <= GETRI_BATCH_TINY_SIZE && ISBATCHED))
     {
         return getri_run_small<T>(handle, n, A, shiftA, lda, strideA, ipiv, shiftP, strideP, info,
                                   batch_count, true, pivot);
     }
-#endif
 
     // compute inverse of U (also check singularity and update info)
     rocsolver_trtri_template<BATCHED, STRIDED, T>(
@@ -345,14 +339,12 @@ rocblas_status rocsolver_getri_template(rocblas_handle handle,
     // ************************************************ //
     // Next, compute inv(A) solving inv(A) * L = inv(U) //
 
-#ifdef OPTIMAL
     // if small size, use optimized kernel for stage 2
     if(n <= TRTRI_MAX_COLS)
     {
         return getri_run_small<T>(handle, n, A, shiftA, lda, strideA, ipiv, shiftP, strideP, info,
                                   batch_count, false, pivot);
     }
-#endif
 
     rocblas_int threads = std::min(((n - 1) / 64 + 1) * 64, BS1);
     rocblas_int ldw = n;

--- a/library/src/lapack/roclapack_trtri.hpp
+++ b/library/src/lapack/roclapack_trtri.hpp
@@ -135,7 +135,6 @@ void rocsolver_trtri_getMemorySize(const rocblas_diagonal diag,
 
     // requirements for TRTI2
     rocblas_int nn = (blk == 1) ? n : blk;
-#ifdef OPTIMAL
     if(nn <= TRTRI_MAX_COLS)
     {
         // if very small size, no workspace needed
@@ -149,12 +148,6 @@ void rocsolver_trtri_getMemorySize(const rocblas_diagonal diag,
         // size for alphas
         w3a = nn * sizeof(T) * batch_count;
     }
-#else
-    // size for TRMV
-    w1a = nn * sizeof(T) * batch_count;
-    // size for alphas
-    w3a = nn * sizeof(T) * batch_count;
-#endif
 
     if(blk == 0)
     {
@@ -231,14 +224,12 @@ void trti2(rocblas_handle handle,
            T* work,
            T* alphas)
 {
-#ifdef OPTIMAL
     // if very small size, use optimized kernel
     if(n <= TRTRI_MAX_COLS)
     {
         trti2_run_small<T>(handle, uplo, diag, n, A, shiftA, lda, strideA, batch_count);
         return;
     }
-#endif
 
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);

--- a/library/src/specialized/roclapack_trtri_specialized_kernels.hpp
+++ b/library/src/specialized/roclapack_trtri_specialized_kernels.hpp
@@ -42,10 +42,11 @@ ROCSOLVER_BEGIN_NAMESPACE
     the library size.
 *************************************************************/
 
-template <rocblas_int DIM, typename T, typename U>
+template <typename T, typename U>
 ROCSOLVER_KERNEL void __launch_bounds__(TRTRI_MAX_COLS)
     trti2_kernel_small(const rocblas_fill uplo,
                        const rocblas_diagonal diagtype,
+                       const rocblas_int n,
                        U AA,
                        const rocblas_int shiftA,
                        const rocblas_int lda,
@@ -54,21 +55,20 @@ ROCSOLVER_KERNEL void __launch_bounds__(TRTRI_MAX_COLS)
     int b = hipBlockIdx_x;
     int i = hipThreadIdx_x;
 
-    if(i >= DIM)
+    if(i >= n)
         return;
 
     // batch instance
     T* A = load_ptr_batch<T>(AA, b, shiftA, strideA);
 
     // read corresponding row from global memory in local array
-    T rA[DIM];
-#pragma unroll
-    for(int j = 0; j < DIM; ++j)
+    T rA[TRTRI_MAX_COLS];
+    for(int j = 0; j < n; ++j)
         rA[j] = A[i + j * lda];
 
     // shared memory (for communication between threads in group)
-    __shared__ T common[DIM];
-    __shared__ T diag[DIM];
+    __shared__ T common[TRTRI_MAX_COLS];
+    __shared__ T diag[TRTRI_MAX_COLS];
     T temp;
 
     // diagonal element
@@ -86,8 +86,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(TRTRI_MAX_COLS)
     // compute element i of each column j
     if(uplo == rocblas_fill_upper)
     {
-#pragma unroll
-        for(rocblas_int j = 1; j < DIM; j++)
+        for(rocblas_int j = 1; j < n; j++)
         {
             // share current column and diagonal
             common[i] = rA[j];
@@ -106,8 +105,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(TRTRI_MAX_COLS)
     }
     else
     {
-#pragma unroll
-        for(rocblas_int j = DIM - 2; j >= 0; j--)
+        for(rocblas_int j = n - 2; j >= 0; j--)
         {
             // share current column and diagonal
             common[i] = rA[j];
@@ -126,8 +124,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(TRTRI_MAX_COLS)
     }
 
     // write results to global memory from local array
-#pragma unroll
-    for(int j = 0; j < DIM; j++)
+    for(int j = 0; j < n; j++)
         A[i + j * lda] = rA[j];
 }
 
@@ -146,86 +143,14 @@ void trti2_run_small(rocblas_handle handle,
                      const rocblas_stride strideA,
                      const rocblas_int batch_count)
 {
-#define RUN_TRTI2_SMALL(DIM)                                                                     \
-    ROCSOLVER_LAUNCH_KERNEL((trti2_kernel_small<DIM, T>), grid, block, 0, stream, uplo, diag, A, \
-                            shiftA, lda, strideA)
-
     dim3 grid(batch_count, 1, 1);
     dim3 block(TRTRI_MAX_COLS, 1, 1);
 
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
 
-    // instantiate cases to make number of columns n known at compile time
-    // this should allow loop unrolling.
-    switch(n)
-    {
-    case 1: RUN_TRTI2_SMALL(1); break;
-    case 2: RUN_TRTI2_SMALL(2); break;
-    case 3: RUN_TRTI2_SMALL(3); break;
-    case 4: RUN_TRTI2_SMALL(4); break;
-    case 5: RUN_TRTI2_SMALL(5); break;
-    case 6: RUN_TRTI2_SMALL(6); break;
-    case 7: RUN_TRTI2_SMALL(7); break;
-    case 8: RUN_TRTI2_SMALL(8); break;
-    case 9: RUN_TRTI2_SMALL(9); break;
-    case 10: RUN_TRTI2_SMALL(10); break;
-    case 11: RUN_TRTI2_SMALL(11); break;
-    case 12: RUN_TRTI2_SMALL(12); break;
-    case 13: RUN_TRTI2_SMALL(13); break;
-    case 14: RUN_TRTI2_SMALL(14); break;
-    case 15: RUN_TRTI2_SMALL(15); break;
-    case 16: RUN_TRTI2_SMALL(16); break;
-    case 17: RUN_TRTI2_SMALL(17); break;
-    case 18: RUN_TRTI2_SMALL(18); break;
-    case 19: RUN_TRTI2_SMALL(19); break;
-    case 20: RUN_TRTI2_SMALL(20); break;
-    case 21: RUN_TRTI2_SMALL(21); break;
-    case 22: RUN_TRTI2_SMALL(22); break;
-    case 23: RUN_TRTI2_SMALL(23); break;
-    case 24: RUN_TRTI2_SMALL(24); break;
-    case 25: RUN_TRTI2_SMALL(25); break;
-    case 26: RUN_TRTI2_SMALL(26); break;
-    case 27: RUN_TRTI2_SMALL(27); break;
-    case 28: RUN_TRTI2_SMALL(28); break;
-    case 29: RUN_TRTI2_SMALL(29); break;
-    case 30: RUN_TRTI2_SMALL(30); break;
-    case 31: RUN_TRTI2_SMALL(31); break;
-    case 32: RUN_TRTI2_SMALL(32); break;
-    case 33: RUN_TRTI2_SMALL(33); break;
-    case 34: RUN_TRTI2_SMALL(34); break;
-    case 35: RUN_TRTI2_SMALL(35); break;
-    case 36: RUN_TRTI2_SMALL(36); break;
-    case 37: RUN_TRTI2_SMALL(37); break;
-    case 38: RUN_TRTI2_SMALL(38); break;
-    case 39: RUN_TRTI2_SMALL(39); break;
-    case 40: RUN_TRTI2_SMALL(40); break;
-    case 41: RUN_TRTI2_SMALL(41); break;
-    case 42: RUN_TRTI2_SMALL(42); break;
-    case 43: RUN_TRTI2_SMALL(43); break;
-    case 44: RUN_TRTI2_SMALL(44); break;
-    case 45: RUN_TRTI2_SMALL(45); break;
-    case 46: RUN_TRTI2_SMALL(46); break;
-    case 47: RUN_TRTI2_SMALL(47); break;
-    case 48: RUN_TRTI2_SMALL(48); break;
-    case 49: RUN_TRTI2_SMALL(49); break;
-    case 50: RUN_TRTI2_SMALL(50); break;
-    case 51: RUN_TRTI2_SMALL(51); break;
-    case 52: RUN_TRTI2_SMALL(52); break;
-    case 53: RUN_TRTI2_SMALL(53); break;
-    case 54: RUN_TRTI2_SMALL(54); break;
-    case 55: RUN_TRTI2_SMALL(55); break;
-    case 56: RUN_TRTI2_SMALL(56); break;
-    case 57: RUN_TRTI2_SMALL(57); break;
-    case 58: RUN_TRTI2_SMALL(58); break;
-    case 59: RUN_TRTI2_SMALL(59); break;
-    case 60: RUN_TRTI2_SMALL(60); break;
-    case 61: RUN_TRTI2_SMALL(61); break;
-    case 62: RUN_TRTI2_SMALL(62); break;
-    case 63: RUN_TRTI2_SMALL(63); break;
-    case 64: RUN_TRTI2_SMALL(64); break;
-    default: ROCSOLVER_UNREACHABLE();
-    }
+    ROCSOLVER_LAUNCH_KERNEL((trti2_kernel_small<T>), grid, block, 0, stream, uplo, diag, n, A,
+                            shiftA, lda, strideA);
 }
 
 /*************************************************************


### PR DESCRIPTION
This PR removes the loop unrolls from the small-size getri and trtri kernels, reducing the library size and allowing them to be built even if the -n flag is passed to the install script. My tests on gfx90a show a minimal impact on performance, though I wasn't able to run the batch tests due to a hang.