### PR TITLE
Hash syevx/sygvx tests input/output for debugging

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -131,17 +131,17 @@ if(BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
     common/lapack/testing_syevdj_heevdj.cpp
     common/lapack/testing_syevdx_heevdx.cpp
     common/lapack/testing_syevj_heevj.cpp
-    common/lapack/testing_syevx_heevx.cpp
     common/lapack/testing_sygv_hegv.cpp
     common/lapack/testing_sygvd_hegvd.cpp
     common/lapack/testing_sygvdj_hegvdj.cpp
     common/lapack/testing_sygvdx_hegvdx.cpp
     common/lapack/testing_sygvj_hegvj.cpp
-    common/lapack/testing_sygvx_hegvx.cpp
     common/lapack/testing_geblttrf_npvt.cpp
     common/lapack/testing_geblttrf_npvt_interleaved.cpp
     common/lapack/testing_geblttrs_npvt.cpp
     common/lapack/testing_geblttrs_npvt_interleaved.cpp
+    common/lapack/testing_sygvx_hegvx.cpp
+    common/lapack/testing_syevx_heevx.cpp
   )
 
   set(rocrefact_inst_files
@@ -160,8 +160,8 @@ if(BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
     common/misc/program_options.cpp
     common/misc/client_environment_helpers.cpp
     ${rocauxiliary_inst_files}
-    ${roclapack_inst_files}
     ${rocrefact_inst_files}
+    ${roclapack_inst_files}
   )
 
   prepend_path("${CMAKE_CURRENT_SOURCE_DIR}/" common_source_files common_source_paths)

--- a/clients/common/lapack/testing_syevx_heevx.hpp
+++ b/clients/common/lapack/testing_syevx_heevx.hpp
@@ -306,6 +306,15 @@ void syevx_heevx_getError(const rocblas_handle handle,
     // input data initialization
     syevx_heevx_initData<true, true, T>(handle, evect, n, dA, lda, bc, hA, A);
 
+    //
+    // Compute input data hash
+    //
+    std::size_t input_hash = 0;
+    for (rocblas_int b = 0; b < bc; ++b)
+    {
+        input_hash = hash_combine(input_hash, hA[b], lda * n);
+    }
+
     // execute computations
     // GPU lapack
     CHECK_ROCBLAS_ERROR(rocsolver_syevx_heevx(
@@ -347,6 +356,48 @@ void syevx_heevx_getError(const rocblas_handle handle,
             err++;
     }
     *max_err = err > *max_err ? err : *max_err;
+
+    //
+    // Compute output hashes
+    //
+    std::size_t lapack_eigenvalues_hash = 0;
+    std::size_t rocsolver_eigenvalues_hash = 0;
+    std::size_t lapack_eigenvectors_hash = 0;
+    std::size_t rocsolver_eigenvectors_hash = 0;
+
+    for(rocblas_int b = 0; b < bc; ++b)
+    {
+        if(hinfo[b][0] == 0)
+        {
+            lapack_eigenvalues_hash = hash_combine(lapack_eigenvalues_hash, hW[b], hNev[b][0]);
+            rocsolver_eigenvalues_hash = hash_combine(rocsolver_eigenvalues_hash, hWRes[b], hNevRes[b][0]);
+
+            if(evect == rocblas_evect_original)
+            {
+                for(int j = 0; j < hNev[b][0]; j++)
+                {
+                    lapack_eigenvectors_hash = hash_combine(lapack_eigenvectors_hash, hZ[b] + j * ldz, ldz);
+                }
+
+                for(int j = 0; j < hNevRes[b][0]; j++)
+                {
+                    rocsolver_eigenvectors_hash = hash_combine(rocsolver_eigenvectors_hash, hZRes[b] + j * ldz, ldz);
+                }
+            }
+        }
+    }
+
+    //
+    // Print hashes
+    //
+    std::cout << "[          ] " << "Input matrix hash: " << input_hash << std::endl << std::flush;
+    std::cout << "[          ] " << "Rocsolver eigenvalues hash: " << rocsolver_eigenvalues_hash << std::endl << std::flush;
+    std::cout << "[          ] " << "LAPACK eigenvalues hash: " << lapack_eigenvalues_hash << std::endl << std::flush;
+    if (evect == rocblas_evect_original)
+    {
+        std::cout << "[          ] " << "Rocsolver eigenvectors hash: " << rocsolver_eigenvectors_hash << std::endl << std::flush;
+        std::cout << "[          ] " << "LAPACK eigenvectors hash: " << lapack_eigenvectors_hash << std::endl << std::flush;
+    }
 
     // (We expect the used input matrices to always converge. Testing
     // implicitly the equivalent non-converged matrix is very complicated and it boils

--- a/clients/common/misc/rocblas_random.hpp
+++ b/clients/common/misc/rocblas_random.hpp
@@ -46,7 +46,13 @@ extern const std::thread::id main_thread_id;
 inline rocblas_rng_t get_seed()
 {
     auto tid = std::this_thread::get_id();
-    return tid == main_thread_id ? rocblas_seed : rocblas_rng_t(std::hash<std::thread::id>{}(tid));
+    /* return tid == main_thread_id ? rocblas_seed : rocblas_rng_t(std::hash<std::thread::id>{}(tid)); */
+
+    auto tid_hash = static_cast<std::size_t>(std::hash<std::thread::id>{}(tid));
+    std::cout << "\u001b[32m[          ] \u001b[33m" << "Random seed hash: " << tid_hash << "\u001b[0m" << std::endl << std::flush;
+
+    auto seed = static_cast<rocblas_rng_t>((tid == main_thread_id) ? rocblas_seed : rocblas_rng_t(tid_hash));
+    return seed;
 }
 
 // Reset the seed (mainly to ensure repeatability of failures in a given suite)

--- a/clients/common/misc/rocblas_random.hpp
+++ b/clients/common/misc/rocblas_random.hpp
@@ -48,11 +48,17 @@ inline rocblas_rng_t get_seed()
     auto tid = std::this_thread::get_id();
     /* return tid == main_thread_id ? rocblas_seed : rocblas_rng_t(std::hash<std::thread::id>{}(tid)); */
 
+    constexpr std::size_t rocblas_default_seed = 69069;
     auto tid_hash = static_cast<std::size_t>(std::hash<std::thread::id>{}(tid));
-    std::cout << "\u001b[32m[          ] \u001b[33m" << "Random seed hash: " << tid_hash << "\u001b[0m" << std::endl << std::flush;
 
-    auto seed = static_cast<rocblas_rng_t>(tid_hash);
-    return seed;
+    bool use_default_seed = (tid == main_thread_id);
+    auto seed = static_cast<std::size_t>(use_default_seed ? rocblas_default_seed : tid_hash);
+    std::cout << "\u001b[32m[          ] \u001b[33m" << "Random seed: type " << (use_default_seed ? "default" : "thread id hash")
+        << ", value: " << seed << "\u001b[0m" << std::endl << std::flush;
+
+    rocblas_rng_t generator;
+    generator.seed(seed);
+    return generator;
 }
 
 // Reset the seed (mainly to ensure repeatability of failures in a given suite)

--- a/clients/common/misc/rocblas_random.hpp
+++ b/clients/common/misc/rocblas_random.hpp
@@ -51,7 +51,7 @@ inline rocblas_rng_t get_seed()
     auto tid_hash = static_cast<std::size_t>(std::hash<std::thread::id>{}(tid));
     std::cout << "\u001b[32m[          ] \u001b[33m" << "Random seed hash: " << tid_hash << "\u001b[0m" << std::endl << std::flush;
 
-    auto seed = static_cast<rocblas_rng_t>((tid == main_thread_id) ? rocblas_seed : rocblas_rng_t(tid_hash));
+    auto seed = static_cast<rocblas_rng_t>(tid_hash);
     return seed;
 }
 

--- a/clients/common/misc/rocblas_random.hpp
+++ b/clients/common/misc/rocblas_random.hpp
@@ -46,19 +46,7 @@ extern const std::thread::id main_thread_id;
 inline rocblas_rng_t get_seed()
 {
     auto tid = std::this_thread::get_id();
-    /* return tid == main_thread_id ? rocblas_seed : rocblas_rng_t(std::hash<std::thread::id>{}(tid)); */
-
-    constexpr std::size_t rocblas_default_seed = 69069;
-    auto tid_hash = static_cast<std::size_t>(std::hash<std::thread::id>{}(tid));
-
-    bool use_default_seed = (tid == main_thread_id);
-    auto seed = static_cast<std::size_t>(use_default_seed ? rocblas_default_seed : tid_hash);
-    std::cout << "\u001b[32m[          ] \u001b[33m" << "Random seed: type " << (use_default_seed ? "default" : "thread id hash")
-        << ", value: " << seed << "\u001b[0m" << std::endl << std::flush;
-
-    rocblas_rng_t generator;
-    generator.seed(seed);
-    return generator;
+    return tid == main_thread_id ? rocblas_seed : rocblas_rng_t(std::hash<std::thread::id>{}(tid));
 }
 
 // Reset the seed (mainly to ensure repeatability of failures in a given suite)

--- a/clients/common/misc/rocsolver_test.hpp
+++ b/clients/common/misc/rocsolver_test.hpp
@@ -51,7 +51,14 @@ namespace fs = std::experimental::filesystem;
 #define USE_ROCBLAS_REALLOC_ON_DEMAND true
 
 #ifdef ROCSOLVER_CLIENTS_TEST
-#define ROCSOLVER_TEST_CHECK(T, max_error, tol) ASSERT_LE((max_error), (tol)*get_epsilon<T>())
+#define ROCSOLVER_TEST_CHECK(T, max_error, tol)                                                       \
+    {                                                                                                 \
+        ASSERT_LE((max_error), (tol)*get_epsilon<T>());                                               \
+        std::cout << "\u001b[32m[          ] \u001b[0m" << "Normalized error <= \u001b[32m"  << (     \
+                (tol > get_safemin<T>()) ? max_error/(tol * get_epsilon<T>()) : get_safemin<T>()      \
+        ) << "\u001b[0m" << std::endl << std::flush;                                                  \
+    }                                                                                                 \
+
 #else // ROCSOLVER_CLIENTS_BENCH
 #define ROCSOLVER_TEST_CHECK(T, max_error, tol)
 #endif


### PR DESCRIPTION
This is a draft PR meant to simplify debugging syevx/sygvx (and related methods) after their tests have been updated.

It keeps the old tests, while adding code to print hashes of input and output matrices, to facilitate pinpointing possible synchronization issues and similar sources of non-determinism.