### PR TITLE
Drop use of f16c instructions

### DIFF
--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##########################################################################
-# Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -37,8 +37,6 @@ target_link_libraries(rocsolver-bench PRIVATE
   roc::rocsolver
 )
 
-# Turn on f16c intrinsics
-target_compile_options(rocsolver-bench PRIVATE -mf16c)
 target_compile_definitions(rocsolver-bench PRIVATE
   ROCM_USE_FLOAT16
   ROCSOLVER_CLIENTS_BENCH

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -186,8 +186,6 @@ target_link_libraries(rocsolver-test PRIVATE
   roc::rocblas
 )
 
-# Turn on f16c intrinsics
-target_compile_options(rocsolver-test PRIVATE -mf16c)
 target_compile_definitions(rocsolver-test PRIVATE
   ROCM_USE_FLOAT16
   ROCSOLVER_CLIENTS_TEST


### PR DESCRIPTION
The rocSOLVER library does not use half-floats so these options are not needed. The -mf16c flag is also troublesome, as it clang takes the enablement of F16C instructions as a license to emit AVX instructions (which are not compatible with old CPUs). See also https://github.com/ROCm/rocBLAS/commit/c6bc09073959a2881a701b88ae1ed9de469354f1.