### PR TITLE
Two fixes for the Jacobi eigensolver

### DIFF
--- a/library/src/lapack/roclapack_syevj_heevj.cpp
+++ b/library/src/lapack/roclapack_syevj_heevj.cpp
@@ -80,7 +80,7 @@ rocblas_status rocsolver_syevj_heevj_impl(rocblas_handle handle,
     // memory workspace allocation
     void *Acpy, *J, *norms, *top, *bottom, *completed;
     rocblas_device_malloc mem(handle, size_Acpy, size_J, size_norms, size_top, size_bottom,
-                              size_completed, size_norms);
+                              size_completed);
 
     if(!mem)
         return rocblas_status_memory_error;

--- a/library/src/lapack/roclapack_syevj_heevj.hpp
+++ b/library/src/lapack/roclapack_syevj_heevj.hpp
@@ -1105,53 +1105,45 @@ template <typename T>
 ROCSOLVER_KERNEL void
     syevj_cycle_pairs(const rocblas_int half_blocks, rocblas_int* top, rocblas_int* bottom)
 {
-    rocblas_int tix = hipThreadIdx_x;
-    rocblas_int i, j, k;
+    rocblas_int n = half_blocks - 1;
 
-    if(half_blocks <= hipBlockDim_x && tix < half_blocks)
+    auto cycle = [n = n](auto i) -> auto
     {
-        if(tix == 0)
-            i = 0;
-        else if(tix == 1)
-            i = bottom[0];
-        else if(tix > 1)
-            i = top[tix - 1];
+        using I = decltype(i);
+        i = (i - 1) % (2 * n + 1) + 1;
+        I j{};
 
-        if(tix == half_blocks - 1)
-            j = top[half_blocks - 1];
+        if(i % 2 == 0)
+        {
+            j = i + 2;
+            if(j > 2 * n)
+            {
+                j = 2 * n + 1;
+            }
+        }
         else
-            j = bottom[tix + 1];
-        __syncthreads();
+        {
+            j = i - 2;
+            if(j < 1)
+            {
+                j = 2;
+            }
+        }
 
-        top[tix] = i;
-        bottom[tix] = j;
-    }
-    else
+        return j;
+    };
+
+    rocblas_int tidx = hipThreadIdx_x;
+    rocblas_int dimx = hipBlockDim_x;
+
+    if(tidx == 0)
     {
-        // shared memory
-        extern __shared__ double lmem[];
-        rocblas_int* sh_top = reinterpret_cast<rocblas_int*>(lmem);
-        rocblas_int* sh_bottom = reinterpret_cast<rocblas_int*>(sh_top + half_blocks);
-
-        for(k = tix; k < half_blocks; k += hipBlockDim_x)
-        {
-            sh_top[k] = top[k];
-            sh_bottom[k] = bottom[k];
-        }
-        __syncthreads();
-
-        for(k = tix; k < half_blocks; k += hipBlockDim_x)
-        {
-            if(k == 1)
-                top[k] = sh_bottom[0];
-            else if(k > 1)
-                top[k] = sh_top[k - 1];
-
-            if(k == half_blocks - 1)
-                bottom[k] = sh_top[half_blocks - 1];
-            else
-                bottom[k] = sh_bottom[k + 1];
-        }
+        bottom[0] = cycle(bottom[0]);
+    }
+    for(rocblas_int l = tidx + 1; l < half_blocks; l += dimx)
+    {
+        top[l] = cycle(top[l]);
+        bottom[l] = cycle(bottom[l]);
     }
 }
 

--- a/library/src/lapack/roclapack_syevj_heevj_batched.cpp
+++ b/library/src/lapack/roclapack_syevj_heevj_batched.cpp
@@ -81,7 +81,7 @@ rocblas_status rocsolver_syevj_heevj_batched_impl(rocblas_handle handle,
     // memory workspace allocation
     void *Acpy, *J, *norms, *top, *bottom, *completed;
     rocblas_device_malloc mem(handle, size_Acpy, size_J, size_norms, size_top, size_bottom,
-                              size_completed, size_norms);
+                              size_completed);
 
     if(!mem)
         return rocblas_status_memory_error;

--- a/library/src/lapack/roclapack_syevj_heevj_strided_batched.cpp
+++ b/library/src/lapack/roclapack_syevj_heevj_strided_batched.cpp
@@ -79,7 +79,7 @@ rocblas_status rocsolver_syevj_heevj_strided_batched_impl(rocblas_handle handle,
     // memory workspace allocation
     void *Acpy, *J, *norms, *top, *bottom, *completed;
     rocblas_device_malloc mem(handle, size_Acpy, size_J, size_norms, size_top, size_bottom,
-                              size_completed, size_norms);
+                              size_completed);
 
     if(!mem)
         return rocblas_status_memory_error;


### PR DESCRIPTION
Cherry-pick [98a2e13](https://github.com/ROCm/rocSOLVER/commit/98a2e13949e3cac3fcc7e5384b0ed7b63159db10) and [791dfe4](791dfe4c7d9114cf62bb3fe567e4c3f850b034c3) into 6.2 release.

The Jacobi solvers were trying to allocate more memory than they needed, and this led to allocation failures with clients that manage their own memory (hipSOLVER in particular). This commit also addresses an issue that can prevent convergence of Jacobi for large matrices.