### PR TITLE
Remove support for gfx940, gfx941

### DIFF
--- a/library/src/specialized/roclapack_trsm_specialized_kernels.hpp
+++ b/library/src/specialized/roclapack_trsm_specialized_kernels.hpp
@@ -859,14 +859,6 @@ rocblas_status rocsolver_trsm_lower(rocblas_handle handle,
     }
 #endif
 
-    // TODO: Some architectures require synchronization between rocSOLVER and rocBLAS kernels; more investigation needed
-    int device;
-    HIP_CHECK(hipGetDevice(&device));
-    hipDeviceProp_t deviceProperties;
-    HIP_CHECK(hipGetDeviceProperties(&deviceProperties, device));
-    std::string deviceFullString(deviceProperties.gcnArchName);
-    std::string deviceString = deviceFullString.substr(0, deviceFullString.find(":"));
-
     // ****** MAIN LOOP ***********
     if(isleft)
     {
@@ -1129,14 +1121,6 @@ rocblas_status rocsolver_trsm_upper(rocblas_handle handle,
                                 optim_mem, work1, work2, work3, work4);
     }
 #endif
-
-    // TODO: Some architectures require synchronization between rocSOLVER and rocBLAS kernels; more investigation needed
-    int device;
-    HIP_CHECK(hipGetDevice(&device));
-    hipDeviceProp_t deviceProperties;
-    HIP_CHECK(hipGetDeviceProperties(&deviceProperties, device));
-    std::string deviceFullString(deviceProperties.gcnArchName);
-    std::string deviceString = deviceFullString.substr(0, deviceFullString.find(":"));
 
     // ****** MAIN LOOP ***********
     if(isleft)

--- a/library/src/specialized/roclapack_trsm_specialized_kernels.hpp
+++ b/library/src/specialized/roclapack_trsm_specialized_kernels.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -866,8 +866,6 @@ rocblas_status rocsolver_trsm_lower(rocblas_handle handle,
     HIP_CHECK(hipGetDeviceProperties(&deviceProperties, device));
     std::string deviceFullString(deviceProperties.gcnArchName);
     std::string deviceString = deviceFullString.substr(0, deviceFullString.find(":"));
-    bool do_sync = (deviceString.find("gfx940") != std::string::npos
-                    || deviceString.find("gfx941") != std::string::npos);
 
     // ****** MAIN LOOP ***********
     if(isleft)
@@ -897,9 +895,6 @@ rocblas_status rocsolver_trsm_lower(rocblas_handle handle,
                 offA = idx2D(j, j, inca, lda);
                 offB = idx2D(j, 0, incb, ldb);
                 FORWARD_SUBSTITUTIONS;
-
-                if(do_sync)
-                    HIP_CHECK(hipStreamSynchronize(stream));
 
                 // update right hand sides
                 ROCBLAS_CHECK(rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none,
@@ -941,9 +936,6 @@ rocblas_status rocsolver_trsm_lower(rocblas_handle handle,
                 offA = idx2D(m - nextpiv, m - nextpiv, inca, lda);
                 offB = idx2D(m - nextpiv, 0, incb, ldb);
                 BACKWARD_SUBSTITUTIONS;
-
-                if(do_sync)
-                    HIP_CHECK(hipStreamSynchronize(stream));
 
                 // update right hand sides
                 ROCBLAS_CHECK(rocsolver_gemm(
@@ -998,9 +990,6 @@ rocblas_status rocsolver_trsm_lower(rocblas_handle handle,
                 offB = idx2D(0, n - nextpiv, incb, ldb);
                 BACKWARD_SUBSTITUTIONS;
 
-                if(do_sync)
-                    HIP_CHECK(hipStreamSynchronize(stream));
-
                 // update left hand sides
                 ROCBLAS_CHECK(rocsolver_gemm(
                     handle, rocblas_operation_none, rocblas_operation_none, m, n - nextpiv, blk,
@@ -1040,9 +1029,6 @@ rocblas_status rocsolver_trsm_lower(rocblas_handle handle,
                 offA = idx2D(j, j, inca, lda);
                 offB = idx2D(0, j, incb, ldb);
                 FORWARD_SUBSTITUTIONS;
-
-                if(do_sync)
-                    HIP_CHECK(hipStreamSynchronize(stream));
 
                 // update left hand sides
                 ROCBLAS_CHECK(rocsolver_gemm(handle, rocblas_operation_none, trans, m, n - nextpiv,
@@ -1151,8 +1137,6 @@ rocblas_status rocsolver_trsm_upper(rocblas_handle handle,
     HIP_CHECK(hipGetDeviceProperties(&deviceProperties, device));
     std::string deviceFullString(deviceProperties.gcnArchName);
     std::string deviceString = deviceFullString.substr(0, deviceFullString.find(":"));
-    bool do_sync = (deviceString.find("gfx940") != std::string::npos
-                    || deviceString.find("gfx941") != std::string::npos);
 
     // ****** MAIN LOOP ***********
     if(isleft)
@@ -1182,9 +1166,6 @@ rocblas_status rocsolver_trsm_upper(rocblas_handle handle,
                 offA = idx2D(j, j, inca, lda);
                 offB = idx2D(j, 0, incb, ldb);
                 FORWARD_SUBSTITUTIONS;
-
-                if(do_sync)
-                    HIP_CHECK(hipStreamSynchronize(stream));
 
                 // update right hand sides
                 ROCBLAS_CHECK(rocsolver_gemm(handle, trans, rocblas_operation_none, m - nextpiv, n,
@@ -1226,9 +1207,6 @@ rocblas_status rocsolver_trsm_upper(rocblas_handle handle,
                 offA = idx2D(m - nextpiv, m - nextpiv, inca, lda);
                 offB = idx2D(m - nextpiv, 0, incb, ldb);
                 BACKWARD_SUBSTITUTIONS;
-
-                if(do_sync)
-                    HIP_CHECK(hipStreamSynchronize(stream));
 
                 // update right hand sides
                 ROCBLAS_CHECK(rocsolver_gemm(
@@ -1283,9 +1261,6 @@ rocblas_status rocsolver_trsm_upper(rocblas_handle handle,
                 offB = idx2D(0, n - nextpiv, incb, ldb);
                 BACKWARD_SUBSTITUTIONS;
 
-                if(do_sync)
-                    HIP_CHECK(hipStreamSynchronize(stream));
-
                 // update left hand sides
                 ROCBLAS_CHECK(rocsolver_gemm(
                     handle, rocblas_operation_none, trans, m, n - nextpiv, blk, &minone, B,
@@ -1325,9 +1300,6 @@ rocblas_status rocsolver_trsm_upper(rocblas_handle handle,
                 offA = idx2D(j, j, inca, lda);
                 offB = idx2D(0, j, incb, ldb);
                 FORWARD_SUBSTITUTIONS;
-
-                if(do_sync)
-                    HIP_CHECK(hipStreamSynchronize(stream));
 
                 // update left hand sides
                 ROCBLAS_CHECK(rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none,


### PR DESCRIPTION
Removes a switch needed for gfx940 and gfx941 as ROCm does not support those targets anymore.