### PR TITLE
Fix libfmt build errors (#828)

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -617,7 +617,9 @@ try
     // print help message
     if(vm.count("help"))
     {
-        fmt::print("{}{}\n", help_str, desc);
+        std::stringstream desc_ss{};
+        desc_ss << desc;
+        fmt::print("{}{}\n", help_str, desc_ss.str());
         return 0;
     }
 

--- a/clients/common/misc/rocblas_test.hpp
+++ b/clients/common/misc/rocblas_test.hpp
@@ -96,16 +96,16 @@ inline void rocblas_expect_status(rocblas_status status, rocblas_status expect)
     }
 }
 
-#define CHECK_HIP_ERROR(ERROR)                                                               \
-    do                                                                                       \
-    {                                                                                        \
-        auto error = ERROR;                                                                  \
-        if(error != hipSuccess)                                                              \
-        {                                                                                    \
-            fmt::print(stderr, "error: {} ({}) at {}:{}\n", hipGetErrorString(error), error, \
-                       __FILE__, __LINE__);                                                  \
-            rocblas_abort();                                                                 \
-        }                                                                                    \
+#define CHECK_HIP_ERROR(ERROR)                                                        \
+    do                                                                                \
+    {                                                                                 \
+        auto error = ERROR;                                                           \
+        if(error != hipSuccess)                                                       \
+        {                                                                             \
+            fmt::print(stderr, "error: {} ({}) at {}:{}\n", hipGetErrorString(error), \
+                       static_cast<int32_t>(error), __FILE__, __LINE__);              \
+            rocblas_abort();                                                          \
+        }                                                                             \
     } while(0)
 
 #define CHECK_ALLOC_QUERY(STATUS)                                                                     \


### PR DESCRIPTION
* Fix build errors with libfmt 10.2.1

* Use `fmt::print` instead of `std::cout`

(cherry picked from commit e5e935060622fcd15e6e80dad877662f2587571f)