### PR TITLE
Enable hashing output for sygvdx

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -168,6 +168,7 @@ try
             "Validate GPU results with CPU? 0 = No, 1 = Yes.\n"
             "                           This will additionally print the relative error of the computations.\n"
             "                           ")
+
         ("hash",
          value<rocblas_int>(&argus.hash_check)->default_value(0),
             "Print hash of GPU results? 0 = No, 1 = Yes.\n"

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -172,7 +172,7 @@ try
         ("hash",
          value<rocblas_int>(&argus.hash_check)->default_value(0),
             "Print hash of GPU results? 0 = No, 1 = Yes.\n"
-            "                           Hash values are deterministic across implementations and executions.\n"
+            "                           Meant for checking reproducibility of computations.\n"
             "                           ")
 
         // size options

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -168,6 +168,11 @@ try
             "Validate GPU results with CPU? 0 = No, 1 = Yes.\n"
             "                           This will additionally print the relative error of the computations.\n"
             "                           ")
+        ("hash",
+         value<rocblas_int>(&argus.hash_check)->default_value(0),
+            "Print hash of GPU results? 0 = No, 1 = Yes.\n"
+            "                           Hash values are deterministic across implementations and executions.\n"
+            "                           ")
 
         // size options
         ("k",

--- a/clients/common/containers/host_strided_batch_vector.hpp
+++ b/clients/common/containers/host_strided_batch_vector.hpp
@@ -264,6 +264,15 @@ public:
         return ((bool)*this) ? hipSuccess : hipErrorOutOfMemory;
     }
 
+    //!
+    //! @brief Get size of vector
+    //! @return number of elements
+    //!
+    size_t size() const
+    {
+        return this->m_nmemb;
+    }
+
 private:
     storage m_storage{storage::block};
     int64_t m_n{};

--- a/clients/common/lapack/testing_sygvdx_hegvdx.hpp
+++ b/clients/common/lapack/testing_sygvdx_hegvdx.hpp
@@ -376,7 +376,11 @@ void sygvdx_hegvdx_getError(const rocblas_handle handle,
                             Vh& hInfo,
                             Vh& hInfoRes,
                             double* max_err,
-                            const bool singular)
+                            const bool singular,
+                            size_t& hashA,
+                            size_t& hashB,
+                            size_t& hashW,
+                            size_t& hashZ)
 {
     constexpr bool COMPLEX = rocblas_is_complex<T>;
 
@@ -395,6 +399,10 @@ void sygvdx_hegvdx_getError(const rocblas_handle handle,
     sygvdx_hegvdx_initData<true, true, T>(handle, itype, evect, n, dA, lda, stA, dB, ldb, stB, bc,
                                           hA, hB, A, B, true, singular);
 
+    // hash inputs
+    hashA = deterministic_hash(hA, bc);
+    hashB = deterministic_hash(hB, bc);
+
     // execute computations
     // GPU lapack
     CHECK_ROCBLAS_ERROR(rocsolver_sygvdx_hegvdx(
@@ -406,6 +414,11 @@ void sygvdx_hegvdx_getError(const rocblas_handle handle,
     CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
     if(evect != rocblas_evect_none)
         CHECK_HIP_ERROR(hZRes.transfer_from(dZ));
+
+    // hash outputs
+    hashW = deterministic_hash(hWRes, bc);
+    if(evect != rocblas_evect_none)
+        hashZ = deterministic_hash(hZRes, bc);
 
     // CPU lapack
     // abstol = 0 ensures max accuracy in rocsolver; for lapack we should use 2*safemin
@@ -664,7 +677,7 @@ void testing_sygvdx_hegvdx(Arguments& argus)
     size_t size_W = size_t(n);
     size_t size_Z = size_t(ldz) * n;
     double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
-    size_t hashA = 0, hashZ = 0;
+    size_t hashA = 0, hashB = 0, hashW = 0, hashZ = 0;
 
     size_t size_WRes = (argus.unit_check || argus.norm_check || argus.hash_check) ? size_W : 0;
     size_t size_ZRes = (argus.unit_check || argus.norm_check || argus.hash_check) ? size_Z : 0;
@@ -773,10 +786,10 @@ void testing_sygvdx_hegvdx(Arguments& argus)
 
         // check computations
         if(argus.unit_check || argus.norm_check || argus.hash_check)
-            sygvdx_hegvdx_getError<STRIDED, T>(handle, itype, evect, erange, uplo, n, dA, lda, stA,
-                                               dB, ldb, stB, vl, vu, il, iu, dNev, dW, stW, dZ, ldz,
-                                               stZ, dInfo, bc, hA, hB, hNev, hNevRes, hW, hWRes, hZ,
-                                               hZRes, hInfo, hInfoRes, &max_error, argus.singular);
+            sygvdx_hegvdx_getError<STRIDED, T>(
+                handle, itype, evect, erange, uplo, n, dA, lda, stA, dB, ldb, stB, vl, vu, il, iu,
+                dNev, dW, stW, dZ, ldz, stZ, dInfo, bc, hA, hB, hNev, hNevRes, hW, hWRes, hZ, hZRes,
+                hInfo, hInfoRes, &max_error, argus.singular, hashA, hashB, hashW, hashZ);
 
         // collect performance data
         if(argus.timing)
@@ -820,16 +833,10 @@ void testing_sygvdx_hegvdx(Arguments& argus)
 
         // check computations
         if(argus.unit_check || argus.norm_check || argus.hash_check)
-            sygvdx_hegvdx_getError<STRIDED, T>(handle, itype, evect, erange, uplo, n, dA, lda, stA,
-                                               dB, ldb, stB, vl, vu, il, iu, dNev, dW, stW, dZ, ldz,
-                                               stZ, dInfo, bc, hA, hB, hNev, hNevRes, hW, hWRes, hZ,
-                                               hZRes, hInfo, hInfoRes, &max_error, argus.singular);
-
-        if(argus.hash_check)
-        {
-            hashA = deterministic_hash(hA);
-            hashZ = deterministic_hash(hZRes);
-        }
+            sygvdx_hegvdx_getError<STRIDED, T>(
+                handle, itype, evect, erange, uplo, n, dA, lda, stA, dB, ldb, stB, vl, vu, il, iu,
+                dNev, dW, stW, dZ, ldz, stZ, dInfo, bc, hA, hB, hNev, hNevRes, hW, hWRes, hZ, hZRes,
+                hInfo, hInfoRes, &max_error, argus.singular, hashA, hashB, hashW, hashZ);
 
         // collect performance data
         if(argus.timing)
@@ -887,8 +894,9 @@ void testing_sygvdx_hegvdx(Arguments& argus)
             rocsolver_bench_endl();
             if(argus.hash_check)
             {
-                rocsolver_bench_output("hash(A)", "hash(Z)");
-                rocsolver_bench_output(ROCSOLVER_FORMAT_HASH(hashA), ROCSOLVER_FORMAT_HASH(hashZ));
+                rocsolver_bench_output("hash(A)", "hash(B)", "hash(W)", "hash(Z)");
+                rocsolver_bench_output(ROCSOLVER_FORMAT_HASH(hashA), ROCSOLVER_FORMAT_HASH(hashB),
+                                       ROCSOLVER_FORMAT_HASH(hashW), ROCSOLVER_FORMAT_HASH(hashZ));
                 rocsolver_bench_endl();
             }
         }

--- a/clients/common/lapack/testing_sygvdx_hegvdx.hpp
+++ b/clients/common/lapack/testing_sygvdx_hegvdx.hpp
@@ -631,8 +631,8 @@ void testing_sygvdx_hegvdx(Arguments& argus)
     rocblas_int bc = argus.batch_count;
     rocblas_int hot_calls = argus.iters;
 
-    rocblas_stride stWRes = (argus.unit_check || argus.norm_check) ? stW : 0;
-    rocblas_stride stZRes = (argus.unit_check || argus.norm_check) ? stZ : 0;
+    rocblas_stride stWRes = (argus.unit_check || argus.norm_check || argus.hash_check) ? stW : 0;
+    rocblas_stride stZRes = (argus.unit_check || argus.norm_check || argus.hash_check) ? stZ : 0;
 
     // check non-supported values
     if(uplo == rocblas_fill_full || evect == rocblas_evect_tridiagonal)
@@ -664,9 +664,10 @@ void testing_sygvdx_hegvdx(Arguments& argus)
     size_t size_W = size_t(n);
     size_t size_Z = size_t(ldz) * n;
     double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
+    size_t hashA = 0, hashZ = 0;
 
-    size_t size_WRes = (argus.unit_check || argus.norm_check) ? size_W : 0;
-    size_t size_ZRes = (argus.unit_check || argus.norm_check) ? size_Z : 0;
+    size_t size_WRes = (argus.unit_check || argus.norm_check || argus.hash_check) ? size_W : 0;
+    size_t size_ZRes = (argus.unit_check || argus.norm_check || argus.hash_check) ? size_Z : 0;
 
     // check invalid sizes
     bool invalid_size = (n < 0 || lda < n || ldb < n || (evect != rocblas_evect_none && ldz < n)
@@ -771,7 +772,7 @@ void testing_sygvdx_hegvdx(Arguments& argus)
         }
 
         // check computations
-        if(argus.unit_check || argus.norm_check)
+        if(argus.unit_check || argus.norm_check || argus.hash_check)
             sygvdx_hegvdx_getError<STRIDED, T>(handle, itype, evect, erange, uplo, n, dA, lda, stA,
                                                dB, ldb, stB, vl, vu, il, iu, dNev, dW, stW, dZ, ldz,
                                                stZ, dInfo, bc, hA, hB, hNev, hNevRes, hW, hWRes, hZ,
@@ -818,7 +819,7 @@ void testing_sygvdx_hegvdx(Arguments& argus)
         }
 
         // check computations
-        if(argus.unit_check || argus.norm_check)
+        if(argus.unit_check || argus.norm_check || argus.hash_check)
             sygvdx_hegvdx_getError<STRIDED, T>(handle, itype, evect, erange, uplo, n, dA, lda, stA,
                                                dB, ldb, stB, vl, vu, il, iu, dNev, dW, stW, dZ, ldz,
                                                stZ, dInfo, bc, hA, hB, hNev, hNevRes, hW, hWRes, hZ,
@@ -831,6 +832,12 @@ void testing_sygvdx_hegvdx(Arguments& argus)
                 dNev, dW, stW, dZ, ldz, stZ, dInfo, bc, hA, hB, hNev, hW, hZ, hInfo, &gpu_time_used,
                 &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels, argus.perf,
                 argus.singular);
+
+        if(argus.hash_check)
+        {
+            hashA = deterministic_hash(hA.data(), hA.size());
+            hashZ = deterministic_hash(hZRes.data(), hZRes.size());
+        }
     }
 
     // validate results for rocsolver-test
@@ -878,6 +885,12 @@ void testing_sygvdx_hegvdx(Arguments& argus)
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
             rocsolver_bench_endl();
+            if(argus.hash_check)
+            {
+                rocsolver_bench_output("hash(A)", "hash(Z)");
+                rocsolver_bench_output(ROCSOLVER_FORMAT_HASH(hashA), ROCSOLVER_FORMAT_HASH(hashZ));
+                rocsolver_bench_endl();
+            }
         }
         else
         {

--- a/clients/common/lapack/testing_sygvdx_hegvdx.hpp
+++ b/clients/common/lapack/testing_sygvdx_hegvdx.hpp
@@ -825,6 +825,12 @@ void testing_sygvdx_hegvdx(Arguments& argus)
                                                stZ, dInfo, bc, hA, hB, hNev, hNevRes, hW, hWRes, hZ,
                                                hZRes, hInfo, hInfoRes, &max_error, argus.singular);
 
+        if(argus.hash_check)
+        {
+            hashA = deterministic_hash(hA);
+            hashZ = deterministic_hash(hZRes);
+        }
+
         // collect performance data
         if(argus.timing)
             sygvdx_hegvdx_getPerfData<STRIDED, T>(
@@ -832,12 +838,6 @@ void testing_sygvdx_hegvdx(Arguments& argus)
                 dNev, dW, stW, dZ, ldz, stZ, dInfo, bc, hA, hB, hNev, hW, hZ, hInfo, &gpu_time_used,
                 &cpu_time_used, hot_calls, argus.profile, argus.profile_kernels, argus.perf,
                 argus.singular);
-
-        if(argus.hash_check)
-        {
-            hashA = deterministic_hash(hA.data(), hA.size());
-            hashZ = deterministic_hash(hZRes.data(), hZRes.size());
-        }
     }
 
     // validate results for rocsolver-test

--- a/clients/common/misc/rocsolver_arguments.hpp
+++ b/clients/common/misc/rocsolver_arguments.hpp
@@ -50,6 +50,7 @@ public:
     // test options
     rocblas_int norm_check = 0;
     rocblas_int unit_check = 1;
+    rocblas_int hash_check = 0;
     rocblas_int timing = 0;
     rocblas_int perf = 0;
     rocblas_int singular = 0;
@@ -118,6 +119,7 @@ public:
         to_consume.erase("perf");
         to_consume.erase("singular");
         to_consume.erase("device");
+        to_consume.erase("hash");
     }
 
     void clear()

--- a/clients/common/misc/rocsolver_test.hpp
+++ b/clients/common/misc/rocsolver_test.hpp
@@ -189,10 +189,12 @@ std::size_t hash_combine(std::size_t seed, T value)
 
 /// Hash contents of the given array.
 ///
-/// If seed == 0 and array_size == 0, then hash_combine(seed, _, array_size) == 0
+/// If seed == 0 and array_size == 0, then hash_combine(seed, b++; b < bc_, array_size) == 0
 template <typename T>
 std::size_t hash_combine(std::size_t seed, T const* array, std::size_t array_size)
 {
+    if(array == nullptr)
+        return (std::size_t)0;
     std::size_t hash = 0;
     if(array_size > 0)
     {
@@ -206,9 +208,22 @@ std::size_t hash_combine(std::size_t seed, T const* array, std::size_t array_siz
     return hash;
 }
 
+#define ROCSOLVER_DETERMINISTIC_HASH_SEED ((std::size_t)1)
+
 /// Wrapper for hash_combine
 template <typename T>
-std::size_t deterministic_hash(T& vector)
+std::size_t deterministic_hash(const T& vector)
 {
-    return hash_combine(1, vector.data(), vector.size());
+    return hash_combine(ROCSOLVER_DETERMINISTIC_HASH_SEED, vector.data(), vector.size());
+}
+
+template <typename T>
+std::size_t deterministic_hash(const T& vector, std::size_t bc)
+{
+    std::size_t hash = ROCSOLVER_DETERMINISTIC_HASH_SEED;
+    for(std::size_t b = 0; b < bc; b++)
+    {
+        hash = hash_combine(hash, vector[b], vector.n() * std::abs(vector.inc()));
+    }
+    return hash;
 }

--- a/clients/common/misc/rocsolver_test.hpp
+++ b/clients/common/misc/rocsolver_test.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -55,6 +55,8 @@ namespace fs = std::experimental::filesystem;
 #else // ROCSOLVER_CLIENTS_BENCH
 #define ROCSOLVER_TEST_CHECK(T, max_error, tol)
 #endif
+
+#define ROCSOLVER_FORMAT_HASH(h) fmt::format("0x{:x}", h)
 
 typedef enum rocsolver_inform_type_
 {
@@ -158,3 +160,55 @@ inline std::ostream& operator<<(std::ostream& os, printable_char x)
 
 // location of the sparse data directory for the re-factorization tests
 fs::path get_sparse_data_dir();
+
+/// Combines `seed` with the hash of `value`, following the spirit of
+/// `boost::hash_combine`.
+///
+/// Extends `std::hash` to combine the hashes of multiple values (e.g.,
+/// from an array). Values will be the same across implementations and executions.
+///
+/// Attention: hash_combine(0, T(0)) != 0
+template <typename T>
+std::size_t hash_combine(std::size_t seed, T value)
+{
+    using S = decltype(std::real(T{}));
+    auto hasher = std::hash<S>();
+
+    if constexpr(rocblas_is_complex<T>)
+    {
+        seed ^= hasher(std::real(value)) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        seed ^= hasher(std::imag(value)) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    }
+    else
+    {
+        seed ^= hasher(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    }
+
+    return seed;
+}
+
+/// Hash contents of the given array.
+///
+/// If seed == 0 and array_size == 0, then hash_combine(seed, _, array_size) == 0
+template <typename T>
+std::size_t hash_combine(std::size_t seed, T const* array, std::size_t array_size)
+{
+    std::size_t hash = 0;
+    if(array_size > 0)
+    {
+        hash = hash_combine(seed, array_size);
+        for(std::size_t i = 0; i < array_size; ++i)
+        {
+            hash = hash_combine(hash, array[i]);
+        }
+    }
+
+    return hash;
+}
+
+/// Wrapper for hash_combine
+template <typename T>
+std::size_t deterministic_hash(T const* array, std::size_t array_size)
+{
+    return hash_combine(1, array, array_size);
+}

--- a/clients/common/misc/rocsolver_test.hpp
+++ b/clients/common/misc/rocsolver_test.hpp
@@ -165,7 +165,7 @@ fs::path get_sparse_data_dir();
 /// `boost::hash_combine`.
 ///
 /// Extends `std::hash` to combine the hashes of multiple values (e.g.,
-/// from an array). Values will be the same across implementations and executions.
+/// from an array).
 ///
 /// Attention: hash_combine(0, T(0)) != 0
 template <typename T>

--- a/clients/common/misc/rocsolver_test.hpp
+++ b/clients/common/misc/rocsolver_test.hpp
@@ -208,7 +208,7 @@ std::size_t hash_combine(std::size_t seed, T const* array, std::size_t array_siz
 
 /// Wrapper for hash_combine
 template <typename T>
-std::size_t deterministic_hash(T const* array, std::size_t array_size)
+std::size_t deterministic_hash(T& vector)
 {
-    return hash_combine(1, array, array_size);
+    return hash_combine(1, vector.data(), vector.size());
 }


### PR DESCRIPTION
This adds a --hash option to rocsolver-bench which will use a deterministic hash function on the outputs and print the result. This is for testing bitwise reproducibility across machines and runs.