### PR TITLE
Make sure containers used in clients are zero-initialized

### DIFF
--- a/clients/common/containers/d_vector.hpp
+++ b/clients/common/containers/d_vector.hpp
@@ -67,6 +67,16 @@ public:
             fmt::print(stderr, "Error allocating {} bytes ({} GB)\n", bytes, bytes >> 30);
             d = nullptr;
         }
+        /* CHECK_HIP_ERROR((hipMemset)(d, 0, bytes)); // Why this doesn't work? */
+        {
+            auto error = (hipMemset)(d, 0, bytes);
+            if(error != hipSuccess)
+            {
+                fmt::print(stderr, "error: {} ({}) at {}:{}\n", hipGetErrorString(error), error,
+                        __FILE__, __LINE__);
+                rocblas_abort();
+            }
+        }
         return d;
     }
 

--- a/clients/common/containers/d_vector.hpp
+++ b/clients/common/containers/d_vector.hpp
@@ -61,19 +61,19 @@ public:
 
     T* device_vector_setup()
     {
-        T* d = nullptr;
+        T* d;
         if((hipMalloc)(&d, bytes) != hipSuccess)
         {
             fmt::print(stderr, "Error allocating {} bytes ({} GB)\n", bytes, bytes >> 30);
             d = nullptr;
         }
-        /* CHECK_HIP_ERROR((hipMemset)(d, 0, bytes)); // Why this doesn't work? */
-        if(d != nullptr)
+        else
         {
-            auto error = (hipMemset)(d, 0, bytes);
-            if(error != hipSuccess)
+            auto status = (hipMemset)(d, 0, bytes);
+            /* CHECK_HIP_ERROR(status); // Why this doesn't work? */
+            if(status != hipSuccess)
             {
-                fmt::print(stderr, "error: {} ({}) at {}:{}\n", hipGetErrorString(error), error,
+                fmt::print(stderr, "error: {} ({}) at {}:{}\n", hipGetErrorString(status), status,
                            __FILE__, __LINE__);
                 rocblas_abort();
             }

--- a/clients/common/containers/d_vector.hpp
+++ b/clients/common/containers/d_vector.hpp
@@ -61,16 +61,15 @@ public:
 
     T* device_vector_setup()
     {
-        T* d;
+        T* d = nullptr;
         if((hipMalloc)(&d, bytes) != hipSuccess)
         {
             fmt::print(stderr, "Error allocating {} bytes ({} GB)\n", bytes, bytes >> 30);
             d = nullptr;
         }
-        else
+        if(d != nullptr)
         {
             auto status = (hipMemset)(d, 0, bytes);
-            /* CHECK_HIP_ERROR(status); // Why this doesn't work? */
             if(status != hipSuccess)
             {
                 fmt::print(stderr, "error: {} ({}) at {}:{}\n", hipGetErrorString(status), status,

--- a/clients/common/containers/d_vector.hpp
+++ b/clients/common/containers/d_vector.hpp
@@ -61,19 +61,20 @@ public:
 
     T* device_vector_setup()
     {
-        T* d;
+        T* d = nullptr;
         if((hipMalloc)(&d, bytes) != hipSuccess)
         {
             fmt::print(stderr, "Error allocating {} bytes ({} GB)\n", bytes, bytes >> 30);
             d = nullptr;
         }
         /* CHECK_HIP_ERROR((hipMemset)(d, 0, bytes)); // Why this doesn't work? */
+        if(d != nullptr)
         {
             auto error = (hipMemset)(d, 0, bytes);
             if(error != hipSuccess)
             {
                 fmt::print(stderr, "error: {} ({}) at {}:{}\n", hipGetErrorString(error), error,
-                        __FILE__, __LINE__);
+                           __FILE__, __LINE__);
                 rocblas_abort();
             }
         }

--- a/clients/common/containers/host_strided_batch_vector.hpp
+++ b/clients/common/containers/host_strided_batch_vector.hpp
@@ -109,7 +109,8 @@ public:
 
             if(valid_parameters)
             {
-                this->m_data = new T[this->m_nmemb];
+                // Value-initialization (`new T{}` or `new T[]{}`) of a non-class type yields zero-initialization
+                this->m_data = new T[this->m_nmemb]{};
             }
         }
     }


### PR DESCRIPTION
This PR adds the minimal changes that are necessary to make sure all containers created in clients are zero-initialized. Those containers' implementation will be revisited in the future.