### PR TITLE
Convert change log to new format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
     - POTRF_64 (with batched and strided\_batched versions)
     - POTRS_64 (with batched and strided\_batched versions)
 
+* Support added for the gfx1151, gfx1200, and gfx1201 architectures
+
 ### Changed
 
 * The rocSPARSE library is now an optional dependency at runtime. If rocSPARSE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
 
 
 ## rocSOLVER 3.27.0 for ROCm 6.3.0
+
 ### Added
-- 64-bit APIs for existing functions:
+
+* 64-bit APIs for existing functions:
     - LACGV_64
     - LARF_64
     - LARFG_64
@@ -25,25 +27,29 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
     - POTRF_64 (with batched and strided\_batched versions)
     - POTRS_64 (with batched and strided\_batched versions)
 
-### Optimized
-- Improved performance of LARFG, LARF, and downstream functions such as GEQR2 and GEQRF on wave64 architectures
-- Improved the performance of BDSQR and GESVD
-- Improved performance of STEDC and divide and conquer Eigensolvers
-
 ### Changed
-- The rocsparse library is now an optional dependency at runtime. If rocsparse
-  is not available, rocsolver's sparse refactorization and solvers functions
+
+* The rocSPARSE library is now an optional dependency at runtime. If rocSPARSE
+  is not available, rocSOLVER's sparse refactorization and solvers functions
   will return `rocblas_status_not_implemented`.
 
-### Fixed
-- Fixed a memory allocation issue in SYEVJ that could cause failures on clients that manage their own memory.
-- Fixed a synchronizarion issue with SYEVJ that could led to convergence failure for large matrices.
-- Fixed a convergence issue in STEIN steaming from numerical orthogonality of the initial choice of eigenvectors.
-- Fixed synchronization issue in STEIN.
+### Optimized
 
-### Known Issues
-- A known issue in STEBZ can lead to errors in routines based on Bisection to compute eigenvalues for
-  symmetric/hermitian matrices (e.g., SYEVX/HEEVX and SYGVX/HEGVX), as well as singular values (e.g.,
+* Improved the performance of LARFG, LARF, and downstream functions such as GEQR2 and GEQRF on wave64 architectures
+* Improved the performance of BDSQR and GESVD
+* Improved the performance of STEDC and divide and conquer Eigensolvers
+
+### Resolved issues
+
+* Fixed a memory allocation issue in SYEVJ that could cause failures on clients that manage their own memory
+* Fixed a synchronizarion issue with SYEVJ that could lead to a convergence failure for large matrices
+* Fixed a convergence issue in STEIN stemming from numerical orthogonality of the initial choice of eigenvectors
+* Fixed synchronization issue in STEIN
+
+### Known issues
+
+* A known issue in STEBZ can lead to errors in routines based on bisection to compute eigenvalues for
+  symmetric/hermitian matrices (for example, SYEVX/HEEVX and SYGVX/HEGVX), as well as singular values (for example,
   BDSVDX and GESVDX).
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
     - POTF2_64 (with batched and strided\_batched versions)
     - POTRF_64 (with batched and strided\_batched versions)
     - POTRS_64 (with batched and strided\_batched versions)
-
 * Support added for the gfx1151, gfx1200, and gfx1201 architectures
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,57 +58,57 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
 
 ### Added
 
-- 64-bit APIs for existing functions:
-    - GETF2_64 (with batched and strided\_batched versions)
-    - GETRF_64 (with batched and strided\_batched versions)
-    - GETRS_64 (with batched and strided\_batched versions)
-- Added gfx900 to default build targets.
-- Partial eigenvalue decomposition routines for symmetric/hermitian matrices using Divide & Conquer and Bisection:
-    - SYEVDX (with batched and strided\_batched versions)
-    - HEEVDX (with batched and strided\_batched versions)
-- Partial generalized symmetric/hermitian-definite eigenvalue decomposition using Divide & Conquer and Bisection:
-    - SYGVDX (with batched and strided\_batched versions)
-    - HEGVDX (with batched and strided\_batched versions)
+* 64-bit APIs for existing functions:
+    * GETF2_64 (with batched and strided\_batched versions)
+    * GETRF_64 (with batched and strided\_batched versions)
+    * GETRS_64 (with batched and strided\_batched versions)
+* Added gfx900 to default build targets.
+* Partial eigenvalue decomposition routines for symmetric/hermitian matrices using Divide & Conquer and Bisection:
+    * SYEVDX (with batched and strided\_batched versions)
+    * HEEVDX (with batched and strided\_batched versions)
+* Partial generalized symmetric/hermitian-definite eigenvalue decomposition using Divide & Conquer and Bisection:
+    * SYGVDX (with batched and strided\_batched versions)
+    * HEGVDX (with batched and strided\_batched versions)
 
 ### Changed
 
-- Renamed install script arguments of the form *_dir to *-path. Arguments of the form *_dir remain functional for
+* Renamed install script arguments of the form *_dir to *-path. Arguments of the form *_dir remain functional for
   backwards compatibility.
-- Functions working with arrays of size n - 1 can now accept null pointers when n = 1.
+* Functions working with arrays of size n - 1 can now accept null pointers when n = 1.
 
 ### Optimized
 
-- Improved performance of Cholesky factorization.
-- Improved performance of splitlu to extract the L and U triangular matrices from the result of sparse factorization matrix M, where M = (L - eye) + U.
+* Improved performance of Cholesky factorization.
+* Improved performance of splitlu to extract the L and U triangular matrices from the result of sparse factorization matrix M, where M = (L - eye) + U.
 
 ### Resolved issues
 
-- Fixed potential accuracy degradation in SYEVJ/HEEVJ for inputs with small eigenvalues.
+* Fixed potential accuracy degradation in SYEVJ/HEEVJ for inputs with small eigenvalues.
 
 
 ## rocSOLVER 3.25.0 for ROCm 6.1.0
 
 ### Added
 
-- Eigensolver routines for symmetric/hermitian matrices using Divide & Conquer and Jacobi algorithm:
-    - SYEVDJ (with batched and strided\_batched versions)
-    - HEEVDJ (with batched and strided\_batched versions)
-- Generalized symmetric/hermitian-definite eigensolvers using Divide & Conquer and Jacobi algorithm:
-    - SYGVDJ (with batched and strided\_batched versions)
-    - HEGVDJ (with batched and strided\_batched versions)
+* Eigensolver routines for symmetric/hermitian matrices using Divide & Conquer and Jacobi algorithm:
+    * SYEVDJ (with batched and strided\_batched versions)
+    * HEEVDJ (with batched and strided\_batched versions)
+* Generalized symmetric/hermitian-definite eigensolvers using Divide & Conquer and Jacobi algorithm:
+    * SYGVDJ (with batched and strided\_batched versions)
+    * HEGVDJ (with batched and strided\_batched versions)
 
 ### Changed
 
-- Relaxed array length requirements for GESVDX with `rocblas_srange_index`.
+* Relaxed array length requirements for GESVDX with `rocblas_srange_index`.
 
 ### Removed
 
-- Removed gfx803 and gfx900 from default build targets.
+* Removed gfx803 and gfx900 from default build targets.
 
 ### Resolved issues
 
-- Corrected singular vector normalization in BDSVDX and GESVDX
-- Fixed potential memory access fault in STEIN, SYEVX/HEEVX, SYGVX/HEGVX, BDSVDX and GESVDX
+* Corrected singular vector normalization in BDSVDX and GESVDX
+* Fixed potential memory access fault in STEIN, SYEVX/HEEVX, SYGVX/HEGVX, BDSVDX and GESVDX
 
 
 ## rocSOLVER 3.24.0 for ROCm 6.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,9 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
 
 
 ## rocSOLVER 3.26.0 for ROCm 6.2.0
+
 ### Added
+
 - 64-bit APIs for existing functions:
     - GETF2_64 (with batched and strided\_batched versions)
     - GETRF_64 (with batched and strided\_batched versions)
@@ -68,21 +70,26 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
     - SYGVDX (with batched and strided\_batched versions)
     - HEGVDX (with batched and strided\_batched versions)
 
-### Optimized
-- Improved performance of Cholesky factorization.
-- Improved performance of splitlu to extract the L and U triangular matrices from the result of sparse factorization matrix M, where M = (L - eye) + U.
-
 ### Changed
+
 - Renamed install script arguments of the form *_dir to *-path. Arguments of the form *_dir remain functional for
   backwards compatibility.
 - Functions working with arrays of size n - 1 can now accept null pointers when n = 1.
 
-### Fixed
+### Optimized
+
+- Improved performance of Cholesky factorization.
+- Improved performance of splitlu to extract the L and U triangular matrices from the result of sparse factorization matrix M, where M = (L - eye) + U.
+
+### Resolved issues
+
 - Fixed potential accuracy degradation in SYEVJ/HEEVJ for inputs with small eigenvalues.
 
 
 ## rocSOLVER 3.25.0 for ROCm 6.1.0
+
 ### Added
+
 - Eigensolver routines for symmetric/hermitian matrices using Divide & Conquer and Jacobi algorithm:
     - SYEVDJ (with batched and strided\_batched versions)
     - HEEVDJ (with batched and strided\_batched versions)
@@ -91,12 +98,15 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
     - HEGVDJ (with batched and strided\_batched versions)
 
 ### Changed
+
 - Relaxed array length requirements for GESVDX with `rocblas_srange_index`.
 
 ### Removed
+
 - Removed gfx803 and gfx900 from default build targets.
 
-### Fixed
+### Resolved issues
+
 - Corrected singular vector normalization in BDSVDX and GESVDX
 - Fixed potential memory access fault in STEIN, SYEVX/HEEVX, SYGVX/HEGVX, BDSVDX and GESVDX
 


### PR DESCRIPTION
These changes convert the changelog into the new standard format with the required headings and bullet format. I've also made some minor copy edits.