### PR TITLE
Fix Windows CI interaction with GitHub labels

### DIFF
--- a/rmake.py
+++ b/rmake.py
@@ -48,6 +48,8 @@ def parse_args():
                         help='Set GPU architectures to build for (optional)')
     parser.add_argument(      '--ci_labels', nargs='?', type=str, required=False, default="",
                         help='Semicolon (";") separated list of GitHub Labels with build options (not implemented, silently ignored)')
+    parser.add_argument(      '--ci_gfx', nargs='?', type=str, required=False, default="",
+                        help='Semicolon (";") separated list of gfx targets expected on test runs (not implemented, silently ignored)')
 
     return parser.parse_args()
 

--- a/rmake.py
+++ b/rmake.py
@@ -46,6 +46,8 @@ def parse_args():
                         help='Specify path to an existing rocSOLVER install directory (optional, default: /opt/rocm/rocsolver)')
     parser.add_argument('-a', '--architecture', dest='gpu_architecture', type=str, required=False, default=None,
                         help='Set GPU architectures to build for (optional)')
+    parser.add_argument(      '--ci_labels', nargs='?', type=str, required=False, default="",
+                        help='Semicolon (";") separated list of GitHub Labels with build options (not implemented, silently ignored)')
 
     return parser.parse_args()
 

--- a/rtest.py
+++ b/rtest.py
@@ -65,6 +65,8 @@ def parse_args():
                         help='Return as if test failed (optional, default: false)')
     # parser.add_argument('-v', '--verbose', required=False, default = False, action='store_true',
     #                     help='Verbose install (optional, default: False)')
+    parser.add_argument(      '--ci_labels', nargs='?', type=str, required=False, default="",
+                        help='Semicolon (";") separated list of GitHub Labels with test options (not implemented, silently ignored)')
     args = parser.parse_args()
 
     if not (args.test or args.emulation):

--- a/rtest.py
+++ b/rtest.py
@@ -67,6 +67,8 @@ def parse_args():
     #                     help='Verbose install (optional, default: False)')
     parser.add_argument(      '--ci_labels', nargs='?', type=str, required=False, default="",
                         help='Semicolon (";") separated list of GitHub Labels with test options (not implemented, silently ignored)')
+    parser.add_argument(      '--ci_gfx', nargs='?', type=str, required=False, default="",
+                        help='Semicolon (";") separated list of gfx targets expected on test runs (not implemented, silently ignored)')
     args = parser.parse_args()
 
     if not (args.test or args.emulation):


### PR DESCRIPTION
Windows CI may pass the `--ci_labels` flag to `rmake.py` and `rtest.py` when GitHub labels are selected, but this flag is not recognized by those Python scripts, which leads to runtime errors.  After this change is applied, `rmake.py` and `rtests.py` will silently ignore the `ci_labels` flag, thus preventing such errors.

Update: added similar code to handle upcoming `ci_gfx` flag.