### PR TITLE
Fix memory allocation issues in Jacobi solvers

### DIFF
--- a/library/src/lapack/roclapack_syevj_heevj.cpp
+++ b/library/src/lapack/roclapack_syevj_heevj.cpp
@@ -80,7 +80,7 @@ rocblas_status rocsolver_syevj_heevj_impl(rocblas_handle handle,
     // memory workspace allocation
     void *Acpy, *J, *norms, *top, *bottom, *completed;
     rocblas_device_malloc mem(handle, size_Acpy, size_J, size_norms, size_top, size_bottom,
-                              size_completed, size_norms);
+                              size_completed);
 
     if(!mem)
         return rocblas_status_memory_error;

--- a/library/src/lapack/roclapack_syevj_heevj_batched.cpp
+++ b/library/src/lapack/roclapack_syevj_heevj_batched.cpp
@@ -81,7 +81,7 @@ rocblas_status rocsolver_syevj_heevj_batched_impl(rocblas_handle handle,
     // memory workspace allocation
     void *Acpy, *J, *norms, *top, *bottom, *completed;
     rocblas_device_malloc mem(handle, size_Acpy, size_J, size_norms, size_top, size_bottom,
-                              size_completed, size_norms);
+                              size_completed);
 
     if(!mem)
         return rocblas_status_memory_error;

--- a/library/src/lapack/roclapack_syevj_heevj_strided_batched.cpp
+++ b/library/src/lapack/roclapack_syevj_heevj_strided_batched.cpp
@@ -79,7 +79,7 @@ rocblas_status rocsolver_syevj_heevj_strided_batched_impl(rocblas_handle handle,
     // memory workspace allocation
     void *Acpy, *J, *norms, *top, *bottom, *completed;
     rocblas_device_malloc mem(handle, size_Acpy, size_J, size_norms, size_top, size_bottom,
-                              size_completed, size_norms);
+                              size_completed);
 
     if(!mem)
         return rocblas_status_memory_error;


### PR DESCRIPTION
The Jacobi solvers where trying to allocate more memory than they needed, and this led to allocation failures with clients that manage their own memory (hipSOLVER in particular).