### PR TITLE
Reduced memory usage for SYEVD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
 ### Removed
 ### Optimized
 
-* Reduced device memory requirements for STEDC, SYEVD/HEEVD, and SYGVD/HEGVD
+* Reduced the device memory requirements for STEDC, SYEVD/HEEVD, and SYGVD/HEGVD
 
 ### Resolved issues
 ### Known issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
 ### Changed
 ### Removed
 ### Optimized
+
+* Reduced device memory requirements for STEDC, SYEVD/HEEVD, and SYGVD/HEGVD
+
 ### Resolved issues
 ### Known issues
 ### Upcoming changes
@@ -22,7 +25,7 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
 * Algorithm selection mechanism for hybrid computation
 * Hybrid computation support for existing routines:
     - BDSQR
-    - GESVD  
+    - GESVD
 
 ### Optimized
 

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -2195,10 +2195,10 @@ void rocsolver_stedc_getMemorySize(const rocblas_evect evect,
 
         // extra requirements for original eigenvectors of small independent blocks
         if(evect != rocblas_evect_tridiagonal)
-            *size_tempvect = (n * n) * batch_count * sizeof(S);
+            *size_tempvect = sizeof(S) * (n * n) * batch_count;
         else
             *size_tempvect = 0;
-        *size_tempgemm = 2 * (n * n) * batch_count * sizeof(S);
+        *size_tempgemm = sizeof(S) * 2 * (n * n) * batch_count;
         if(BATCHED && !COMPLEX)
             *size_workArr = sizeof(S*) * batch_count;
         else

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -2044,9 +2044,9 @@ void local_gemm(rocblas_handle handle,
                 S* B,
                 S* temp,
                 S* work,
-                const rocblas_int shiftT,
-                const rocblas_int ldt,
-                const rocblas_stride strideT,
+                const rocblas_int shiftV,
+                const rocblas_int ldv,
+                const rocblas_stride strideV,
                 const rocblas_int batch_count,
                 S** workArr)
 {
@@ -2061,7 +2061,7 @@ void local_gemm(rocblas_handle handle,
 
     // temp = A*B
     rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, n, n, n, &one, A, shiftA,
-                   lda, strideA, B, shiftT, ldt, strideT, &zero, temp, shiftT, ldt, strideT,
+                   lda, strideA, B, shiftV, ldv, strideV, &zero, temp, shiftV, ldv, strideV,
                    batch_count, workArr);
 
     // A = temp
@@ -2089,9 +2089,9 @@ void local_gemm(rocblas_handle handle,
                 S* B,
                 S* temp,
                 S* work,
-                const rocblas_int shiftT,
-                const rocblas_int ldt,
-                const rocblas_stride strideT,
+                const rocblas_int shiftV,
+                const rocblas_int ldv,
+                const rocblas_stride strideV,
                 const rocblas_int batch_count,
                 S** workArr)
 {
@@ -2108,34 +2108,32 @@ void local_gemm(rocblas_handle handle,
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
     rocblas_int blocks = (n - 1) / BS2 + 1;
-    ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, S, true>), dim3(blocks, blocks, batch_count),
-                            dim3(BS2, BS2), 0, stream, copymat_to_buffer, n, n, A, shiftA, lda,
-                            strideA, work, rocblas_fill_full);
+    ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, S, true>), dim3(blocks, blocks, batch_count), dim3(BS2, BS2),
+                            0, stream, copymat_to_buffer, n, n, A, shiftA, lda, strideA, work);
 
     // temp = work*B
     rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, n, n, n, &one, work,
-                   shiftT, ldt, strideT, B, shiftT, ldt, strideT, &zero, temp, shiftT, ldt, strideT,
+                   shiftV, ldv, strideV, B, shiftV, ldv, strideV, &zero, temp, shiftV, ldv, strideV,
                    batch_count, workArr);
 
     // real(A) = temp
-    ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, S, true>), dim3(blocks, blocks, batch_count),
-                            dim3(BS2, BS2), 0, stream, copymat_from_buffer, n, n, A, shiftA, lda,
-                            strideA, temp, rocblas_fill_full);
+    ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, S, true>), dim3(blocks, blocks, batch_count), dim3(BS2, BS2),
+                            0, stream, copymat_from_buffer, n, n, A, shiftA, lda, strideA, temp);
 
     // work = imag(A)
     ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, S, false>), dim3(blocks, blocks, batch_count),
                             dim3(BS2, BS2), 0, stream, copymat_to_buffer, n, n, A, shiftA, lda,
-                            strideA, work, rocblas_fill_full);
+                            strideA, work);
 
     // temp = work*B
     rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, n, n, n, &one, work,
-                   shiftT, ldt, strideT, B, shiftT, ldt, strideT, &zero, temp, shiftT, ldt, strideT,
+                   shiftV, ldv, strideV, B, shiftV, ldv, strideV, &zero, temp, shiftV, ldv, strideV,
                    batch_count, workArr);
 
     // imag(A) = temp
     ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, S, false>), dim3(blocks, blocks, batch_count),
                             dim3(BS2, BS2), 0, stream, copymat_from_buffer, n, n, A, shiftA, lda,
-                            strideA, temp, rocblas_fill_full);
+                            strideA, temp);
 
     rocblas_set_pointer_mode(handle, old_mode);
 }
@@ -2196,7 +2194,10 @@ void rocsolver_stedc_getMemorySize(const rocblas_evect evect,
         rocsolver_steqr_getMemorySize<T, S>(evect, n, batch_count, size_work_stack);
 
         // extra requirements for original eigenvectors of small independent blocks
-        *size_tempvect = (n * n) * batch_count * sizeof(S);
+        if(evect != rocblas_evect_tridiagonal)
+            *size_tempvect = (n * n) * batch_count * sizeof(S);
+        else
+            *size_tempvect = 0;
         *size_tempgemm = 2 * (n * n) * batch_count * sizeof(S);
         if(BATCHED && !COMPLEX)
             *size_workArr = sizeof(S*) * batch_count;
@@ -2323,16 +2324,20 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         ssfmax = sqrt(ssfmax) / S(3.0);
         rocblas_int blocksn = (n - 1) / BS2 + 1;
 
-        // initialize identity matrix in C if required
+        // initialize identity matrix in V
+        // if evect is tridiagonal we can store V directly in C
+        // otherwise, they must be kept separate to compute C*V
+        S* V = tempvect;
+        rocblas_int ldv = n;
+        rocblas_stride strideV = n * n;
         if(evect == rocblas_evect_tridiagonal)
-            ROCSOLVER_LAUNCH_KERNEL(init_ident<T>, dim3(blocksn, blocksn, batch_count),
-                                    dim3(BS2, BS2), 0, stream, n, n, C, shiftC, ldc, strideC);
-
-        // initialize identity matrix in tempvect
-        rocblas_int ldt = n;
-        rocblas_stride strideT = n * n;
+        {
+            V = (S*)(C + shiftC);
+            ldv = (rocblas_int)(sizeof(T) / sizeof(S)) * ldc;
+            strideV = (rocblas_int)(sizeof(T) / sizeof(S)) * strideC;
+        }
         ROCSOLVER_LAUNCH_KERNEL(init_ident<S>, dim3(blocksn, blocksn, batch_count), dim3(BS2, BS2),
-                                0, stream, n, n, tempvect, 0, ldt, strideT);
+                                0, stream, n, n, V, 0, ldv, strideV);
 
         // find max number of sub-blocks to consider during the divide phase
         rocblas_int maxlevs = stedc_num_levels<rocsolver_stedc_mode_qr>(n);
@@ -2352,8 +2357,8 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         //-----------------------------
         ROCSOLVER_LAUNCH_KERNEL((stedc_solve_kernel<S>),
                                 dim3(maxblks, STEDC_NUM_SPLIT_BLKS, batch_count), dim3(1), 0,
-                                stream, n, D + shiftD, strideD, E + shiftE, strideE, tempvect, 0,
-                                ldt, strideT, info, (S*)work_stack, splits, eps, ssfmin, ssfmax);
+                                stream, n, D + shiftD, strideD, E + shiftE, strideE, V, 0, ldv,
+                                strideV, info, (S*)work_stack, splits, eps, ssfmin, ssfmax);
 
         // 3. merge phase
         //----------------
@@ -2372,8 +2377,8 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_kernel<rocsolver_stedc_mode_qr, S>),
                                     dim3(numgrps2, STEDC_NUM_SPLIT_BLKS, batch_count),
                                     dim3(STEDC_BDIM), lmemsize1, stream, k, n, D + shiftD, strideD,
-                                    E + shiftE, strideE, tempvect, 0, ldt, strideT, tmpz, tempgemm,
-                                    splits, eps);
+                                    E + shiftE, strideE, V, 0, ldv, strideV, tmpz, tempgemm, splits,
+                                    eps);
 
             // b. solve to find merged eigen values
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_kernel<rocsolver_stedc_mode_qr, S>),
@@ -2385,21 +2390,40 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeVectors_kernel<rocsolver_stedc_mode_qr, S>),
                                     dim3(numgrps3, STEDC_NUM_SPLIT_BLKS, batch_count),
                                     dim3(STEDC_BDIM), lmemsize3, stream, k, n, D + shiftD, strideD,
-                                    E + shiftE, strideE, tempvect, 0, ldt, strideT, tmpz, tempgemm,
-                                    splits);
+                                    E + shiftE, strideE, V, 0, ldv, strideV, tmpz, tempgemm, splits);
 
             // c. update level
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeUpdate_kernel<rocsolver_stedc_mode_qr, S>),
                                     dim3(numgrps3, STEDC_NUM_SPLIT_BLKS, batch_count),
                                     dim3(STEDC_BDIM), lmemsize3, stream, k, n, D + shiftD, strideD,
-                                    tempvect, 0, ldt, strideT, tmpz, tempgemm, splits);
+                                    V, 0, ldv, strideV, tmpz, tempgemm, splits);
         }
 
         // 4. update and sort
         //----------------------
-        // eigenvectors C <- C*tempvect
-        local_gemm<BATCHED, STRIDED, T>(handle, n, C, shiftC, ldc, strideC, tempvect, tempgemm,
-                                        tempgemm + strideT, 0, ldt, strideT, batch_count, workArr);
+        if(evect != rocblas_evect_tridiagonal)
+        {
+            // eigenvectors C <- C*V
+            local_gemm<BATCHED, STRIDED, T>(handle, n, C, shiftC, ldc, strideC, V, tempgemm,
+                                            tempgemm + strideV, 0, ldv, strideV, batch_count,
+                                            workArr);
+        }
+        else if constexpr(rocblas_is_complex<T>)
+        {
+            // V is stored in C but is of type S; need to convert to type T
+            // tempgemm = V
+            ROCSOLVER_LAUNCH_KERNEL(copy_mat<S>, dim3(blocksn, blocksn, batch_count), dim3(BS2, BS2),
+                                    0, stream, copymat_to_buffer, n, n, V, 0, ldv, strideV, tempgemm);
+
+            // imag(C) = zeros
+            ROCSOLVER_LAUNCH_KERNEL(set_zero<T>, dim3(blocksn, blocksn, batch_count),
+                                    dim3(BS2, BS2), 0, stream, n, n, C, shiftC, ldc, strideC);
+
+            // real(C) = tempgemm
+            ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, S, true>), dim3(blocksn, blocksn, batch_count),
+                                    dim3(BS2, BS2), 0, stream, copymat_from_buffer, n, n, C, shiftC,
+                                    ldc, strideC, tempgemm);
+        }
 
         // finally sort eigenvalues and eigenvectors
         auto const nblocks = batch_count;

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -2192,23 +2192,16 @@ void rocsolver_stedc_getMemorySize(const rocblas_evect evect,
     // otherwise use divide and conquer algorithm:
     else
     {
-        size_t s1, s2;
-
         // requirements for solver of small independent blocks
-        rocsolver_steqr_getMemorySize<T, S>(evect, n, batch_count, &s1);
+        rocsolver_steqr_getMemorySize<T, S>(evect, n, batch_count, size_work_stack);
 
         // extra requirements for original eigenvectors of small independent blocks
         *size_tempvect = (n * n) * batch_count * sizeof(S);
         *size_tempgemm = 2 * (n * n) * batch_count * sizeof(S);
-        if(COMPLEX)
-            s2 = n * n * batch_count * sizeof(S);
-        else
-            s2 = 0;
         if(BATCHED && !COMPLEX)
             *size_workArr = sizeof(S*) * batch_count;
         else
             *size_workArr = 0;
-        *size_work_stack = std::max(s1, s2);
 
         // size for split blocks and sub-blocks positions
         *size_splits_map = sizeof(rocblas_int) * (5 * n + 2) * batch_count;
@@ -2406,8 +2399,7 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         //----------------------
         // eigenvectors C <- C*tempvect
         local_gemm<BATCHED, STRIDED, T>(handle, n, C, shiftC, ldc, strideC, tempvect, tempgemm,
-                                        static_cast<S*>(work_stack), 0, ldt, strideT, batch_count,
-                                        workArr);
+                                        tempgemm + strideT, 0, ldt, strideT, batch_count, workArr);
 
         // finally sort eigenvalues and eigenvectors
         auto const nblocks = batch_count;

--- a/library/src/lapack/roclapack_syevd_heevd.hpp
+++ b/library/src/lapack/roclapack_syevd_heevd.hpp
@@ -86,12 +86,12 @@ void rocsolver_syevd_heevd_getMemorySize(const rocblas_evect evect,
     if(evect == rocblas_evect_original)
     {
         // extra requirements for computing eigenvalues and vectors (stedc)
-        rocsolver_stedc_getMemorySize<BATCHED, T, S>(rocblas_evect_tridiagonal, n, batch_count, &w12,
-                                                     &w22, &w31, size_tmpz, size_splits, &unused);
+        rocsolver_stedc_getMemorySize<BATCHED, T, S>(rocblas_evect_tridiagonal, n, batch_count, &w31,
+                                                     &w22, &w12, size_tmpz, size_splits, &unused);
 
         // extra requirements for ormtr/unmtr
         rocsolver_ormtr_unmtr_getMemorySize<BATCHED, T>(rocblas_side_left, uplo, n, n, batch_count,
-                                                        &unused, &w13, &w23, &w32, &unused);
+                                                        &unused, &w23, &w13, &w32, &unused);
 
         *size_work3 = std::max(w31, w32);
     }
@@ -198,11 +198,11 @@ rocblas_status rocsolver_syevd_heevd_template(rocblas_handle handle,
 
         rocsolver_stedc_template<false, ISBATCHED, T>(
             handle, rocblas_evect_tridiagonal, n, D, 0, strideD, E, 0, strideE, tmptau_W, 0, ldw,
-            strideW, info, batch_count, work1, (S*)work2, (S*)work3, tmpz, splits, (S**)workArr);
+            strideW, info, batch_count, work3, (S*)work2, (S*)work1, tmpz, splits, (S**)workArr);
 
         rocsolver_ormtr_unmtr_template<BATCHED, STRIDED>(
             handle, rocblas_side_left, uplo, rocblas_operation_none, n, n, A, shiftA, lda, strideA,
-            tau, n, tmptau_W, 0, ldw, strideW, batch_count, scalars, (T*)work1, (T*)work2,
+            tau, n, tmptau_W, 0, ldw, strideW, batch_count, scalars, (T*)work2, (T*)work1,
             (T*)work3, workArr);
 
         // copy matrix product into A

--- a/library/src/lapack/roclapack_sytrd_hetrd.hpp
+++ b/library/src/lapack/roclapack_sytrd_hetrd.hpp
@@ -59,7 +59,7 @@ void rocsolver_sytrd_hetrd_getMemorySize(const rocblas_int n,
         return;
     }
 
-    size_t s1 = 0, s2;
+    size_t s1 = 0, s2 = 0;
 
     // size required to store temporary matrix W
     if(n > xxTRD_xxTD2_SWITCHSIZE)


### PR DESCRIPTION
This PR reduces the amount of memory required by SYEVD by about 1/4 in the real case and 2/5 in the complex case. It should result in a slight performance boost as well.

In STEDC, when evect is tridiagonal (which is how SYEVD always calls STEDC), the original code initializes C to the identity and then later uses local_gemm to compute C <- C*tempvect. But, since C is the identity, this is a do-nothing operation. I've changed it so that this case will skip the local_gemm and won't allocate tempvect (an n*n matrix), instead writing to C directly.