### PR TITLE
Cherry-pick to docs/6.3.2: Fix three broken links to rocBLAS and netlib

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@
 rocSOLVER documentation
 ********************************************************************
 
-rocSOLVER is an implementation of `LAPACK routines <https://www.netlib.org/lapack/explore-html/modules.html>`_ 
+rocSOLVER is an implementation of `LAPACK routines <https://www.netlib.org/lapack/index.html>`_
 on top of the :doc:`AMD ROCm platform <rocm:index>`. rocSOLVER is implemented in the
 :doc:`HIP programming language <hip:index>` and optimized for AMD GPUs.
 

--- a/docs/reference/deprecated.rst
+++ b/docs/reference/deprecated.rst
@@ -9,8 +9,8 @@ Deprecated rocSOLVER components
 ********************************
 
 Originally, rocSOLVER maintained its own types and helpers as aliases to those of rocBLAS.
-These aliases are now deprecated. See the `rocBLAS types <https://rocm.docs.amd.com/projects/rocBLAS/en/latest/API_Reference_Guide.html#rocblas-datatypes>`_
-and `rocBLAS auxiliary functions <https://rocm.docs.amd.com/projects/rocBLAS/en/latest/API_Reference_Guide.html#auxiliary-functions>`_
+These aliases are now deprecated. See the :doc:`rocBLAS types <rocblas:reference/datatypes>`
+and :doc:`rocBLAS auxiliary functions <rocblas:reference/helper-functions>`
 documentation for information on the suggested replacements.
 
 * Deprecated :ref:`deptypes`.


### PR DESCRIPTION
Fix three broken links

Cherry-picked from develop but had to resolve a merge conflict.