### PR TITLE
Revert "Update changelog to mention the `stebz` synchronization defect (#752)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,11 +39,6 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
 ### Fixed
 - Fixed potential accuracy degradation in SYEVJ/HEEVJ for inputs with small eigenvalues.
 
-### Known Issues
-- A known issue in STEBZ can lead to errors in routines based on Bisection to compute eigenvalues for
-  symmetric/hermitian matrices (e.g., SYEVX/HEEVX and SYGVX/HEGVX), as well as singular values (e.g.,
-  BDSVDX and GESVDX).
-
 
 ## rocSOLVER 3.25.0 for ROCm 6.1.0
 ### Added


### PR DESCRIPTION
This reverts commit [1eb0f16](https://github.com/ROCm/rocSOLVER/commit/1eb0f161413b6a6f68fc549003b295b454073d25), as it was not cherry-picked into 6.2.