### PR TITLE
Fix calls to `syevd_getMemorySize`

### DIFF
--- a/library/src/lapack/roclapack_gesdd.cpp
+++ b/library/src/lapack/roclapack_gesdd.cpp
@@ -76,7 +76,7 @@ rocblas_status rocsolver_gesdd_impl(rocblas_handle handle,
         size_splits, size_tmptau_W, size_tau, size_workArr, size_workArr2;
 
     rocsolver_gesdd_getMemorySize<false, T, SS>(
-        left_svect, right_svect, m, n, strideS, batch_count, &size_VUtmp, &size_UVtmpZ,
+        handle, left_svect, right_svect, m, n, strideS, batch_count, &size_VUtmp, &size_UVtmpZ,
         &size_scalars, &size_work1, &size_work2, &size_work3, &size_work4, &size_work5_ipiv,
         &size_splits, &size_tmptau_W, &size_tau, &size_workArr, &size_workArr2);
 

--- a/library/src/lapack/roclapack_gesdd.hpp
+++ b/library/src/lapack/roclapack_gesdd.hpp
@@ -201,7 +201,8 @@ rocblas_status rocsolver_gesdd_argCheck(rocblas_handle handle,
 
 /** Helper to calculate workspace sizes **/
 template <bool BATCHED, typename T, typename SS>
-void rocsolver_gesdd_getMemorySize(const rocblas_svect left_svect,
+void rocsolver_gesdd_getMemorySize(rocblas_handle handle,
+                                   const rocblas_svect left_svect,
                                    const rocblas_svect right_svect,
                                    const rocblas_int m,
                                    const rocblas_int n,
@@ -263,8 +264,8 @@ void rocsolver_gesdd_getMemorySize(const rocblas_svect left_svect,
     {
         // Requirements for Divide-and-Conquer eigensolver
         rocsolver_syevd_heevd_getMemorySize<BATCHED, T, SS>(
-            rocblas_evect_original, rocblas_fill_upper, n, batch_count, &a1, &b1, &c1, &d1, &e1,
-            &f1, &g1, &h1, size_workArr2);
+            handle, rocblas_evect_original, rocblas_fill_upper, n, batch_count, &a1, &b1, &c1, &d1,
+            &e1, &f1, &g1, &h1, size_workArr2);
 
         // Requirements for QR factorization
         rocsolver_geqrf_getMemorySize<BATCHED, T>(m, n, batch_count, &a2, &b2, &c2, &d2, &f2);
@@ -281,8 +282,8 @@ void rocsolver_gesdd_getMemorySize(const rocblas_svect left_svect,
     {
         // Requirements for Divide-and-Conquer eigensolver
         rocsolver_syevd_heevd_getMemorySize<BATCHED, T, SS>(
-            rocblas_evect_original, rocblas_fill_upper, m, batch_count, &a1, &b1, &c1, &d1, &e1,
-            &f1, &g1, &h1, size_workArr2);
+            handle, rocblas_evect_original, rocblas_fill_upper, m, batch_count, &a1, &b1, &c1, &d1,
+            &e1, &f1, &g1, &h1, size_workArr2);
 
         // Requirements for LQ factorization
         rocsolver_gelqf_getMemorySize<BATCHED, T>(m, n, batch_count, &a2, &b2, &c2, &d2, &f2);

--- a/library/src/lapack/roclapack_gesdd_batched.cpp
+++ b/library/src/lapack/roclapack_gesdd_batched.cpp
@@ -78,7 +78,7 @@ rocblas_status rocsolver_gesdd_batched_impl(rocblas_handle handle,
         size_splits, size_tmptau_W, size_tau, size_workArr, size_workArr2;
 
     rocsolver_gesdd_getMemorySize<true, T, SS>(
-        left_svect, right_svect, m, n, strideS, batch_count, &size_VUtmp, &size_UVtmpZ,
+        handle, left_svect, right_svect, m, n, strideS, batch_count, &size_VUtmp, &size_UVtmpZ,
         &size_scalars, &size_work1, &size_work2, &size_work3, &size_work4, &size_work5_ipiv,
         &size_splits, &size_tmptau_W, &size_tau, &size_workArr, &size_workArr2);
 

--- a/library/src/lapack/roclapack_gesdd_strided_batched.cpp
+++ b/library/src/lapack/roclapack_gesdd_strided_batched.cpp
@@ -76,7 +76,7 @@ rocblas_status rocsolver_gesdd_strided_batched_impl(rocblas_handle handle,
         size_splits, size_tmptau_W, size_tau, size_workArr, size_workArr2;
 
     rocsolver_gesdd_getMemorySize<false, T, SS>(
-        left_svect, right_svect, m, n, strideS, batch_count, &size_VUtmp, &size_UVtmpZ,
+        handle, left_svect, right_svect, m, n, strideS, batch_count, &size_VUtmp, &size_UVtmpZ,
         &size_scalars, &size_work1, &size_work2, &size_work3, &size_work4, &size_work5_ipiv,
         &size_splits, &size_tmptau_W, &size_tau, &size_workArr, &size_workArr2);
 


### PR DESCRIPTION
Method `syevd_getMemorySize` has been recently updated to include rocBLAS's `handle`, which breaks `gesdd_getMemorySize`.  This includes the missing argument and fixes all calls of `gesdd_getMemorySize`.