### PR TITLE
Fix dead link to .pdf that does not exist

### DIFF
--- a/docs/howto/memory.rst
+++ b/docs/howto/memory.rst
@@ -10,7 +10,8 @@ rocSOLVER Memory Model
 
 Almost all LAPACK and rocSOLVER routines require workspace memory in order to compute their results. In contrast to LAPACK, however, pointers to the workspace are not explicitly passed to rocSOLVER functions as arguments; instead, they are managed behind-the-scenes using a configurable device memory model.
 
-rocSOLVER makes use of and is integrated with `the rocBLAS memory model`_. Workspace memory, and the scheme used to manage it, is tracked on a per-``rocblas_handle`` basis. The same functionality that is used to manipulate rocBLAS's workspace memory will also affect rocSOLVER's workspace memory. You can also refer to `rocBLAS Device Memory Management <https://github.com/ROCm/rocBLAS/blob/develop/docs/Device_Memory_Allocation.pdf>`_.
+rocSOLVER makes use of and is integrated with `the rocBLAS memory model`_. Workspace memory, and the scheme used to manage it, is tracked on a per- ``rocblas_handle`` basis. The same functionality that is used to manipulate rocBLAS's workspace memory will also affect rocSOLVER's workspace memory. 
+You can also refer to the rocBLAS :ref:`rocblas:Device Memory allocation in detail` documentation.
 
 There are four schemes for device memory management:
 


### PR DESCRIPTION
This fixes a dead link in memory.rst that leads to an old PDF file that is no longer in the develop branch. I replaced the link with one to the Device Memory section of the rocBLAS programmers guide, which should have up-to-date information.