### PR TITLE
Fix tolerance for HEGVDX tests

### DIFF
--- a/clients/common/lapack/testing_sygvdx_hegvdx.hpp
+++ b/clients/common/lapack/testing_sygvdx_hegvdx.hpp
@@ -1108,9 +1108,9 @@ void testing_sygvdx_hegvdx(Arguments& argus)
     }
 
     // validate results for rocsolver-test
-    // using 4 * n * machine_precision as tolerance
+    // using 5 * n * machine_precision as tolerance
     if(argus.unit_check)
-        ROCSOLVER_TEST_CHECK(T, max_error, 4 * n);
+        ROCSOLVER_TEST_CHECK(T, max_error, 5 * n);
 
     // output results for rocsolver-bench
     if(argus.timing)


### PR DESCRIPTION
As part of PR #810, the tolerances for `sygvdx` and `hegvdx` tests were set too tight, which made a few of `hegvdx`' tests fail.

This PR changes the tolerance to allow all tests to pass on all architectures (some tests will only pass by a tiny margin).