### PR TITLE
Hybrid execution of sterf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
 ## (Unreleased) rocSOLVER
 
 ### Added
+
+* Hybrid computation support for existing routines:
+    - STERF
+
 ### Changed
 ### Removed
 ### Optimized
@@ -22,7 +26,7 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
 * Algorithm selection mechanism for hybrid computation
 * Hybrid computation support for existing routines:
     - BDSQR
-    - GESVD  
+    - GESVD
 
 ### Optimized
 

--- a/clients/common/auxiliary/testing_sterf.hpp
+++ b/clients/common/auxiliary/testing_sterf.hpp
@@ -213,6 +213,19 @@ void testing_sterf(Arguments& argus)
 
     rocblas_int hot_calls = argus.iters;
 
+    if(argus.alg_mode)
+    {
+        EXPECT_ROCBLAS_STATUS(
+            rocsolver_set_alg_mode(handle, rocsolver_function_sterf, rocsolver_alg_mode_hybrid),
+            rocblas_status_success);
+
+        rocsolver_alg_mode alg_mode;
+        EXPECT_ROCBLAS_STATUS(rocsolver_get_alg_mode(handle, rocsolver_function_sterf, &alg_mode),
+                              rocblas_status_success);
+
+        EXPECT_EQ(alg_mode, rocsolver_alg_mode_hybrid);
+    }
+
     // check non-supported values
     // N/A
 

--- a/clients/common/lapack/testing_syev_heev.hpp
+++ b/clients/common/lapack/testing_syev_heev.hpp
@@ -398,6 +398,19 @@ void testing_syev_heev(Arguments& argus)
     rocblas_int bc = argus.batch_count;
     rocblas_int hot_calls = argus.iters;
 
+    if(argus.alg_mode)
+    {
+        EXPECT_ROCBLAS_STATUS(
+            rocsolver_set_alg_mode(handle, rocsolver_function_sterf, rocsolver_alg_mode_hybrid),
+            rocblas_status_success);
+
+        rocsolver_alg_mode alg_mode;
+        EXPECT_ROCBLAS_STATUS(rocsolver_get_alg_mode(handle, rocsolver_function_sterf, &alg_mode),
+                              rocblas_status_success);
+
+        EXPECT_EQ(alg_mode, rocsolver_alg_mode_hybrid);
+    }
+
     // check non-supported values
     if(uplo == rocblas_fill_full || evect == rocblas_evect_tridiagonal)
     {

--- a/clients/gtest/auxiliary/sterf_gtest.cpp
+++ b/clients/gtest/auxiliary/sterf_gtest.cpp
@@ -65,7 +65,8 @@ Arguments sterf_setup_arguments(sterf_tuple tup)
     return arg;
 }
 
-class STERF : public ::TestWithParam<sterf_tuple>
+template <rocblas_int MODE>
+class STERF_BASE : public ::TestWithParam<sterf_tuple>
 {
 protected:
     void TearDown() override
@@ -77,12 +78,21 @@ protected:
     void run_tests()
     {
         Arguments arg = sterf_setup_arguments(GetParam());
+        arg.alg_mode = MODE;
 
         if(arg.peek<rocblas_int>("n") == 0)
             testing_sterf_bad_arg<T>();
 
         testing_sterf<T>(arg);
     }
+};
+
+class STERF : public STERF_BASE<0>
+{
+};
+
+class STERF_HYBRID : public STERF_BASE<1>
+{
 };
 
 // non-batch tests
@@ -97,6 +107,20 @@ TEST_P(STERF, __double)
     run_tests<double>();
 }
 
+TEST_P(STERF_HYBRID, __float)
+{
+    run_tests<float>();
+}
+
+TEST_P(STERF_HYBRID, __double)
+{
+    run_tests<double>();
+}
+
 INSTANTIATE_TEST_SUITE_P(daily_lapack, STERF, ValuesIn(large_matrix_size_range));
 
 INSTANTIATE_TEST_SUITE_P(checkin_lapack, STERF, ValuesIn(matrix_size_range));
+
+INSTANTIATE_TEST_SUITE_P(daily_lapack, STERF_HYBRID, ValuesIn(large_matrix_size_range));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack, STERF_HYBRID, ValuesIn(matrix_size_range));

--- a/clients/gtest/lapack/syev_heev_gtest.cpp
+++ b/clients/gtest/lapack/syev_heev_gtest.cpp
@@ -81,6 +81,7 @@ Arguments syev_heev_setup_arguments(syev_heev_tuple tup)
     return arg;
 }
 
+template <rocblas_int MODE>
 class SYEV_HEEV : public ::TestWithParam<syev_heev_tuple>
 {
 protected:
@@ -93,6 +94,7 @@ protected:
     void run_tests()
     {
         Arguments arg = syev_heev_setup_arguments(GetParam());
+        arg.alg_mode = MODE;
 
         if(arg.peek<rocblas_int>("n") == 0 && arg.peek<char>("evect") == 'N'
            && arg.peek<char>("uplo") == 'L')
@@ -103,11 +105,19 @@ protected:
     }
 };
 
-class SYEV : public SYEV_HEEV
+class SYEV : public SYEV_HEEV<0>
 {
 };
 
-class HEEV : public SYEV_HEEV
+class HEEV : public SYEV_HEEV<0>
+{
+};
+
+class SYEV_HYBRID : public SYEV_HEEV<1>
+{
+};
+
+class HEEV_HYBRID : public SYEV_HEEV<1>
 {
 };
 
@@ -129,6 +139,26 @@ TEST_P(HEEV, __float_complex)
 }
 
 TEST_P(HEEV, __double_complex)
+{
+    run_tests<false, false, rocblas_double_complex>();
+}
+
+TEST_P(SYEV_HYBRID, __float)
+{
+    run_tests<false, false, float>();
+}
+
+TEST_P(SYEV_HYBRID, __double)
+{
+    run_tests<false, false, double>();
+}
+
+TEST_P(HEEV_HYBRID, __float_complex)
+{
+    run_tests<false, false, rocblas_float_complex>();
+}
+
+TEST_P(HEEV_HYBRID, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
@@ -155,6 +185,26 @@ TEST_P(HEEV, batched__double_complex)
     run_tests<true, true, rocblas_double_complex>();
 }
 
+TEST_P(SYEV_HYBRID, batched__float)
+{
+    run_tests<true, true, float>();
+}
+
+TEST_P(SYEV_HYBRID, batched__double)
+{
+    run_tests<true, true, double>();
+}
+
+TEST_P(HEEV_HYBRID, batched__float_complex)
+{
+    run_tests<true, true, rocblas_float_complex>();
+}
+
+TEST_P(HEEV_HYBRID, batched__double_complex)
+{
+    run_tests<true, true, rocblas_double_complex>();
+}
+
 // strided_batched tests
 
 TEST_P(SYEV, strided_batched__float)
@@ -177,13 +227,49 @@ TEST_P(HEEV, strided_batched__double_complex)
     run_tests<false, true, rocblas_double_complex>();
 }
 
+TEST_P(SYEV_HYBRID, strided_batched__float)
+{
+    run_tests<false, true, float>();
+}
+
+TEST_P(SYEV_HYBRID, strided_batched__double)
+{
+    run_tests<false, true, double>();
+}
+
+TEST_P(HEEV_HYBRID, strided_batched__float_complex)
+{
+    run_tests<false, true, rocblas_float_complex>();
+}
+
+TEST_P(HEEV_HYBRID, strided_batched__double_complex)
+{
+    run_tests<false, true, rocblas_double_complex>();
+}
+
 // daily_lapack tests normal execution with medium to large sizes
 INSTANTIATE_TEST_SUITE_P(daily_lapack, SYEV, Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
 
 INSTANTIATE_TEST_SUITE_P(daily_lapack, HEEV, Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(daily_lapack,
+                         SYEV_HYBRID,
+                         Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(daily_lapack,
+                         HEEV_HYBRID,
+                         Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
 
 // checkin_lapack tests normal execution with small sizes, invalid sizes,
 // quick returns, and corner cases
 INSTANTIATE_TEST_SUITE_P(checkin_lapack, SYEV, Combine(ValuesIn(size_range), ValuesIn(op_range)));
 
 INSTANTIATE_TEST_SUITE_P(checkin_lapack, HEEV, Combine(ValuesIn(size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+                         SYEV_HYBRID,
+                         Combine(ValuesIn(size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+                         HEEV_HYBRID,
+                         Combine(ValuesIn(size_range), ValuesIn(op_range)));

--- a/library/include/rocsolver/rocsolver-extra-types.h
+++ b/library/include/rocsolver/rocsolver-extra-types.h
@@ -188,6 +188,7 @@ typedef enum rocsolver_function_
 {
     rocsolver_function_bdsqr = 401,
     rocsolver_function_gesvd = 402,
+    rocsolver_function_sterf = 403,
 } rocsolver_function;
 
 #endif /* ROCSOLVER_EXTRA_TYPES_H */

--- a/library/include/rocsolver/rocsolver-functions.h
+++ b/library/include/rocsolver/rocsolver-functions.h
@@ -4005,6 +4005,10 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_zbdsqr(rocblas_handle handle,
     The matrix is not represented explicitly, but rather as the array of
     diagonal elements D and the array of symmetric off-diagonal elements E.
 
+    \note
+    A hybrid (CPU+GPU) approach is available for STERF, primarily intended for
+    homogeneous architectures. Use \ref rocsolver_set_alg_mode to enable it.
+
     @param[in]
     handle      rocblas_handle.
     @param[in]

--- a/library/src/auxiliary/rocauxiliary_bdsqr_hybrid.hpp
+++ b/library/src/auxiliary/rocauxiliary_bdsqr_hybrid.hpp
@@ -1365,12 +1365,12 @@ rocblas_status rocsolver_bdsqr_host_batch_template(rocblas_handle handle,
     // -----------------------------------
     // transfer arrays from device to host
     // -----------------------------------
-    rocsolver_hybrid_array<S, S*> hD;
-    rocsolver_hybrid_array<S, S*> hE;
-    rocsolver_hybrid_array<T, W1> hV;
-    rocsolver_hybrid_array<T, W2> hU;
-    rocsolver_hybrid_array<T, W3> hC;
-    rocsolver_hybrid_array<I, I*> hInfo;
+    rocsolver_hybrid_array<S, I, S*> hD;
+    rocsolver_hybrid_array<S, I, S*> hE;
+    rocsolver_hybrid_array<T, I, W1> hV;
+    rocsolver_hybrid_array<T, I, W2> hU;
+    rocsolver_hybrid_array<T, I, W3> hC;
+    rocsolver_hybrid_array<I, I, I*> hInfo;
 
     ROCBLAS_CHECK(hD.init_async(n, D, strideD, batch_count, stream));
     ROCBLAS_CHECK(hE.init_async(n - 1, E, strideE, batch_count, stream));

--- a/library/src/auxiliary/rocauxiliary_bdsqr_hybrid.hpp
+++ b/library/src/auxiliary/rocauxiliary_bdsqr_hybrid.hpp
@@ -35,6 +35,7 @@
 
 #include "lapack_host_functions.hpp"
 #include "rocauxiliary_lasr.hpp"
+#include "rocsolver_hybrid_array.hpp"
 
 ROCSOLVER_BEGIN_NAMESPACE
 
@@ -1341,15 +1342,15 @@ rocblas_status rocsolver_bdsqr_host_batch_template(rocblas_handle handle,
                                                    const rocblas_stride strideD,
                                                    S* E,
                                                    const rocblas_stride strideE,
-                                                   W1 V_arg,
+                                                   W1 V,
                                                    const I shiftV,
                                                    const I ldv,
                                                    const rocblas_stride strideV,
-                                                   W2 U_arg,
+                                                   W2 U,
                                                    const I shiftU,
                                                    const I ldu,
                                                    const rocblas_stride strideU,
-                                                   W3 C_arg,
+                                                   W3 C,
                                                    const I shiftC,
                                                    const I ldc,
                                                    const rocblas_stride strideC,
@@ -1358,183 +1359,48 @@ rocblas_status rocsolver_bdsqr_host_batch_template(rocblas_handle handle,
                                                    I* splits_map,
                                                    S* work)
 {
-    // -------------------------
-    // copy D into hD, E into hE
-    // -------------------------
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
 
-    W1 V = V_arg;
-    W2 U = U_arg;
-    W3 C = C_arg;
+    // -----------------------------------
+    // transfer arrays from device to host
+    // -----------------------------------
+    rocsolver_hybrid_array<S, S*> hD;
+    rocsolver_hybrid_array<S, S*> hE;
+    rocsolver_hybrid_array<T, W1> hV;
+    rocsolver_hybrid_array<T, W2> hU;
+    rocsolver_hybrid_array<T, W3> hC;
+    rocsolver_hybrid_array<I, I*> hInfo;
 
-    // handle  batch case with array of pointers on device
-    std::vector<T*> Vp_array(batch_count);
-    std::vector<T*> Up_array(batch_count);
-    std::vector<T*> Cp_array(batch_count);
-
+    ROCBLAS_CHECK(hD.init_async(n, D, strideD, batch_count, stream));
+    ROCBLAS_CHECK(hE.init_async(n - 1, E, strideE, batch_count, stream));
     if(nv > 0)
-    {
-        bool const is_device_V_arg = is_device_pointer((void*)V_arg);
-        if(is_device_V_arg)
-        {
-            // note "T *" and "T * const" may be considered different types
-            bool constexpr is_array_of_device_pointers
-                = !(std::is_same<W1, T*>::value || std::is_same<W1, T* const>::value);
-            bool constexpr need_copy_W1 = is_array_of_device_pointers;
-            if constexpr(need_copy_W1)
-            {
-                size_t const nbytes = sizeof(T*) * batch_count;
-                void* const dst = (void*)&(Vp_array[0]);
-                void* const src = (void*)V_arg;
-                HIP_CHECK(hipMemcpyAsync(dst, src, nbytes, hipMemcpyDefault, stream));
-                HIP_CHECK(hipStreamSynchronize(stream));
-                V = &(Vp_array[0]);
-            }
-        }
-    }
-
+        ROCBLAS_CHECK(hV.init_pointers_only(V + shiftV, strideV, batch_count, stream));
     if(nu > 0)
-    {
-        bool const is_device_U_arg = is_device_pointer((void*)U_arg);
-        if(is_device_U_arg)
-        {
-            bool constexpr is_array_of_device_pointers
-                = !(std::is_same<W2, T*>::value || std::is_same<W2, T* const>::value);
-            bool constexpr need_copy_W2 = is_array_of_device_pointers;
-            if constexpr(need_copy_W2)
-            {
-                size_t const nbytes = sizeof(T*) * batch_count;
-                void* const dst = (void*)&(Up_array[0]);
-                void* const src = (void*)U_arg;
-                HIP_CHECK(hipMemcpyAsync(dst, src, nbytes, hipMemcpyDefault, stream));
-                HIP_CHECK(hipStreamSynchronize(stream));
-                U = &(Up_array[0]);
-            }
-        }
-    }
-
+        ROCBLAS_CHECK(hU.init_pointers_only(U + shiftU, strideU, batch_count, stream));
     if(nc > 0)
-    {
-        bool const is_device_C_arg = is_device_pointer((void*)C_arg);
-        if(is_device_C_arg)
-        {
-            bool constexpr is_array_of_device_pointers
-                = !(std::is_same<W3, T*>::value || std::is_same<W3, T* const>::value);
-            bool constexpr need_copy_W3 = is_array_of_device_pointers;
-            if constexpr(need_copy_W3)
-            {
-                size_t const nbytes = sizeof(T*) * batch_count;
-                void* const dst = (void*)&(Cp_array[0]);
-                void* const src = (void*)C_arg;
-                HIP_CHECK(hipMemcpyAsync(dst, src, nbytes, hipMemcpyDefault, stream));
-                HIP_CHECK(hipStreamSynchronize(stream));
-                C = &(Cp_array[0]);
-            }
-        }
-    }
-
-    S* hD = nullptr;
-    S* hE = nullptr;
-
-    size_t const E_size = (n - 1);
-    HIP_CHECK(hipHostMalloc(&hD, (sizeof(S) * std::max(1, batch_count)) * n));
-    HIP_CHECK(hipHostMalloc(&hE, (sizeof(S) * std::max(1, batch_count)) * E_size));
-
-    // ----------------------------------------------------
-    // copy info_array[] on device to linfo_array[] on host
-    // ----------------------------------------------------
-    I* linfo_array = nullptr;
-    HIP_CHECK(hipHostMalloc(&linfo_array, sizeof(I) * std::max(1, batch_count)));
-    {
-        void* const dst = &(linfo_array[0]);
-        void* const src = &(info_array[0]);
-        size_t const nbytes = sizeof(I) * batch_count;
-        hipMemcpyKind const kind = hipMemcpyDeviceToHost;
-
-        HIP_CHECK(hipMemcpyAsync(dst, src, nbytes, kind, stream));
-    }
+        ROCBLAS_CHECK(hC.init_pointers_only(C + shiftC, strideC, batch_count, stream));
+    ROCBLAS_CHECK(hInfo.init_async(1, info_array, 1, batch_count, stream));
+    HIP_CHECK(hipStreamSynchronize(stream));
 
     S* hwork = nullptr;
     HIP_CHECK(hipHostMalloc(&hwork, sizeof(S) * (4 * n)));
+    S* dwork = nullptr;
+    HIP_CHECK(hipMalloc(&dwork, sizeof(S) * (4 * n)));
 
-    // -------------------------------------------------
-    // transfer arrays D(:) and E(:) from Device to Host
-    // -------------------------------------------------
-    bool const use_single_copy_for_D = (batch_count == 1) || (strideD == n);
-    if(use_single_copy_for_D)
-    {
-        void* const dst = (void*)&(hD[0]);
-        void* const src = (void*)&(D[0]);
-        size_t const sizeBytes = sizeof(S) * n * batch_count;
-        hipMemcpyKind const kind = hipMemcpyDeviceToHost;
-
-        HIP_CHECK(hipMemcpyAsync(dst, src, sizeBytes, kind, stream));
-    }
-    else
-    {
-        for(I bid = 0; bid < batch_count; bid++)
-        {
-            void* const dst = (void*)&(hD[bid * n]);
-            void* const src = (void*)&(D[bid * strideD]);
-            size_t const sizeBytes = sizeof(S) * n;
-            hipMemcpyKind const kind = hipMemcpyDeviceToHost;
-            HIP_CHECK(hipMemcpyAsync(dst, src, sizeBytes, kind, stream));
-        }
-    }
-
-    {
-        for(I bid = 0; bid < batch_count; bid++)
-        {
-            void* const dst = (void*)&(hE[bid * E_size]);
-            void* const src = (void*)&(E[bid * strideE]);
-            size_t const sizeBytes = sizeof(S) * E_size;
-            hipMemcpyKind const kind = hipMemcpyDeviceToHost;
-            HIP_CHECK(hipMemcpyAsync(dst, src, sizeBytes, kind, stream));
-        }
-    }
-
-    // -------------------------------------------------
+    // --------------------------------------
     // Execute for each instance in the batch
-    // -------------------------------------------------
-    HIP_CHECK(hipStreamSynchronize(stream));
-
-    S* dwork_ = nullptr;
-    HIP_CHECK(hipMalloc(&dwork_, sizeof(S) * (4 * n)));
-
+    // --------------------------------------
     for(I bid = 0; bid < batch_count; bid++)
     {
-        if(linfo_array[bid] != 0)
-        {
+        if(hInfo[bid][0] != 0)
             continue;
-        }
 
         char uplo = (uplo_in == rocblas_fill_lower) ? 'L' : 'U';
-        S* d_ = &(hD[bid * n]);
-        S* e_ = &(hE[bid * E_size]);
-
-        T* v_ = (nv > 0) ? load_ptr_batch<T>(V, bid, shiftV, strideV) : nullptr;
-        T* u_ = (nu > 0) ? load_ptr_batch<T>(U, bid, shiftU, strideU) : nullptr;
-        T* c_ = (nc > 0) ? load_ptr_batch<T>(C, bid, shiftC, strideC) : nullptr;
-        S* work_ = &(hwork[0]);
-
         I info = 0;
 
-        I nru = nu;
-        I ncc = nc;
-
-        // NOTE: lapack dbdsqr() accepts "VT" and "ldvt" for transpose of V
-        // as input variable however, rocsolver bdsqr() accepts variable called "V" and "ldv"
-        // but it is  actually holding "VT"
-        T* vt_ = v_;
-        I ldvt = ldv;
-
-        I nrv = n;
-        I ncvt = nv;
-        bool const values_only = (ncvt == 0) && (nru == 0) && (ncc == 0);
-
-        bdsqr_single_template<S, T, I>(handle, uplo, n, ncvt, nru, ncc, d_, e_, vt_, ldvt, u_, ldu,
-                                       c_, ldc, work_, info, dwork_, stream);
+        bdsqr_single_template<S, T, I>(handle, uplo, n, nv, nu, nc, hD[bid], hE[bid], hV[bid], ldv,
+                                       hU[bid], ldu, hC[bid], ldc, hwork, info, dwork, stream);
 
         if(info == 0)
         {
@@ -1543,80 +1409,31 @@ rocblas_status rocsolver_bdsqr_host_batch_template(rocblas_handle handle,
             S const zero = S(0);
             for(I i = 0; i < (n - 1); i++)
             {
-                e_[i] = zero;
+                hE[bid][i] = zero;
             }
         }
 
-        if(linfo_array[bid] == 0)
+        if(hInfo[bid][0] == 0)
         {
-            linfo_array[bid] = info;
+            hInfo[bid][0] = info;
         }
     } // end for bid
 
-    // -------------------------------------------------
-    // transfer arrays D(:) and E(:) from host to device
-    // -------------------------------------------------
-    if(use_single_copy_for_D)
-    {
-        void* const src = (void*)&(hD[0]);
-        void* const dst = (void*)D;
-        size_t const sizeBytes = sizeof(S) * n * batch_count;
-        hipMemcpyKind const kind = hipMemcpyHostToDevice;
-
-        HIP_CHECK(hipMemcpyAsync(dst, src, sizeBytes, kind, stream));
-    }
-    else
-    {
-        for(I bid = 0; bid < batch_count; bid++)
-        {
-            void* const src = (void*)&(hD[bid * n]);
-            void* const dst = (void*)(D + bid * strideD);
-            size_t const sizeBytes = sizeof(S) * n;
-            hipMemcpyKind const kind = hipMemcpyHostToDevice;
-            HIP_CHECK(hipMemcpyAsync(dst, src, sizeBytes, kind, stream));
-        }
-    }
-
-    {
-        for(I bid = 0; bid < batch_count; bid++)
-        {
-            void* const src = (void*)&(hE[bid * E_size]);
-            void* const dst = (void*)&(E[bid * strideE]);
-            size_t const sizeBytes = sizeof(S) * E_size;
-            hipMemcpyKind const kind = hipMemcpyHostToDevice;
-            HIP_CHECK(hipMemcpyAsync(dst, src, sizeBytes, kind, stream));
-        }
-    }
-
-    // ------------------------------------------------------
-    // copy linfo_array[] from host to info_array[] on device
-    // ------------------------------------------------------
-    {
-        void* const src = (void*)&(linfo_array[0]);
-        void* const dst = (void*)&(info_array[0]);
-        size_t const nbytes = sizeof(I) * batch_count;
-        hipMemcpyKind const kind = hipMemcpyHostToDevice;
-
-        HIP_CHECK(hipMemcpyAsync(dst, src, nbytes, kind, stream));
-    }
-
+    // -----------------------------------
+    // transfer arrays from host to device
+    // -----------------------------------
+    ROCBLAS_CHECK(hD.push_to_device_async(stream));
+    ROCBLAS_CHECK(hE.push_to_device_async(stream));
+    ROCBLAS_CHECK(hInfo.push_to_device_async(stream));
     HIP_CHECK(hipStreamSynchronize(stream));
 
     // ----------------------
     // free allocated storage
     // ----------------------
     HIP_CHECK(hipHostFree(hwork));
-    hwork = nullptr;
-    HIP_CHECK(hipHostFree(hD));
-    hD = nullptr;
-    HIP_CHECK(hipHostFree(hE));
-    hE = nullptr;
-    HIP_CHECK(hipFree(dwork_));
-    dwork_ = nullptr;
-    HIP_CHECK(hipHostFree(linfo_array));
-    linfo_array = nullptr;
+    HIP_CHECK(hipFree(dwork));
 
-    return (rocblas_status_success);
+    return rocblas_status_success;
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/library/src/auxiliary/rocauxiliary_bdsqr_hybrid.hpp
+++ b/library/src/auxiliary/rocauxiliary_bdsqr_hybrid.hpp
@@ -5,7 +5,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     June 2017
- * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,7 +35,7 @@
 
 #include "lapack_host_functions.hpp"
 #include "rocauxiliary_lasr.hpp"
-#include "rocsolver_hybrid_array.hpp"
+#include "rocsolver_hybrid_storage.hpp"
 
 ROCSOLVER_BEGIN_NAMESPACE
 
@@ -1365,12 +1365,12 @@ rocblas_status rocsolver_bdsqr_host_batch_template(rocblas_handle handle,
     // -----------------------------------
     // transfer arrays from device to host
     // -----------------------------------
-    rocsolver_hybrid_array<S, I, S*> hD;
-    rocsolver_hybrid_array<S, I, S*> hE;
-    rocsolver_hybrid_array<T, I, W1> hV;
-    rocsolver_hybrid_array<T, I, W2> hU;
-    rocsolver_hybrid_array<T, I, W3> hC;
-    rocsolver_hybrid_array<I, I, I*> hInfo;
+    rocsolver_hybrid_storage<S, I, S*> hD;
+    rocsolver_hybrid_storage<S, I, S*> hE;
+    rocsolver_hybrid_storage<T, I, W1> hV;
+    rocsolver_hybrid_storage<T, I, W2> hU;
+    rocsolver_hybrid_storage<T, I, W3> hC;
+    rocsolver_hybrid_storage<I, I, I*> hInfo;
 
     ROCBLAS_CHECK(hD.init_async(n, D, strideD, batch_count, stream));
     ROCBLAS_CHECK(hE.init_async(n - 1, E, strideE, batch_count, stream));

--- a/library/src/auxiliary/rocauxiliary_bdsqr_hybrid.hpp
+++ b/library/src/auxiliary/rocauxiliary_bdsqr_hybrid.hpp
@@ -1358,26 +1358,6 @@ rocblas_status rocsolver_bdsqr_host_batch_template(rocblas_handle handle,
                                                    I* splits_map,
                                                    S* work)
 {
-    // -------------------------------
-    // lambda expression as helper
-    // -------------------------------
-    auto is_device_pointer = [](void* ptr) -> bool {
-        hipPointerAttribute_t dev_attributes;
-        if(ptr == nullptr)
-        {
-            return (false);
-        }
-
-        auto istat = hipPointerGetAttributes(&dev_attributes, ptr);
-        if(istat != hipSuccess)
-        {
-            std::cout << "is_device_pointer: istat = " << istat << " " << hipGetErrorName(istat)
-                      << std::endl;
-        }
-        assert(istat == hipSuccess);
-        return (dev_attributes.type == hipMemoryTypeDevice);
-    };
-
     // -------------------------
     // copy D into hD, E into hE
     // -------------------------

--- a/library/src/auxiliary/rocauxiliary_bdsqr_hybrid.hpp
+++ b/library/src/auxiliary/rocauxiliary_bdsqr_hybrid.hpp
@@ -1422,9 +1422,9 @@ rocblas_status rocsolver_bdsqr_host_batch_template(rocblas_handle handle,
     // -----------------------------------
     // transfer arrays from host to device
     // -----------------------------------
-    ROCBLAS_CHECK(hD.push_to_device_async(stream));
-    ROCBLAS_CHECK(hE.push_to_device_async(stream));
-    ROCBLAS_CHECK(hInfo.push_to_device_async(stream));
+    ROCBLAS_CHECK(hD.write_to_device_async(stream));
+    ROCBLAS_CHECK(hE.write_to_device_async(stream));
+    ROCBLAS_CHECK(hInfo.write_to_device_async(stream));
     HIP_CHECK(hipStreamSynchronize(stream));
 
     // ----------------------

--- a/library/src/auxiliary/rocauxiliary_sterf.hpp
+++ b/library/src/auxiliary/rocauxiliary_sterf.hpp
@@ -46,21 +46,16 @@ ROCSOLVER_BEGIN_NAMESPACE
 
 /** STERF_SQ_E squares the elements of E **/
 template <typename T>
-__device__ void sterf_sq_e(const rocblas_int start, const rocblas_int end, T* E)
+__device__ __host__ void sterf_sq_e(const rocblas_int start, const rocblas_int end, T* E)
 {
     for(int i = start; i < end; i++)
         E[i] = E[i] * E[i];
 }
 
-/** STERF_KERNEL implements the main loop of the sterf algorithm
-    to compute the eigenvalues of a symmetric tridiagonal matrix given by D
-    and E **/
 template <typename T>
-ROCSOLVER_KERNEL void sterf_kernel(const rocblas_int n,
-                                   T* DD,
-                                   const rocblas_stride strideD,
-                                   T* EE,
-                                   const rocblas_stride strideE,
+__device__ __host__ void run_sterf(const rocblas_int n,
+                                   T* D,
+                                   T* E,
                                    rocblas_int* info,
                                    rocblas_int* stack,
                                    const rocblas_int max_iters,
@@ -68,11 +63,6 @@ ROCSOLVER_KERNEL void sterf_kernel(const rocblas_int n,
                                    const T ssfmin,
                                    const T ssfmax)
 {
-    rocblas_int bid = hipBlockIdx_x;
-
-    T* D = DD + (bid * strideD);
-    T* E = EE + (bid * strideE);
-
     rocblas_int m, l, lsv, lend, lendsv;
     rocblas_int l1 = 0;
     rocblas_int iters = 0;
@@ -85,7 +75,7 @@ ROCSOLVER_KERNEL void sterf_kernel(const rocblas_int n,
             E[l1 - 1] = 0;
         for(m = l1; m < n - 1; m++)
         {
-            if(abs(E[m]) <= sqrt(abs(D[m])) * sqrt(abs(D[m + 1])) * eps)
+            if(std::abs(E[m]) <= std::sqrt(std::abs(D[m])) * std::sqrt(std::abs(D[m + 1])) * eps)
             {
                 E[m] = 0;
                 break;
@@ -109,7 +99,7 @@ ROCSOLVER_KERNEL void sterf_kernel(const rocblas_int n,
         sterf_sq_e(l, lend, E);
 
         // Choose iteration type (QL or QR)
-        if(abs(D[lend]) < abs(D[l]))
+        if(std::abs(D[lend]) < std::abs(D[l]))
         {
             lend = lsv;
             l = lendsv;
@@ -122,7 +112,7 @@ ROCSOLVER_KERNEL void sterf_kernel(const rocblas_int n,
             {
                 // Find small subdiagonal element
                 for(m = l; m <= lend - 1; m++)
-                    if(abs(E[m]) <= eps * eps * abs(D[m] * D[m + 1]))
+                    if(std::abs(E[m]) <= eps * eps * std::abs(D[m] * D[m + 1]))
                         break;
 
                 if(m < lend)
@@ -137,7 +127,7 @@ ROCSOLVER_KERNEL void sterf_kernel(const rocblas_int n,
                 {
                     // Use lae2 to compute 2x2 eigenvalues. Using rte, rt1, rt2.
                     T rte, rt1, rt2;
-                    rte = sqrt(E[l]);
+                    rte = std::sqrt(E[l]);
                     lae2(D[l], rte, D[l + 1], rt1, rt2);
                     D[l] = rt1;
                     D[l + 1] = rt2;
@@ -153,12 +143,12 @@ ROCSOLVER_KERNEL void sterf_kernel(const rocblas_int n,
                     T sigma, gamma, r, rte, c, s;
 
                     // Form shift
-                    rte = sqrt(E[l]);
+                    rte = std::sqrt(E[l]);
                     sigma = (D[l + 1] - p) / (2 * rte);
                     if(sigma >= 0)
-                        r = abs(sqrt(1 + sigma * sigma));
+                        r = std::abs(sqrt(1 + sigma * sigma));
                     else
-                        r = -abs(sqrt(1 + sigma * sigma));
+                        r = -std::abs(sqrt(1 + sigma * sigma));
                     sigma = p - (rte / (sigma + r));
 
                     c = 1;
@@ -198,7 +188,7 @@ ROCSOLVER_KERNEL void sterf_kernel(const rocblas_int n,
             {
                 // Find small subdiagonal element
                 for(m = l; m >= lend + 1; m--)
-                    if(abs(E[m - 1]) <= eps * eps * abs(D[m] * D[m - 1]))
+                    if(std::abs(E[m - 1]) <= eps * eps * std::abs(D[m] * D[m - 1]))
                         break;
 
                 if(m > lend)
@@ -213,7 +203,7 @@ ROCSOLVER_KERNEL void sterf_kernel(const rocblas_int n,
                 {
                     // Use lae2 to compute 2x2 eigenvalues. Using rte, rt1, rt2.
                     T rte, rt1, rt2;
-                    rte = sqrt(E[l - 1]);
+                    rte = std::sqrt(E[l - 1]);
                     lae2(D[l], rte, D[l - 1], rt1, rt2);
                     D[l] = rt1;
                     D[l - 1] = rt2;
@@ -229,12 +219,12 @@ ROCSOLVER_KERNEL void sterf_kernel(const rocblas_int n,
                     T sigma, gamma, r, rte, c, s;
 
                     // Form shift. Using rte, r, c, s.
-                    rte = sqrt(E[l - 1]);
+                    rte = std::sqrt(E[l - 1]);
                     sigma = (D[l - 1] - p) / (2 * rte);
                     if(sigma >= 0)
-                        r = abs(sqrt(1 + sigma * sigma));
+                        r = std::abs(std::sqrt(1 + sigma * sigma));
                     else
-                        r = -abs(sqrt(1 + sigma * sigma));
+                        r = -std::abs(std::sqrt(1 + sigma * sigma));
                     sigma = p - (rte / (sigma + r));
 
                     c = 1;
@@ -277,14 +267,14 @@ ROCSOLVER_KERNEL void sterf_kernel(const rocblas_int n,
     // Check for convergence
     for(int i = 0; i < n - 1; i++)
         if(E[i] != 0)
-            info[bid]++;
+            (*info)++;
 
     // Sort eigenvalues
     /** (TODO: the quick-sort method implemented in lasrt_increasing fails for some cases.
         Substituting it here with a simple sorting algorithm. If more performance is required in
         the future, lasrt_increasing should be debugged or another quick-sort method
         could be implemented) **/
-    //lasrt_increasing(n, D, stack + bid * (2 * 32));
+    //lasrt_increasing(n, D, stack);
 
     for(int ii = 1; ii < n; ii++)
     {
@@ -305,6 +295,32 @@ ROCSOLVER_KERNEL void sterf_kernel(const rocblas_int n,
             D[l] = p;
         }
     }
+}
+
+/** STERF_KERNEL implements the main loop of the sterf algorithm
+    to compute the eigenvalues of a symmetric tridiagonal matrix given by D
+    and E **/
+template <typename T>
+ROCSOLVER_KERNEL void sterf_kernel(const rocblas_int n,
+                                   T* DD,
+                                   const rocblas_stride strideD,
+                                   T* EE,
+                                   const rocblas_stride strideE,
+                                   rocblas_int* infoA,
+                                   rocblas_int* stackA,
+                                   const rocblas_int max_iters,
+                                   const T eps,
+                                   const T ssfmin,
+                                   const T ssfmax)
+{
+    rocblas_int bid = hipBlockIdx_x;
+
+    T* D = DD + (bid * strideD);
+    T* E = EE + (bid * strideE);
+    rocblas_int* info = infoA + bid;
+    rocblas_int* stack = stackA + bid * (2 * 32);
+
+    run_sterf<T>(n, D, E, info, stack, max_iters, eps, ssfmin, ssfmax);
 }
 
 template <typename T>
@@ -368,6 +384,9 @@ rocblas_status rocsolver_sterf_template(rocblas_handle handle,
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
 
+    rocsolver_alg_mode alg_mode;
+    ROCBLAS_CHECK(rocsolver_get_alg_mode(handle, rocsolver_function_sterf, &alg_mode));
+
     rocblas_int blocksReset = (batch_count - 1) / BS1 + 1;
     dim3 gridReset(blocksReset, 1, 1);
     dim3 threads(BS1, 1, 1);
@@ -385,8 +404,15 @@ rocblas_status rocsolver_sterf_template(rocblas_handle handle,
     ssfmin = sqrt(ssfmin) / (eps * eps);
     ssfmax = sqrt(ssfmax) / T(3.0);
 
-    ROCSOLVER_LAUNCH_KERNEL(sterf_kernel<T>, dim3(batch_count), dim3(1), 0, stream, n, D + shiftD,
-                            strideD, E + shiftE, strideE, info, stack, 30 * n, eps, ssfmin, ssfmax);
+    if(alg_mode == rocsolver_alg_mode_hybrid)
+    {
+    }
+    else
+    {
+        ROCSOLVER_LAUNCH_KERNEL(sterf_kernel<T>, dim3(batch_count), dim3(1), 0, stream, n,
+                                D + shiftD, strideD, E + shiftE, strideE, info, stack, 30 * n, eps,
+                                ssfmin, ssfmax);
+    }
 
     return rocblas_status_success;
 }

--- a/library/src/auxiliary/rocauxiliary_sterf.hpp
+++ b/library/src/auxiliary/rocauxiliary_sterf.hpp
@@ -407,9 +407,9 @@ rocblas_status rocsolver_sterf_template(rocblas_handle handle,
 
     if(alg_mode == rocsolver_alg_mode_hybrid)
     {
-        rocsolver_hybrid_array<T, U> hD;
-        rocsolver_hybrid_array<T, U> hE;
-        rocsolver_hybrid_array<rocblas_int, rocblas_int*> hInfo;
+        rocsolver_hybrid_array<T, rocblas_int, U> hD;
+        rocsolver_hybrid_array<T, rocblas_int, U> hE;
+        rocsolver_hybrid_array<rocblas_int, rocblas_int, rocblas_int*> hInfo;
 
         ROCBLAS_CHECK(hD.init_async(n, D + shiftD, strideD, batch_count, stream));
         ROCBLAS_CHECK(hE.init_async(n - 1, E + shiftE, strideE, batch_count, stream));

--- a/library/src/auxiliary/rocauxiliary_sterf.hpp
+++ b/library/src/auxiliary/rocauxiliary_sterf.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,7 +35,7 @@
 #include "lapack_device_functions.hpp"
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
-#include "rocsolver_hybrid_array.hpp"
+#include "rocsolver_hybrid_storage.hpp"
 
 ROCSOLVER_BEGIN_NAMESPACE
 
@@ -407,9 +407,9 @@ rocblas_status rocsolver_sterf_template(rocblas_handle handle,
 
     if(alg_mode == rocsolver_alg_mode_hybrid)
     {
-        rocsolver_hybrid_array<T, rocblas_int, U> hD;
-        rocsolver_hybrid_array<T, rocblas_int, U> hE;
-        rocsolver_hybrid_array<rocblas_int, rocblas_int, rocblas_int*> hInfo;
+        rocsolver_hybrid_storage<T, rocblas_int, U> hD;
+        rocsolver_hybrid_storage<T, rocblas_int, U> hE;
+        rocsolver_hybrid_storage<rocblas_int, rocblas_int, rocblas_int*> hInfo;
 
         ROCBLAS_CHECK(hD.init_async(n, D + shiftD, strideD, batch_count, stream));
         ROCBLAS_CHECK(hE.init_async(n - 1, E + shiftE, strideE, batch_count, stream));

--- a/library/src/auxiliary/rocauxiliary_sterf.hpp
+++ b/library/src/auxiliary/rocauxiliary_sterf.hpp
@@ -35,6 +35,7 @@
 #include "lapack_device_functions.hpp"
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
+#include "rocsolver_hybrid_array.hpp"
 
 ROCSOLVER_BEGIN_NAMESPACE
 
@@ -406,6 +407,33 @@ rocblas_status rocsolver_sterf_template(rocblas_handle handle,
 
     if(alg_mode == rocsolver_alg_mode_hybrid)
     {
+        rocsolver_hybrid_array<T, U> hD_array;
+        rocsolver_hybrid_array<T, U> hE_array;
+        rocsolver_hybrid_array<rocblas_int, rocblas_int*> hInfo_array;
+
+        ROCBLAS_CHECK(hD_array.init_async(n, D + shiftD, strideD, batch_count, stream));
+        ROCBLAS_CHECK(hE_array.init_async(n - 1, E + shiftE, strideE, batch_count, stream));
+        ROCBLAS_CHECK(hInfo_array.init_async(1, info, 1, batch_count, stream));
+        HIP_CHECK(hipStreamSynchronize(stream));
+
+        for(rocblas_int b = 0; b < batch_count; b++)
+        {
+            T *hD, *hE;
+            rocblas_int* hInfo;
+
+            ROCBLAS_CHECK(hD_array.get_from_device_async(&hD, b, stream));
+            ROCBLAS_CHECK(hE_array.get_from_device_async(&hE, b, stream));
+            ROCBLAS_CHECK(hInfo_array.get_from_device_async(&hInfo, b, stream));
+            HIP_CHECK(hipStreamSynchronize(stream));
+
+            run_sterf<T>(n, hD, hE, hInfo, nullptr, 30 * n, eps, ssfmin, ssfmax);
+
+            ROCBLAS_CHECK(hD_array.push_to_device_async(b, stream));
+            ROCBLAS_CHECK(hE_array.push_to_device_async(b, stream));
+            ROCBLAS_CHECK(hInfo_array.push_to_device_async(b, stream));
+        }
+
+        HIP_CHECK(hipStreamSynchronize(stream));
     }
     else
     {

--- a/library/src/auxiliary/rocauxiliary_sterf.hpp
+++ b/library/src/auxiliary/rocauxiliary_sterf.hpp
@@ -407,32 +407,23 @@ rocblas_status rocsolver_sterf_template(rocblas_handle handle,
 
     if(alg_mode == rocsolver_alg_mode_hybrid)
     {
-        rocsolver_hybrid_array<T, U> hD_array;
-        rocsolver_hybrid_array<T, U> hE_array;
-        rocsolver_hybrid_array<rocblas_int, rocblas_int*> hInfo_array;
+        rocsolver_hybrid_array<T, U> hD;
+        rocsolver_hybrid_array<T, U> hE;
+        rocsolver_hybrid_array<rocblas_int, rocblas_int*> hInfo;
 
-        ROCBLAS_CHECK(hD_array.init_async(n, D + shiftD, strideD, batch_count, stream));
-        ROCBLAS_CHECK(hE_array.init_async(n - 1, E + shiftE, strideE, batch_count, stream));
-        ROCBLAS_CHECK(hInfo_array.init_async(1, info, 1, batch_count, stream));
+        ROCBLAS_CHECK(hD.init_async(n, D + shiftD, strideD, batch_count, stream));
+        ROCBLAS_CHECK(hE.init_async(n - 1, E + shiftE, strideE, batch_count, stream));
+        ROCBLAS_CHECK(hInfo.init_async(1, info, 1, batch_count, stream));
         HIP_CHECK(hipStreamSynchronize(stream));
 
         for(rocblas_int b = 0; b < batch_count; b++)
         {
-            T *hD, *hE;
-            rocblas_int* hInfo;
-
-            ROCBLAS_CHECK(hD_array.get_from_device_async(&hD, b, stream));
-            ROCBLAS_CHECK(hE_array.get_from_device_async(&hE, b, stream));
-            ROCBLAS_CHECK(hInfo_array.get_from_device_async(&hInfo, b, stream));
-            HIP_CHECK(hipStreamSynchronize(stream));
-
-            run_sterf<T>(n, hD, hE, hInfo, nullptr, 30 * n, eps, ssfmin, ssfmax);
-
-            ROCBLAS_CHECK(hD_array.push_to_device_async(b, stream));
-            ROCBLAS_CHECK(hE_array.push_to_device_async(b, stream));
-            ROCBLAS_CHECK(hInfo_array.push_to_device_async(b, stream));
+            run_sterf<T>(n, hD[b], hE[b], hInfo[b], nullptr, 30 * n, eps, ssfmin, ssfmax);
         }
 
+        ROCBLAS_CHECK(hD.push_to_device_async(stream));
+        ROCBLAS_CHECK(hE.push_to_device_async(stream));
+        ROCBLAS_CHECK(hInfo.push_to_device_async(stream));
         HIP_CHECK(hipStreamSynchronize(stream));
     }
     else

--- a/library/src/auxiliary/rocauxiliary_sterf.hpp
+++ b/library/src/auxiliary/rocauxiliary_sterf.hpp
@@ -421,9 +421,9 @@ rocblas_status rocsolver_sterf_template(rocblas_handle handle,
             run_sterf<T>(n, hD[b], hE[b], hInfo[b], nullptr, 30 * n, eps, ssfmin, ssfmax);
         }
 
-        ROCBLAS_CHECK(hD.push_to_device_async(stream));
-        ROCBLAS_CHECK(hE.push_to_device_async(stream));
-        ROCBLAS_CHECK(hInfo.push_to_device_async(stream));
+        ROCBLAS_CHECK(hD.write_to_device_async(stream));
+        ROCBLAS_CHECK(hE.write_to_device_async(stream));
+        ROCBLAS_CHECK(hInfo.write_to_device_async(stream));
         HIP_CHECK(hipStreamSynchronize(stream));
     }
     else

--- a/library/src/common/rocsolver_handle.cpp
+++ b/library/src/common/rocsolver_handle.cpp
@@ -66,6 +66,12 @@ rocblas_status rocsolver_set_alg_mode_impl(rocblas_handle handle,
             handle_data->bdsqr_mode = mode;
             return rocblas_status_success;
         }
+    case rocsolver_function_sterf:
+        if(mode == rocsolver_alg_mode_gpu || mode == rocsolver_alg_mode_hybrid)
+        {
+            handle_data->sterf_mode = mode;
+            return rocblas_status_success;
+        }
     }
 
     return rocblas_status_invalid_value;
@@ -95,6 +101,7 @@ rocblas_status rocsolver_get_alg_mode_impl(rocblas_handle handle,
         {
         case rocsolver_function_gesvd:
         case rocsolver_function_bdsqr: *mode = handle_data->bdsqr_mode; break;
+        case rocsolver_function_sterf: *mode = handle_data->sterf_mode; break;
         default: return rocblas_status_invalid_value;
         }
     }

--- a/library/src/include/lapack_device_functions.hpp
+++ b/library/src/include/lapack_device_functions.hpp
@@ -363,7 +363,7 @@ __device__ void lasr(const rocblas_side side,
     [ a b ]
     [ b c ] **/
 template <typename T, std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
-__device__ void lae2(T& a, T& b, T& c, T& rt1, T& rt2)
+__device__ __host__ void lae2(T& a, T& b, T& c, T& rt1, T& rt2)
 {
     T sm = a + c;
     T adf = abs(a - c);

--- a/library/src/include/lib_device_helpers.hpp
+++ b/library/src/include/lib_device_helpers.hpp
@@ -98,7 +98,7 @@ __device__ void
 /** FIND_MAX_TRIDIAG finds the element with the largest magnitude in the
     tridiagonal matrix **/
 template <typename T>
-__device__ T find_max_tridiag(const rocblas_int start, const rocblas_int end, T* D, T* E)
+__device__ __host__ T find_max_tridiag(const rocblas_int start, const rocblas_int end, T* D, T* E)
 {
     T anorm = abs(D[end]);
     for(int i = start; i < end; i++)
@@ -109,7 +109,8 @@ __device__ T find_max_tridiag(const rocblas_int start, const rocblas_int end, T*
 /** SCALE_TRIDIAG scales the elements of the tridiagonal matrix by a given
     scale factor **/
 template <typename T>
-__device__ void scale_tridiag(const rocblas_int start, const rocblas_int end, T* D, T* E, T scale)
+__device__ __host__ void
+    scale_tridiag(const rocblas_int start, const rocblas_int end, T* D, T* E, T scale)
 {
     D[end] *= scale;
     for(int i = start; i < end; i++)
@@ -117,6 +118,457 @@ __device__ void scale_tridiag(const rocblas_int start, const rocblas_int end, T*
         D[i] *= scale;
         E[i] *= scale;
     }
+}
+
+template <typename S, typename I>
+__device__ static void shell_sort_ascending(const I n, S* a, I* map = nullptr)
+{
+    // -----------------------------------------------
+    // Sort array a[0...(n-1)] and generate permutation vector
+    // in map[] if map[] is available
+    // Note: performs in a single thread block
+    // -----------------------------------------------
+    if((n <= 0) || (a == nullptr))
+    {
+        return;
+    };
+
+    bool const is_root_thread
+        = (hipThreadIdx_x == 0) && (hipThreadIdx_y == 0) && (hipThreadIdx_z == 0);
+
+    int constexpr ngaps = 8;
+    int const gaps[ngaps] = {701, 301, 132, 57, 23, 10, 4, 1}; // # Ciura gap sequence
+
+    auto const k_start = hipThreadIdx_x + hipThreadIdx_y * hipBlockDim_x
+        + hipThreadIdx_z * (hipBlockDim_x * hipBlockDim_y);
+
+    auto const k_inc = (hipBlockDim_x * hipBlockDim_y) * hipBlockDim_z;
+
+    bool const has_map = (map != nullptr);
+
+    __syncthreads();
+    if(has_map)
+    {
+        for(auto k = k_start; k < n; k += k_inc)
+        {
+            map[k] = k;
+        };
+    };
+    __syncthreads();
+
+    if(is_root_thread)
+    {
+        for(auto igap = 0; igap < ngaps; igap++)
+        {
+            auto const gap = gaps[igap];
+
+            for(I i = gap; i < n; i += 1)
+            {
+                {
+                    S const temp = a[i];
+                    auto const itemp = (has_map) ? map[i] : 0;
+
+                    auto j = i;
+
+                    while((j >= gap) && (a[j - gap] > temp))
+                    {
+                        a[j] = a[j - gap];
+                        if(has_map)
+                        {
+                            map[j] = map[j - gap];
+                        };
+                        j -= gap;
+                    };
+
+                    a[j] = temp;
+                    if(has_map)
+                    {
+                        map[j] = itemp;
+                    };
+                };
+            };
+        };
+    };
+    __syncthreads();
+#ifdef NDEBUG
+#else
+    if(n >= 2)
+    {
+        for(auto k = k_start; k < (n - 1); k += k_inc)
+        {
+            assert(a[k] <= a[k + 1]);
+        };
+    };
+    __syncthreads();
+#endif
+}
+
+template <typename S, typename I>
+__device__ static void shell_sort_descending(const I n, S* a, I* map = nullptr)
+{
+    // -----------------------------------------------
+    // Sort array a[0...(n-1)] and generate permutation vector
+    // in map[] if map[] is available
+    // Note: performs in a single thread block
+    // -----------------------------------------------
+
+    if((n <= 0) || (a == nullptr))
+    {
+        return;
+    };
+
+    bool const is_root_thread
+        = (hipThreadIdx_x == 0) && (hipThreadIdx_y == 0) && (hipThreadIdx_z == 0);
+
+    int constexpr ngaps = 8;
+    int const gaps[ngaps] = {701, 301, 132, 57, 23, 10, 4, 1}; // # Ciura gap sequence
+
+    auto const k_start = hipThreadIdx_x + hipThreadIdx_y * hipBlockDim_x
+        + hipThreadIdx_z * (hipBlockDim_x * hipBlockDim_y);
+
+    auto const k_inc = (hipBlockDim_x * hipBlockDim_y) * hipBlockDim_z;
+
+    bool const has_map = (map != nullptr);
+
+    __syncthreads();
+    if(has_map)
+    {
+        for(auto k = k_start; k < n; k += k_inc)
+        {
+            map[k] = k;
+        };
+    };
+    __syncthreads();
+
+    if(is_root_thread)
+    {
+        for(auto igap = 0; igap < ngaps; igap++)
+        {
+            auto const gap = gaps[igap];
+
+            for(rocblas_int i = gap; i < n; i += 1)
+            {
+                {
+                    S const temp = a[i];
+                    auto const itemp = (has_map) ? map[i] : 0;
+
+                    auto j = i;
+
+                    while((j >= gap) && (a[j - gap] < temp))
+                    {
+                        a[j] = a[j - gap];
+                        if(has_map)
+                        {
+                            map[j] = map[j - gap];
+                        };
+                        j -= gap;
+                    };
+
+                    a[j] = temp;
+                    if(has_map)
+                    {
+                        map[j] = itemp;
+                    };
+                };
+            };
+        };
+    };
+    __syncthreads();
+#ifdef NDEBUG
+#else
+    if(n >= 2)
+    {
+        for(auto k = k_start; k < (n - 1); k += k_inc)
+        {
+            assert(a[k] >= a[k + 1]);
+        };
+    };
+    __syncthreads();
+#endif
+}
+
+template <typename S, typename I>
+__device__ static void shell_sort(const I n, S* a, I* map = nullptr, const bool is_ascending = true)
+{
+    if((n <= 0) || (a == nullptr))
+    {
+        return;
+    };
+
+    if(is_ascending)
+    {
+        shell_sort_ascending(n, a, map);
+    }
+    else
+    {
+        shell_sort_descending(n, a, map);
+    };
+}
+
+template <typename S, typename I>
+__device__ static void selection_sort_ascending(const I n, S* D, I* map = nullptr)
+{
+    // ---------------------------------------------------
+    // Sort entries in D[0...(n-1)]
+    // generates permutation vector in map[] if map[] is available
+    // Note: performs in a single thread block
+    // ---------------------------------------------------
+    if((n <= 0) || (D == nullptr))
+    {
+        return;
+    };
+
+    auto const tid = hipThreadIdx_x + hipThreadIdx_y * hipBlockDim_x
+        + hipThreadIdx_z * (hipBlockDim_x * hipBlockDim_y);
+
+    auto const nthreads = (hipBlockDim_x * hipBlockDim_y) * hipBlockDim_z;
+
+    auto const k_start = tid;
+    auto const k_inc = nthreads;
+    bool const is_root_thread = (tid == 0);
+
+    bool const has_map = (map != nullptr);
+
+    __syncthreads();
+
+    if(has_map)
+    {
+        for(auto k = k_start; k < n; k += k_inc)
+        {
+            map[k] = k;
+        };
+    };
+
+    __syncthreads();
+
+    if(is_root_thread)
+    {
+        for(I ii = 1; ii < n; ii++)
+        {
+            auto l = ii - 1;
+            auto m = l;
+            auto p = D[l];
+            auto ip = (has_map) ? map[l] : 0;
+
+            for(auto j = ii; j < n; j++)
+            {
+                if(D[j] < p)
+                {
+                    m = j;
+                    p = D[j];
+                    if(has_map)
+                    {
+                        ip = map[j];
+                    };
+                }
+            }
+            if(m != l)
+            {
+                D[m] = D[l];
+                D[l] = p;
+
+                if(has_map)
+                {
+                    map[m] = map[l];
+                    map[l] = ip;
+                };
+            }
+        }
+    }
+    __syncthreads();
+#ifdef NDEBUG
+#else
+    if(n >= 2)
+    {
+        for(auto k = k_start; k < (n - 1); k += k_inc)
+        {
+            assert(D[k] <= D[k + 1]);
+        };
+    };
+    __syncthreads();
+#endif
+}
+
+template <typename S, typename I>
+__device__ static void selection_sort_descending(const I n, S* D, I* map = nullptr)
+{
+    // ---------------------------------------------------
+    // Sort entries in D[0...(n-1)]
+    // generates permutation vector in map[] if map[] is available
+    // Note: performs in a single thread block
+    // ---------------------------------------------------
+    if((n <= 0) || (D == nullptr))
+    {
+        return;
+    };
+
+    auto const tid = hipThreadIdx_x + hipThreadIdx_y * hipBlockDim_x
+        + hipThreadIdx_z * (hipBlockDim_x * hipBlockDim_y);
+
+    auto const nthreads = (hipBlockDim_x * hipBlockDim_y) * hipBlockDim_z;
+
+    auto const k_start = tid;
+    auto const k_inc = nthreads;
+    bool const is_root_thread = (tid == 0);
+
+    bool const has_map = (map != nullptr);
+
+    __syncthreads();
+
+    if(has_map)
+    {
+        for(auto k = k_start; k < n; k += k_inc)
+        {
+            map[k] = k;
+        };
+    };
+
+    __syncthreads();
+
+    if(is_root_thread)
+    {
+        for(I ii = 1; ii < n; ii++)
+        {
+            auto l = ii - 1;
+            auto m = l;
+            auto p = D[l];
+            auto ip = (has_map) ? map[l] : 0;
+
+            for(auto j = ii; j < n; j++)
+            {
+                if(D[j] > p)
+                {
+                    m = j;
+                    p = D[j];
+                    if(has_map)
+                    {
+                        ip = map[j];
+                    };
+                }
+            }
+            if(m != l)
+            {
+                D[m] = D[l];
+                D[l] = p;
+
+                if(has_map)
+                {
+                    map[m] = map[l];
+                    map[l] = ip;
+                };
+            }
+        }
+    }
+    __syncthreads();
+#ifdef NDEBUG
+#else
+    if(n >= 2)
+    {
+        for(auto k = k_start; k < (n - 1); k += k_inc)
+        {
+            assert(D[k] >= D[k + 1]);
+        };
+    };
+    __syncthreads();
+#endif
+}
+
+template <typename S, typename I>
+__device__ static void selection_sort(const I n, S* a, I* map = nullptr, const bool is_ascending = true)
+{
+    if((n <= 0) || (a == nullptr))
+    {
+        return;
+    };
+
+    if(is_ascending)
+    {
+        selection_sort_ascending(n, a, map);
+    }
+    else
+    {
+        selection_sort_descending(n, a, map);
+    };
+}
+
+template <typename T, typename I>
+__device__ static void permute_swap(const I n, T* C, I ldc, I* map, const I nev = -1)
+{
+    // --------------------------------------------
+    // perform swaps to implement permutation vector
+    // the permutation vector will be restored to the
+    // identity permutation 0,1,2,...
+    //
+    // Note: performs in a thread block
+    // --------------------------------------------
+    {
+        bool const has_work = (n >= 1) && (C != nullptr) && (ldc >= 1) && (map != nullptr);
+        if(!has_work)
+        {
+            return;
+        }
+    }
+
+    auto const tid = hipThreadIdx_x + hipThreadIdx_y * hipBlockDim_x
+        + hipThreadIdx_z * (hipBlockDim_x * hipBlockDim_y);
+
+    auto const nthreads = (hipBlockDim_x * hipBlockDim_y) * hipBlockDim_z;
+
+    auto const k_start = tid;
+    auto const k_inc = nthreads;
+
+    bool const is_root_thread = (tid == 0);
+
+    auto const nn = (nev >= 0) ? nev : n;
+
+    for(I i = 0; i < nn; i++)
+    {
+        __syncthreads();
+
+        while(map[i] != i)
+        {
+            auto const map_i = map[i];
+            auto const map_ii = map[map[i]];
+
+            __syncthreads();
+
+            if(is_root_thread)
+            {
+                map[map_i] = map_i;
+                map[i] = map_ii;
+            }
+
+            __syncthreads();
+
+            // ---------------------------------------
+            // swap columns C( 0:(n-1),map_i) and C( 0:(n-1),map_ii)
+            // ---------------------------------------
+
+            for(auto k = k_start; k < n; k += k_inc)
+            {
+                auto const k_map_i = k + (map_i * static_cast<int64_t>(ldc));
+                auto const k_map_ii = k + (map_ii * static_cast<int64_t>(ldc));
+
+                auto const ctemp = C[k_map_i];
+                C[k_map_i] = C[k_map_ii];
+                C[k_map_ii] = ctemp;
+            }
+
+            __syncthreads();
+        }
+    }
+#ifdef NDEBUG
+#else
+    // ----------------------------------------------------------
+    // extra check that map[] is restored to identity permutation
+    // ----------------------------------------------------------
+    __syncthreads();
+    for(auto k = k_start; k < nn; k += k_inc)
+    {
+        assert(map[k] == k);
+    }
+    __syncthreads();
+#endif
 }
 
 // **********************************************************
@@ -784,457 +1236,6 @@ ROCSOLVER_KERNEL void check_singularity(const rocblas_int n,
 
     if(hipThreadIdx_y == 0)
         info[b] = _info;
-}
-
-template <typename S, typename I>
-__device__ static void shell_sort_ascending(const I n, S* a, I* map = nullptr)
-{
-    // -----------------------------------------------
-    // Sort array a[0...(n-1)] and generate permutation vector
-    // in map[] if map[] is available
-    // Note: performs in a single thread block
-    // -----------------------------------------------
-    if((n <= 0) || (a == nullptr))
-    {
-        return;
-    };
-
-    bool const is_root_thread
-        = (hipThreadIdx_x == 0) && (hipThreadIdx_y == 0) && (hipThreadIdx_z == 0);
-
-    int constexpr ngaps = 8;
-    int const gaps[ngaps] = {701, 301, 132, 57, 23, 10, 4, 1}; // # Ciura gap sequence
-
-    auto const k_start = hipThreadIdx_x + hipThreadIdx_y * hipBlockDim_x
-        + hipThreadIdx_z * (hipBlockDim_x * hipBlockDim_y);
-
-    auto const k_inc = (hipBlockDim_x * hipBlockDim_y) * hipBlockDim_z;
-
-    bool const has_map = (map != nullptr);
-
-    __syncthreads();
-    if(has_map)
-    {
-        for(auto k = k_start; k < n; k += k_inc)
-        {
-            map[k] = k;
-        };
-    };
-    __syncthreads();
-
-    if(is_root_thread)
-    {
-        for(auto igap = 0; igap < ngaps; igap++)
-        {
-            auto const gap = gaps[igap];
-
-            for(I i = gap; i < n; i += 1)
-            {
-                {
-                    S const temp = a[i];
-                    auto const itemp = (has_map) ? map[i] : 0;
-
-                    auto j = i;
-
-                    while((j >= gap) && (a[j - gap] > temp))
-                    {
-                        a[j] = a[j - gap];
-                        if(has_map)
-                        {
-                            map[j] = map[j - gap];
-                        };
-                        j -= gap;
-                    };
-
-                    a[j] = temp;
-                    if(has_map)
-                    {
-                        map[j] = itemp;
-                    };
-                };
-            };
-        };
-    };
-    __syncthreads();
-#ifdef NDEBUG
-#else
-    if(n >= 2)
-    {
-        for(auto k = k_start; k < (n - 1); k += k_inc)
-        {
-            assert(a[k] <= a[k + 1]);
-        };
-    };
-    __syncthreads();
-#endif
-}
-
-template <typename S, typename I>
-__device__ static void shell_sort_descending(const I n, S* a, I* map = nullptr)
-{
-    // -----------------------------------------------
-    // Sort array a[0...(n-1)] and generate permutation vector
-    // in map[] if map[] is available
-    // Note: performs in a single thread block
-    // -----------------------------------------------
-
-    if((n <= 0) || (a == nullptr))
-    {
-        return;
-    };
-
-    bool const is_root_thread
-        = (hipThreadIdx_x == 0) && (hipThreadIdx_y == 0) && (hipThreadIdx_z == 0);
-
-    int constexpr ngaps = 8;
-    int const gaps[ngaps] = {701, 301, 132, 57, 23, 10, 4, 1}; // # Ciura gap sequence
-
-    auto const k_start = hipThreadIdx_x + hipThreadIdx_y * hipBlockDim_x
-        + hipThreadIdx_z * (hipBlockDim_x * hipBlockDim_y);
-
-    auto const k_inc = (hipBlockDim_x * hipBlockDim_y) * hipBlockDim_z;
-
-    bool const has_map = (map != nullptr);
-
-    __syncthreads();
-    if(has_map)
-    {
-        for(auto k = k_start; k < n; k += k_inc)
-        {
-            map[k] = k;
-        };
-    };
-    __syncthreads();
-
-    if(is_root_thread)
-    {
-        for(auto igap = 0; igap < ngaps; igap++)
-        {
-            auto const gap = gaps[igap];
-
-            for(rocblas_int i = gap; i < n; i += 1)
-            {
-                {
-                    S const temp = a[i];
-                    auto const itemp = (has_map) ? map[i] : 0;
-
-                    auto j = i;
-
-                    while((j >= gap) && (a[j - gap] < temp))
-                    {
-                        a[j] = a[j - gap];
-                        if(has_map)
-                        {
-                            map[j] = map[j - gap];
-                        };
-                        j -= gap;
-                    };
-
-                    a[j] = temp;
-                    if(has_map)
-                    {
-                        map[j] = itemp;
-                    };
-                };
-            };
-        };
-    };
-    __syncthreads();
-#ifdef NDEBUG
-#else
-    if(n >= 2)
-    {
-        for(auto k = k_start; k < (n - 1); k += k_inc)
-        {
-            assert(a[k] >= a[k + 1]);
-        };
-    };
-    __syncthreads();
-#endif
-}
-
-template <typename S, typename I>
-__device__ static void shell_sort(const I n, S* a, I* map = nullptr, const bool is_ascending = true)
-{
-    if((n <= 0) || (a == nullptr))
-    {
-        return;
-    };
-
-    if(is_ascending)
-    {
-        shell_sort_ascending(n, a, map);
-    }
-    else
-    {
-        shell_sort_descending(n, a, map);
-    };
-}
-
-template <typename S, typename I>
-__device__ static void selection_sort_ascending(const I n, S* D, I* map = nullptr)
-{
-    // ---------------------------------------------------
-    // Sort entries in D[0...(n-1)]
-    // generates permutation vector in map[] if map[] is available
-    // Note: performs in a single thread block
-    // ---------------------------------------------------
-    if((n <= 0) || (D == nullptr))
-    {
-        return;
-    };
-
-    auto const tid = hipThreadIdx_x + hipThreadIdx_y * hipBlockDim_x
-        + hipThreadIdx_z * (hipBlockDim_x * hipBlockDim_y);
-
-    auto const nthreads = (hipBlockDim_x * hipBlockDim_y) * hipBlockDim_z;
-
-    auto const k_start = tid;
-    auto const k_inc = nthreads;
-    bool const is_root_thread = (tid == 0);
-
-    bool const has_map = (map != nullptr);
-
-    __syncthreads();
-
-    if(has_map)
-    {
-        for(auto k = k_start; k < n; k += k_inc)
-        {
-            map[k] = k;
-        };
-    };
-
-    __syncthreads();
-
-    if(is_root_thread)
-    {
-        for(I ii = 1; ii < n; ii++)
-        {
-            auto l = ii - 1;
-            auto m = l;
-            auto p = D[l];
-            auto ip = (has_map) ? map[l] : 0;
-
-            for(auto j = ii; j < n; j++)
-            {
-                if(D[j] < p)
-                {
-                    m = j;
-                    p = D[j];
-                    if(has_map)
-                    {
-                        ip = map[j];
-                    };
-                }
-            }
-            if(m != l)
-            {
-                D[m] = D[l];
-                D[l] = p;
-
-                if(has_map)
-                {
-                    map[m] = map[l];
-                    map[l] = ip;
-                };
-            }
-        }
-    }
-    __syncthreads();
-#ifdef NDEBUG
-#else
-    if(n >= 2)
-    {
-        for(auto k = k_start; k < (n - 1); k += k_inc)
-        {
-            assert(D[k] <= D[k + 1]);
-        };
-    };
-    __syncthreads();
-#endif
-}
-
-template <typename S, typename I>
-__device__ static void selection_sort_descending(const I n, S* D, I* map = nullptr)
-{
-    // ---------------------------------------------------
-    // Sort entries in D[0...(n-1)]
-    // generates permutation vector in map[] if map[] is available
-    // Note: performs in a single thread block
-    // ---------------------------------------------------
-    if((n <= 0) || (D == nullptr))
-    {
-        return;
-    };
-
-    auto const tid = hipThreadIdx_x + hipThreadIdx_y * hipBlockDim_x
-        + hipThreadIdx_z * (hipBlockDim_x * hipBlockDim_y);
-
-    auto const nthreads = (hipBlockDim_x * hipBlockDim_y) * hipBlockDim_z;
-
-    auto const k_start = tid;
-    auto const k_inc = nthreads;
-    bool const is_root_thread = (tid == 0);
-
-    bool const has_map = (map != nullptr);
-
-    __syncthreads();
-
-    if(has_map)
-    {
-        for(auto k = k_start; k < n; k += k_inc)
-        {
-            map[k] = k;
-        };
-    };
-
-    __syncthreads();
-
-    if(is_root_thread)
-    {
-        for(I ii = 1; ii < n; ii++)
-        {
-            auto l = ii - 1;
-            auto m = l;
-            auto p = D[l];
-            auto ip = (has_map) ? map[l] : 0;
-
-            for(auto j = ii; j < n; j++)
-            {
-                if(D[j] > p)
-                {
-                    m = j;
-                    p = D[j];
-                    if(has_map)
-                    {
-                        ip = map[j];
-                    };
-                }
-            }
-            if(m != l)
-            {
-                D[m] = D[l];
-                D[l] = p;
-
-                if(has_map)
-                {
-                    map[m] = map[l];
-                    map[l] = ip;
-                };
-            }
-        }
-    }
-    __syncthreads();
-#ifdef NDEBUG
-#else
-    if(n >= 2)
-    {
-        for(auto k = k_start; k < (n - 1); k += k_inc)
-        {
-            assert(D[k] >= D[k + 1]);
-        };
-    };
-    __syncthreads();
-#endif
-}
-
-template <typename S, typename I>
-__device__ static void selection_sort(const I n, S* a, I* map = nullptr, const bool is_ascending = true)
-{
-    if((n <= 0) || (a == nullptr))
-    {
-        return;
-    };
-
-    if(is_ascending)
-    {
-        selection_sort_ascending(n, a, map);
-    }
-    else
-    {
-        selection_sort_descending(n, a, map);
-    };
-}
-
-template <typename T, typename I>
-__device__ static void permute_swap(const I n, T* C, I ldc, I* map, const I nev = -1)
-{
-    // --------------------------------------------
-    // perform swaps to implement permutation vector
-    // the permutation vector will be restored to the
-    // identity permutation 0,1,2,...
-    //
-    // Note: performs in a thread block
-    // --------------------------------------------
-    {
-        bool const has_work = (n >= 1) && (C != nullptr) && (ldc >= 1) && (map != nullptr);
-        if(!has_work)
-        {
-            return;
-        }
-    }
-
-    auto const tid = hipThreadIdx_x + hipThreadIdx_y * hipBlockDim_x
-        + hipThreadIdx_z * (hipBlockDim_x * hipBlockDim_y);
-
-    auto const nthreads = (hipBlockDim_x * hipBlockDim_y) * hipBlockDim_z;
-
-    auto const k_start = tid;
-    auto const k_inc = nthreads;
-
-    bool const is_root_thread = (tid == 0);
-
-    auto const nn = (nev >= 0) ? nev : n;
-
-    for(I i = 0; i < nn; i++)
-    {
-        __syncthreads();
-
-        while(map[i] != i)
-        {
-            auto const map_i = map[i];
-            auto const map_ii = map[map[i]];
-
-            __syncthreads();
-
-            if(is_root_thread)
-            {
-                map[map_i] = map_i;
-                map[i] = map_ii;
-            }
-
-            __syncthreads();
-
-            // ---------------------------------------
-            // swap columns C( 0:(n-1),map_i) and C( 0:(n-1),map_ii)
-            // ---------------------------------------
-
-            for(auto k = k_start; k < n; k += k_inc)
-            {
-                auto const k_map_i = k + (map_i * static_cast<int64_t>(ldc));
-                auto const k_map_ii = k + (map_ii * static_cast<int64_t>(ldc));
-
-                auto const ctemp = C[k_map_i];
-                C[k_map_i] = C[k_map_ii];
-                C[k_map_ii] = ctemp;
-            }
-
-            __syncthreads();
-        }
-    }
-#ifdef NDEBUG
-#else
-    // ----------------------------------------------------------
-    // extra check that map[] is restored to identity permutation
-    // ----------------------------------------------------------
-    __syncthreads();
-    for(auto k = k_start; k < nn; k += k_inc)
-    {
-        assert(map[k] == k);
-    }
-    __syncthreads();
-#endif
 }
 
 /** SWAP swaps the values of vectors x and y of dimension n.

--- a/library/src/include/lib_device_helpers.hpp
+++ b/library/src/include/lib_device_helpers.hpp
@@ -581,8 +581,8 @@ enum copymat_direction
     copymat_from_buffer
 };
 
-/** A mask that is always true. Typically used to make the mask optional,
-    by acting as the default when no other mask is provided. **/
+/** A mask that is always true. Typically used to make the mask optional, by acting as the default when
+    no other mask is provided. **/
 struct no_mask
 {
     __device__ constexpr bool operator[](rocblas_int) const noexcept
@@ -591,7 +591,9 @@ struct no_mask
     }
 };
 
-/** An mask defined by an integer array (e.g., the info array) **/
+/** An mask defined by an integer array (e.g., the info array). By default, a non-zero value for the ith integer
+    indicates that the data for batch i should be copied over. Data will not be copied if the mask value is zero.
+    This behaviour is reversed if the negate transform is passed to the constructor. **/
 struct info_mask
 {
     enum mask_transform

--- a/library/src/include/lib_host_helpers.hpp
+++ b/library/src/include/lib_host_helpers.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -180,7 +180,8 @@ static bool is_device_pointer(void* ptr)
 
     auto istat = hipPointerGetAttributes(&dev_attributes, ptr);
     if(istat != hipSuccess)
-        fmt::print(stderr, "is_device_pointer: istat = {} {}\n", istat, hipGetErrorName(istat));
+        fmt::print(stderr, "is_device_pointer: istat = {} {}\n", static_cast<std::int32_t>(istat),
+                   hipGetErrorName(istat));
 
     assert(istat == hipSuccess);
     return (dev_attributes.type == hipMemoryTypeDevice);

--- a/library/src/include/lib_host_helpers.hpp
+++ b/library/src/include/lib_host_helpers.hpp
@@ -30,6 +30,8 @@
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
+#include <fmt/core.h>
+#include <fmt/ostream.h>
 #include <hip/hip_runtime.h>
 #include <rocblas/rocblas.h>
 
@@ -168,6 +170,20 @@ static double imag_part(std::complex<double> z)
 static double imag_part(rocblas_complex_num<double> z)
 {
     return (z.imag());
+}
+
+static bool is_device_pointer(void* ptr)
+{
+    hipPointerAttribute_t dev_attributes;
+    if(ptr == nullptr)
+        return false;
+
+    auto istat = hipPointerGetAttributes(&dev_attributes, ptr);
+    if(istat != hipSuccess)
+        fmt::print(stderr, "is_device_pointer: istat = {} {}\n", istat, hipGetErrorName(istat));
+
+    assert(istat == hipSuccess);
+    return (dev_attributes.type == hipMemoryTypeDevice);
 }
 
 #ifdef ROCSOLVER_VERIFY_ASSUMPTIONS

--- a/library/src/include/rocsolver_handle.hpp
+++ b/library/src/include/rocsolver_handle.hpp
@@ -37,6 +37,7 @@ struct rocsolver_handle_data_
     rocblas_int checksum;
 
     rocsolver_alg_mode bdsqr_mode = rocsolver_alg_mode_gpu;
+    rocsolver_alg_mode sterf_mode = rocsolver_alg_mode_gpu;
 };
 
 typedef struct rocsolver_handle_data_* rocsolver_handle_data;

--- a/library/src/include/rocsolver_hybrid_array.hpp
+++ b/library/src/include/rocsolver_hybrid_array.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -57,12 +57,21 @@ struct rocsolver_hybrid_array
     T** batch_array;
     T* val_array;
 
+    /* Constructor */
     rocsolver_hybrid_array()
         : src_array(nullptr)
         , batch_array(nullptr)
         , val_array(nullptr)
     {
     }
+
+    /* Disallow copying. */
+    rocsolver_hybrid_array(const rocsolver_hybrid_array&) = delete;
+
+    /* Disallow assigning. */
+    rocsolver_hybrid_array& operator=(const rocsolver_hybrid_array&) = delete;
+
+    /* Destructor */
     ~rocsolver_hybrid_array()
     {
         if(val_array)

--- a/library/src/include/rocsolver_hybrid_array.hpp
+++ b/library/src/include/rocsolver_hybrid_array.hpp
@@ -1,0 +1,170 @@
+/* **************************************************************************
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ * *************************************************************************/
+
+#pragma once
+
+#include "common_host_helpers.hpp"
+#include "lib_host_helpers.hpp"
+#include "rocsolver/rocsolver.h"
+
+ROCSOLVER_BEGIN_NAMESPACE
+
+template <typename T, typename U>
+struct rocsolver_hybrid_array
+{
+    rocblas_int dim, batch_count;
+    rocblas_stride stride;
+
+    U src_array;
+    T** batch_array;
+    T* curr_array;
+
+    rocsolver_hybrid_array()
+        : src_array(nullptr)
+        , batch_array(nullptr)
+        , curr_array(nullptr)
+    {
+    }
+    ~rocsolver_hybrid_array()
+    {
+        if(curr_array)
+        {
+            free(curr_array);
+            if(batch_array)
+                free(batch_array);
+        }
+    }
+
+    rocblas_status init_async(rocblas_int dim,
+                              U array,
+                              rocblas_stride stride,
+                              rocblas_int batch_count,
+                              hipStream_t stream)
+    {
+        if(curr_array)
+        {
+            free(curr_array);
+            if(batch_array)
+                free(batch_array);
+        }
+
+        this->dim = dim;
+        this->src_array = array;
+        this->stride = stride;
+        this->batch_count = batch_count;
+
+        bool constexpr is_strided = (std::is_same<U, T*>::value || std::is_same<U, T* const>::value);
+        bool is_device = is_device_pointer(array);
+
+        if(is_device)
+        {
+            size_t bytes = sizeof(T) * dim;
+            curr_array = (T*)malloc(bytes);
+
+            if(is_strided)
+                batch_array = nullptr;
+            else
+            {
+                bytes = sizeof(T*) * batch_count;
+                batch_array = (T**)malloc(bytes);
+                HIP_CHECK(hipMemcpyAsync(batch_array, array, bytes, hipMemcpyDeviceToHost, stream));
+            }
+        }
+        else
+        {
+            curr_array = nullptr;
+
+            if(is_strided)
+                batch_array = nullptr;
+            else
+                batch_array = (T**)src_array;
+        }
+
+        return rocblas_status_success;
+    }
+
+    rocblas_status get_from_device_async(T** dst, rocblas_int bid, hipStream_t stream)
+    {
+        if(!src_array)
+            return rocblas_status_internal_error;
+
+        if(curr_array)
+        {
+            *dst = curr_array;
+            size_t bytes = sizeof(T) * dim;
+
+            if(batch_array)
+            {
+                HIP_CHECK(hipMemcpyAsync(curr_array, batch_array[bid], bytes, hipMemcpyDeviceToHost,
+                                         stream));
+            }
+            else
+            {
+                HIP_CHECK(hipMemcpyAsync(curr_array, src_array + bid * stride, bytes,
+                                         hipMemcpyDeviceToHost, stream));
+            }
+        }
+        else
+        {
+            if(batch_array)
+            {
+                *dst = batch_array[bid];
+            }
+            else
+            {
+                *dst = src_array + bid * stride;
+            }
+        }
+
+        return rocblas_status_success;
+    }
+    rocblas_status push_to_device_async(rocblas_int bid, hipStream_t stream)
+    {
+        if(!src_array)
+            return rocblas_status_internal_error;
+
+        if(curr_array)
+        {
+            size_t bytes = sizeof(T) * dim;
+
+            if(batch_array)
+            {
+                HIP_CHECK(hipMemcpyAsync(batch_array[bid], curr_array, bytes, hipMemcpyHostToDevice,
+                                         stream));
+            }
+            else
+            {
+                HIP_CHECK(hipMemcpyAsync(src_array + bid * stride, curr_array, bytes,
+                                         hipMemcpyHostToDevice, stream));
+            }
+        }
+
+        return rocblas_status_success;
+    }
+};
+
+ROCSOLVER_END_NAMESPACE

--- a/library/src/include/rocsolver_hybrid_array.hpp
+++ b/library/src/include/rocsolver_hybrid_array.hpp
@@ -52,13 +52,62 @@ struct rocsolver_hybrid_array
     ~rocsolver_hybrid_array()
     {
         if(val_array)
-        {
             free(val_array);
-            if(batch_array)
-                free(batch_array);
-        }
+        if(batch_array && (val_array || this->dim < 0))
+            free(batch_array);
     }
 
+    rocblas_status init_pointers_only(U array,
+                                      rocblas_stride stride,
+                                      rocblas_int batch_count,
+                                      hipStream_t stream)
+    {
+        if(val_array)
+            free(val_array);
+        if(batch_array && (val_array || this->dim < 0))
+            free(batch_array);
+
+        this->dim = -1;
+        this->src_array = array;
+        this->stride = stride;
+        this->batch_count = batch_count;
+
+        bool constexpr is_strided = (std::is_same<U, T*>::value || std::is_same<U, T* const>::value);
+        bool is_device = is_device_pointer((void*)array);
+
+        if(is_device)
+        {
+            // pointers only; don't allocate val_array
+            val_array = nullptr;
+
+            if(is_strided)
+            {
+                // data is strided; batch_array not needed
+                batch_array = nullptr;
+            }
+            else
+            {
+                // data is batched; read device pointers into batch_array
+                size_t batch_bytes = sizeof(T*) * batch_count;
+                batch_array = (T**)malloc(batch_bytes);
+                HIP_CHECK(
+                    hipMemcpyAsync(batch_array, array, batch_bytes, hipMemcpyDeviceToHost, stream));
+                HIP_CHECK(hipStreamSynchronize(stream));
+            }
+        }
+        else
+        {
+            // data on host; use src_array directly
+            val_array = nullptr;
+
+            if(is_strided)
+                batch_array = nullptr;
+            else
+                batch_array = (T**)src_array;
+        }
+
+        return rocblas_status_success;
+    }
     rocblas_status init_async(rocblas_int dim,
                               U array,
                               rocblas_stride stride,
@@ -66,11 +115,12 @@ struct rocsolver_hybrid_array
                               hipStream_t stream)
     {
         if(val_array)
-        {
             free(val_array);
-            if(batch_array)
-                free(batch_array);
-        }
+        if(batch_array && (val_array || this->dim < 0))
+            free(batch_array);
+
+        if(dim < 0)
+            return rocblas_status_internal_error;
 
         this->dim = dim;
         this->src_array = array;
@@ -78,7 +128,7 @@ struct rocsolver_hybrid_array
         this->batch_count = batch_count;
 
         bool constexpr is_strided = (std::is_same<U, T*>::value || std::is_same<U, T* const>::value);
-        bool is_device = is_device_pointer(array);
+        bool is_device = is_device_pointer((void*)array);
 
         if(is_device)
         {
@@ -141,6 +191,8 @@ struct rocsolver_hybrid_array
     {
         if(!src_array)
             return rocblas_status_internal_error;
+        if(dim < 0)
+            return rocblas_status_internal_error;
 
         if(val_array)
         {
@@ -188,7 +240,7 @@ struct rocsolver_hybrid_array
             if(batch_array)
                 return batch_array[bid];
             else
-                return src_array + bid * stride;
+                return (T*)(src_array + bid * stride);
         }
     }
 };

--- a/library/src/include/rocsolver_hybrid_array.hpp
+++ b/library/src/include/rocsolver_hybrid_array.hpp
@@ -41,19 +41,19 @@ struct rocsolver_hybrid_array
 
     U src_array;
     T** batch_array;
-    T* curr_array;
+    T* val_array;
 
     rocsolver_hybrid_array()
         : src_array(nullptr)
         , batch_array(nullptr)
-        , curr_array(nullptr)
+        , val_array(nullptr)
     {
     }
     ~rocsolver_hybrid_array()
     {
-        if(curr_array)
+        if(val_array)
         {
-            free(curr_array);
+            free(val_array);
             if(batch_array)
                 free(batch_array);
         }
@@ -65,9 +65,9 @@ struct rocsolver_hybrid_array
                               rocblas_int batch_count,
                               hipStream_t stream)
     {
-        if(curr_array)
+        if(val_array)
         {
-            free(curr_array);
+            free(val_array);
             if(batch_array)
                 free(batch_array);
         }
@@ -82,21 +82,52 @@ struct rocsolver_hybrid_array
 
         if(is_device)
         {
-            size_t bytes = sizeof(T) * dim;
-            curr_array = (T*)malloc(bytes);
+            // allocate space on host for data from device
+            size_t dim_bytes = sizeof(T) * dim;
+            size_t val_bytes = sizeof(T) * dim * batch_count;
+            val_array = (T*)malloc(val_bytes);
 
             if(is_strided)
+            {
+                // data is strided; batch_array not needed
                 batch_array = nullptr;
+
+                // read data to val_array
+                if(batch_count == 1 || stride == dim)
+                {
+                    HIP_CHECK(hipMemcpyAsync(val_array, src_array, val_bytes, hipMemcpyDeviceToHost,
+                                             stream));
+                }
+                else
+                {
+                    for(rocblas_int bid = 0; bid < batch_count; bid++)
+                    {
+                        HIP_CHECK(hipMemcpyAsync(val_array + bid * dim, src_array + bid * stride,
+                                                 dim_bytes, hipMemcpyDeviceToHost, stream));
+                    }
+                }
+            }
             else
             {
-                bytes = sizeof(T*) * batch_count;
-                batch_array = (T**)malloc(bytes);
-                HIP_CHECK(hipMemcpyAsync(batch_array, array, bytes, hipMemcpyDeviceToHost, stream));
+                // data is batched; read device pointers into batch_array
+                size_t batch_bytes = sizeof(T*) * batch_count;
+                batch_array = (T**)malloc(batch_bytes);
+                HIP_CHECK(
+                    hipMemcpyAsync(batch_array, array, batch_bytes, hipMemcpyDeviceToHost, stream));
+                HIP_CHECK(hipStreamSynchronize(stream));
+
+                // read data to val_array
+                for(rocblas_int bid = 0; bid < batch_count; bid++)
+                {
+                    HIP_CHECK(hipMemcpyAsync(val_array + bid * dim, batch_array[bid], dim_bytes,
+                                             hipMemcpyDeviceToHost, stream));
+                }
             }
         }
         else
         {
-            curr_array = nullptr;
+            // data on host; use src_array directly
+            val_array = nullptr;
 
             if(is_strided)
                 batch_array = nullptr;
@@ -106,64 +137,59 @@ struct rocsolver_hybrid_array
 
         return rocblas_status_success;
     }
-
-    rocblas_status get_from_device_async(T** dst, rocblas_int bid, hipStream_t stream)
+    rocblas_status push_to_device_async(hipStream_t stream)
     {
         if(!src_array)
             return rocblas_status_internal_error;
 
-        if(curr_array)
+        if(val_array)
         {
-            *dst = curr_array;
-            size_t bytes = sizeof(T) * dim;
+            size_t dim_bytes = sizeof(T) * dim;
+            size_t val_bytes = sizeof(T) * dim * batch_count;
 
-            if(batch_array)
+            if(!batch_array)
             {
-                HIP_CHECK(hipMemcpyAsync(curr_array, batch_array[bid], bytes, hipMemcpyDeviceToHost,
-                                         stream));
+                if(batch_count == 1 || stride == dim)
+                {
+                    HIP_CHECK(hipMemcpyAsync(src_array, val_array, val_bytes, hipMemcpyHostToDevice,
+                                             stream));
+                }
+                else
+                {
+                    for(rocblas_int bid = 0; bid < batch_count; bid++)
+                    {
+                        HIP_CHECK(hipMemcpyAsync(src_array + bid * stride, val_array + bid * dim,
+                                                 dim_bytes, hipMemcpyHostToDevice, stream));
+                    }
+                }
             }
             else
             {
-                HIP_CHECK(hipMemcpyAsync(curr_array, src_array + bid * stride, bytes,
-                                         hipMemcpyDeviceToHost, stream));
-            }
-        }
-        else
-        {
-            if(batch_array)
-            {
-                *dst = batch_array[bid];
-            }
-            else
-            {
-                *dst = src_array + bid * stride;
+                for(rocblas_int bid = 0; bid < batch_count; bid++)
+                {
+                    HIP_CHECK(hipMemcpyAsync(batch_array[bid], val_array + bid * dim, dim_bytes,
+                                             hipMemcpyHostToDevice, stream));
+                }
             }
         }
 
         return rocblas_status_success;
     }
-    rocblas_status push_to_device_async(rocblas_int bid, hipStream_t stream)
+
+    T* operator[](rocblas_int bid)
     {
         if(!src_array)
-            return rocblas_status_internal_error;
+            return nullptr;
 
-        if(curr_array)
+        if(val_array)
+            return val_array + bid * dim;
+        else
         {
-            size_t bytes = sizeof(T) * dim;
-
             if(batch_array)
-            {
-                HIP_CHECK(hipMemcpyAsync(batch_array[bid], curr_array, bytes, hipMemcpyHostToDevice,
-                                         stream));
-            }
+                return batch_array[bid];
             else
-            {
-                HIP_CHECK(hipMemcpyAsync(src_array + bid * stride, curr_array, bytes,
-                                         hipMemcpyHostToDevice, stream));
-            }
+                return src_array + bid * stride;
         }
-
-        return rocblas_status_success;
     }
 };
 

--- a/library/src/include/rocsolver_hybrid_array.hpp
+++ b/library/src/include/rocsolver_hybrid_array.hpp
@@ -33,6 +33,20 @@
 
 ROCSOLVER_BEGIN_NAMESPACE
 
+/* ROCSOLVER_HYBRID_ARRAY provides a wrapper for data arrays that is intended to simplify host memory
+   allocation as well as data transfers to and from the device. Hybrid algorithms can use rocsolver_hybrid_array
+   to read device data to the host so that the data may be operated upon, and then write the resultant data
+   back to the device. Two modes are supported:
+
+   * Standard mode: Used to read device data onto the host, which may then be operated upon by host code.
+     A typical workflow will call init_async to allocate a host buffer and read the data into the buffer,
+     execute host code on the buffered data through the pointer provided by the [] operator, and then call
+     write_to_device_async to write the resultant data back to the device.
+
+   * Pointers only mode: Used to read device pointers from a batched array onto the host, so that device
+     kernels may be called on each individual batch instance. A typical workflow will call init_pointers_only
+     to allocate a host buffer for the device pointers, and then execute device kernels on the pointers
+     provided by the [] operator. */
 template <typename T, typename I, typename U>
 struct rocsolver_hybrid_array
 {
@@ -57,8 +71,8 @@ struct rocsolver_hybrid_array
             free(batch_array);
     }
 
-    /* Initializes internal arrays to hold pointer data. Primarily used to read device pointers
-       from a batched array for use on the host; no other data is read from the device. */
+    /* Used to read device pointers from a batched array for use on the host; no other data is read from the
+       device. */
     rocblas_status init_pointers_only(U array, rocblas_stride stride, I batch_count, hipStream_t stream)
     {
         if(val_array)
@@ -107,8 +121,8 @@ struct rocsolver_hybrid_array
 
         return rocblas_status_success;
     }
-    /* Initializes internal arrays to hold data from the device. Device pointers are read into batch_array
-       (if applicable), and matrix data is read into val_array. */
+    /* Used to read device data into a host buffer, which is managed by this class. Data for all batch instances
+       will be read into the buffer. */
     rocblas_status init_async(I dim, U array, rocblas_stride stride, I batch_count, hipStream_t stream)
     {
         if(val_array)
@@ -184,9 +198,9 @@ struct rocsolver_hybrid_array
 
         return rocblas_status_success;
     }
-    /* Copies data from val_array back to the device. Returns an error if initialized for pointers
+    /* Copies data from host buffer back to the device. Returns an error if initialized for pointers
        only. */
-    rocblas_status push_to_device_async(hipStream_t stream)
+    rocblas_status write_to_device_async(hipStream_t stream)
     {
         if(!src_array)
             return rocblas_status_internal_error;

--- a/library/src/include/rocsolver_hybrid_array.hpp
+++ b/library/src/include/rocsolver_hybrid_array.hpp
@@ -33,10 +33,10 @@
 
 ROCSOLVER_BEGIN_NAMESPACE
 
-template <typename T, typename U>
+template <typename T, typename I, typename U>
 struct rocsolver_hybrid_array
 {
-    rocblas_int dim, batch_count;
+    I dim, batch_count;
     rocblas_stride stride;
 
     U src_array;
@@ -57,10 +57,7 @@ struct rocsolver_hybrid_array
             free(batch_array);
     }
 
-    rocblas_status init_pointers_only(U array,
-                                      rocblas_stride stride,
-                                      rocblas_int batch_count,
-                                      hipStream_t stream)
+    rocblas_status init_pointers_only(U array, rocblas_stride stride, I batch_count, hipStream_t stream)
     {
         if(val_array)
             free(val_array);
@@ -108,11 +105,7 @@ struct rocsolver_hybrid_array
 
         return rocblas_status_success;
     }
-    rocblas_status init_async(rocblas_int dim,
-                              U array,
-                              rocblas_stride stride,
-                              rocblas_int batch_count,
-                              hipStream_t stream)
+    rocblas_status init_async(I dim, U array, rocblas_stride stride, I batch_count, hipStream_t stream)
     {
         if(val_array)
             free(val_array);
@@ -150,7 +143,7 @@ struct rocsolver_hybrid_array
                 }
                 else
                 {
-                    for(rocblas_int bid = 0; bid < batch_count; bid++)
+                    for(I bid = 0; bid < batch_count; bid++)
                     {
                         HIP_CHECK(hipMemcpyAsync(val_array + bid * dim, src_array + bid * stride,
                                                  dim_bytes, hipMemcpyDeviceToHost, stream));
@@ -167,7 +160,7 @@ struct rocsolver_hybrid_array
                 HIP_CHECK(hipStreamSynchronize(stream));
 
                 // read data to val_array
-                for(rocblas_int bid = 0; bid < batch_count; bid++)
+                for(I bid = 0; bid < batch_count; bid++)
                 {
                     HIP_CHECK(hipMemcpyAsync(val_array + bid * dim, batch_array[bid], dim_bytes,
                                              hipMemcpyDeviceToHost, stream));
@@ -208,7 +201,7 @@ struct rocsolver_hybrid_array
                 }
                 else
                 {
-                    for(rocblas_int bid = 0; bid < batch_count; bid++)
+                    for(I bid = 0; bid < batch_count; bid++)
                     {
                         HIP_CHECK(hipMemcpyAsync(src_array + bid * stride, val_array + bid * dim,
                                                  dim_bytes, hipMemcpyHostToDevice, stream));
@@ -217,7 +210,7 @@ struct rocsolver_hybrid_array
             }
             else
             {
-                for(rocblas_int bid = 0; bid < batch_count; bid++)
+                for(I bid = 0; bid < batch_count; bid++)
                 {
                     HIP_CHECK(hipMemcpyAsync(batch_array[bid], val_array + bid * dim, dim_bytes,
                                              hipMemcpyHostToDevice, stream));
@@ -228,7 +221,7 @@ struct rocsolver_hybrid_array
         return rocblas_status_success;
     }
 
-    T* operator[](rocblas_int bid)
+    T* operator[](I bid)
     {
         if(!src_array)
             return nullptr;

--- a/library/src/include/rocsolver_hybrid_array.hpp
+++ b/library/src/include/rocsolver_hybrid_array.hpp
@@ -57,6 +57,8 @@ struct rocsolver_hybrid_array
             free(batch_array);
     }
 
+    /* Initializes internal arrays to hold pointer data. Primarily used to read device pointers
+       from a batched array for use on the host; no other data is read from the device. */
     rocblas_status init_pointers_only(U array, rocblas_stride stride, I batch_count, hipStream_t stream)
     {
         if(val_array)
@@ -105,6 +107,8 @@ struct rocsolver_hybrid_array
 
         return rocblas_status_success;
     }
+    /* Initializes internal arrays to hold data from the device. Device pointers are read into batch_array
+       (if applicable), and matrix data is read into val_array. */
     rocblas_status init_async(I dim, U array, rocblas_stride stride, I batch_count, hipStream_t stream)
     {
         if(val_array)
@@ -180,6 +184,8 @@ struct rocsolver_hybrid_array
 
         return rocblas_status_success;
     }
+    /* Copies data from val_array back to the device. Returns an error if initialized for pointers
+       only. */
     rocblas_status push_to_device_async(hipStream_t stream)
     {
         if(!src_array)
@@ -221,6 +227,8 @@ struct rocsolver_hybrid_array
         return rocblas_status_success;
     }
 
+    /* Gets a pointer to the data for batch index bid. If initialized for pointers only, the
+       returned pointer may be on the device. Otherwise, the pointer is on the host. */
     T* operator[](I bid)
     {
         if(!src_array)

--- a/library/src/include/rocsolver_hybrid_storage.hpp
+++ b/library/src/include/rocsolver_hybrid_storage.hpp
@@ -33,8 +33,8 @@
 
 ROCSOLVER_BEGIN_NAMESPACE
 
-/* ROCSOLVER_HYBRID_ARRAY provides a wrapper for data arrays that is intended to simplify host memory
-   allocation as well as data transfers to and from the device. Hybrid algorithms can use rocsolver_hybrid_array
+/* ROCSOLVER_HYBRID_STORAGE provides a wrapper for data arrays that is intended to simplify host memory
+   allocation as well as data transfers to and from the device. Hybrid algorithms can use rocsolver_hybrid_storage
    to read device data to the host so that the data may be operated upon, and then write the resultant data
    back to the device. Two modes are supported:
 
@@ -47,8 +47,13 @@ ROCSOLVER_BEGIN_NAMESPACE
      kernels may be called on each individual batch instance. A typical workflow will call init_pointers_only
      to allocate a host buffer for the device pointers, and then execute device kernels on the pointers
      provided by the [] operator. */
-template <typename T, typename I, typename U>
-struct rocsolver_hybrid_array
+template <typename T,
+          typename I,
+          typename U,
+          std::enable_if_t<std::is_trivial<T>::value && std::is_standard_layout<T>::value
+                               && !std::is_pointer<T>::value,
+                           int> = 0>
+struct rocsolver_hybrid_storage
 {
     I dim, batch_count;
     rocblas_stride stride;
@@ -58,7 +63,7 @@ struct rocsolver_hybrid_array
     T* val_array;
 
     /* Constructor */
-    rocsolver_hybrid_array()
+    rocsolver_hybrid_storage()
         : src_array(nullptr)
         , batch_array(nullptr)
         , val_array(nullptr)
@@ -66,18 +71,24 @@ struct rocsolver_hybrid_array
     }
 
     /* Disallow copying. */
-    rocsolver_hybrid_array(const rocsolver_hybrid_array&) = delete;
+    rocsolver_hybrid_storage(const rocsolver_hybrid_storage&) = delete;
 
     /* Disallow assigning. */
-    rocsolver_hybrid_array& operator=(const rocsolver_hybrid_array&) = delete;
+    rocsolver_hybrid_storage& operator=(const rocsolver_hybrid_storage&) = delete;
 
     /* Destructor */
-    ~rocsolver_hybrid_array()
+    ~rocsolver_hybrid_storage()
     {
         if(val_array)
+        {
+            memset(val_array, 0, sizeof(T) * this->dim * this->batch_count);
             free(val_array);
+        }
         if(batch_array && (val_array || this->dim < 0))
+        {
+            memset(batch_array, 0, sizeof(T*) * this->batch_count);
             free(batch_array);
+        }
     }
 
     /* Used to read device pointers from a batched array for use on the host; no other data is read from the
@@ -85,9 +96,17 @@ struct rocsolver_hybrid_array
     rocblas_status init_pointers_only(U array, rocblas_stride stride, I batch_count, hipStream_t stream)
     {
         if(val_array)
+        {
+            memset(val_array, 0, sizeof(T) * this->dim * this->batch_count);
             free(val_array);
+            val_array = nullptr;
+        }
         if(batch_array && (val_array || this->dim < 0))
+        {
+            memset(batch_array, 0, sizeof(T*) * this->batch_count);
             free(batch_array);
+            batch_array = nullptr;
+        }
 
         this->dim = -1;
         this->src_array = array;
@@ -100,18 +119,15 @@ struct rocsolver_hybrid_array
         if(is_device)
         {
             // pointers only; don't allocate val_array
-            val_array = nullptr;
 
-            if(is_strided)
-            {
-                // data is strided; batch_array not needed
-                batch_array = nullptr;
-            }
-            else
+            if(!is_strided)
             {
                 // data is batched; read device pointers into batch_array
                 size_t batch_bytes = sizeof(T*) * batch_count;
                 batch_array = (T**)malloc(batch_bytes);
+                if(!batch_array)
+                    return rocblas_status_memory_error;
+                memset(batch_array, 0, batch_bytes);
                 HIP_CHECK(
                     hipMemcpyAsync(batch_array, array, batch_bytes, hipMemcpyDeviceToHost, stream));
                 HIP_CHECK(hipStreamSynchronize(stream));
@@ -120,11 +136,8 @@ struct rocsolver_hybrid_array
         else
         {
             // data on host; use src_array directly
-            val_array = nullptr;
 
-            if(is_strided)
-                batch_array = nullptr;
-            else
+            if(!is_strided)
                 batch_array = (T**)src_array;
         }
 
@@ -135,12 +148,28 @@ struct rocsolver_hybrid_array
     rocblas_status init_async(I dim, U array, rocblas_stride stride, I batch_count, hipStream_t stream)
     {
         if(val_array)
+        {
+            memset(val_array, 0, sizeof(T) * this->dim * this->batch_count);
             free(val_array);
+            val_array = nullptr;
+        }
         if(batch_array && (val_array || this->dim < 0))
+        {
+            memset(batch_array, 0, sizeof(T*) * this->batch_count);
             free(batch_array);
+            batch_array = nullptr;
+        }
 
         if(dim < 0)
             return rocblas_status_internal_error;
+        if(dim == 0)
+        {
+            this->dim = 0;
+            this->src_array = 0;
+            this->stride = 0;
+            this->batch_count = 0;
+            return rocblas_status_success;
+        }
 
         this->dim = dim;
         this->src_array = array;
@@ -156,11 +185,13 @@ struct rocsolver_hybrid_array
             size_t dim_bytes = sizeof(T) * dim;
             size_t val_bytes = sizeof(T) * dim * batch_count;
             val_array = (T*)malloc(val_bytes);
+            if(!val_array)
+                return rocblas_status_memory_error;
+            memset(val_array, 0, val_bytes);
 
             if(is_strided)
             {
                 // data is strided; batch_array not needed
-                batch_array = nullptr;
 
                 // read data to val_array
                 if(batch_count == 1 || stride == dim)
@@ -182,6 +213,9 @@ struct rocsolver_hybrid_array
                 // data is batched; read device pointers into batch_array
                 size_t batch_bytes = sizeof(T*) * batch_count;
                 batch_array = (T**)malloc(batch_bytes);
+                if(!batch_array)
+                    return rocblas_status_memory_error;
+                memset(batch_array, 0, batch_bytes);
                 HIP_CHECK(
                     hipMemcpyAsync(batch_array, array, batch_bytes, hipMemcpyDeviceToHost, stream));
                 HIP_CHECK(hipStreamSynchronize(stream));
@@ -197,11 +231,8 @@ struct rocsolver_hybrid_array
         else
         {
             // data on host; use src_array directly
-            val_array = nullptr;
 
-            if(is_strided)
-                batch_array = nullptr;
-            else
+            if(!is_strided)
                 batch_array = (T**)src_array;
         }
 
@@ -215,6 +246,8 @@ struct rocsolver_hybrid_array
             return rocblas_status_internal_error;
         if(dim < 0)
             return rocblas_status_internal_error;
+        if(dim == 0)
+            return rocblas_status_success;
 
         if(val_array)
         {

--- a/library/src/include/rocsolver_hybrid_storage.hpp
+++ b/library/src/include/rocsolver_hybrid_storage.hpp
@@ -31,6 +31,12 @@
 #include "lib_host_helpers.hpp"
 #include "rocsolver/rocsolver.h"
 
+#ifdef _WIN32
+#include <malloc.h>
+#else
+#include <stdlib.h>
+#endif
+
 ROCSOLVER_BEGIN_NAMESPACE
 
 /* ROCSOLVER_HYBRID_STORAGE provides a wrapper for data arrays that is intended to simplify host memory
@@ -82,12 +88,20 @@ struct rocsolver_hybrid_storage
         if(val_array)
         {
             memset(val_array, 0, sizeof(T) * this->dim * this->batch_count);
+#ifdef _WIN32
+            _aligned_free(val_array);
+#else
             free(val_array);
+#endif
         }
         if(batch_array && (val_array || this->dim < 0))
         {
             memset(batch_array, 0, sizeof(T*) * this->batch_count);
+#ifdef _WIN32
+            _aligned_free(batch_array);
+#else
             free(batch_array);
+#endif
         }
     }
 
@@ -98,13 +112,21 @@ struct rocsolver_hybrid_storage
         if(val_array)
         {
             memset(val_array, 0, sizeof(T) * this->dim * this->batch_count);
+#ifdef _WIN32
+            _aligned_free(val_array);
+#else
             free(val_array);
+#endif
             val_array = nullptr;
         }
         if(batch_array && (val_array || this->dim < 0))
         {
             memset(batch_array, 0, sizeof(T*) * this->batch_count);
+#ifdef _WIN32
+            _aligned_free(batch_array);
+#else
             free(batch_array);
+#endif
             batch_array = nullptr;
         }
 
@@ -124,9 +146,14 @@ struct rocsolver_hybrid_storage
             {
                 // data is batched; read device pointers into batch_array
                 size_t batch_bytes = sizeof(T*) * batch_count;
-                batch_array = (T**)malloc(batch_bytes);
+#ifdef _WIN32
+                batch_array = (T**)_aligned_malloc(batch_bytes, sizeof(void*));
                 if(!batch_array)
                     return rocblas_status_memory_error;
+#else
+                if(posix_memalign((void**)&batch_array, sizeof(void*), batch_bytes) != 0)
+                    return rocblas_status_memory_error;
+#endif
                 memset(batch_array, 0, batch_bytes);
                 HIP_CHECK(
                     hipMemcpyAsync(batch_array, array, batch_bytes, hipMemcpyDeviceToHost, stream));
@@ -150,13 +177,21 @@ struct rocsolver_hybrid_storage
         if(val_array)
         {
             memset(val_array, 0, sizeof(T) * this->dim * this->batch_count);
+#ifdef _WIN32
+            _aligned_free(val_array);
+#else
             free(val_array);
+#endif
             val_array = nullptr;
         }
         if(batch_array && (val_array || this->dim < 0))
         {
             memset(batch_array, 0, sizeof(T*) * this->batch_count);
+#ifdef _WIN32
+            _aligned_free(batch_array);
+#else
             free(batch_array);
+#endif
             batch_array = nullptr;
         }
 
@@ -184,9 +219,14 @@ struct rocsolver_hybrid_storage
             // allocate space on host for data from device
             size_t dim_bytes = sizeof(T) * dim;
             size_t val_bytes = sizeof(T) * dim * batch_count;
-            val_array = (T*)malloc(val_bytes);
+#ifdef _WIN32
+            val_array = (T**)_aligned_malloc(val_bytes, sizeof(void*));
             if(!val_array)
                 return rocblas_status_memory_error;
+#else
+            if(posix_memalign((void**)&val_array, sizeof(void*), val_bytes) != 0)
+                return rocblas_status_memory_error;
+#endif
             memset(val_array, 0, val_bytes);
 
             if(is_strided)
@@ -212,9 +252,14 @@ struct rocsolver_hybrid_storage
             {
                 // data is batched; read device pointers into batch_array
                 size_t batch_bytes = sizeof(T*) * batch_count;
-                batch_array = (T**)malloc(batch_bytes);
+#ifdef _WIN32
+                batch_array = (T**)_aligned_malloc(batch_bytes, sizeof(void*));
                 if(!batch_array)
                     return rocblas_status_memory_error;
+#else
+                if(posix_memalign((void**)&batch_array, sizeof(void*), batch_bytes) != 0)
+                    return rocblas_status_memory_error;
+#endif
                 memset(batch_array, 0, batch_bytes);
                 HIP_CHECK(
                     hipMemcpyAsync(batch_array, array, batch_bytes, hipMemcpyDeviceToHost, stream));

--- a/library/src/include/rocsolver_hybrid_storage.hpp
+++ b/library/src/include/rocsolver_hybrid_storage.hpp
@@ -220,7 +220,7 @@ struct rocsolver_hybrid_storage
             size_t dim_bytes = sizeof(T) * dim;
             size_t val_bytes = sizeof(T) * dim * batch_count;
 #ifdef _WIN32
-            val_array = (T**)_aligned_malloc(val_bytes, sizeof(void*));
+            val_array = (T*)_aligned_malloc(val_bytes, sizeof(void*));
             if(!val_array)
                 return rocblas_status_memory_error;
 #else


### PR DESCRIPTION
This is a revamp of https://github.com/ROCm/rocSOLVER/pull/462 using the new hybrid infrastructure that was introduced for GESVD. Here's a brief summary of changes:

- Added CPU execution path for STERF. Tests for STERF_HYBRID and SYEV_HYBRID have been added to verify correctness.
- Rearranged functions in lib_device_helpers, so that device functions are no longer present in the kernels section.
- is_device_pointer has been moved from a lambda function to a reusable function in lib_host_helpers.
- Created a new class, rocsolver_hybrid_array, to assist with memory allocation and data transfers to and from the device. I have revised rocsolver_bdsqr_host_batch_template to use this new functionality.