### PR TITLE
(WIP) Add functionality to print hashes and computed errors in tests

### DIFF
--- a/clients/common/lapack/testing_sygvx_hegvx.hpp
+++ b/clients/common/lapack/testing_sygvx_hegvx.hpp
@@ -430,8 +430,11 @@ void sygvx_hegvx_getError(const rocblas_handle handle,
     // Compute input data hash (combine matrices A and B)
     //
     std::size_t input_hash = 0;
-    input_hash = hash_combine(input_hash, hA[0], lda * n * bc);
-    input_hash = hash_combine(input_hash, hB[0], ldb * n * bc);
+    for(rocblas_int b = 0; b < bc; ++b)
+    {
+        input_hash = hash_combine(input_hash, hA[0], lda * n);
+        input_hash = hash_combine(input_hash, hB[0], ldb * n);
+    }
 
     // execute computations
     // GPU lapack

--- a/clients/common/lapack/testing_sygvx_hegvx.hpp
+++ b/clients/common/lapack/testing_sygvx_hegvx.hpp
@@ -263,6 +263,8 @@ void sygvx_hegvx_initData(const rocblas_handle handle,
             // for testing purposes, we start with a reduced matrix M for the standard equivalent problem
             // with spectrum in a desired range (-20, 20). Then we construct the generalized pair
             // (A, B) from there.
+
+            [[maybe_unused]] volatile auto mptr = memset(hB[b], 0, n * ldb * sizeof(T));
             for(rocblas_int i = 0; i < n; i++)
             {
                 // scale matrices and set hA = M (symmetric/hermitian), hB = U (upper triangular)
@@ -424,6 +426,13 @@ void sygvx_hegvx_getError(const rocblas_handle handle,
     sygvx_hegvx_initData<true, true, T>(handle, itype, evect, n, dA, lda, stA, dB, ldb, stB, bc, hA,
                                         hB, A, B, true, singular);
 
+    //
+    // Compute input data hash (combine matrices A and B)
+    //
+    std::size_t input_hash = 0;
+    input_hash = hash_combine(input_hash, hA[0], lda * n * bc);
+    input_hash = hash_combine(input_hash, hB[0], ldb * n * bc);
+
     // execute computations
     // GPU lapack
     CHECK_ROCBLAS_ERROR(rocsolver_sygvx_hegvx(STRIDED, handle, itype, evect, erange, uplo, n,
@@ -470,6 +479,41 @@ void sygvx_hegvx_getError(const rocblas_handle handle,
         EXPECT_EQ(hNev[b][0], hNevRes[b][0]) << "where b = " << b;
         if(hNev[b][0] != hNevRes[b][0])
             *max_err += 1;
+    }
+
+    //
+    // Compute output hashes
+    //
+    std::size_t rocsolver_eigenvalues_hash = 0;
+    std::size_t rocsolver_eigenvectors_hash = 0;
+
+    for(rocblas_int b = 0; b < bc; ++b)
+    {
+        if(hInfo[b][0] == 0)
+        {
+            rocsolver_eigenvalues_hash
+                = hash_combine(rocsolver_eigenvalues_hash, hWRes[b], hNevRes[b][0]);
+
+            if(evect == rocblas_evect_original)
+            {
+                rocsolver_eigenvectors_hash
+                    = hash_combine(rocsolver_eigenvectors_hash, hZRes[b], hNevRes[b][0] * ldz);
+            }
+        }
+    }
+
+    //
+    // Print hashes
+    //
+    ROCSOLVER_GTEST_MSG_PRINTER << "Input matrix hash: " << input_hash << std::endl << std::flush;
+    ROCSOLVER_GTEST_MSG_PRINTER << "Rocsolver eigenvalues hash: " << rocsolver_eigenvalues_hash
+                                << std::endl
+                                << std::flush;
+    if(evect == rocblas_evect_original)
+    {
+        ROCSOLVER_GTEST_MSG_PRINTER
+            << "Rocsolver eigenvectors hash: " << rocsolver_eigenvectors_hash << std::endl
+            << std::flush;
     }
 
     double err;

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -191,6 +191,7 @@ target_compile_options(rocsolver-test PRIVATE -mf16c)
 target_compile_definitions(rocsolver-test PRIVATE
   ROCM_USE_FLOAT16
   ROCSOLVER_CLIENTS_TEST
+  ROCSOLVER_CLIENTS_TEST_PRINT_EXTRA_MESSAGES
 )
 
 add_test(


### PR DESCRIPTION
rocSOLVER's tests currently output no useful information for passing tests, which makes it hard to ascertain when new code adversely affects the accuracy of methods while also hindering the investigation of bugs that may affect determinism.

This PR adds code to print the computed error in each test and hashing functions to allow printing hashes of input and output matrices, when desired.