### PR TITLE
Potential improvement to set/restore_diag in GEQR2

### DIFF
--- a/library/src/auxiliary/rocauxiliary_larfg.hpp
+++ b/library/src/auxiliary/rocauxiliary_larfg.hpp
@@ -220,22 +220,22 @@ rocblas_status
 }
 
 template <typename T, typename I, typename U, typename UB, bool COMPLEX = rocblas_is_complex<T>>
-rocblas_status rocsolver_larfg_general_template(rocblas_handle handle,
-                                                const I n,
-                                                U alpha,
-                                                const rocblas_stride shifta,
-                                                UB beta,
-                                                const rocblas_stride shiftb,
-                                                const rocblas_stride strideb,
-                                                U x,
-                                                const rocblas_stride shiftx,
-                                                const I incx,
-                                                const rocblas_stride stridex,
-                                                T* tau,
-                                                const rocblas_stride strideP,
-                                                const I batch_count,
-                                                T* work,
-                                                T* norms)
+rocblas_status rocsolver_larfg_template(rocblas_handle handle,
+                                        const I n,
+                                        U alpha,
+                                        const rocblas_stride shifta,
+                                        UB beta,
+                                        const rocblas_stride shiftb,
+                                        const rocblas_stride strideb,
+                                        U x,
+                                        const rocblas_stride shiftx,
+                                        const I incx,
+                                        const rocblas_stride stridex,
+                                        T* tau,
+                                        const rocblas_stride strideP,
+                                        const I batch_count,
+                                        T* work,
+                                        T* norms)
 {
     // TODO: How to get alpha for trace logging
     ROCSOLVER_ENTER("larfg", "n:", n, "shiftA:", shifta, "shiftX:", shiftx, "incx:", incx,
@@ -315,8 +315,8 @@ rocblas_status rocsolver_larfg_template(rocblas_handle handle,
                                         T* work,
                                         T* norms)
 {
-    return rocsolver_larfg_general_template(handle, n, alpha, shifta, (T*)nullptr, 0, 0, x, shiftx,
-                                            incx, stridex, tau, strideP, batch_count, work, norms);
+    return rocsolver_larfg_template(handle, n, alpha, shifta, (T*)nullptr, 0, 0, x, shiftx, incx,
+                                    stridex, tau, strideP, batch_count, work, norms);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/library/src/include/rocsolver_run_specialized_kernels.hpp
+++ b/library/src/include/rocsolver_run_specialized_kernels.hpp
@@ -59,7 +59,7 @@ rocblas_status larf_run_small(rocblas_handle handle,
                               const I batch_count);
 
 // larfg
-template <bool IMPLICIT_UNIT, typename T, typename I, typename U, typename UB>
+template <typename T, typename I, typename U, typename UB>
 rocblas_status larfg_run_small(rocblas_handle handle,
                                const I n,
                                U alpha,

--- a/library/src/include/rocsolver_run_specialized_kernels.hpp
+++ b/library/src/include/rocsolver_run_specialized_kernels.hpp
@@ -59,12 +59,15 @@ rocblas_status larf_run_small(rocblas_handle handle,
                               const I batch_count);
 
 // larfg
-template <typename T, typename I, typename U>
+template <bool IMPLICIT_UNIT, typename T, typename I, typename U, typename UB>
 rocblas_status larfg_run_small(rocblas_handle handle,
                                const I n,
                                U alpha,
                                const rocblas_stride shiftA,
                                const rocblas_stride strideA,
+                               UB beta,
+                               const rocblas_stride shiftB,
+                               const rocblas_stride strideB,
                                U x,
                                const rocblas_stride shiftX,
                                const I incX,

--- a/library/src/lapack/roclapack_geqr2.hpp
+++ b/library/src/lapack/roclapack_geqr2.hpp
@@ -69,7 +69,7 @@ void rocsolver_geqr2_getMemorySize(const I m,
     *size_Abyx_norms = std::max(s1, s2);
 
     // size of array to store temporary diagonal values
-    *size_diag = sizeof(T) * batch_count;
+    *size_diag = sizeof(T) * std::min(m, n) * batch_count;
 }
 
 template <typename T, typename I, typename U>
@@ -131,23 +131,13 @@ rocblas_status rocsolver_geqr2_template(rocblas_handle handle,
     for(I j = 0; j < dim; ++j)
     {
         // generate Householder reflector to work on column j
-        rocsolver_larfg_general_template<false, T>(handle, m - j, A, shiftA + idx2D(j, j, lda), diag, 0, 1, A,
+        rocsolver_larfg_general_template<false, T>(handle, m - j, A, shiftA + idx2D(j, j, lda), diag, j, dim, A,
                                  shiftA + idx2D(std::min(j + 1, m - 1), j, lda), (I)1, strideA,
                                  (ipiv + j), strideP, batch_count, (T*)work_workArr, Abyx_norms);
-
-        // // restore original value of A(j,j)
-        // ROCSOLVER_LAUNCH_KERNEL((restore_diag<T, I>), dim3(batch_count, 1, 1), dim3(1, 1, 1), 0,
-        //                         stream, diag, 0, 1, A, shiftA + idx2D(j, j, lda), lda, strideA,
-        //                         (I)1);
 
         // Apply Householder reflector to the rest of matrix from the left
         if(j < n - 1)
         {
-            // // insert one in A(j,j) tobuild/apply the householder matrix
-            // ROCSOLVER_LAUNCH_KERNEL((set_diag<T, I>), dim3(batch_count, 1, 1), dim3(1, 1, 1), 0,
-            //                         stream, diag, 0, 1, A, shiftA + idx2D(j, j, lda), lda, strideA,
-            //                         (I)1, true);
-
             // conjugate tau
             if(COMPLEX)
                 rocsolver_lacgv_template<T>(handle, (I)1, ipiv, j, (I)1, strideP, batch_count);
@@ -157,21 +147,17 @@ rocblas_status rocsolver_geqr2_template(rocblas_handle handle,
                                     A, shiftA + idx2D(j, j + 1, lda), lda, strideA, batch_count,
                                     scalars, Abyx_norms, (T**)work_workArr);
 
-            // // restore original value of A(j,j)
-            // ROCSOLVER_LAUNCH_KERNEL((restore_diag<T, I>), dim3(batch_count, 1, 1), dim3(1, 1, 1), 0,
-            //                         stream, diag, 0, 1, A, shiftA + idx2D(j, j, lda), lda, strideA,
-            //                         (I)1);
-
             // restore tau
             if(COMPLEX)
                 rocsolver_lacgv_template<T>(handle, (I)1, ipiv, j, (I)1, strideP, batch_count);
         }
-
-        // restore original value of A(j,j)
-        ROCSOLVER_LAUNCH_KERNEL((restore_diag<T, I>), dim3(batch_count, 1, 1), dim3(1, 1, 1), 0,
-                                stream, diag, 0, 1, A, shiftA + idx2D(j, j, lda), lda, strideA,
-                                (I)1);
     }
+
+    // restore diagonal values of A
+    constexpr int DIAG_NTHREADS = 64;
+    I blocks = (dim - 1) / DIAG_NTHREADS + 1;
+    ROCSOLVER_LAUNCH_KERNEL((restore_diag<T, I>), dim3(batch_count, blocks, 1), dim3(1, DIAG_NTHREADS, 1), 0,
+                            stream, diag, 0, dim, A, shiftA, lda, strideA, dim);
 
     return rocblas_status_success;
 }

--- a/library/src/lapack/roclapack_geqr2.hpp
+++ b/library/src/lapack/roclapack_geqr2.hpp
@@ -131,9 +131,10 @@ rocblas_status rocsolver_geqr2_template(rocblas_handle handle,
     for(I j = 0; j < dim; ++j)
     {
         // generate Householder reflector to work on column j
-        rocsolver_larfg_general_template<false, T>(handle, m - j, A, shiftA + idx2D(j, j, lda), diag, j, dim, A,
-                                 shiftA + idx2D(std::min(j + 1, m - 1), j, lda), (I)1, strideA,
-                                 (ipiv + j), strideP, batch_count, (T*)work_workArr, Abyx_norms);
+        rocsolver_larfg_general_template<T>(handle, m - j, A, shiftA + idx2D(j, j, lda), diag, j,
+                                            dim, A, shiftA + idx2D(std::min(j + 1, m - 1), j, lda),
+                                            (I)1, strideA, (ipiv + j), strideP, batch_count,
+                                            (T*)work_workArr, Abyx_norms);
 
         // Apply Householder reflector to the rest of matrix from the left
         if(j < n - 1)
@@ -156,8 +157,9 @@ rocblas_status rocsolver_geqr2_template(rocblas_handle handle,
     // restore diagonal values of A
     constexpr int DIAG_NTHREADS = 64;
     I blocks = (dim - 1) / DIAG_NTHREADS + 1;
-    ROCSOLVER_LAUNCH_KERNEL((restore_diag<T, I>), dim3(batch_count, blocks, 1), dim3(1, DIAG_NTHREADS, 1), 0,
-                            stream, diag, 0, dim, A, shiftA, lda, strideA, dim);
+    ROCSOLVER_LAUNCH_KERNEL((restore_diag<T, I>), dim3(batch_count, blocks, 1),
+                            dim3(1, DIAG_NTHREADS, 1), 0, stream, diag, 0, dim, A, shiftA, lda,
+                            strideA, dim);
 
     return rocblas_status_success;
 }

--- a/library/src/lapack/roclapack_geqr2.hpp
+++ b/library/src/lapack/roclapack_geqr2.hpp
@@ -131,10 +131,9 @@ rocblas_status rocsolver_geqr2_template(rocblas_handle handle,
     for(I j = 0; j < dim; ++j)
     {
         // generate Householder reflector to work on column j
-        rocsolver_larfg_general_template<T>(handle, m - j, A, shiftA + idx2D(j, j, lda), diag, j,
-                                            dim, A, shiftA + idx2D(std::min(j + 1, m - 1), j, lda),
-                                            (I)1, strideA, (ipiv + j), strideP, batch_count,
-                                            (T*)work_workArr, Abyx_norms);
+        rocsolver_larfg_template<T>(handle, m - j, A, shiftA + idx2D(j, j, lda), diag, j, dim, A,
+                                    shiftA + idx2D(std::min(j + 1, m - 1), j, lda), (I)1, strideA,
+                                    (ipiv + j), strideP, batch_count, (T*)work_workArr, Abyx_norms);
 
         // Apply Householder reflector to the rest of matrix from the left
         if(j < n - 1)

--- a/library/src/specialized/rocauxiliary_larfg_specialized_kernels.hpp
+++ b/library/src/specialized/rocauxiliary_larfg_specialized_kernels.hpp
@@ -44,12 +44,15 @@ ROCSOLVER_BEGIN_NAMESPACE
     the library size.
 *************************************************************/
 
-template <typename T, typename I, typename U>
+template <bool IMPLICIT_UNIT, typename T, typename I, typename U, typename UB>
 ROCSOLVER_KERNEL void __launch_bounds__(LARFG_SSKER_THREADS)
     larfg_kernel_small(const I n,
                        U alpha,
                        const rocblas_stride shiftA,
                        const rocblas_stride strideA,
+                       UB beta,
+                       const rocblas_stride shiftB,
+                       const rocblas_stride strideB,
                        U xx,
                        const rocblas_stride shiftX,
                        const I incX,
@@ -62,6 +65,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(LARFG_SSKER_THREADS)
 
     // select batch instance
     T* a = load_ptr_batch<T>(alpha, bid, shiftA, strideA);
+    T* b = load_ptr_batch<T>(beta, bid, shiftB, strideB);
     T* x = load_ptr_batch<T>(xx, bid, shiftX, strideX);
     T* tau = load_ptr_batch<T>(tauA, bid, 0, strideP);
 
@@ -78,7 +82,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(LARFG_SSKER_THREADS)
 
     // set tau, beta, and put scaling factor into sval[0]
     if(tid == 0)
-        run_set_taubeta<T>(tau, sval, a);
+        run_set_taubeta<IMPLICIT_UNIT, T>(tau, sval, a, b);
     __syncthreads();
 
     // scale x by scaling factor
@@ -90,12 +94,15 @@ ROCSOLVER_KERNEL void __launch_bounds__(LARFG_SSKER_THREADS)
     Launchers of specialized  kernels
 *************************************************************/
 
-template <typename T, typename I, typename U>
+template <bool IMPLICIT_UNIT, typename T, typename I, typename U, typename UB>
 rocblas_status larfg_run_small(rocblas_handle handle,
                                const I n,
                                U alpha,
                                const rocblas_stride shiftA,
                                const rocblas_stride strideA,
+                               UB beta,
+                               const rocblas_stride shiftB,
+                               const rocblas_stride strideB,
                                U x,
                                const rocblas_stride shiftX,
                                const I incX,
@@ -110,8 +117,8 @@ rocblas_status larfg_run_small(rocblas_handle handle,
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
 
-    ROCSOLVER_LAUNCH_KERNEL(larfg_kernel_small<T>, grid, block, 0, stream, n, alpha, shiftA,
-                            strideA, x, shiftX, incX, strideX, tau, strideP);
+    ROCSOLVER_LAUNCH_KERNEL((larfg_kernel_small<IMPLICIT_UNIT, T>), grid, block, 0, stream, n, alpha, shiftA,
+                            strideA, beta, shiftB, strideB, x, shiftX, incX, strideX, tau, strideP);
 
     return rocblas_status_success;
 }
@@ -120,10 +127,16 @@ rocblas_status larfg_run_small(rocblas_handle handle,
     Instantiation macros
 *************************************************************/
 
-#define INSTANTIATE_LARFG_SMALL(T, I, U)                                              \
-    template rocblas_status larfg_run_small<T, I, U>(                                 \
-        rocblas_handle handle, const I n, U alpha, const rocblas_stride shiftA,       \
-        const rocblas_stride strideA, U x, const rocblas_stride shiftX, const I incX, \
+#define INSTANTIATE_LARFG_SMALL(T, I, U)                                                          \
+    template rocblas_status larfg_run_small<true, T, I, U, T*>(                                   \
+        rocblas_handle handle, const I n, U alpha, const rocblas_stride shiftA,                   \
+        const rocblas_stride strideA, T* beta, const rocblas_stride shiftB,                       \
+        const rocblas_stride strideB, U x, const rocblas_stride shiftX, const I incX,             \
+        const rocblas_stride strideX, T* tau, const rocblas_stride strideP, const I batch_count); \
+    template rocblas_status larfg_run_small<false, T, I, U, T*>(                                  \
+        rocblas_handle handle, const I n, U alpha, const rocblas_stride shiftA,                   \
+        const rocblas_stride strideA, T* beta, const rocblas_stride shiftB,                       \
+        const rocblas_stride strideB, U x, const rocblas_stride shiftX, const I incX,             \
         const rocblas_stride strideX, T* tau, const rocblas_stride strideP, const I batch_count)
 
 ROCSOLVER_END_NAMESPACE


### PR DESCRIPTION
This PR aims to reduce the impact of `set_diag` and `restore_diag` kernels to the runtime of GEQR2 indicated by profiling. This is achieved by:
1. Combining `larfg` and `set_diag` to reduce the number of global memory reads and writes:
   - This is achieved by modifying `larfg` to write both the unit diagonal and non-unit diagonal values thus eliminating the call to `set_diag`.
2. Reduce kernel launch overhead of `set_diag` and `restore_diag`:
   - `set_diag` is explained above. Launch overhead of `restore_diag` is reduced by launching the kernel once to restore all diagonal values at the expense of additional memory footprint.

The following chart shows the speedup of `geqrf` with these changes on real single precision square matrices.
![log_compare_sgeqrf_m](https://github.com/user-attachments/assets/784f0f36-817d-476c-afa8-25bf8df43941)

Note:
- I tried the suggestion of using `larfb` instead of `larf` but it performed worse due to increased global memory access. I got similar results with my attempt to modify `larf` to assume implicit unit diagonal.
- This is my attempt of a solution to this problem and I am open to try other suggestions.