### PR TITLE
Use stedc instead of sterf in syevd

### DIFF
--- a/clients/common/auxiliary/testing_bdsqr.hpp
+++ b/clients/common/auxiliary/testing_bdsqr.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -478,7 +478,7 @@ void testing_bdsqr(Arguments& argus)
     rocblas_fill uplo = char2rocblas_fill(uploC);
     rocblas_int hot_calls = argus.iters;
 
-    if(argus.alg_mode)
+    if(argus.alg_mode == 1)
     {
         EXPECT_ROCBLAS_STATUS(
             rocsolver_set_alg_mode(handle, rocsolver_function_bdsqr, rocsolver_alg_mode_hybrid),

--- a/clients/common/auxiliary/testing_sterf.hpp
+++ b/clients/common/auxiliary/testing_sterf.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -213,7 +213,7 @@ void testing_sterf(Arguments& argus)
 
     rocblas_int hot_calls = argus.iters;
 
-    if(argus.alg_mode)
+    if(argus.alg_mode == 1)
     {
         EXPECT_ROCBLAS_STATUS(
             rocsolver_set_alg_mode(handle, rocsolver_function_sterf, rocsolver_alg_mode_hybrid),

--- a/clients/common/lapack/testing_gesvd.hpp
+++ b/clients/common/lapack/testing_gesvd.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -548,7 +548,7 @@ void testing_gesvd(Arguments& argus)
     rocblas_int bc = argus.batch_count;
     rocblas_int hot_calls = argus.iters;
 
-    if(argus.alg_mode)
+    if(argus.alg_mode == 1)
     {
         EXPECT_ROCBLAS_STATUS(
             rocsolver_set_alg_mode(handle, rocsolver_function_gesvd, rocsolver_alg_mode_hybrid),

--- a/clients/common/lapack/testing_syev_heev.hpp
+++ b/clients/common/lapack/testing_syev_heev.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -398,7 +398,7 @@ void testing_syev_heev(Arguments& argus)
     rocblas_int bc = argus.batch_count;
     rocblas_int hot_calls = argus.iters;
 
-    if(argus.alg_mode)
+    if(argus.alg_mode == 1)
     {
         EXPECT_ROCBLAS_STATUS(
             rocsolver_set_alg_mode(handle, rocsolver_function_sterf, rocsolver_alg_mode_hybrid),

--- a/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/clients/common/lapack/testing_syevd_heevd.hpp
@@ -422,15 +422,15 @@ void testing_syevd_heevd(Arguments& argus)
     rocblas_int bc = argus.batch_count;
     rocblas_int hot_calls = argus.iters;
 
-    EXPECT_ROCBLAS_STATUS(
-        rocsolver_set_alg_mode(handle, rocsolver_function_sterf, rocsolver_alg_mode_hybrid),
-        rocblas_status_success);
+    // EXPECT_ROCBLAS_STATUS(
+    //     rocsolver_set_alg_mode(handle, rocsolver_function_sterf, rocsolver_alg_mode_hybrid),
+    //     rocblas_status_success);
 
-    rocsolver_alg_mode alg_mode;
-    EXPECT_ROCBLAS_STATUS(rocsolver_get_alg_mode(handle, rocsolver_function_sterf, &alg_mode),
-                          rocblas_status_success);
+    // rocsolver_alg_mode alg_mode;
+    // EXPECT_ROCBLAS_STATUS(rocsolver_get_alg_mode(handle, rocsolver_function_sterf, &alg_mode),
+    //                       rocblas_status_success);
 
-    EXPECT_EQ(alg_mode, rocsolver_alg_mode_hybrid);
+    // EXPECT_EQ(alg_mode, rocsolver_alg_mode_hybrid);
 
     // check non-supported values
     if(uplo == rocblas_fill_full || evect == rocblas_evect_tridiagonal)

--- a/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/clients/common/lapack/testing_syevd_heevd.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -421,6 +421,16 @@ void testing_syevd_heevd(Arguments& argus)
     rocblas_fill uplo = char2rocblas_fill(uploC);
     rocblas_int bc = argus.batch_count;
     rocblas_int hot_calls = argus.iters;
+
+    EXPECT_ROCBLAS_STATUS(
+        rocsolver_set_alg_mode(handle, rocsolver_function_sterf, rocsolver_alg_mode_hybrid),
+        rocblas_status_success);
+
+    rocsolver_alg_mode alg_mode;
+    EXPECT_ROCBLAS_STATUS(rocsolver_get_alg_mode(handle, rocsolver_function_sterf, &alg_mode),
+                          rocblas_status_success);
+
+    EXPECT_EQ(alg_mode, rocsolver_alg_mode_hybrid);
 
     // check non-supported values
     if(uplo == rocblas_fill_full || evect == rocblas_evect_tridiagonal)

--- a/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/clients/common/lapack/testing_syevd_heevd.hpp
@@ -422,7 +422,7 @@ void testing_syevd_heevd(Arguments& argus)
     rocblas_int bc = argus.batch_count;
     rocblas_int hot_calls = argus.iters;
 
-    if(argus.alg_mode)
+    if(argus.alg_mode == 1)
     {
         EXPECT_ROCBLAS_STATUS(
             rocsolver_set_alg_mode(handle, rocsolver_function_sterf, rocsolver_alg_mode_hybrid),

--- a/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/clients/common/lapack/testing_syevd_heevd.hpp
@@ -422,15 +422,18 @@ void testing_syevd_heevd(Arguments& argus)
     rocblas_int bc = argus.batch_count;
     rocblas_int hot_calls = argus.iters;
 
-    // EXPECT_ROCBLAS_STATUS(
-    //     rocsolver_set_alg_mode(handle, rocsolver_function_sterf, rocsolver_alg_mode_hybrid),
-    //     rocblas_status_success);
+    if(argus.alg_mode)
+    {
+        EXPECT_ROCBLAS_STATUS(
+            rocsolver_set_alg_mode(handle, rocsolver_function_sterf, rocsolver_alg_mode_hybrid),
+            rocblas_status_success);
 
-    // rocsolver_alg_mode alg_mode;
-    // EXPECT_ROCBLAS_STATUS(rocsolver_get_alg_mode(handle, rocsolver_function_sterf, &alg_mode),
-    //                       rocblas_status_success);
+        rocsolver_alg_mode alg_mode;
+        EXPECT_ROCBLAS_STATUS(rocsolver_get_alg_mode(handle, rocsolver_function_sterf, &alg_mode),
+                              rocblas_status_success);
 
-    // EXPECT_EQ(alg_mode, rocsolver_alg_mode_hybrid);
+        EXPECT_EQ(alg_mode, rocsolver_alg_mode_hybrid);
+    }
 
     // check non-supported values
     if(uplo == rocblas_fill_full || evect == rocblas_evect_tridiagonal)

--- a/clients/gtest/lapack/syevd_heevd_gtest.cpp
+++ b/clients/gtest/lapack/syevd_heevd_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -81,6 +81,7 @@ Arguments syevd_heevd_setup_arguments(syevd_heevd_tuple tup)
     return arg;
 }
 
+template <rocblas_int MODE>
 class SYEVD_HEEVD : public ::TestWithParam<syevd_heevd_tuple>
 {
 protected:
@@ -93,6 +94,7 @@ protected:
     void run_tests()
     {
         Arguments arg = syevd_heevd_setup_arguments(GetParam());
+        arg.alg_mode = MODE;
 
         if(arg.peek<rocblas_int>("n") == 0 && arg.peek<char>("evect") == 'N'
            && arg.peek<char>("uplo") == 'L')
@@ -103,11 +105,19 @@ protected:
     }
 };
 
-class SYEVD : public SYEVD_HEEVD
+class SYEVD : public SYEVD_HEEVD<0>
 {
 };
 
-class HEEVD : public SYEVD_HEEVD
+class HEEVD : public SYEVD_HEEVD<0>
+{
+};
+
+class SYEVD_HYBRID : public SYEVD_HEEVD<1>
+{
+};
+
+class HEEVD_HYBRID : public SYEVD_HEEVD<1>
 {
 };
 
@@ -129,6 +139,26 @@ TEST_P(HEEVD, __float_complex)
 }
 
 TEST_P(HEEVD, __double_complex)
+{
+    run_tests<false, false, rocblas_double_complex>();
+}
+
+TEST_P(SYEVD_HYBRID, __float)
+{
+    run_tests<false, false, float>();
+}
+
+TEST_P(SYEVD_HYBRID, __double)
+{
+    run_tests<false, false, double>();
+}
+
+TEST_P(HEEVD_HYBRID, __float_complex)
+{
+    run_tests<false, false, rocblas_float_complex>();
+}
+
+TEST_P(HEEVD_HYBRID, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
@@ -155,6 +185,26 @@ TEST_P(HEEVD, batched__double_complex)
     run_tests<true, true, rocblas_double_complex>();
 }
 
+TEST_P(SYEVD_HYBRID, batched__float)
+{
+    run_tests<true, true, float>();
+}
+
+TEST_P(SYEVD_HYBRID, batched__double)
+{
+    run_tests<true, true, double>();
+}
+
+TEST_P(HEEVD_HYBRID, batched__float_complex)
+{
+    run_tests<true, true, rocblas_float_complex>();
+}
+
+TEST_P(HEEVD_HYBRID, batched__double_complex)
+{
+    run_tests<true, true, rocblas_double_complex>();
+}
+
 // strided_batched tests
 
 TEST_P(SYEVD, strided_batched__float)
@@ -177,13 +227,49 @@ TEST_P(HEEVD, strided_batched__double_complex)
     run_tests<false, true, rocblas_double_complex>();
 }
 
+TEST_P(SYEVD_HYBRID, strided_batched__float)
+{
+    run_tests<false, true, float>();
+}
+
+TEST_P(SYEVD_HYBRID, strided_batched__double)
+{
+    run_tests<false, true, double>();
+}
+
+TEST_P(HEEVD_HYBRID, strided_batched__float_complex)
+{
+    run_tests<false, true, rocblas_float_complex>();
+}
+
+TEST_P(HEEVD_HYBRID, strided_batched__double_complex)
+{
+    run_tests<false, true, rocblas_double_complex>();
+}
+
 // daily_lapack tests normal execution with medium to large sizes
 INSTANTIATE_TEST_SUITE_P(daily_lapack, SYEVD, Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
 
 INSTANTIATE_TEST_SUITE_P(daily_lapack, HEEVD, Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(daily_lapack,
+                         SYEVD_HYBRID,
+                         Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(daily_lapack,
+                         HEEVD_HYBRID,
+                         Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
 
 // checkin_lapack tests normal execution with small sizes, invalid sizes,
 // quick returns, and corner cases
 INSTANTIATE_TEST_SUITE_P(checkin_lapack, SYEVD, Combine(ValuesIn(size_range), ValuesIn(op_range)));
 
 INSTANTIATE_TEST_SUITE_P(checkin_lapack, HEEVD, Combine(ValuesIn(size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+                         SYEVD_HYBRID,
+                         Combine(ValuesIn(size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+                         HEEVD_HYBRID,
+                         Combine(ValuesIn(size_range), ValuesIn(op_range)));

--- a/library/src/lapack/roclapack_syevd_heevd.cpp
+++ b/library/src/lapack/roclapack_syevd_heevd.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc.
  * *************************************************************************/
 
 #include "roclapack_syevd_heevd.hpp"
@@ -53,7 +53,7 @@ rocblas_status rocsolver_syevd_heevd_impl(rocblas_handle handle,
     size_t size_tau;
 
     rocsolver_syevd_heevd_getMemorySize<false, T, S>(
-        evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
+        handle, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
         &size_tmpz, &size_splits, &size_tmptau_W, &size_tau, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_syevd_heevd.hpp
+++ b/library/src/lapack/roclapack_syevd_heevd.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -83,7 +83,7 @@ void rocsolver_syevd_heevd_getMemorySize(const rocblas_evect evect,
     rocsolver_sytrd_hetrd_getMemorySize<BATCHED, T>(n, batch_count, size_scalars, &w11, &w21, &t1,
                                                     &unused);
 
-    if(evect == rocblas_evect_original)
+    // if(evect == rocblas_evect_original)
     {
         // extra requirements for computing eigenvalues and vectors (stedc)
         rocsolver_stedc_getMemorySize<BATCHED, T, S>(rocblas_evect_tridiagonal, n, batch_count, &w31,
@@ -95,15 +95,15 @@ void rocsolver_syevd_heevd_getMemorySize(const rocblas_evect evect,
 
         *size_work3 = std::max(w31, w32);
     }
-    else
-    {
-        // extra requirements for computing only the eigenvalues (sterf)
-        rocsolver_sterf_getMemorySize<T>(n, batch_count, &w12);
+    // else
+    // {
+    //     // extra requirements for computing only the eigenvalues (sterf)
+    //     rocsolver_sterf_getMemorySize<T>(n, batch_count, &w12);
 
-        *size_work3 = 0;
-        *size_tmpz = 0;
-        *size_splits = 0;
-    }
+    //     *size_work3 = 0;
+    //     *size_tmpz = 0;
+    //     *size_splits = 0;
+    // }
 
     // size of array for temporary matrix products
     t2 = sizeof(T) * n * n * batch_count;
@@ -184,13 +184,13 @@ rocblas_status rocsolver_syevd_heevd_template(rocblas_handle handle,
                                             strideE, tau, n, batch_count, scalars, (T*)work1,
                                             (T*)work2, tmptau_W, workArr);
 
-    if(evect != rocblas_evect_original)
-    {
-        // only compute eigenvalues
-        rocsolver_sterf_template<S>(handle, n, D, 0, strideD, E, 0, strideE, info, batch_count,
-                                    (rocblas_int*)work1);
-    }
-    else
+    // if(evect != rocblas_evect_original)
+    // {
+    //     // only compute eigenvalues
+    //     rocsolver_sterf_template<S>(handle, n, D, 0, strideD, E, 0, strideE, info, batch_count,
+    //                                 (rocblas_int*)work1);
+    // }
+    // else
     {
         constexpr bool ISBATCHED = BATCHED || STRIDED;
         const rocblas_int ldw = n;
@@ -200,16 +200,19 @@ rocblas_status rocsolver_syevd_heevd_template(rocblas_handle handle,
             handle, rocblas_evect_tridiagonal, n, D, 0, strideD, E, 0, strideE, tmptau_W, 0, ldw,
             strideW, info, batch_count, work3, (S*)work2, (S*)work1, tmpz, splits, (S**)workArr);
 
-        rocsolver_ormtr_unmtr_template<BATCHED, STRIDED>(
-            handle, rocblas_side_left, uplo, rocblas_operation_none, n, n, A, shiftA, lda, strideA,
-            tau, n, tmptau_W, 0, ldw, strideW, batch_count, scalars, (T*)work2, (T*)work1,
-            (T*)work3, workArr);
+        if(evect == rocblas_evect_original)
+        {
+            rocsolver_ormtr_unmtr_template<BATCHED, STRIDED>(
+                handle, rocblas_side_left, uplo, rocblas_operation_none, n, n, A, shiftA, lda,
+                strideA, tau, n, tmptau_W, 0, ldw, strideW, batch_count, scalars, (T*)work2,
+                (T*)work1, (T*)work3, workArr);
 
-        // copy matrix product into A
-        const rocblas_int copyblocks = (n - 1) / BS2 + 1;
-        ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(copyblocks, copyblocks, batch_count),
-                                dim3(BS2, BS2), 0, stream, n, n, tmptau_W, 0, ldw, strideW, A,
-                                shiftA, lda, strideA);
+            // copy matrix product into A
+            const rocblas_int copyblocks = (n - 1) / BS2 + 1;
+            ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(copyblocks, copyblocks, batch_count),
+                                    dim3(BS2, BS2), 0, stream, n, n, tmptau_W, 0, ldw, strideW, A,
+                                    shiftA, lda, strideA);
+        }
     }
 
     return rocblas_status_success;

--- a/library/src/lapack/roclapack_syevd_heevd.hpp
+++ b/library/src/lapack/roclapack_syevd_heevd.hpp
@@ -83,27 +83,16 @@ void rocsolver_syevd_heevd_getMemorySize(const rocblas_evect evect,
     rocsolver_sytrd_hetrd_getMemorySize<BATCHED, T>(n, batch_count, size_scalars, &w11, &w21, &t1,
                                                     &unused);
 
-    // if(evect == rocblas_evect_original)
-    {
-        // extra requirements for computing eigenvalues and vectors (stedc)
-        rocsolver_stedc_getMemorySize<BATCHED, T, S>(rocblas_evect_tridiagonal, n, batch_count, &w31,
-                                                     &w22, &w12, size_tmpz, size_splits, &unused);
+    // extra requirements for computing eigenvalues and vectors (stedc)
+    rocsolver_stedc_getMemorySize<BATCHED, T, S>(rocblas_evect_tridiagonal, n, batch_count, &w31,
+                                                 &w22, &w12, size_tmpz, size_splits, &unused);
 
+    if(evect == rocblas_evect_original)
+    {
         // extra requirements for ormtr/unmtr
         rocsolver_ormtr_unmtr_getMemorySize<BATCHED, T>(rocblas_side_left, uplo, n, n, batch_count,
                                                         &unused, &w23, &w13, &w32, &unused);
-
-        *size_work3 = std::max(w31, w32);
     }
-    // else
-    // {
-    //     // extra requirements for computing only the eigenvalues (sterf)
-    //     rocsolver_sterf_getMemorySize<T>(n, batch_count, &w12);
-
-    //     *size_work3 = 0;
-    //     *size_tmpz = 0;
-    //     *size_splits = 0;
-    // }
 
     // size of array for temporary matrix products
     t2 = sizeof(T) * n * n * batch_count;
@@ -111,6 +100,7 @@ void rocsolver_syevd_heevd_getMemorySize(const rocblas_evect evect,
     // get max values
     *size_work1 = std::max({w11, w12, w13});
     *size_work2 = std::max({w21, w22, w23});
+    *size_work3 = std::max(w31, w32);
     *size_tmptau_W = std::max(t1, t2);
 
     // size of array for temporary householder scalars
@@ -158,6 +148,9 @@ rocblas_status rocsolver_syevd_heevd_template(rocblas_handle handle,
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
 
+    rocsolver_alg_mode sterf_mode;
+    ROCBLAS_CHECK(rocsolver_get_alg_mode(handle, rocsolver_function_sterf, &sterf_mode));
+
     rocblas_int blocksReset = (batch_count - 1) / BS1 + 1;
     dim3 gridReset(blocksReset, 1, 1);
     dim3 threads(BS1, 1, 1);
@@ -184,13 +177,13 @@ rocblas_status rocsolver_syevd_heevd_template(rocblas_handle handle,
                                             strideE, tau, n, batch_count, scalars, (T*)work1,
                                             (T*)work2, tmptau_W, workArr);
 
-    // if(evect != rocblas_evect_original)
-    // {
-    //     // only compute eigenvalues
-    //     rocsolver_sterf_template<S>(handle, n, D, 0, strideD, E, 0, strideE, info, batch_count,
-    //                                 (rocblas_int*)work1);
-    // }
-    // else
+    if(sterf_mode == rocsolver_alg_mode_hybrid && evect != rocblas_evect_original)
+    {
+        // only compute eigenvalues
+        rocsolver_sterf_template<S>(handle, n, D, 0, strideD, E, 0, strideE, info, batch_count,
+                                    (rocblas_int*)work1);
+    }
+    else
     {
         constexpr bool ISBATCHED = BATCHED || STRIDED;
         const rocblas_int ldw = n;

--- a/library/src/lapack/roclapack_syevd_heevd.hpp
+++ b/library/src/lapack/roclapack_syevd_heevd.hpp
@@ -44,7 +44,8 @@ ROCSOLVER_BEGIN_NAMESPACE
 
 /** Helper to calculate workspace sizes **/
 template <bool BATCHED, typename T, typename S>
-void rocsolver_syevd_heevd_getMemorySize(const rocblas_evect evect,
+void rocsolver_syevd_heevd_getMemorySize(rocblas_handle handle,
+                                         const rocblas_evect evect,
                                          const rocblas_fill uplo,
                                          const rocblas_int n,
                                          const rocblas_int batch_count,
@@ -73,6 +74,9 @@ void rocsolver_syevd_heevd_getMemorySize(const rocblas_evect evect,
         return;
     }
 
+    rocsolver_alg_mode alg_mode;
+    rocsolver_get_alg_mode(handle, rocsolver_function_sterf, &alg_mode);
+
     size_t unused;
     size_t w11 = 0, w12 = 0, w13 = 0;
     size_t w21 = 0, w22 = 0, w23 = 0;
@@ -83,9 +87,17 @@ void rocsolver_syevd_heevd_getMemorySize(const rocblas_evect evect,
     rocsolver_sytrd_hetrd_getMemorySize<BATCHED, T>(n, batch_count, size_scalars, &w11, &w21, &t1,
                                                     &unused);
 
-    // extra requirements for computing eigenvalues and vectors (stedc)
-    rocsolver_stedc_getMemorySize<BATCHED, T, S>(rocblas_evect_tridiagonal, n, batch_count, &w31,
-                                                 &w22, &w12, size_tmpz, size_splits, &unused);
+    if(alg_mode != rocsolver_alg_mode_hybrid || evect == rocblas_evect_original)
+    {
+        // extra requirements for computing eigenvalues and vectors (stedc)
+        rocsolver_stedc_getMemorySize<BATCHED, T, S>(rocblas_evect_tridiagonal, n, batch_count, &w31,
+                                                     &w22, &w12, size_tmpz, size_splits, &unused);
+    }
+    else
+    {
+        *size_splits = 0;
+        *size_tmpz = 0;
+    }
 
     if(evect == rocblas_evect_original)
     {
@@ -179,12 +191,13 @@ rocblas_status rocsolver_syevd_heevd_template(rocblas_handle handle,
 
     if(sterf_mode == rocsolver_alg_mode_hybrid && evect != rocblas_evect_original)
     {
-        // only compute eigenvalues
+        // only in hybrid mode, compute eigenvalues using sterf
         rocsolver_sterf_template<S>(handle, n, D, 0, strideD, E, 0, strideE, info, batch_count,
                                     (rocblas_int*)work1);
     }
     else
     {
+        // for performance reasons, we use stedc to compute eigenvalues even if the eigenvectors are ignored
         constexpr bool ISBATCHED = BATCHED || STRIDED;
         const rocblas_int ldw = n;
         const rocblas_stride strideW = n * n;
@@ -193,6 +206,7 @@ rocblas_status rocsolver_syevd_heevd_template(rocblas_handle handle,
             handle, rocblas_evect_tridiagonal, n, D, 0, strideD, E, 0, strideE, tmptau_W, 0, ldw,
             strideW, info, batch_count, work3, (S*)work2, (S*)work1, tmpz, splits, (S**)workArr);
 
+        // update the eigenvectors (if applicable)
         if(evect == rocblas_evect_original)
         {
             rocsolver_ormtr_unmtr_template<BATCHED, STRIDED>(

--- a/library/src/lapack/roclapack_syevd_heevd_batched.cpp
+++ b/library/src/lapack/roclapack_syevd_heevd_batched.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -78,7 +78,7 @@ rocblas_status rocsolver_syevd_heevd_batched_impl(rocblas_handle handle,
     size_t size_tau;
 
     rocsolver_syevd_heevd_getMemorySize<true, T, S>(
-        evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
+        handle, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
         &size_tmpz, &size_splits, &size_tmptau_W, &size_tau, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_syevd_heevd_strided_batched.cpp
+++ b/library/src/lapack/roclapack_syevd_heevd_strided_batched.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -77,7 +77,7 @@ rocblas_status rocsolver_syevd_heevd_strided_batched_impl(rocblas_handle handle,
     size_t size_tau;
 
     rocsolver_syevd_heevd_getMemorySize<false, T, S>(
-        evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
+        handle, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
         &size_tmpz, &size_splits, &size_tmptau_W, &size_tau, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))

--- a/library/src/lapack/roclapack_sygvd_hegvd.cpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -80,9 +80,9 @@ rocblas_status rocsolver_sygvd_hegvd_impl(rocblas_handle handle,
     // size of temporary info array
     size_t size_iinfo;
     rocsolver_sygvd_hegvd_getMemorySize<false, false, T, S>(
-        itype, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
-        &size_work4, &size_tmpz, &size_splits, &size_tau, &size_pivots_workArr, &size_iinfo,
-        &optim_mem);
+        handle, itype, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2,
+        &size_work3, &size_work4, &size_tmpz, &size_splits, &size_tau, &size_pivots_workArr,
+        &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,

--- a/library/src/lapack/roclapack_sygvd_hegvd.hpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,7 +42,8 @@
 ROCSOLVER_BEGIN_NAMESPACE
 
 template <bool BATCHED, bool STRIDED, typename T, typename S>
-void rocsolver_sygvd_hegvd_getMemorySize(const rocblas_eform itype,
+void rocsolver_sygvd_hegvd_getMemorySize(rocblas_handle handle,
+                                         const rocblas_eform itype,
                                          const rocblas_evect evect,
                                          const rocblas_fill uplo,
                                          const rocblas_int n,
@@ -94,9 +95,9 @@ void rocsolver_sygvd_hegvd_getMemorySize(const rocblas_eform itype,
     *size_work4 = std::max(*size_work4, temp4);
 
     // requirements for calling SYEV/HEEV
-    rocsolver_syevd_heevd_getMemorySize<BATCHED, T, S>(evect, uplo, n, batch_count, &unused, &temp1,
-                                                       &temp2, &temp3, size_tmpz, size_splits,
-                                                       &temp4, size_tau, &temp5);
+    rocsolver_syevd_heevd_getMemorySize<BATCHED, T, S>(handle, evect, uplo, n, batch_count, &unused,
+                                                       &temp1, &temp2, &temp3, size_tmpz,
+                                                       size_splits, &temp4, size_tau, &temp5);
     *size_work1 = std::max(*size_work1, temp1);
     *size_work2 = std::max(*size_work2, temp2);
     *size_work3 = std::max(*size_work3, temp3);

--- a/library/src/lapack/roclapack_sygvd_hegvd_batched.cpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd_batched.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -81,9 +81,9 @@ rocblas_status rocsolver_sygvd_hegvd_batched_impl(rocblas_handle handle,
     // size of temporary info array
     size_t size_iinfo;
     rocsolver_sygvd_hegvd_getMemorySize<true, false, T, S>(
-        itype, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
-        &size_work4, &size_tmpz, &size_splits, &size_tau, &size_pivots_workArr, &size_iinfo,
-        &optim_mem);
+        handle, itype, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2,
+        &size_work3, &size_work4, &size_tmpz, &size_splits, &size_tau, &size_pivots_workArr,
+        &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,

--- a/library/src/lapack/roclapack_sygvd_hegvd_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sygvd_hegvd_strided_batched.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -79,9 +79,9 @@ rocblas_status rocsolver_sygvd_hegvd_strided_batched_impl(rocblas_handle handle,
     // size of temporary info array
     size_t size_iinfo;
     rocsolver_sygvd_hegvd_getMemorySize<false, true, T, S>(
-        itype, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
-        &size_work4, &size_tmpz, &size_splits, &size_tau, &size_pivots_workArr, &size_iinfo,
-        &optim_mem);
+        handle, itype, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2,
+        &size_work3, &size_work4, &size_tmpz, &size_splits, &size_tau, &size_pivots_workArr,
+        &size_iinfo, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,


### PR DESCRIPTION
Performance numbers reveal that running syevd with stedc is orders of magnitude faster than with sterf, so this PR changes syevd to use stedc instead of sterf.

To preserve access to the numerical properties of sterf, syevd will still use sterf if hybrid sterf is enabled, since the performance difference there is much less.