### PR TITLE
Enable offload-compress when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ option(BUILD_SHARED_LIBS "Build rocSOLVER as a shared library" ON)
 # Include helper functions and wrapper functions
 include(util)
 include(CMakeDependentOption)
+include(CheckCXXCompilerFlag)
 
 option(BUILD_TESTING "Build rocSOLVER tests" OFF)
 if(BUILD_TESTING)
@@ -143,6 +144,8 @@ option(BUILD_ADDRESS_SANITIZER "Build with address sanitizer enabled" OFF)
 option(BUILD_CODE_COVERAGE "Build rocSOLVER with code coverage enabled" OFF)
 option(WERROR "Treat warnings as errors" OFF)
 option(BUILD_COMPRESSED_DBG "Enable compressed debug symbols" ON)
+check_cxx_compiler_flag("--offload-compress" CXX_COMPILER_SUPPORTS_OFFLOAD_COMPRESS)
+cmake_dependent_option(BUILD_OFFLOAD_COMPRESS "Build with offload compression" ON CXX_COMPILER_SUPPORTS_OFFLOAD_COMPRESS OFF)
 
 cmake_dependent_option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY
   "Build with file/folder reorg backward compatibility enabled" OFF "NOT WIN32" OFF)

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -405,6 +405,10 @@ if(CMAKE_CXX_COMPILER MATCHES ".*clang\\+\\+.*")
   )
 endif()
 
+if(BUILD_OFFLOAD_COMPRESS)
+  target_compile_options(rocsolver PRIVATE "--offload-compress")
+endif()
+
 target_include_directories(rocsolver
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/library/include>


### PR DESCRIPTION
This change significantly reduces the size of the rocSOLVER library on disk. In my test, the size of librocsolver.so.0.4 changed from 2,017,868,176 bytes to 135,433,664 bytes. This is a savings of 93%.

Note that the size of the package download is slightly increased, as the compression done by offload compress is less effective than the compression used for the package file. Offload compress ends up reducing the effectiveness of the package compression. However, the difference in download size is minor compared to the benefits in installed size.