### PR TITLE
Use std::min and std::max

### DIFF
--- a/clients/common/auxiliary/testing_bdsqr.hpp
+++ b/clients/common/auxiliary/testing_bdsqr.hpp
@@ -183,19 +183,19 @@ void bdsqr_initData(const rocblas_handle handle,
         if(nv > 0)
         {
             memset(hV[0], 0, ldv * nv * sizeof(T));
-            for(rocblas_int i = 0; i < min(n, nv); ++i)
+            for(rocblas_int i = 0; i < std::min(n, nv); ++i)
                 hV[0][i + i * ldv] = T(1.0);
         }
         if(nu > 0)
         {
             memset(hU[0], 0, ldu * n * sizeof(T));
-            for(rocblas_int i = 0; i < min(n, nu); ++i)
+            for(rocblas_int i = 0; i < std::min(n, nu); ++i)
                 hU[0][i + i * ldu] = T(1.0);
         }
         if(nc > 0)
         {
             memset(hC[0], 0, ldc * nc * sizeof(T));
-            for(rocblas_int i = 0; i < min(n, nc); ++i)
+            for(rocblas_int i = 0; i < std::min(n, nc); ++i)
                 hC[0][i + i * ldc] = T(1.0);
         }
     }
@@ -313,7 +313,7 @@ void bdsqr_getError(const rocblas_handle handle,
     if(hInfo[0][0] == 0 && (nv || nu))
     {
         err = 0;
-        rocblas_int n_comp = min(n, nvRes);
+        rocblas_int n_comp = std::min(n, nvRes);
 
         if(uplo == rocblas_fill_upper)
         {
@@ -503,20 +503,20 @@ void testing_bdsqr(Arguments& argus)
 
     if(nv && nu)
     {
-        nvRes = nvA = max(nv, nu);
-        nuRes = nuA = max(nvRes, nc);
-        lduRes = max(lduRes, nuRes);
+        nvRes = nvA = std::max(nv, nu);
+        nuRes = nuA = std::max(nvRes, nc);
+        lduRes = std::max(lduRes, nuRes);
     }
     else if(nu)
     {
         nvRes = nvT = nu;
-        nuRes = nuA = max(nu, nc);
+        nuRes = nuA = std::max(nu, nc);
         ldvRes = n;
-        lduRes = max(lduRes, nuRes);
+        lduRes = std::max(lduRes, nuRes);
     }
     else if(nv || nc)
     {
-        nuRes = nuT = max(nv, nc);
+        nuRes = nuT = std::max(nv, nc);
         lduRes = nuRes;
     }
 
@@ -525,11 +525,11 @@ void testing_bdsqr(Arguments& argus)
     // errors in the rest of the unit test
     size_t size_D = size_t(n);
     size_t size_E = n > 1 ? size_t(n - 1) : 1;
-    size_t size_V = max(size_t(ldv) * nv, 1);
-    size_t size_U = max(size_t(ldu) * n, 1);
-    size_t size_C = max(size_t(ldc) * nc, 1);
-    size_t size_VRes = max(size_t(ldvRes) * nvRes, 1);
-    size_t size_URes = max(size_t(lduRes) * n, 1);
+    size_t size_V = std::max(size_t(ldv) * nv, size_t(1));
+    size_t size_U = std::max(size_t(ldu) * n, size_t(1));
+    size_t size_C = std::max(size_t(ldc) * nc, size_t(1));
+    size_t size_VRes = std::max(size_t(ldvRes) * nvRes, size_t(1));
+    size_t size_URes = std::max(size_t(lduRes) * n, size_t(1));
     double max_error = 0, gpu_time_used = 0, cpu_time_used = 0, max_errorv = 0;
 
     // check invalid sizes

--- a/clients/common/auxiliary/testing_labrd.hpp
+++ b/clients/common/auxiliary/testing_labrd.hpp
@@ -325,7 +325,7 @@ void testing_labrd(Arguments& argus)
     rocblas_local_handle handle;
     rocblas_int m = argus.get<rocblas_int>("m");
     rocblas_int n = argus.get<rocblas_int>("n", m);
-    rocblas_int nb = argus.get<rocblas_int>("k", min(m, n));
+    rocblas_int nb = argus.get<rocblas_int>("k", std::min(m, n));
     rocblas_int lda = argus.get<rocblas_int>("lda", m);
     rocblas_int ldx = argus.get<rocblas_int>("ldx", m);
     rocblas_int ldy = argus.get<rocblas_int>("ldy", n);
@@ -350,7 +350,8 @@ void testing_labrd(Arguments& argus)
     size_t size_YRes = (argus.unit_check || argus.norm_check) ? size_Y : 0;
 
     // check invalid sizes
-    bool invalid_size = (m < 0 || n < 0 || nb < 0 || nb > min(m, n) || lda < m || ldx < m || ldy < n);
+    bool invalid_size
+        = (m < 0 || n < 0 || nb < 0 || nb > std::min(m, n) || lda < m || ldx < m || ldy < n);
     if(invalid_size)
     {
         EXPECT_ROCBLAS_STATUS(rocsolver_labrd(handle, m, n, nb, (T*)nullptr, lda, (S*)nullptr,
@@ -443,7 +444,7 @@ void testing_labrd(Arguments& argus)
     // validate results for rocsolver-test
     // using nb * max(m,n) * machine_precision as tolerance
     if(argus.unit_check)
-        ROCSOLVER_TEST_CHECK(T, max_error, nb * max(m, n));
+        ROCSOLVER_TEST_CHECK(T, max_error, nb * std::max(m, n));
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/clients/common/auxiliary/testing_orgtr_ungtr.hpp
+++ b/clients/common/auxiliary/testing_orgtr_ungtr.hpp
@@ -96,7 +96,7 @@ void orgtr_ungtr_initData(const rocblas_handle handle,
     if(CPU)
     {
         using S = decltype(std::real(T{}));
-        size_t s = max(hIpiv.n(), 2);
+        size_t s = std::max(hIpiv.n(), int64_t(2));
         std::vector<S> E(s - 1);
         std::vector<S> D(s);
 

--- a/clients/common/auxiliary/testing_ormbr_unmbr.hpp
+++ b/clients/common/auxiliary/testing_ormbr_unmbr.hpp
@@ -146,7 +146,7 @@ void ormbr_unmbr_initData(const rocblas_handle handle,
     if(CPU)
     {
         using S = decltype(std::real(T{}));
-        size_t s = max(hIpiv.n(), 2);
+        size_t s = std::max(hIpiv.n(), int64_t(2));
         std::vector<S> E(s - 1);
         std::vector<S> D(s);
         std::vector<T> P(s);
@@ -216,7 +216,7 @@ void ormbr_unmbr_getError(const rocblas_handle handle,
                           Th& hCr,
                           double* max_err)
 {
-    size_t size_W = max(max(m, n), k);
+    size_t size_W = std::max(std::max(m, n), k);
     std::vector<T> hW(size_W);
 
     // initialize data
@@ -263,7 +263,7 @@ void ormbr_unmbr_getPerfData(const rocblas_handle handle,
                              const bool profile_kernels,
                              const bool perf)
 {
-    size_t size_W = max(max(m, n), k);
+    size_t size_W = std::max(std::max(m, n), k);
     std::vector<T> hW(size_W);
 
     if(!perf)
@@ -338,9 +338,9 @@ void testing_ormbr_unmbr(Arguments& argus)
         n = argus.get<rocblas_int>("n");
         m = argus.get<rocblas_int>("m", n);
     }
-    rocblas_int k = argus.get<rocblas_int>("k", min(m, n));
+    rocblas_int k = argus.get<rocblas_int>("k", std::min(m, n));
     rocblas_int nq = (sideC == 'L' ? m : n);
-    rocblas_int lda = argus.get<rocblas_int>("lda", storevC == 'C' ? nq : min(nq, k));
+    rocblas_int lda = argus.get<rocblas_int>("lda", storevC == 'C' ? nq : std::min(nq, k));
     rocblas_int ldc = argus.get<rocblas_int>("ldc", m);
 
     rocblas_side side = char2rocblas_side(sideC);
@@ -366,7 +366,7 @@ void testing_ormbr_unmbr(Arguments& argus)
 
     // determine sizes
     bool left = (side == rocblas_side_left);
-    size_t size_P = size_t(min(nq, k));
+    size_t size_P = size_t(std::min(nq, k));
     size_t size_C = size_t(ldc) * n;
 
     bool row = (storev == rocblas_row_wise);
@@ -376,8 +376,8 @@ void testing_ormbr_unmbr(Arguments& argus)
     size_t size_Cr = (argus.unit_check || argus.norm_check) ? size_C : 0;
 
     // check invalid sizes
-    bool invalid_size
-        = ((m < 0 || n < 0 || k < 0 || ldc < m) || (row && lda < min(nq, k)) || (!row && lda < nq));
+    bool invalid_size = ((m < 0 || n < 0 || k < 0 || ldc < m) || (row && lda < std::min(nq, k))
+                         || (!row && lda < nq));
     if(invalid_size)
     {
         EXPECT_ROCBLAS_STATUS(rocsolver_ormbr_unmbr(handle, storev, side, trans, m, n, k,

--- a/clients/common/auxiliary/testing_ormlx_unmlx.hpp
+++ b/clients/common/auxiliary/testing_ormlx_unmlx.hpp
@@ -188,7 +188,7 @@ void ormlx_unmlx_getError(const rocblas_handle handle,
                           Th& hCr,
                           double* max_err)
 {
-    size_t size_W = max(max(m, n), k);
+    size_t size_W = std::max(std::max(m, n), k);
     std::vector<T> hW(size_W);
 
     // initialize data
@@ -234,7 +234,7 @@ void ormlx_unmlx_getPerfData(const rocblas_handle handle,
                              const bool profile_kernels,
                              const bool perf)
 {
-    size_t size_W = max(max(m, n), k);
+    size_t size_W = std::max(std::max(m, n), k);
     std::vector<T> hW(size_W);
 
     if(!perf)

--- a/clients/common/auxiliary/testing_ormxl_unmxl.hpp
+++ b/clients/common/auxiliary/testing_ormxl_unmxl.hpp
@@ -188,7 +188,7 @@ void ormxl_unmxl_getError(const rocblas_handle handle,
                           Th& hCr,
                           double* max_err)
 {
-    size_t size_W = max(max(m, n), k);
+    size_t size_W = std::max(std::max(m, n), k);
     std::vector<T> hW(size_W);
 
     // initialize data
@@ -234,7 +234,7 @@ void ormxl_unmxl_getPerfData(const rocblas_handle handle,
                              const bool profile_kernels,
                              const bool perf)
 {
-    size_t size_W = max(max(m, n), k);
+    size_t size_W = std::max(std::max(m, n), k);
     std::vector<T> hW(size_W);
 
     if(!perf)

--- a/clients/common/auxiliary/testing_ormxr_unmxr.hpp
+++ b/clients/common/auxiliary/testing_ormxr_unmxr.hpp
@@ -188,7 +188,7 @@ void ormxr_unmxr_getError(const rocblas_handle handle,
                           Th& hCr,
                           double* max_err)
 {
-    size_t size_W = max(max(m, n), k);
+    size_t size_W = std::max(std::max(m, n), k);
     std::vector<T> hW(size_W);
 
     // initialize data
@@ -234,7 +234,7 @@ void ormxr_unmxr_getPerfData(const rocblas_handle handle,
                              const bool profile_kernels,
                              const bool perf)
 {
-    size_t size_W = max(max(m, n), k);
+    size_t size_W = std::max(std::max(m, n), k);
     std::vector<T> hW(size_W);
 
     if(!perf)

--- a/clients/common/lapack/testing_gebd2_gebrd.hpp
+++ b/clients/common/lapack/testing_gebd2_gebrd.hpp
@@ -233,7 +233,7 @@ void gebd2_gebrd_getError(const rocblas_handle handle,
     constexpr bool COMPLEX = rocblas_is_complex<T>;
     constexpr bool VERIFY_IMPLICIT_TEST = false;
 
-    std::vector<T> hW(max(m, n));
+    std::vector<T> hW(std::max(m, n));
 
     // input data initialization
     gebd2_gebrd_initData<true, true, T>(handle, m, n, dA, lda, stA, dD, stD, dE, stE, dTauq, stQ,
@@ -259,13 +259,14 @@ void gebd2_gebrd_getError(const rocblas_handle handle,
         {
             memcpy(hARes[b], hA[b], lda * n * sizeof(T));
             GEBRD
-            ? cpu_gebrd(m, n, hARes[b], lda, hD[b], hE[b], hTauq[b], hTaup[b], hW.data(), max(m, n))
+            ? cpu_gebrd(m, n, hARes[b], lda, hD[b], hE[b], hTauq[b], hTaup[b], hW.data(),
+                        std::max(m, n))
             : cpu_gebd2(m, n, hARes[b], lda, hD[b], hE[b], hTauq[b], hTaup[b], hW.data());
         }
     }
 
     // reconstruct A from the factorization for implicit testing
-    std::vector<T> vec(max(m, n));
+    std::vector<T> vec(std::max(m, n));
     vec[0] = 1;
     for(rocblas_int b = 0; b < bc; ++b)
     {
@@ -376,7 +377,7 @@ void gebd2_gebrd_getPerfData(const rocblas_handle handle,
                              const bool profile_kernels,
                              const bool perf)
 {
-    std::vector<T> hW(max(m, n));
+    std::vector<T> hW(std::max(m, n));
 
     if(!perf)
     {
@@ -388,7 +389,7 @@ void gebd2_gebrd_getPerfData(const rocblas_handle handle,
         for(rocblas_int b = 0; b < bc; ++b)
         {
             GEBRD
-            ? cpu_gebrd(m, n, hA[b], lda, hD[b], hE[b], hTauq[b], hTaup[b], hW.data(), max(m, n))
+            ? cpu_gebrd(m, n, hA[b], lda, hD[b], hE[b], hTauq[b], hTaup[b], hW.data(), std::max(m, n))
             : cpu_gebd2(m, n, hA[b], lda, hD[b], hE[b], hTauq[b], hTaup[b], hW.data());
         }
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
@@ -447,10 +448,10 @@ void testing_gebd2_gebrd(Arguments& argus)
     rocblas_int n = argus.get<rocblas_int>("n", m);
     rocblas_int lda = argus.get<rocblas_int>("lda", m);
     rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
-    rocblas_stride stD = argus.get<rocblas_stride>("strideD", min(m, n));
-    rocblas_stride stE = argus.get<rocblas_stride>("strideE", min(m, n) - 1);
-    rocblas_stride stQ = argus.get<rocblas_stride>("strideQ", min(m, n));
-    rocblas_stride stP = argus.get<rocblas_stride>("strideP", min(m, n));
+    rocblas_stride stD = argus.get<rocblas_stride>("strideD", std::min(m, n));
+    rocblas_stride stE = argus.get<rocblas_stride>("strideE", std::min(m, n) - 1);
+    rocblas_stride stQ = argus.get<rocblas_stride>("strideQ", std::min(m, n));
+    rocblas_stride stP = argus.get<rocblas_stride>("strideP", std::min(m, n));
 
     rocblas_int bc = argus.batch_count;
     rocblas_int hot_calls = argus.iters;
@@ -462,10 +463,10 @@ void testing_gebd2_gebrd(Arguments& argus)
 
     // determine sizes
     size_t size_A = lda * n;
-    size_t size_D = min(m, n);
-    size_t size_E = min(m, n) - 1;
-    size_t size_Q = min(m, n);
-    size_t size_P = min(m, n);
+    size_t size_D = std::min(m, n);
+    size_t size_E = std::min(m, n) - 1;
+    size_t size_Q = std::min(m, n);
+    size_t size_P = std::min(m, n);
     double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
 
     size_t size_ARes = (argus.unit_check || argus.norm_check) ? size_A : 0;

--- a/clients/common/lapack/testing_geblttrf_npvt_interleaved.hpp
+++ b/clients/common/lapack/testing_geblttrf_npvt_interleaved.hpp
@@ -515,9 +515,9 @@ void testing_geblttrf_npvt_interleaved(Arguments& argus)
 
     // determine sizes
     rocblas_int n = nb * nblocks;
-    size_t size_A = max(size_t(lda) * n, stA) * bc;
-    size_t size_B = max(size_t(ldb) * n, stB) * bc;
-    size_t size_C = max(size_t(ldc) * n, stC) * bc;
+    size_t size_A = std::max(size_t(lda) * n, size_t(stA)) * bc;
+    size_t size_B = std::max(size_t(ldb) * n, size_t(stB)) * bc;
+    size_t size_C = std::max(size_t(ldc) * n, size_t(stC)) * bc;
     double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
 
     size_t size_BRes = (argus.unit_check || argus.norm_check) ? size_B : 0;

--- a/clients/common/lapack/testing_geblttrs_npvt_interleaved.hpp
+++ b/clients/common/lapack/testing_geblttrs_npvt_interleaved.hpp
@@ -483,10 +483,10 @@ void testing_geblttrs_npvt_interleaved(Arguments& argus)
 
     // determine sizes
     rocblas_int n = nb * nblocks;
-    size_t size_A = max(size_t(lda) * n, stA) * bc;
-    size_t size_B = max(size_t(ldb) * n, stB) * bc;
-    size_t size_C = max(size_t(ldc) * n, stC) * bc;
-    size_t size_X = max(size_t(ldx) * nrhs * nblocks, stX) * bc;
+    size_t size_A = std::max(size_t(lda) * n, size_t(stA)) * bc;
+    size_t size_B = std::max(size_t(ldb) * n, size_t(stB)) * bc;
+    size_t size_C = std::max(size_t(ldc) * n, size_t(stC)) * bc;
+    size_t size_X = std::max(size_t(ldx) * nrhs * nblocks, size_t(stX)) * bc;
     double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
 
     size_t size_XRes = size_X;

--- a/clients/common/lapack/testing_gels.hpp
+++ b/clients/common/lapack/testing_gels.hpp
@@ -253,7 +253,7 @@ void gels_getError(const rocblas_handle handle,
                    double* max_err,
                    const bool singular)
 {
-    rocblas_int sizeW = max(1, min(m, n) + max(min(m, n), nrhs));
+    rocblas_int sizeW = std::max(1, std::min(m, n) + std::max(std::min(m, n), nrhs));
     std::vector<T> hW(sizeW);
 
     // input data initialization
@@ -281,7 +281,7 @@ void gels_getError(const rocblas_handle handle,
     *max_err = 0;
     for(rocblas_int b = 0; b < bc; ++b)
     {
-        err = norm_error('I', max(m, n), nrhs, ldb, hB[b], hBRes[b]);
+        err = norm_error('I', std::max(m, n), nrhs, ldb, hB[b], hBRes[b]);
         *max_err = err > *max_err ? err : *max_err;
     }
 
@@ -321,7 +321,7 @@ void gels_getPerfData(const rocblas_handle handle,
                       const bool perf,
                       const bool singular)
 {
-    rocblas_int sizeW = max(1, min(m, n) + max(min(m, n), nrhs));
+    rocblas_int sizeW = std::max(1, std::min(m, n) + std::max(std::min(m, n), nrhs));
     std::vector<T> hW(sizeW);
 
     if(!perf)
@@ -385,7 +385,7 @@ void testing_gels(Arguments& argus)
     rocblas_int n = argus.get<rocblas_int>("n", m);
     rocblas_int nrhs = argus.get<rocblas_int>("nrhs", n);
     rocblas_int lda = argus.get<rocblas_int>("lda", m);
-    rocblas_int ldb = argus.get<rocblas_int>("ldb", max(m, n));
+    rocblas_int ldb = argus.get<rocblas_int>("ldb", std::max(m, n));
     rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
     rocblas_stride stB = argus.get<rocblas_stride>("strideB", ldb * nrhs);
 
@@ -555,7 +555,7 @@ void testing_gels(Arguments& argus)
     // validate results for rocsolver-test
     // using max(m,n) * machine_precision as tolerance
     if(argus.unit_check)
-        ROCSOLVER_TEST_CHECK(T, max_error, max(m, n));
+        ROCSOLVER_TEST_CHECK(T, max_error, std::max(m, n));
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/clients/common/lapack/testing_gels_outofplace.hpp
+++ b/clients/common/lapack/testing_gels_outofplace.hpp
@@ -203,7 +203,7 @@ void gels_outofplace_initData(const rocblas_handle handle,
         std::bernoulli_distribution coinflip(0.5);
 
         const rocblas_int rowsB = (trans == rocblas_operation_none) ? m : n;
-        const rocblas_int ldx = max(m, n);
+        const rocblas_int ldx = std::max(m, n);
 
         for(rocblas_int b = 0; b < bc; ++b)
         {
@@ -284,7 +284,7 @@ void gels_outofplace_getError(const rocblas_handle handle,
                               double* max_err,
                               const bool singular)
 {
-    rocblas_int sizeW = max(1, min(m, n) + max(min(m, n), nrhs));
+    rocblas_int sizeW = std::max(1, std::min(m, n) + std::max(std::min(m, n), nrhs));
     std::vector<T> hW(sizeW);
 
     // input data initialization
@@ -303,7 +303,7 @@ void gels_outofplace_getError(const rocblas_handle handle,
     // CPU lapack
     for(rocblas_int b = 0; b < bc; ++b)
     {
-        cpu_gels(trans, m, n, nrhs, hA[b], lda, hX[b], max(m, n), hW.data(), sizeW, hInfo[b]);
+        cpu_gels(trans, m, n, nrhs, hA[b], lda, hX[b], std::max(m, n), hW.data(), sizeW, hInfo[b]);
     }
 
     // error is ||hX - hXRes|| / ||hX||
@@ -321,7 +321,7 @@ void gels_outofplace_getError(const rocblas_handle handle,
         if(hInfo[b][0] == 0)
         {
             const rocblas_int rowsX = (trans == rocblas_operation_none) ? n : m;
-            err = norm_error('I', rowsX, nrhs, max(m, n), hX[b], hXRes[b], ldx);
+            err = norm_error('I', rowsX, nrhs, std::max(m, n), hX[b], hXRes[b], ldx);
             *max_err = err > *max_err ? err : *max_err;
         }
     }
@@ -366,7 +366,7 @@ void gels_outofplace_getPerfData(const rocblas_handle handle,
                                  const bool perf,
                                  const bool singular)
 {
-    rocblas_int sizeW = max(1, min(m, n) + max(min(m, n), nrhs));
+    rocblas_int sizeW = std::max(1, std::min(m, n) + std::max(std::min(m, n), nrhs));
     std::vector<T> hW(sizeW);
 
     if(!perf)
@@ -378,7 +378,8 @@ void gels_outofplace_getPerfData(const rocblas_handle handle,
         *cpu_time_used = get_time_us_no_sync();
         for(rocblas_int b = 0; b < bc; ++b)
         {
-            cpu_gels(trans, m, n, nrhs, hA[b], lda, hX[b], max(m, n), hW.data(), sizeW, hInfo[b]);
+            cpu_gels(trans, m, n, nrhs, hA[b], lda, hX[b], std::max(m, n), hW.data(), sizeW,
+                     hInfo[b]);
         }
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
@@ -536,7 +537,7 @@ void testing_gels_outofplace(Arguments& argus)
         host_batch_vector<T> hA(size_A, 1, bc);
         host_batch_vector<T> hB(size_B, 1, bc);
         host_batch_vector<T> hBRes(size_BRes, 1, bc);
-        host_batch_vector<T> hX(max(m, n) * nrhs, 1, bc);
+        host_batch_vector<T> hX(std::max(m, n) * nrhs, 1, bc);
         host_batch_vector<T> hXRes(size_XRes, 1, bc);
         host_strided_batch_vector<rocblas_int> hInfo(1, 1, 1, bc);
         host_strided_batch_vector<rocblas_int> hInfoRes(1, 1, 1, bc);
@@ -585,7 +586,7 @@ void testing_gels_outofplace(Arguments& argus)
         host_strided_batch_vector<T> hA(size_A, 1, stA, bc);
         host_strided_batch_vector<T> hB(size_B, 1, stB, bc);
         host_strided_batch_vector<T> hBRes(size_BRes, 1, stBRes, bc);
-        host_strided_batch_vector<T> hX(max(m, n) * nrhs, 1, max(m, n) * nrhs, bc);
+        host_strided_batch_vector<T> hX(std::max(m, n) * nrhs, 1, std::max(m, n) * nrhs, bc);
         host_strided_batch_vector<T> hXRes(size_XRes, 1, stXRes, bc);
         host_strided_batch_vector<rocblas_int> hInfo(1, 1, 1, bc);
         host_strided_batch_vector<rocblas_int> hInfoRes(1, 1, 1, bc);
@@ -631,7 +632,7 @@ void testing_gels_outofplace(Arguments& argus)
     // validate results for rocsolver-test
     // using max(m,n) * machine_precision as tolerance
     if(argus.unit_check)
-        ROCSOLVER_TEST_CHECK(T, max_error, max(m, n));
+        ROCSOLVER_TEST_CHECK(T, max_error, std::max(m, n));
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/clients/common/lapack/testing_gesvd.hpp
+++ b/clients/common/lapack/testing_gesvd.hpp
@@ -293,8 +293,8 @@ void gesvd_getError(const rocblas_handle handle,
 {
     using W = decltype(std::real(T{}));
 
-    rocblas_int lwork = 5 * max(m, n);
-    rocblas_int lrwork = (rocblas_is_complex<T> ? 5 * min(m, n) : 0);
+    rocblas_int lwork = 5 * std::max(m, n);
+    rocblas_int lrwork = (rocblas_is_complex<T> ? 5 * std::min(m, n) : 0);
     std::vector<T> work(lwork);
     std::vector<W> rwork(lrwork);
     std::vector<T> A(lda * n * bc);
@@ -342,7 +342,7 @@ void gesvd_getError(const rocblas_handle handle,
         {
             for(rocblas_int i = 0; i < m; i++)
             {
-                for(rocblas_int j = 0; j < min(m, n); j++)
+                for(rocblas_int j = 0; j < std::min(m, n); j++)
                     Ures[b][i + j * ldures] = hA[b][i + j * lda];
             }
         }
@@ -352,7 +352,7 @@ void gesvd_getError(const rocblas_handle handle,
         CHECK_HIP_ERROR(hA.transfer_from(dA));
         for(rocblas_int b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < min(m, n); i++)
+            for(rocblas_int i = 0; i < std::min(m, n); i++)
             {
                 for(rocblas_int j = 0; j < n; j++)
                     Vres[b][i + j * ldvres] = hA[b][i + j * lda];
@@ -379,7 +379,7 @@ void gesvd_getError(const rocblas_handle handle,
     for(rocblas_int b = 0; b < bc; ++b)
     {
         // error is ||hS - hSres||
-        err = norm_error('F', 1, min(m, n), 1, hS[b], hSres[b]);
+        err = norm_error('F', 1, std::min(m, n), 1, hS[b], hSres[b]);
         *max_err = err > *max_err ? err : *max_err;
 
         // Check the singular vectors if required
@@ -387,7 +387,7 @@ void gesvd_getError(const rocblas_handle handle,
         {
             err = 0;
             // check singular vectors implicitly (A*v_k = s_k*u_k)
-            for(rocblas_int k = 0; k < min(m, n); ++k)
+            for(rocblas_int k = 0; k < std::min(m, n); ++k)
             {
                 for(rocblas_int i = 0; i < m; ++i)
                 {
@@ -440,8 +440,8 @@ void gesvd_getPerfData(const rocblas_handle handle,
 {
     using W = decltype(std::real(T{}));
 
-    rocblas_int lwork = 5 * max(m, n);
-    rocblas_int lrwork = (rocblas_is_complex<T> ? 5 * min(m, n) : 0);
+    rocblas_int lwork = 5 * std::max(m, n);
+    rocblas_int lrwork = (rocblas_is_complex<T> ? 5 * std::min(m, n) : 0);
     std::vector<T> work(lwork);
     std::vector<W> rwork(lrwork);
     std::vector<T> A;
@@ -511,12 +511,12 @@ void testing_gesvd(Arguments& argus)
     rocblas_int n = argus.get<rocblas_int>("n", m);
     rocblas_int lda = argus.get<rocblas_int>("lda", m);
     rocblas_int ldu = argus.get<rocblas_int>("ldu", m);
-    rocblas_int ldv = argus.get<rocblas_int>("ldv", (rightvC == 'A' ? n : min(m, n)));
+    rocblas_int ldv = argus.get<rocblas_int>("ldv", (rightvC == 'A' ? n : std::min(m, n)));
     rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
-    rocblas_stride stS = argus.get<rocblas_stride>("strideS", min(m, n));
+    rocblas_stride stS = argus.get<rocblas_stride>("strideS", std::min(m, n));
     rocblas_stride stU = argus.get<rocblas_stride>("strideU", ldu * m);
     rocblas_stride stV = argus.get<rocblas_stride>("strideV", ldv * n);
-    rocblas_stride stE = argus.get<rocblas_stride>("strideE", min(m, n) - 1);
+    rocblas_stride stE = argus.get<rocblas_stride>("strideE", std::min(m, n) - 1);
     char faC = argus.get<char>("fast_alg");
 
     rocblas_svect leftv = char2rocblas_svect(leftvC);
@@ -591,8 +591,8 @@ void testing_gesvd(Arguments& argus)
     size_t size_UT = 0;
     size_t size_VT = 0;
     size_t size_A = size_t(lda) * n;
-    size_t size_S = size_t(min(m, n));
-    size_t size_E = size_t(min(m, n) - 1);
+    size_t size_S = size_t(std::min(m, n));
+    size_t size_E = size_t(std::min(m, n) - 1);
     size_t size_V = size_t(ldv) * n;
     size_t size_U = size_t(ldu) * m;
     if(argus.unit_check || argus.norm_check)
@@ -646,7 +646,7 @@ void testing_gesvd(Arguments& argus)
     bool invalid_size = (n < 0 || m < 0 || lda < m || ldu < 1 || ldv < 1 || bc < 0)
         || ((leftv == rocblas_svect_all || leftv == rocblas_svect_singular) && ldu < m)
         || ((rightv == rocblas_svect_all && ldv < n)
-            || (rightv == rocblas_svect_singular && ldv < min(m, n)));
+            || (rightv == rocblas_svect_singular && ldv < std::min(m, n)));
 
     if(invalid_size)
     {
@@ -827,9 +827,9 @@ void testing_gesvd(Arguments& argus)
     // using 2 * min(m, n) * machine_precision as tolerance
     if(argus.unit_check)
     {
-        ROCSOLVER_TEST_CHECK(T, max_error, 2 * min(m, n));
+        ROCSOLVER_TEST_CHECK(T, max_error, 2 * std::min(m, n));
         if(svects)
-            ROCSOLVER_TEST_CHECK(T, max_errorv, 2 * min(m, n));
+            ROCSOLVER_TEST_CHECK(T, max_errorv, 2 * std::min(m, n));
     }
 
     // output results for rocsolver-bench

--- a/clients/common/lapack/testing_gesvdj.hpp
+++ b/clients/common/lapack/testing_gesvdj.hpp
@@ -312,8 +312,8 @@ void gesvdj_getError(const rocblas_handle handle,
                      double* max_err,
                      double* max_errv)
 {
-    rocblas_int lwork = 5 * max(m, n);
-    rocblas_int lrwork = (rocblas_is_complex<T> ? 5 * min(m, n) : 0);
+    rocblas_int lwork = 5 * std::max(m, n);
+    rocblas_int lrwork = (rocblas_is_complex<T> ? 5 * std::min(m, n) : 0);
     std::vector<T> work(lwork);
     std::vector<SS> rwork(lrwork);
     std::vector<T> A(lda * n * bc);
@@ -392,7 +392,7 @@ void gesvdj_getError(const rocblas_handle handle,
     for(rocblas_int b = 0; b < bc; ++b)
     {
         // error is ||hS - hSres||
-        err = norm_error('F', 1, min(m, n), 1, hS[b], hSres[b]);
+        err = norm_error('F', 1, std::min(m, n), 1, hS[b], hSres[b]);
         *max_err = err > *max_err ? err : *max_err;
 
         // Check the singular vectors if required
@@ -400,7 +400,7 @@ void gesvdj_getError(const rocblas_handle handle,
         {
             err = 0;
             // check singular vectors implicitly (A*v_k = s_k*u_k)
-            for(rocblas_int k = 0; k < min(m, n); ++k)
+            for(rocblas_int k = 0; k < std::min(m, n); ++k)
             {
                 for(rocblas_int i = 0; i < m; ++i)
                 {
@@ -462,8 +462,8 @@ void gesvdj_getPerfData(const rocblas_handle handle,
                         const bool profile_kernels,
                         const bool perf)
 {
-    rocblas_int lwork = 5 * max(m, n);
-    rocblas_int lrwork = 5 * min(m, n);
+    rocblas_int lwork = 5 * std::max(m, n);
+    rocblas_int lrwork = 5 * std::min(m, n);
     std::vector<T> work(lwork);
     std::vector<SS> rwork(lrwork);
     std::vector<T> A;
@@ -534,11 +534,11 @@ void testing_gesvdj(Arguments& argus)
     rocblas_int n = argus.get<rocblas_int>("n", m);
     rocblas_int lda = argus.get<rocblas_int>("lda", m);
     rocblas_int ldu = argus.get<rocblas_int>("ldu", m);
-    rocblas_int ldv = argus.get<rocblas_int>("ldv", (rightvC == 'A' ? n : min(m, n)));
+    rocblas_int ldv = argus.get<rocblas_int>("ldv", (rightvC == 'A' ? n : std::min(m, n)));
     rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
-    rocblas_stride stS = argus.get<rocblas_stride>("strideS", min(m, n));
+    rocblas_stride stS = argus.get<rocblas_stride>("strideS", std::min(m, n));
     rocblas_stride stU
-        = argus.get<rocblas_stride>("strideU", (leftvC == 'A' ? ldu * m : ldu * min(m, n)));
+        = argus.get<rocblas_stride>("strideU", (leftvC == 'A' ? ldu * m : ldu * std::min(m, n)));
     rocblas_stride stV = argus.get<rocblas_stride>("strideV", ldv * n);
 
     S abstol = S(argus.get<double>("abstol", 0));
@@ -600,7 +600,7 @@ void testing_gesvdj(Arguments& argus)
         if(rightv == rocblas_svect_none)
         {
             rightvT = rocblas_svect_singular;
-            ldvT = min(m, n);
+            ldvT = std::min(m, n);
             mT = m;
             nT = n;
         }
@@ -615,8 +615,8 @@ void testing_gesvdj(Arguments& argus)
     size_t size_UT = 0;
     size_t size_VT = 0;
     size_t size_A = size_t(lda) * n;
-    size_t size_S = size_t(min(m, n));
-    size_t size_U = (leftvC == 'A' ? size_t(ldu) * m : size_t(ldu) * min(m, n));
+    size_t size_S = size_t(std::min(m, n));
+    size_t size_U = (leftvC == 'A' ? size_t(ldu) * m : size_t(ldu) * std::min(m, n));
     size_t size_V = size_t(ldv) * n;
     if(argus.unit_check || argus.norm_check)
     {
@@ -625,7 +625,7 @@ void testing_gesvdj(Arguments& argus)
         {
             if(leftv == rocblas_svect_none)
             {
-                size_UT = size_t(lduT) * min(mT, nT);
+                size_UT = size_t(lduT) * std::min(mT, nT);
                 size_Ures = size_UT;
                 ldures = lduT;
             }
@@ -659,7 +659,7 @@ void testing_gesvdj(Arguments& argus)
     bool invalid_size = (n < 0 || m < 0 || lda < m || ldu < 1 || ldv < 1 || bc < 0)
         || ((leftv == rocblas_svect_all || leftv == rocblas_svect_singular) && ldu < m)
         || ((rightv == rocblas_svect_all && ldv < n)
-            || (rightv == rocblas_svect_singular && ldv < min(m, n)));
+            || (rightv == rocblas_svect_singular && ldv < std::min(m, n)));
 
     if(invalid_size)
     {
@@ -847,9 +847,9 @@ void testing_gesvdj(Arguments& argus)
     // using 2 * min(m, n) * machine_precision as tolerance
     if(argus.unit_check)
     {
-        ROCSOLVER_TEST_CHECK(T, max_error, 2 * min(m, n));
+        ROCSOLVER_TEST_CHECK(T, max_error, 2 * std::min(m, n));
         if(svects)
-            ROCSOLVER_TEST_CHECK(T, max_errorv, 2 * min(m, n));
+            ROCSOLVER_TEST_CHECK(T, max_errorv, 2 * std::min(m, n));
     }
 
     // output results for rocsolver-bench

--- a/clients/common/lapack/testing_gesvdj_notransv.hpp
+++ b/clients/common/lapack/testing_gesvdj_notransv.hpp
@@ -326,8 +326,8 @@ void gesvdj_notransv_getError(const rocblas_handle handle,
                               double* max_err,
                               double* max_errv)
 {
-    rocblas_int lwork = 5 * max(m, n);
-    rocblas_int lrwork = (rocblas_is_complex<T> ? 5 * min(m, n) : 0);
+    rocblas_int lwork = 5 * std::max(m, n);
+    rocblas_int lrwork = (rocblas_is_complex<T> ? 5 * std::min(m, n) : 0);
     std::vector<T> work(lwork);
     std::vector<SS> rwork(lrwork);
     std::vector<T> A(lda * n * bc);
@@ -408,7 +408,7 @@ void gesvdj_notransv_getError(const rocblas_handle handle,
     for(rocblas_int b = 0; b < bc; ++b)
     {
         // error is ||hS - hSres||
-        err = norm_error('F', 1, min(m, n), 1, hS[b], hSres[b]);
+        err = norm_error('F', 1, std::min(m, n), 1, hS[b], hSres[b]);
         *max_err = err > *max_err ? err : *max_err;
 
         // Check the singular vectors if required
@@ -416,7 +416,7 @@ void gesvdj_notransv_getError(const rocblas_handle handle,
         {
             err = 0;
             // check singular vectors implicitly (A*v_k = s_k*u_k)
-            for(rocblas_int k = 0; k < min(m, n); ++k)
+            for(rocblas_int k = 0; k < std::min(m, n); ++k)
             {
                 for(rocblas_int i = 0; i < m; ++i)
                 {
@@ -478,8 +478,8 @@ void gesvdj_notransv_getPerfData(const rocblas_handle handle,
                                  const bool profile_kernels,
                                  const bool perf)
 {
-    rocblas_int lwork = 5 * max(m, n);
-    rocblas_int lrwork = 5 * min(m, n);
+    rocblas_int lwork = 5 * std::max(m, n);
+    rocblas_int lrwork = 5 * std::min(m, n);
     std::vector<T> work(lwork);
     std::vector<SS> rwork(lrwork);
     std::vector<T> A;
@@ -556,11 +556,11 @@ void testing_gesvdj_notransv(Arguments& argus)
     rocblas_int ldu = argus.get<rocblas_int>("ldu", m);
     rocblas_int ldv = argus.get<rocblas_int>("ldv", n);
     rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
-    rocblas_stride stS = argus.get<rocblas_stride>("strideS", min(m, n));
+    rocblas_stride stS = argus.get<rocblas_stride>("strideS", std::min(m, n));
     rocblas_stride stU
-        = argus.get<rocblas_stride>("strideU", (leftvC == 'A' ? ldu * m : ldu * min(m, n)));
+        = argus.get<rocblas_stride>("strideU", (leftvC == 'A' ? ldu * m : ldu * std::min(m, n)));
     rocblas_stride stV
-        = argus.get<rocblas_stride>("strideV", (rightvC == 'A' ? ldv * n : ldv * min(m, n)));
+        = argus.get<rocblas_stride>("strideV", (rightvC == 'A' ? ldv * n : ldv * std::min(m, n)));
 
     S abstol = S(argus.get<double>("abstol", 0));
     rocblas_int max_sweeps = argus.get<rocblas_int>("max_sweeps", 100);
@@ -636,9 +636,9 @@ void testing_gesvdj_notransv(Arguments& argus)
     size_t size_UT = 0;
     size_t size_VT = 0;
     size_t size_A = size_t(lda) * n;
-    size_t size_S = size_t(min(m, n));
-    size_t size_U = (leftvC == 'A' ? size_t(ldu) * m : size_t(ldu) * min(m, n));
-    size_t size_V = (rightvC == 'A' ? size_t(ldv) * n : size_t(ldv) * min(m, n));
+    size_t size_S = size_t(std::min(m, n));
+    size_t size_U = (leftvC == 'A' ? size_t(ldu) * m : size_t(ldu) * std::min(m, n));
+    size_t size_V = (rightvC == 'A' ? size_t(ldv) * n : size_t(ldv) * std::min(m, n));
     if(argus.unit_check || argus.norm_check)
     {
         size_Sres = size_S;
@@ -646,7 +646,7 @@ void testing_gesvdj_notransv(Arguments& argus)
         {
             if(leftv == rocblas_svect_none)
             {
-                size_UT = size_t(lduT) * min(mT, nT);
+                size_UT = size_t(lduT) * std::min(mT, nT);
                 size_Ures = size_UT;
                 ldures = lduT;
             }
@@ -658,7 +658,7 @@ void testing_gesvdj_notransv(Arguments& argus)
 
             if(rightv == rocblas_svect_none)
             {
-                size_VT = size_t(ldvT) * min(mT, nT);
+                size_VT = size_t(ldvT) * std::min(mT, nT);
                 size_Vres = size_VT;
                 ldvres = ldvT;
             }
@@ -867,9 +867,9 @@ void testing_gesvdj_notransv(Arguments& argus)
     // using 2 * min(m, n) * machine_precision as tolerance
     if(argus.unit_check)
     {
-        ROCSOLVER_TEST_CHECK(T, max_error, 2 * min(m, n));
+        ROCSOLVER_TEST_CHECK(T, max_error, 2 * std::min(m, n));
         if(svects)
-            ROCSOLVER_TEST_CHECK(T, max_errorv, 2 * min(m, n));
+            ROCSOLVER_TEST_CHECK(T, max_errorv, 2 * std::min(m, n));
     }
 
     // output results for rocsolver-bench

--- a/clients/common/lapack/testing_gesvdx.hpp
+++ b/clients/common/lapack/testing_gesvdx.hpp
@@ -370,8 +370,8 @@ void gesvdx_getError(const rocblas_handle handle,
     //  or wait for problems with gesvdx_ to be fixed)
 
     std::vector<rocblas_int> offset(bc);
-    rocblas_int lwork = 5 * max(m, n);
-    rocblas_int lrwork = (rocblas_is_complex<T> ? 5 * min(m, n) : 0);
+    rocblas_int lwork = 5 * std::max(m, n);
+    rocblas_int lrwork = (rocblas_is_complex<T> ? 5 * std::min(m, n) : 0);
     std::vector<T> work(lwork);
     std::vector<S> rwork(lrwork);
     rocblas_int minn = std::min(m, n);
@@ -999,9 +999,9 @@ void testing_gesvdx(Arguments& argus)
     // using 2 * min(m, n) * machine_precision as tolerance
     if(argus.unit_check)
     {
-        ROCSOLVER_TEST_CHECK(T, max_error, 2 * min(m, n));
+        ROCSOLVER_TEST_CHECK(T, max_error, 2 * std::min(m, n));
         if(svects)
-            ROCSOLVER_TEST_CHECK(T, max_errorv, 4 * min(m, n));
+            ROCSOLVER_TEST_CHECK(T, max_errorv, 4 * std::min(m, n));
     }
 
     // output results for rocsolver-bench

--- a/clients/common/lapack/testing_gesvdx_notransv.hpp
+++ b/clients/common/lapack/testing_gesvdx_notransv.hpp
@@ -384,8 +384,8 @@ void gesvdx_notransv_getError(const rocblas_handle handle,
     //  or wait for problems with gesvdx_ to be fixed)
 
     std::vector<rocblas_int> offset(bc);
-    rocblas_int lwork = 5 * max(m, n);
-    rocblas_int lrwork = (rocblas_is_complex<T> ? 5 * min(m, n) : 0);
+    rocblas_int lwork = 5 * std::max(m, n);
+    rocblas_int lrwork = (rocblas_is_complex<T> ? 5 * std::min(m, n) : 0);
     std::vector<T> work(lwork);
     std::vector<S> rwork(lrwork);
     rocblas_int minn = std::min(m, n);
@@ -1021,9 +1021,9 @@ void testing_gesvdx_notransv(Arguments& argus)
     // using 2 * min(m, n) * machine_precision as tolerance
     if(argus.unit_check)
     {
-        ROCSOLVER_TEST_CHECK(T, max_error, 2 * min(m, n));
+        ROCSOLVER_TEST_CHECK(T, max_error, 2 * std::min(m, n));
         if(svects)
-            ROCSOLVER_TEST_CHECK(T, max_errorv, 4 * min(m, n));
+            ROCSOLVER_TEST_CHECK(T, max_errorv, 4 * std::min(m, n));
     }
 
     // output results for rocsolver-bench

--- a/clients/gtest/testing_managed_malloc.hpp
+++ b/clients/gtest/testing_managed_malloc.hpp
@@ -209,7 +209,7 @@ void testing_managed_malloc(Arguments& argus)
     rocblas_local_handle handle;
     rocblas_int m = argus.get<rocblas_int>("m");
     rocblas_int n = argus.get<rocblas_int>("n", m);
-    rocblas_int nb = argus.get<rocblas_int>("k", min(m, n));
+    rocblas_int nb = argus.get<rocblas_int>("k", std::min(m, n));
     rocblas_int lda = argus.get<rocblas_int>("lda", m);
     rocblas_int ldx = argus.get<rocblas_int>("ldx", m);
     rocblas_int ldy = argus.get<rocblas_int>("ldy", n);
@@ -241,7 +241,8 @@ void testing_managed_malloc(Arguments& argus)
     double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
 
     // check invalid sizes
-    bool invalid_size = (m < 0 || n < 0 || nb < 0 || nb > min(m, n) || lda < m || ldx < m || ldy < n);
+    bool invalid_size
+        = (m < 0 || n < 0 || nb < 0 || nb > std::min(m, n) || lda < m || ldx < m || ldy < n);
     if(invalid_size)
     {
         EXPECT_ROCBLAS_STATUS(rocsolver_labrd(handle, m, n, nb, (T*)nullptr, lda, (S*)nullptr,
@@ -326,7 +327,7 @@ void testing_managed_malloc(Arguments& argus)
     // validate results for rocsolver-test
     // using nb * max(m,n) * machine_precision as tolerance
     if(argus.unit_check)
-        ROCSOLVER_TEST_CHECK(T, max_error, nb * max(m, n));
+        ROCSOLVER_TEST_CHECK(T, max_error, nb * std::max(m, n));
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/common/include/common_host_helpers.hpp
+++ b/common/include/common_host_helpers.hpp
@@ -157,11 +157,11 @@ void print_to_stream(std::ostream& os,
     else
     {
         // symmetric case
-        for(int i = 0; i < min(m, n); i++)
+        for(int i = 0; i < std::min(m, n); i++)
         {
             if(!empty)
                 s += "    ";
-            for(int j = 0; j < min(m, n); j++)
+            for(int j = 0; j < std::min(m, n); j++)
             {
                 if(uplo == rocblas_fill_upper)
                 {
@@ -203,7 +203,7 @@ void print_device_matrix(std::ostream& os,
                          const rocblas_fill uplo = rocblas_fill_full,
                          const rocblas_int inca = 1)
 {
-    size_t to_read = max(inca * (m - 1) + m, lda * (n - 1) + n);
+    size_t to_read = std::max(inca * (m - 1) + m, lda * (n - 1) + n);
 
     std::vector<T> hA(to_read);
     THROW_IF_HIP_ERROR(
@@ -225,7 +225,7 @@ void print_device_matrix(std::ostream& os,
                          const rocblas_fill uplo = rocblas_fill_full,
                          const rocblas_int inca = 1)
 {
-    size_t to_read = max(inca * (m - 1) + m, lda * (n - 1) + n);
+    size_t to_read = std::max(inca * (m - 1) + m, lda * (n - 1) + n);
 
     std::vector<T> hA(to_read);
     T* AA[1];
@@ -247,7 +247,7 @@ void print_device_matrix(const std::string file,
                          const rocblas_fill uplo = rocblas_fill_full,
                          const rocblas_int inca = 1)
 {
-    size_t to_read = max(inca * (m - 1) + m, lda * (n - 1) + n);
+    size_t to_read = std::max(inca * (m - 1) + m, lda * (n - 1) + n);
 
     std::ofstream os(file);
     std::vector<T> hA(to_read);
@@ -269,7 +269,7 @@ void print_device_matrix(const std::string file,
                          const rocblas_fill uplo = rocblas_fill_full,
                          const rocblas_int inca = 1)
 {
-    size_t to_read = max(inca * (m - 1) + m, lda * (n - 1) + n);
+    size_t to_read = std::max(inca * (m - 1) + m, lda * (n - 1) + n);
 
     std::ofstream os(file);
     std::vector<T> hA(to_read);

--- a/library/src/auxiliary/rocauxiliary_stedcj.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedcj.hpp
@@ -324,7 +324,7 @@ void rocsolver_stedcj_getMemorySize(const rocblas_evect evect,
         *size_workArr = sizeof(S*) * batch_count;
     else
         *size_workArr = 0;
-    *size_work_stack = max(s1, s2);
+    *size_work_stack = std::max(s1, s2);
 
     // size for split blocks and sub-blocks positions
     *size_splits_map = sizeof(rocblas_int) * (5 * n + 2) * batch_count;

--- a/library/src/include/lapack_device_functions.hpp
+++ b/library/src/include/lapack_device_functions.hpp
@@ -811,7 +811,7 @@ __device__ void lagtf(rocblas_int n, T* a, T lambda, T* b, T* c, T tol, T* d, ro
         return;
     }
 
-    tol = max(tol, eps);
+    tol = std::max(tol, eps);
     scale1 = abs(a[0]) + abs(b[0]);
     for(rocblas_int k = 0; k < n - 1; k++)
     {
@@ -859,7 +859,7 @@ __device__ void lagtf(rocblas_int n, T* a, T lambda, T* b, T* c, T tol, T* d, ro
             }
         }
 
-        if(max(piv1, piv2) <= tol && in[n - 1] == 0)
+        if(std::max(piv1, piv2) <= tol && in[n - 1] == 0)
             in[n - 1] = k + 1;
     }
 
@@ -882,9 +882,9 @@ __device__ void
     {
         tol = abs(a[0]);
         if(n > 1)
-            tol = max(tol, max(abs(a[1]), abs(b[0])));
+            tol = std::max(tol, std::max(abs(a[1]), abs(b[0])));
         for(k = 2; k < n; k++)
-            tol = max(max(tol, abs(a[k])), max(abs(b[k - 1]), abs(d[k - 2])));
+            tol = std::max(std::max(tol, abs(a[k])), std::max(abs(b[k - 1]), abs(d[k - 2])));
         tol = tol * eps;
         if(tol == 0)
             tol = eps;

--- a/library/src/include/lapack_device_functions.hpp
+++ b/library/src/include/lapack_device_functions.hpp
@@ -811,7 +811,7 @@ __device__ void lagtf(rocblas_int n, T* a, T lambda, T* b, T* c, T tol, T* d, ro
         return;
     }
 
-    tol = std::max(tol, eps);
+    tol = std::fmax(tol, eps);
     scale1 = abs(a[0]) + abs(b[0]);
     for(rocblas_int k = 0; k < n - 1; k++)
     {
@@ -859,7 +859,7 @@ __device__ void lagtf(rocblas_int n, T* a, T lambda, T* b, T* c, T tol, T* d, ro
             }
         }
 
-        if(std::max(piv1, piv2) <= tol && in[n - 1] == 0)
+        if(std::fmax(piv1, piv2) <= tol && in[n - 1] == 0)
             in[n - 1] = k + 1;
     }
 
@@ -882,9 +882,9 @@ __device__ void
     {
         tol = abs(a[0]);
         if(n > 1)
-            tol = std::max(tol, std::max(abs(a[1]), abs(b[0])));
+            tol = std::fmax(tol, std::fmax(abs(a[1]), abs(b[0])));
         for(k = 2; k < n; k++)
-            tol = std::max(std::max(tol, abs(a[k])), std::max(abs(b[k - 1]), abs(d[k - 2])));
+            tol = std::fmax(std::fmax(tol, abs(a[k])), std::fmax(abs(b[k - 1]), abs(d[k - 2])));
         tol = tol * eps;
         if(tol == 0)
             tol = eps;

--- a/library/src/include/lib_device_helpers.hpp
+++ b/library/src/include/lib_device_helpers.hpp
@@ -105,7 +105,7 @@ __device__ T find_max_tridiag(const rocblas_int start, const rocblas_int end, T*
 {
     T anorm = abs(D[end]);
     for(int i = start; i < end; i++)
-        anorm = std::max(anorm, std::max(abs(D[i]), abs(E[i])));
+        anorm = std::fmax(anorm, std::fmax(abs(D[i]), abs(E[i])));
     return anorm;
 }
 

--- a/library/src/include/lib_device_helpers.hpp
+++ b/library/src/include/lib_device_helpers.hpp
@@ -105,7 +105,7 @@ __device__ T find_max_tridiag(const rocblas_int start, const rocblas_int end, T*
 {
     T anorm = abs(D[end]);
     for(int i = start; i < end; i++)
-        anorm = max(anorm, max(abs(D[i]), abs(E[i])));
+        anorm = std::max(anorm, std::max(abs(D[i]), abs(E[i])));
     return anorm;
 }
 

--- a/library/src/lapack/roclapack_syevx_heevx.hpp
+++ b/library/src/lapack/roclapack_syevx_heevx.hpp
@@ -310,7 +310,7 @@ void rocsolver_syevx_heevx_getMemorySize(const rocblas_evect evect,
     *size_tau = sizeof(T) * n * batch_count;
 
     // size of array for temporary split off block sizes
-    *size_nsplit_workArr = max(*size_nsplit_workArr, sizeof(rocblas_int) * batch_count);
+    *size_nsplit_workArr = std::max(*size_nsplit_workArr, sizeof(rocblas_int) * batch_count);
 }
 
 template <bool BATCHED, bool STRIDED, typename T, typename S, typename U>

--- a/library/src/lapack/roclapack_sygvdx_hegvdx.hpp
+++ b/library/src/lapack/roclapack_sygvdx_hegvdx.hpp
@@ -144,25 +144,25 @@ void rocsolver_sygvdx_hegvdx_getMemorySize(const rocblas_eform itype,
     rocsolver_potrf_getMemorySize<BATCHED, STRIDED, T>(n, uplo, batch_count, size_scalars,
                                                        size_work1, size_work2, size_work3, size_work4,
                                                        size_work7_workArr, size_iinfo, &opt1);
-    *size_iinfo = max(*size_iinfo, sizeof(rocblas_int) * batch_count);
+    *size_iinfo = std::max(*size_iinfo, sizeof(rocblas_int) * batch_count);
 
     // requirements for calling SYGST/HEGST
     rocsolver_sygst_hegst_getMemorySize<BATCHED, STRIDED, T>(uplo, itype, n, batch_count, &unused,
                                                              &temp1, &temp2, &temp3, &temp4, &opt2);
-    *size_work1 = max(*size_work1, temp1);
-    *size_work2 = max(*size_work2, temp2);
-    *size_work3 = max(*size_work3, temp3);
-    *size_work4 = max(*size_work4, temp4);
+    *size_work1 = std::max(*size_work1, temp1);
+    *size_work2 = std::max(*size_work2, temp2);
+    *size_work3 = std::max(*size_work3, temp3);
+    *size_work4 = std::max(*size_work4, temp4);
 
     // requirements for calling SYEVDX/HEEVDX
     rocsolver_syevdx_heevdx_getMemorySize<BATCHED, T, S>(
         evect, uplo, n, batch_count, &unused, &temp1, &temp2, &temp3, &temp4, size_work5,
         size_work6_ifail, size_D, size_E, size_iblock, size_isplit, size_tau, &temp5);
-    *size_work1 = max(*size_work1, temp1);
-    *size_work2 = max(*size_work2, temp2);
-    *size_work3 = max(*size_work3, temp3);
-    *size_work4 = max(*size_work4, temp4);
-    *size_work7_workArr = max(*size_work7_workArr, temp5);
+    *size_work1 = std::max(*size_work1, temp1);
+    *size_work2 = std::max(*size_work2, temp2);
+    *size_work3 = std::max(*size_work3, temp3);
+    *size_work4 = std::max(*size_work4, temp4);
+    *size_work7_workArr = std::max(*size_work7_workArr, temp5);
 
     if(evect == rocblas_evect_original)
     {
@@ -174,10 +174,10 @@ void rocsolver_sygvdx_hegvdx_getMemorySize(const rocblas_eform itype,
             // requirements for calling TRSM
             rocsolver_trsm_mem<BATCHED, STRIDED, T>(rocblas_side_left, trans, n, n, batch_count,
                                                     &temp1, &temp2, &temp3, &temp4, &opt3);
-            *size_work1 = max(*size_work1, temp1);
-            *size_work2 = max(*size_work2, temp2);
-            *size_work3 = max(*size_work3, temp3);
-            *size_work4 = max(*size_work4, temp4);
+            *size_work1 = std::max(*size_work1, temp1);
+            *size_work2 = std::max(*size_work2, temp2);
+            *size_work3 = std::max(*size_work3, temp3);
+            *size_work4 = std::max(*size_work4, temp4);
         }
     }
 

--- a/library/src/lapack/roclapack_sygvdx_hegvdx_inplace.hpp
+++ b/library/src/lapack/roclapack_sygvdx_hegvdx_inplace.hpp
@@ -147,25 +147,25 @@ void rocsolver_sygvdx_hegvdx_inplace_getMemorySize(const rocblas_eform itype,
     rocsolver_potrf_getMemorySize<BATCHED, STRIDED, T>(n, uplo, batch_count, size_scalars,
                                                        size_work1, size_work2, size_work3, size_work4,
                                                        size_work7_workArr, size_iinfo, &opt1);
-    *size_iinfo = max(*size_iinfo, sizeof(rocblas_int) * batch_count);
+    *size_iinfo = std::max(*size_iinfo, sizeof(rocblas_int) * batch_count);
 
     // requirements for calling SYGST/HEGST
     rocsolver_sygst_hegst_getMemorySize<BATCHED, STRIDED, T>(uplo, itype, n, batch_count, &unused,
                                                              &temp1, &temp2, &temp3, &temp4, &opt2);
-    *size_work1 = max(*size_work1, temp1);
-    *size_work2 = max(*size_work2, temp2);
-    *size_work3 = max(*size_work3, temp3);
-    *size_work4 = max(*size_work4, temp4);
+    *size_work1 = std::max(*size_work1, temp1);
+    *size_work2 = std::max(*size_work2, temp2);
+    *size_work3 = std::max(*size_work3, temp3);
+    *size_work4 = std::max(*size_work4, temp4);
 
     // requirements for calling SYEVDX/HEEVDX
     rocsolver_syevdx_heevdx_inplace_getMemorySize<BATCHED, T, S>(
         evect, uplo, n, batch_count, &unused, &temp1, &temp2, &temp3, &temp4, size_work5,
         size_work6_ifail, size_D, size_E, size_iblock, size_isplit, size_tau, size_nev, &temp5);
-    *size_work1 = max(*size_work1, temp1);
-    *size_work2 = max(*size_work2, temp2);
-    *size_work3 = max(*size_work3, temp3);
-    *size_work4 = max(*size_work4, temp4);
-    *size_work7_workArr = max(*size_work7_workArr, temp5);
+    *size_work1 = std::max(*size_work1, temp1);
+    *size_work2 = std::max(*size_work2, temp2);
+    *size_work3 = std::max(*size_work3, temp3);
+    *size_work4 = std::max(*size_work4, temp4);
+    *size_work7_workArr = std::max(*size_work7_workArr, temp5);
 
     if(evect == rocblas_evect_original)
     {
@@ -177,10 +177,10 @@ void rocsolver_sygvdx_hegvdx_inplace_getMemorySize(const rocblas_eform itype,
             // requirements for calling TRSM
             rocsolver_trsm_mem<BATCHED, STRIDED, T>(rocblas_side_left, trans, n, n, batch_count,
                                                     &temp1, &temp2, &temp3, &temp4, &opt3);
-            *size_work1 = max(*size_work1, temp1);
-            *size_work2 = max(*size_work2, temp2);
-            *size_work3 = max(*size_work3, temp3);
-            *size_work4 = max(*size_work4, temp4);
+            *size_work1 = std::max(*size_work1, temp1);
+            *size_work2 = std::max(*size_work2, temp2);
+            *size_work3 = std::max(*size_work3, temp3);
+            *size_work4 = std::max(*size_work4, temp4);
         }
     }
 

--- a/library/src/refact/rocrefact_csrrf_splitlu.hpp
+++ b/library/src/refact/rocrefact_csrrf_splitlu.hpp
@@ -536,7 +536,7 @@ rocblas_status rocsolver_csrrf_splitlu_template(rocblas_handle handle,
         return rocblas_status_success;
     }
 
-    const rocblas_int avg_nnzM = max(1, nnzT / n);
+    const rocblas_int avg_nnzM = std::max(1, nnzT / n);
     const rocblas_int waveSize = cal_wave_size(avg_nnzM);
     const rocblas_int nx = waveSize;
     const rocblas_int ny = BS1 / nx;

--- a/library/src/specialized/roclapack_getf2_specialized_kernels.hpp
+++ b/library/src/specialized/roclapack_getf2_specialized_kernels.hpp
@@ -56,7 +56,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(GETF2_SSKER_MAX_M)
     // (SHUFFLES DO NOT IMPROVE PERFORMANCE IN THIS CASE)
     extern __shared__ double lmem[];
     T* common = reinterpret_cast<T*>(lmem);
-    common += ty * max(m, DIM);
+    common += ty * std::max(m, DIM);
 
     // local variables
     T pivot_value;
@@ -574,7 +574,7 @@ rocblas_status getf2_run_small(rocblas_handle handle,
     I nthds = m;
     I msize;
     if(pivot)
-        msize = max(m, n);
+        msize = std::max(m, n);
     else
         msize = n + 1;
 


### PR DESCRIPTION
The clang compiler provides integer min and max functions when building for the HIP language. This may result in 64-bit integers being implicitly converted to 32-bit. To avoid this, we will always use std::min and std::max as those functions are strict about matching arguments.