### PR TITLE
Fix static builds

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -436,9 +436,10 @@ if (BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
   )
 endif( )
 
-# Following Boost conventions of prefixing 'lib' on static built libraries, across all platforms
 if(NOT BUILD_SHARED_LIBS)
+  # Following Boost conventions of prefixing 'lib' on static built libraries, across all platforms
   set_target_properties(rocsolver PROPERTIES PREFIX "lib")
+  target_compile_definitions(rocsolver PRIVATE ROCSOLVER_STATIC_LIB)
 endif()
 
 if(OPTIMAL)

--- a/library/src/refact/rocsolver_rfinfo.cpp
+++ b/library/src/refact/rocsolver_rfinfo.cpp
@@ -78,7 +78,6 @@ static bool load_function(void* handle, const char* symbol, Fn& fn)
     if(err)
         fmt::print(stderr, "rocsolver: error loading {:s}: {:s}\n", symbol, err);
 #endif /* NDEBUG */
-    bool err = false;
 #endif /* _WIN32 */
     return !err;
 #else


### PR DESCRIPTION
Adds the preprocessor flag ROCSOLVER_STATIC_LIB to check if we're building as a static library or not, and uses it to prevent trying to use dlopen() and dlsym() if so.