### PR TITLE
Fix synchronization issue in stein

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
 
 ### Fixed
 - Fixed potential accuracy degradation in SYEVJ/HEEVJ for inputs with small eigenvalues.
+- Fixed synchronization issue in STEIN.
 
 
 ## rocSOLVER 3.25.0 for ROCm 6.1.0

--- a/library/src/auxiliary/rocauxiliary_stein.hpp
+++ b/library/src/auxiliary/rocauxiliary_stein.hpp
@@ -238,6 +238,7 @@ __device__ void run_stein(const int tid,
                 nrm2<MAX_THDS, S>(tid, blksize, work, 1, sval2);
                 __syncthreads();
                 scl = (work[sidx[0] - 1] >= 0 ? S(1) / sval2[0] : S(-1) / sval2[0]);
+                __syncthreads();
                 for(i = tid; i < blksize; i += MAX_THDS) // <- scal
                     work[i] = work[i] * scl;
                 __syncthreads();


### PR DESCRIPTION
As @jmachado-amd suspected, there is in fact a synchronization defect in STEIN. There may still be issues in STEBZ, but this is likely the primary culprit for our test failures in the X functions along with the initial eigenvector choices resolved by https://github.com/ROCm/rocSOLVER/pull/714.