### PR TITLE
use rocBLAS trsm_workspace_max_size 

### DIFF
--- a/clients/gtest/lapack/getri_gtest.cpp
+++ b/clients/gtest/lapack/getri_gtest.cpp
@@ -59,7 +59,8 @@ const vector<vector<int>> matrix_size_range = {
 
 // for daily_lapack tests
 const vector<vector<int>> large_matrix_size_range
-    = {{192, 192, 1}, {500, 600, 1}, {640, 640, 0}, {1000, 1024, 0}, {1200, 1230, 0}};
+    = {{192, 192, 1}, {255, 255, 1},   {511, 511, 1},  {511, 511, 0},
+       {640, 640, 0}, {1023, 1023, 0}, {1200, 1230, 0}};
 
 Arguments getri_setup_arguments(getri_tuple tup, bool outofplace)
 {


### PR DESCRIPTION
rocBLAS.hpp is modified to use rocBLAS trsm workspace max size to determine the amount of temporary work space for rocBLAS TRSM.

This may solve a problem with GETRI where GETRI may give incorrect results for certain values of n such as 255, 383, 511, 639, 767, 895, 1023 