### PR TITLE
Disable extra targets when compiling with address sanitizer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,10 @@ message(STATUS "Benchmarks: ${BUILD_CLIENTS_BENCHMARKS}")
 message(STATUS "Samples: ${BUILD_CLIENTS_SAMPLES}")
 
 if(NOT DEFINED AMDGPU_TARGETS)
-  set(XNACK_PLUS_TARGETS gfx90a:xnack+)
+  set(XNACK_PLUS_TARGETS
+    gfx90a:xnack+
+    gfx908:xnack+
+    gfx942:xnack+)
   set(XNACK_MINUS_TARGETS gfx90a:xnack-)
   set(MISC_TARGETS
     gfx942
@@ -171,20 +174,20 @@ if(NOT DEFINED AMDGPU_TARGETS)
     gfx1151
     gfx1200
     gfx1201)
-  set(DEFAULT_TARGETS
-    gfx900
-    gfx906:xnack-
-    gfx908:xnack-
-    gfx1010
-    gfx1030)
   if(BUILD_ADDRESS_SANITIZER)
     set(OPTIONAL_TARGETS_QUERY ${XNACK_PLUS_TARGETS})
   else()
     set(OPTIONAL_TARGETS_QUERY ${XNACK_MINUS_TARGETS} ${MISC_TARGETS})
+    set(DEFAULT_TARGETS
+      gfx900
+      gfx906:xnack-
+      gfx908:xnack-
+      gfx1010
+      gfx1030)
   endif()
   # Query for compiler support of GPU archs
   rocm_check_target_ids(OPTIONAL_AMDGPU_TARGETS TARGETS ${OPTIONAL_TARGETS_QUERY})
-  set(AMDGPU_TARGETS_INIT ${OPTIONAL_AMDGPU_TARGETS} ${DEFAULT_TARGETS})
+  set(AMDGPU_TARGETS_INIT ${OPTIONAL_AMDGPU_TARGETS} ${DEFAULT_TARETS})
 endif()
 
 # Set this before finding hip so that hip::device has the required arch flags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,27 +161,30 @@ message(STATUS "Benchmarks: ${BUILD_CLIENTS_BENCHMARKS}")
 message(STATUS "Samples: ${BUILD_CLIENTS_SAMPLES}")
 
 if(NOT DEFINED AMDGPU_TARGETS)
-  # Query for compiler support of GPU archs
-  rocm_check_target_ids(OPTIONAL_AMDGPU_TARGETS
-    TARGETS
-      gfx90a:xnack-
-      gfx90a:xnack+
-      gfx942
-      gfx1100
-      gfx1101
-      gfx1102
-      gfx1151
-      gfx1200
-      gfx1201
-  )
-  set(AMDGPU_TARGETS_INIT
+  set(XNACK_PLUS_TARGETS gfx90a:xnack+)
+  set(XNACK_MINUS_TARGETS gfx90a:xnack-)
+  set(MISC_TARGETS
+    gfx942
+    gfx1100
+    gfx1101
+    gfx1102
+    gfx1151
+    gfx1200
+    gfx1201)
+  set(DEFAULT_TARGETS
     gfx900
     gfx906:xnack-
     gfx908:xnack-
     gfx1010
-    gfx1030
-    ${OPTIONAL_AMDGPU_TARGETS}
-  )
+    gfx1030)
+  if(BUILD_ADDRESS_SANITIZER)
+    set(OPTIONAL_TARGETS_QUERY ${XNACK_PLUS_TARGETS})
+  else()
+    set(OPTIONAL_TARGETS_QUERY ${XNACK_MINUS_TARGETS} ${MISC_TARGETS})
+  endif()
+  # Query for compiler support of GPU archs
+  rocm_check_target_ids(OPTIONAL_AMDGPU_TARGETS TARGETS ${OPTIONAL_TARGETS_QUERY})
+  set(AMDGPU_TARGETS_INIT ${OPTIONAL_AMDGPU_TARGETS} ${DEFAULT_TARGETS})
 endif()
 
 # Set this before finding hip so that hip::device has the required arch flags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,7 +187,7 @@ if(NOT DEFINED AMDGPU_TARGETS)
   endif()
   # Query for compiler support of GPU archs
   rocm_check_target_ids(OPTIONAL_AMDGPU_TARGETS TARGETS ${OPTIONAL_TARGETS_QUERY})
-  set(AMDGPU_TARGETS_INIT ${OPTIONAL_AMDGPU_TARGETS} ${DEFAULT_TARETS})
+  set(AMDGPU_TARGETS_INIT ${OPTIONAL_AMDGPU_TARGETS} ${DEFAULT_TARGETS})
 endif()
 
 # Set this before finding hip so that hip::device has the required arch flags


### PR DESCRIPTION
CI team has asked us to disable unneeded targets when building with address sanitizer to speed up build times. This patch switches off our extra targets that don't support xnack or use xnack- when BUILD_ADDRESS_SANITIZER is on.