### PR TITLE
(WIP) Optimize latrd 

### DIFF
--- a/library/src/auxiliary/rocauxiliary_latrd.hpp
+++ b/library/src/auxiliary/rocauxiliary_latrd.hpp
@@ -37,9 +37,9 @@
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
 
-ROCSOLVER_BEGIN_NAMESPACE
-
 #include "../auxiliary/rocauxiliary_latrd_coop.hpp"
+
+ROCSOLVER_BEGIN_NAMESPACE
 
 template <bool BATCHED, typename T>
 void rocsolver_latrd_getMemorySize(const rocblas_int n,

--- a/library/src/auxiliary/rocauxiliary_latrd.hpp
+++ b/library/src/auxiliary/rocauxiliary_latrd.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     June 2017
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,6 +38,8 @@
 #include "rocsolver/rocsolver.h"
 
 ROCSOLVER_BEGIN_NAMESPACE
+
+#include "../auxiliary/rocauxiliary_latrd_coop.hpp"
 
 template <bool BATCHED, typename T>
 void rocsolver_latrd_getMemorySize(const rocblas_int n,
@@ -122,27 +124,27 @@ rocblas_status rocsolver_latrd_argCheck(rocblas_handle handle,
 }
 
 template <typename T, typename S, typename U, bool COMPLEX = rocblas_is_complex<T>>
-rocblas_status rocsolver_latrd_template(rocblas_handle handle,
-                                        const rocblas_fill uplo,
-                                        const rocblas_int n,
-                                        const rocblas_int k,
-                                        U A,
-                                        const rocblas_int shiftA,
-                                        const rocblas_int lda,
-                                        const rocblas_stride strideA,
-                                        S* E,
-                                        const rocblas_stride strideE,
-                                        T* tau,
-                                        const rocblas_stride strideP,
-                                        T* W,
-                                        const rocblas_int shiftW,
-                                        const rocblas_int ldw,
-                                        const rocblas_stride strideW,
-                                        const rocblas_int batch_count,
-                                        T* scalars,
-                                        T* work,
-                                        T* norms,
-                                        T** workArr)
+rocblas_status rocsolver_latrd_org_template(rocblas_handle handle,
+                                            const rocblas_fill uplo,
+                                            const rocblas_int n,
+                                            const rocblas_int k,
+                                            U A,
+                                            const rocblas_int shiftA,
+                                            const rocblas_int lda,
+                                            const rocblas_stride strideA,
+                                            S* E,
+                                            const rocblas_stride strideE,
+                                            T* tau,
+                                            const rocblas_stride strideP,
+                                            T* W,
+                                            const rocblas_int shiftW,
+                                            const rocblas_int ldw,
+                                            const rocblas_stride strideW,
+                                            const rocblas_int batch_count,
+                                            T* scalars,
+                                            T* work,
+                                            T* norms,
+                                            T** workArr)
 {
     ROCSOLVER_ENTER("latrd", "uplo:", uplo, "n:", n, "k:", k, "shiftA:", shiftA, "lda:", lda,
                     "shiftW:", shiftW, "ldw:", ldw, "bc:", batch_count);
@@ -350,6 +352,49 @@ rocblas_status rocsolver_latrd_template(rocblas_handle handle,
 
     rocblas_set_pointer_mode(handle, old_mode);
     return rocblas_status_success;
+}
+
+template <typename T, typename S, typename U, bool COMPLEX = rocblas_is_complex<T>>
+rocblas_status rocsolver_latrd_template(rocblas_handle handle,
+                                        const rocblas_fill uplo,
+                                        const rocblas_int n,
+                                        const rocblas_int k,
+                                        U A,
+                                        const rocblas_int shiftA,
+                                        const rocblas_int lda,
+                                        const rocblas_stride strideA,
+                                        S* E,
+                                        const rocblas_stride strideE,
+                                        T* tau,
+                                        const rocblas_stride strideP,
+                                        T* W,
+                                        const rocblas_int shiftW,
+                                        const rocblas_int ldw,
+                                        const rocblas_stride strideW,
+                                        const rocblas_int batch_count,
+                                        T* scalars,
+                                        T* work,
+                                        T* norms,
+                                        T** workArr)
+{
+    bool constexpr is_complex = rocblas_is_complex<T>;
+    bool constexpr use_latrd_coop = !is_complex;
+    rocblas_status istat = rocblas_status_success;
+
+    if constexpr(use_latrd_coop)
+    {
+        istat = rocsolver_latrd_coop_template(handle, uplo, n, k, A, shiftA, lda, strideA, E,
+                                              strideE, tau, strideP, W, shiftW, ldw, strideW,
+                                              batch_count, scalars, work, norms, workArr);
+    }
+    else
+    {
+        istat = rocsolver_latrd_org_template(handle, uplo, n, k, A, shiftA, lda, strideA, E,
+                                             strideE, tau, strideP, W, shiftW, ldw, strideW,
+                                             batch_count, scalars, work, norms, workArr);
+    }
+
+    return (istat);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/library/src/auxiliary/rocauxiliary_latrd_coop.hpp
+++ b/library/src/auxiliary/rocauxiliary_latrd_coop.hpp
@@ -152,15 +152,6 @@ static __device__ __host__ I first_tile(I const ia, I const mb, I const myprow, 
     I const jtile = (itile + ((myprow + nprow - iproc) % nprow));
 
     assert((jtile % nprow) == myprow);
-    if(iproc == myprow)
-    {
-        assert((itile * mb) <= ia);
-        assert(ia <= (itile * mb + (mb - 1)));
-    }
-    else
-    {
-        assert(ia < jtile * mb);
-    }
 
     return (jtile);
 }
@@ -581,8 +572,8 @@ static void __device__ Xnrm2_body(cg::grid_group cg_grid,
     double dnorm = 0;
     if(is_column_X)
     {
-        auto const itile_start = find_next_tile(ix, mb, myprow, nprow);
-        auto const itile_end = find_next_tile(ix + n - 1, mb, myprow, nprow);
+        auto const itile_start = first_tile(ix, mb, myprow, nprow);
+        auto const itile_end = first_tile(ix + n - 1, mb, myprow, nprow);
         auto const ntiles = (itile_end - itile_start) / nprow;
 
         {
@@ -612,8 +603,8 @@ static void __device__ Xnrm2_body(cg::grid_group cg_grid,
     }
     else
     {
-        auto const jtile_start = find_next_tile(jx, nb, mypcol, npcol);
-        auto const jtile_end = find_next_tile(jx + n - 1, nb, mypcol, npcol);
+        auto const jtile_start = first_tile(jx, nb, mypcol, npcol);
+        auto const jtile_end = first_tile(jx + n - 1, nb, mypcol, npcol);
         auto const ntiles = (jtile_end - jtile_start) / npcol;
 
         {
@@ -659,6 +650,238 @@ static void __device__ Xnrm2_body(cg::grid_group cg_grid,
     }
 
     cg_grid.sync();
+}
+
+// -------------------------------
+// compute the dot product
+// and return in "ans"
+//
+//
+// NOTE: assume *ans has been set to zero
+// -------------------------------
+template <typename T, typename I>
+static void __device__ Xdot_body(I const n,
+
+                                 T const* const X_,
+                                 I const ix,
+                                 I const jx,
+                                 I const ldx,
+                                 I const incx,
+
+                                 T const* const Y_,
+                                 I const iy,
+                                 I const jy,
+                                 I const ldy,
+                                 I const incy,
+
+                                 T* const ans,
+
+                                 I const mb,
+                                 I const nb,
+                                 I const myprow,
+                                 I const mypcol,
+                                 I const nprow,
+                                 I const npcol)
+{
+    if(n <= 0)
+    {
+        return;
+    };
+
+    bool constexpr is_complex = rocblas_is_complex<T>;
+
+    I const tix = hipThreadIdx_x;
+    I const tiy = hipThreadIdx_y;
+    I const nx = hipBlockDim_x;
+    I const ny = hipBlockDim_y;
+
+    auto idx2D = [](auto i, auto j, auto ld) { return (i + j * static_cast<int64_t>(ld)); };
+
+    bool const is_column_X = (incx == 1);
+    bool const is_column_Y = (incy == 1);
+    {
+        assert((incx == 1) || (incx == ldx));
+        assert((incy == 1) || (incy == ldy));
+    }
+
+    auto const ip_X = idx2D(ix, jx, ldx);
+    auto Xvec = [=](auto const i) -> T { return (X_[ip_X + i * static_cast<int64_t>(incx)]); };
+
+    auto const ip_Y = idx2D(iy, jy, ldy);
+    auto Yvec = [=](auto const i) -> T { return (Y_[ip_Y + i * static_cast<int64_t>(incy)]); };
+
+    extern __shared__ double lmem[];
+
+    T* dsum_sh = (T*)&(lmem[0]);
+
+    T dsum = 0;
+    if(is_column_X)
+    {
+        auto const itile_start = first_tile(ix, mb, myprow, nprow);
+        auto const itile_end = first_tile(ix + n - 1, mb, myprow, nprow);
+        auto const ntiles = (itile_end - itile_start) / nprow;
+
+        {
+            assert(itile_start <= itile_end);
+            assert(ntiles * nprow == (itile_end - itile_start));
+        }
+
+        for(auto it = (0 + tiy); it <= ntiles; it += ny)
+        {
+            auto const itile = itile_start + it * nprow;
+            auto const istart = std::max(ix, itile * mb);
+            auto const iend = std::min(ix + n - 1, itile * mb + (mb - 1));
+
+            for(auto iix = (istart + tix); iix <= iend; iix += nx)
+            {
+                T const xi = Xvec((iix - ix));
+                T const yi = Yvec((iix - ix));
+                if constexpr(is_complex)
+                {
+                    dsum += conj(xi) * yi;
+                }
+                else
+                {
+                    dsum += xi * yi;
+                }
+            }
+        }
+    }
+    else
+    {
+        auto const jtile_start = first_tile(jx, nb, mypcol, npcol);
+        auto const jtile_end = first_tile(jx + n - 1, nb, mypcol, npcol);
+        auto const ntiles = (jtile_end - jtile_start) / npcol;
+
+        {
+            assert(jtile_start <= jtile_end);
+            assert(ntiles * npcol == (jtile_end - jtile_start));
+        }
+
+        for(auto it = (0 + tiy); it <= ntiles; it += ny)
+        {
+            auto const jtile = jtile_start + it * npcol;
+            auto const jstart = std::max(jx, it * nb);
+            auto const jend = std::min(jx + n - 1, it * nb + (nb - 1));
+
+            for(auto jjx = (jstart + tix); jjx <= jend; jjx += nx)
+            {
+                T const xj = Xvec((jjx - jx));
+                T const yj = Yvec((jjx - jx));
+                if constexpr(is_complex)
+                {
+                    dsum += conj(xj) * yj;
+                }
+                else
+                {
+                    dsum += xj * yj;
+                }
+            }
+        }
+    }
+
+    auto const cg_block = cg::this_thread_block();
+    dsum = reduce_sum(cg_block, dsum_sh, dsum);
+
+    bool const need_atomic_update = (is_column_X) ? (nprow > 1) : (npcol > 1);
+    if(cg_block.thread_rank() == 0)
+    {
+        if(need_atomic_update)
+        {
+            atomicAdd(ans, (dsum));
+        }
+        else
+        {
+            *ans += (dsum);
+        }
+    }
+}
+
+template <typename T, typename I, typename Istride, typename UX, typename UY>
+__global__ static void Xdot_batch_kernel(I const n,
+
+                                         UX X_,
+                                         Istride const shiftX,
+                                         I const ix,
+                                         I const jx,
+                                         I const ldx,
+                                         I const incx,
+                                         Istride const strideX,
+
+                                         UY Y_,
+                                         Istride const shiftY,
+                                         I const iy,
+                                         I const jy,
+                                         I const ldy,
+                                         I const incy,
+                                         Istride const strideY,
+
+                                         I const batch_count,
+                                         I const mb,
+                                         I const nb,
+                                         T* const ans,
+                                         T* const work)
+{
+    I const myprow = hipBlockIdx_x;
+    I const mypcol = hipBlockIdx_y;
+    I const nprow = hipGridDim_x;
+    I const npcol = hipGridDim_y;
+
+    for(I bid = 0; bid < batch_count; bid++)
+    {
+        T const* const Xp = load_ptr_batch(X_, bid, shiftX, strideX);
+        T const* const Yp = load_ptr_batch(Y_, bid, shiftY, strideY);
+        T* const ansp = ans + bid;
+
+        Xdot_body<T, I>(n, Xp, ix, jx, ldx, incx, Yp, iy, jy, ldy, incy, ansp,
+
+                        mb, nb, myprow, mypcol, nprow, npcol);
+    }
+}
+
+template <typename T, typename I, typename Istride, typename UX, typename UY, typename Tex>
+static void rocsolverCall_dot(rocblas_handle handle,
+                              I const n,
+
+                              UX X_,
+                              Istride const shiftX,
+                              I const ix,
+                              I const jx,
+                              I const ldx,
+                              I const incx,
+                              Istride const strideX,
+
+                              UY Y_,
+                              Istride const shiftY,
+                              I const iy,
+                              I const jy,
+                              I const ldy,
+                              I const incy,
+                              Istride const strideY,
+
+                              I const batch_count,
+                              T* const norms,
+                              I const mb,
+                              I const nb,
+                              Tex* const workspace,
+                              T** const workArr)
+{
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    auto const nx = 32;
+    auto const ny = 32;
+    auto const num_cu = get_num_cu();
+    size_t const ld_size = 64 * 1024;
+
+    {
+        auto const istat = hipMemset(norms, 0, sizeof(T) * batch_count);
+        assert(istat == hipSuccess);
+    }
+
+    Xdot_batch_kernel<T, I, Istride><<<dim3(num_cu, 1, 1), dim3(nx, ny, 1), ld_size, stream>>>(
+        n, X_, shiftX, ix, jx, ldx, incx, strideX, Y_, shiftY, iy, jy, ldy, incy, strideY,
+        batch_count, mb, nb, norms, workspace);
 }
 
 template <typename T, typename I>
@@ -1231,8 +1454,10 @@ static __device__ void Xsymv_body(char const c_uplo,
 
     bool const is_column_X = (incx == 1);
     bool const is_column_Y = (incy == 1);
-    assert((incx == 1) || (incx == ldx));
-    assert((incy == 1) || (incy == ldy));
+    {
+        assert((incx == 1) || (incx == ldx));
+        assert((incy == 1) || (incy == ldy));
+    }
 
     auto idx2D = [](auto i, auto j, auto ld) { return (i + j * static_cast<int64_t>(ld)); };
 
@@ -1761,9 +1986,18 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
             rocblasCall_scal<T>(handle, n - j - 1, (tau + j), strideP, W,
                                 shiftW + idx2D(j + 1, j, ldw), 1, strideW, batch_count);
 
-            rocblasCall_dot<COMPLEX, T>(handle, n - 1 - j, W, shiftW + idx2D(j + 1, j, ldw), 1,
-                                        strideW, A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
-                                        batch_count, norms, work, workArr);
+            if(use_org)
+            {
+                rocblasCall_dot<COMPLEX, T>(handle, n - 1 - j, W, shiftW + idx2D(j + 1, j, ldw), 1,
+                                            strideW, A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
+                                            batch_count, norms, work, workArr);
+            }
+            else
+            {
+                rocsolverCall_dot<T, rocblas_int, rocblas_stride>(
+                    handle, n - 1 - j, W, shiftW, j + 1, j, ldw, 1, strideW, A, shiftA, j + 1, j,
+                    lda, 1, strideA, batch_count, norms, mb, nb, work, workArr);
+            }
 
             // (TODO: rocblas_axpy is not yet ready to be used in rocsolver. When it becomes
             //  available, we can use it instead of the scale_axpy kernel, if it provides

--- a/library/src/auxiliary/rocauxiliary_latrd_coop.hpp
+++ b/library/src/auxiliary/rocauxiliary_latrd_coop.hpp
@@ -51,7 +51,7 @@
 
 ROCSOLVER_BEGIN_NAMESPACE
 
-#define PRINT_PROFILE
+#undef PRINT_PROFILE
 #ifdef PRINT_PROFILE
 #define CLOCK64() clock64()
 #else
@@ -78,10 +78,30 @@ __device__ T reduce_sum_shfl_wsize(I const wsize, T val)
 {
     // Each iteration halves the number of active threads
     // Each thread adds its partial sum[i] to sum[lane+i]
-    for(auto offset = wsize / 2; offset > 0; offset /= 2)
+    if(wsize == 64)
     {
-        val += __shfl_down(val, offset);
-        // g.sync();
+        val += __shfl_down(val, 32); // offset = 32
+        val += __shfl_down(val, 16); // offset = 16
+        val += __shfl_down(val, 8); // offset = 8
+        val += __shfl_down(val, 4); // offset = 4
+        val += __shfl_down(val, 2); // offset = 2
+        val += __shfl_down(val, 1); // offset = 1
+    }
+    else if(wsize == 32)
+    {
+        val += __shfl_down(val, 16); // offset = 16
+        val += __shfl_down(val, 8); // offset = 8
+        val += __shfl_down(val, 4); // offset = 4
+        val += __shfl_down(val, 2); // offset = 2
+        val += __shfl_down(val, 1); // offset = 1
+    }
+    else
+    {
+        for(auto offset = wsize / 2; offset > 0; offset /= 2)
+        {
+            val += __shfl_down(val, offset);
+            // g.sync();
+        }
     }
     return val; // note: only thread 0 will return full sum
 }
@@ -229,7 +249,8 @@ static __device__ void Xgemv_sh(char const trans,
                                 I const incx,
 
                                 T* const Y_,
-                                I const incy)
+                                I const incy,
+                                T* const tmp_sh)
 {
     bool constexpr is_complex = rocblas_is_complex<T>;
 
@@ -368,6 +389,13 @@ static __device__ void Xgemv_sh(char const trans,
     }
     else
     {
+        for(auto i = (0 + tixy); i < nn; i += nthreads)
+        {
+            tmp_sh[i] = 0;
+        }
+
+        __syncthreads();
+
         // ------------------------------------------------------
         // Y(1:nn) += alpha * tranpose( A(1:mm, 1:nn) ) * X(1:mm)
         // ------------------------------------------------------
@@ -391,8 +419,16 @@ static __device__ void Xgemv_sh(char const trans,
             y_j = reduce_sum_shfl_wsize(wsize, y_j);
             if(is_wave_rank0)
             {
-                gatomicAdd(&(Yvec(ja)), alpha * y_j);
+                // gatomicAdd(&(Yvec(ja)), alpha * y_j);
+                gatomicAdd(&(tmp_sh[ja]), y_j);
             }
+        }
+
+        __syncthreads();
+        for(auto ja = (0 + tixy); ja < nn; ja += nthreads)
+        {
+            T const y_j = tmp_sh[ja];
+            gatomicAdd(&(Yvec(ja)), alpha * y_j);
         }
     }
 }
@@ -549,6 +585,10 @@ static __global__ void lower_stage2(I const n,
     pfree += size_mat;
     total_bytes += size_mat;
 
+    T* const tmp_sh = (T*)pfree;
+    pfree += sizeof(T) * nn;
+    total_bytes += sizeof(T) * nn;
+
     {
         assert(total_bytes <= lds_size);
     }
@@ -665,7 +705,7 @@ static __global__ void lower_stage2(I const n,
 
                                A + idx2D(j + 1, j, lda), 1,
 
-                               W + idx2D(0, j, ldw), 1);
+                               W + idx2D(0, j, ldw), 1, tmp_sh);
 
                 tic = CLOCK64();
 
@@ -711,7 +751,7 @@ static __global__ void lower_stage2(I const n,
 
                                W + idx2D(0, j, ldw), 1,
 
-                               W + idx2D(j + 1, j, ldw), 1);
+                               W + idx2D(j + 1, j, ldw), 1, tmp_sh);
 
                 cg_grid.sync();
                 time_gemv_n1 += CLOCK64() - tic;
@@ -746,7 +786,7 @@ static __global__ void lower_stage2(I const n,
 
                            A + idx2D(j + 1, j, lda), 1,
 
-                           W + idx2D(0, j, ldw), 1);
+                           W + idx2D(0, j, ldw), 1, tmp_sh);
 
             cg_grid.sync();
 
@@ -783,7 +823,7 @@ static __global__ void lower_stage2(I const n,
 
                            W + idx2D(0, j, ldw), 1,
 
-                           W + idx2D(j + 1, j, ldw), 1);
+                           W + idx2D(j + 1, j, ldw), 1, tmp_sh);
 
             cg_grid.sync();
             time_gemv_n2 += CLOCK64() - tic;
@@ -897,6 +937,10 @@ static __global__ void upper_stage2(I const n,
     pfree += mat_size;
     total_bytes += mat_size;
 
+    T* const tmp_sh = (T*)pfree;
+    pfree += sizeof(T) * nn;
+    total_bytes += sizeof(T) * nn;
+
     {
         size_t const ld_size = 64 * 1024;
         assert(total_bytes <= ld_size);
@@ -952,6 +996,7 @@ static __global__ void upper_stage2(I const n,
                 // ------------------
                 I const jj = ixy / ia_size;
                 I const ii = ixy % ia_size;
+                assert(ixy == (ii + jj * ia_size));
 
                 A_sh(ii, jj) = Amat(ii + ia_start, jj);
                 W_sh(ii, jj) = Wmat(ii + ia_start, jj);
@@ -983,7 +1028,7 @@ static __global__ void upper_stage2(I const n,
 
                      A + idx2D(0, j, lda), 1,
 
-                     W + idx2D(j + 1, jw, ldw), 1);
+                     W + idx2D(j + 1, jw, ldw), 1, tmp_sh);
             cg_grid.sync();
         }
 
@@ -1027,7 +1072,7 @@ static __global__ void upper_stage2(I const n,
 
                      W + idx2D(j + 1, jw, ldw), 1,
 
-                     W + idx2D(0, jw, ldw), 1);
+                     W + idx2D(0, jw, ldw), 1, tmp_sh);
             cg_grid.sync();
         }
 #endif
@@ -1068,7 +1113,7 @@ static __global__ void upper_stage2(I const n,
 
                      A + idx2D(0, j, lda), 1,
 
-                     W + idx2D(j + 1, jw, ldw), 1);
+                     W + idx2D(j + 1, jw, ldw), 1, tmp_sh);
 
             cg_grid.sync();
         }
@@ -1114,7 +1159,7 @@ static __global__ void upper_stage2(I const n,
 
                      W + idx2D(j + 1, jw, ldw), 1,
 
-                     W + idx2D(0, jw, ldw), 1);
+                     W + idx2D(0, jw, ldw), 1, tmp_sh);
 
             cg_grid.sync();
         }
@@ -1202,7 +1247,7 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
         auto const mb = ceil(mm, num_cu);
 
         auto ld = is_even(mb) ? mb + 1 : mb;
-        return (sizeof_T * (ld * nn) * 2);
+        return (sizeof_T * ((ld * nn) * 2 + nn));
     };
 
     if(uplo == rocblas_fill_lower)
@@ -1261,7 +1306,7 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
                     shiftW + idx2D(j + 1, j, ldw), 1, strideW, batch_count, work, workArr);
             }
 
-            bool use_lower_stage2
+            bool const use_lower_stage2
                 = get_cooperative_launch() && (need_lds_size(n - j - 1, j, sizeof(T)) <= lds_size);
 #ifdef NDEBUG
 #else

--- a/library/src/auxiliary/rocauxiliary_latrd_coop.hpp
+++ b/library/src/auxiliary/rocauxiliary_latrd_coop.hpp
@@ -33,18 +33,56 @@
 
 #pragma once
 
-#ifndef ROCSOLVER_LATRD_COOP_H
-#define ROCSOLVER_LATRD_COOP_H 1
-
 #include <algorithm>
 #include <cmath>
 #include <complex>
+#include <limits>
 
+#include "hip/hip_cooperative_groups.h"
 #include "hip/hip_runtime.h"
 #include "hip/hip_runtime_api.h"
 
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
+
+ROCSOLVER_BEGIN_NAMESPACE
+
+namespace cg = cooperative_groups;
+
+template <typename T>
+__device__ T reduce_sum(cg::thread_group g, T* temp, T val)
+{
+    auto const lane = g.thread_rank();
+    g.sync();
+
+    // Each iteration halves the number of active threads
+    // Each thread adds its partial sum[i] to sum[lane+i]
+    for(auto i = g.size() / 2; i > 0; i /= 2)
+    {
+        temp[lane] = val;
+        g.sync(); // wait for all threads to store
+        if(lane < i)
+            val += temp[lane + i];
+        g.sync(); // wait for all threads to load
+    }
+    return val; // note: only thread 0 will return full sum
+}
+
+#if(0)
+template <typename T>
+__device__ int reduce_sum_shfl(cg::thread_block g, T const val)
+{
+    g.sync();
+    // Each iteration halves the number of active threads
+    // Each thread adds its partial sum[i] to sum[lane+i]
+    for(auto i = g.size() / 2; i > 0; i /= 2)
+    {
+        val += __shfl_down(val, i);
+        g.sync();
+    }
+    return val; // note: only thread 0 will return full sum
+}
+#endif
 
 static int get_num_cu(int deviceId = 0)
 {
@@ -114,7 +152,119 @@ static __device__ __host__ I first_tile(I const ia, I const mb, I const myprow, 
     I const jtile = (itile + ((myprow + nprow - iproc) % nprow));
 
     assert((jtile % nprow) == myprow);
+    if(iproc == myprow)
+    {
+        assert((itile * mb) <= ia);
+        assert(ia <= (itile * mb + (mb - 1)));
+    }
+    else
+    {
+        assert(ia < jtile * mb);
+    }
+
     return (jtile);
+}
+
+template <typename S>
+static __device__ __host__ S lamch(char const ctype)
+{
+    if((ctype == 'E') || (ctype == 'e'))
+    {
+        return (std::numeric_limits<S>::epsilon() / 2);
+    }
+    if((ctype == 'S') || (ctype == 's'))
+    {
+        return (std::numeric_limits<S>::min());
+    }
+    if((ctype == 'B') || (ctype == 'b'))
+    {
+        return (std::numeric_limits<S>::base());
+    }
+    if((ctype == 'P') || (ctype == 'p'))
+    {
+        S const eps = std::numeric_limits<S>::epsilon() / 2;
+        S const base = std::numeric_limits<S>::base();
+        return (eps * base);
+    }
+    if((ctype == 'O') || (ctype == 'o'))
+    {
+        return (std::numeric_limits<S>::max());
+    }
+    return (0);
+}
+
+// --------------------------------------------------------------
+// computes  sqrt( x^2 + y^2 + z^2 ) without unnecessary overflow
+// assume x, y, z are not complex types
+// --------------------------------------------------------------
+template <typename S>
+static __device__ S lapy3(S const x, S const y, S const z)
+{
+    assert(!rocblas_is_complex<S>);
+
+    auto square = [](auto d) { return (d * d); };
+
+    auto const xabs = std::abs(x);
+    auto const yabs = std::abs(y);
+    auto const zabs = std::abs(z);
+    auto const w = std::max(xabs, std::max(yabs, zabs));
+    auto const ans = (w == 0)
+        ? (xabs + yabs + zabs)
+        : w * std::sqrt(square(xabs / w) + square(yabs / w) + square(zabs / w));
+    return (ans);
+}
+
+// -------------------------------------------------------
+// computes sqrt( x^2 + y^2 ) without unnecessary overflow
+// assume x, y are not complex types
+// -------------------------------------------------------
+template <typename S>
+static __device__ S lapy2(S const x, S const y)
+{
+    S const one = 1;
+    S const zero = 0;
+    bool const x_is_nan = std::isnan(x);
+    bool const y_is_nan = std::isnan(y);
+    S dlapy2 = zero;
+    if(x_is_nan)
+    {
+        dlapy2 = x;
+    }
+    if(y_is_nan)
+    {
+        dlapy2 = y;
+    }
+
+    auto const hugeval = lamch<S>('O'); // overflow
+
+    auto square = [](auto d) { return (d * d); };
+
+    if(!(x_is_nan || y_is_nan))
+    {
+        auto const xabs = std::abs(x);
+        auto const yabs = std::abs(y);
+        auto const w = std::max(xabs, yabs);
+        auto const z = std::min(xabs, yabs);
+        if((z == zero) || (w > hugeval))
+        {
+            dlapy2 = w;
+        }
+        else
+        {
+            dlapy2 = w * std::sqrt(one + square(z / w));
+        }
+    }
+    return (dlapy2);
+}
+
+// ---------------------------------------
+// Fortran sign intrinsic
+// return  abs value of a times  sign of b
+// ---------------------------------------
+template <typename S>
+static __device__ S sign(S const a, S const b)
+{
+    return (std::abs(a) * ((b < 0) ? -1 : 1));
 }
 
 template <typename T, typename I>
@@ -134,7 +284,7 @@ __device__ void Xscale_body(I const n,
 
 {
     {
-        bool const has_work = (n >= 1) && (alpha != 1);
+        bool const has_work = (n >= 1);
         if(!has_work)
         {
             return;
@@ -154,8 +304,12 @@ __device__ void Xscale_body(I const n,
     // incx can only be 1 (column) or ldx (row)
     // ----------------------------------------
     bool const is_column_X = (incx == 1);
+    {
+        assert((incx == 1) || (incx == ldx));
+    }
 
-    auto X = [=](auto iix, auto jjx) -> T& { return (X_[idx2D(iix, jjx, ldx)]); };
+    auto const ip_X = idx2D(ix, jx, ldx);
+    auto Xvec = [=](auto i) -> T& { return (X_[ip_X + i * static_cast<int64_t>(incx)]); };
 
     if(is_column_X)
     {
@@ -164,6 +318,7 @@ __device__ void Xscale_body(I const n,
         I const tile_inc = nprow;
 
         I const ntiles = (tile_end - tile_start) / tile_inc;
+        assert((ntiles * tile_inc) == (tile_end - tile_start));
 
         for(auto it = (0 + tiy); it <= ntiles; it += ny)
         {
@@ -171,9 +326,19 @@ __device__ void Xscale_body(I const n,
             I const i_start = std::max(ix, tile * mb);
             I const i_end = std::min(ix + n - 1, tile * mb + (mb - 1));
 
-            for(auto i = (i_start + tix); i <= i_end; i += nx)
+            if(is_alpha_zero)
             {
-                X(i, jx) = (is_alpha_zero) ? zero : alpha * X(i, jx);
+                for(auto i = (i_start + tix); i <= i_end; i += nx)
+                {
+                    Xvec(i - ix) = zero;
+                }
+            }
+            else
+            {
+                for(auto i = (i_start + tix); i <= i_end; i += nx)
+                {
+                    Xvec(i - ix) *= alpha;
+                }
             }
         }
     }
@@ -184,6 +349,7 @@ __device__ void Xscale_body(I const n,
         auto const tile_inc = npcol;
 
         auto const ntiles = (tile_end - tile_start) / tile_inc;
+        assert((ntiles * tile_inc) == (tile_end - tile_start));
 
         for(auto it = (0 + tiy); it <= ntiles; it += ny)
         {
@@ -192,9 +358,19 @@ __device__ void Xscale_body(I const n,
             auto const j_start = std::max(jx, tile * nb);
             auto const j_end = std::min(jx + n - 1, tile * nb + (nb - 1));
 
-            for(auto j = (j_start + tix); j <= j_end; j += nx)
+            if(is_alpha_zero)
             {
-                X(ix, j) = (is_alpha_zero) ? zero : alpha * X(ix, j);
+                for(auto j = (j_start + tix); j <= j_end; j += nx)
+                {
+                    Xvec(j - jx) = zero;
+                }
+            }
+            else
+            {
+                for(auto j = (j_start + tix); j <= j_end; j += nx)
+                {
+                    Xvec(j - jx) *= alpha;
+                }
             }
         }
     }
@@ -227,6 +403,141 @@ static __global__ void Xscale_batch_kernel(I const n,
         auto const Xp = load_ptr_batch(X_, bid, shift_X, stride_X);
         Xscale_body(n, alpha, Xp, ix, jx, ldx, incx, mb, nb, myprow, mypcol, nprow, npcol);
     }
+}
+
+template <typename T, typename I>
+__device__ void Xlacgv_body(I const n,
+                            T* const X_,
+                            I const ix,
+                            I const jx,
+                            I const ldx,
+                            I const incx,
+                            I const mb,
+                            I const nb,
+                            I const myprow,
+                            I const mypcol,
+                            I const nprow,
+                            I const npcol)
+
+{
+    {
+        bool const has_work = (n >= 1);
+        if(!has_work)
+        {
+            return;
+        }
+    }
+
+    I const tix = hipThreadIdx_x;
+    I const tiy = hipThreadIdx_y;
+    I const nx = hipBlockDim_x;
+    I const ny = hipBlockDim_y;
+
+    auto idx2D = [](auto i, auto j, auto ld) { return (i + j * static_cast<int64_t>(ld)); };
+    // ----------------------------------------
+    // incx can only be 1 (column) or ldx (row)
+    // ----------------------------------------
+    bool const is_column_X = (incx == 1);
+    assert((incx == 1) || (incx == ldx));
+
+    auto const ip_X = idx2D(ix, jx, ldx);
+    auto Xvec = [=](auto i) -> T& { return (X_[ip_X + i * static_cast<int64_t>(incx)]); };
+
+    if(is_column_X)
+    {
+        I const tile_start = first_tile(ix, mb, myprow, nprow);
+        I const tile_end = first_tile(ix + n - 1, mb, myprow, nprow);
+        I const tile_inc = nprow;
+
+        I const ntiles = (tile_end - tile_start) / tile_inc;
+
+        for(auto it = (0 + tiy); it <= ntiles; it += ny)
+        {
+            I const tile = tile_start + it * tile_inc;
+            I const i_start = std::max(ix, tile * mb);
+            I const i_end = std::min(ix + n - 1, tile * mb + (mb - 1));
+
+            {
+                for(auto i = (i_start + tix); i <= i_end; i += nx)
+                {
+                    Xvec(i - ix) = conj(Xvec(i - ix));
+                }
+            }
+        }
+    }
+    else
+    {
+        auto const tile_start = first_tile(jx, nb, mypcol, npcol);
+        auto const tile_end = first_tile(jx + n - 1, nb, mypcol, npcol);
+        auto const tile_inc = npcol;
+
+        auto const ntiles = (tile_end - tile_start) / tile_inc;
+
+        for(auto it = (0 + tiy); it <= ntiles; it += ny)
+        {
+            auto const tile = tile_start + it * tile_inc;
+
+            auto const j_start = std::max(jx, tile * nb);
+            auto const j_end = std::min(jx + n - 1, tile * nb + (nb - 1));
+
+            {
+                for(auto j = (j_start + tix); j <= j_end; j += nx)
+                {
+                    Xvec(j - jx) = conj(Xvec(j - jx));
+                }
+            }
+        }
+    }
+}
+
+template <typename T, typename I, typename Istride, typename UX>
+static __global__ void Xlacgv_batch_kernel(I const n,
+                                           UX X_,
+                                           Istride const shift_X,
+                                           I const ix,
+                                           I const jx,
+                                           I const ldx,
+                                           I const incx,
+                                           Istride const stride_X,
+                                           I const batch_count,
+                                           I const mb,
+                                           I const nb)
+{
+    I const myprow = hipBlockIdx_x;
+    I const mypcol = hipBlockIdx_y;
+    I const nprow = hipGridDim_x;
+    I const npcol = hipGridDim_y;
+
+    for(I bid = 0; bid < batch_count; bid++)
+    {
+        auto const Xp = load_ptr_batch(X_, bid, shift_X, stride_X);
+        Xlacgv_body(n, Xp, ix, jx, ldx, incx, mb, nb, myprow, mypcol, nprow, npcol);
+    }
+}
+
+template <typename T, typename I, typename Istride, typename UX>
+static void rocsolverCall_lacgv_template(rocblas_handle handle,
+                                         I const n,
+                                         UX X_,
+                                         Istride const shiftX,
+                                         I const ix,
+                                         I const jx,
+                                         I const ldx,
+                                         I const incx,
+                                         Istride strideX,
+                                         I const batch_count,
+                                         I const mb,
+                                         I const nb)
+{
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+    size_t const lds_size = 64 * 1024;
+    auto const NX = 32;
+    auto const NY = 32;
+    auto const num_cu = get_num_cu();
+
+    Xlacgv_batch_kernel<T, I, Istride><<<dim3(num_cu, 1, 1), dim3(NX, NY, 1), lds_size, stream>>>(
+        n, X_, shiftX, ix, jx, ldx, incx, strideX, batch_count, mb, nb);
 }
 
 // ----------------------
@@ -265,6 +576,19 @@ static __device__ void Xgemv_body(char const trans,
 {
     bool constexpr is_complex = rocblas_is_complex<T>;
 
+    {
+        bool const has_work = (m >= 1) && (n >= 1) && (alpha != 0);
+        if(!has_work)
+        {
+            return;
+        }
+    }
+
+    {
+        bool const is_valid_lda = (lda >= 1) && (lda >= m);
+        assert(is_valid_lda);
+    }
+
     I const tix = hipThreadIdx_x;
     I const tiy = hipThreadIdx_y;
     I const nx = hipBlockDim_x;
@@ -272,53 +596,95 @@ static __device__ void Xgemv_body(char const trans,
 
     bool const is_transpose = (trans == 'T') || (trans == 't');
     bool const is_conj_transpose = (trans == 'C') || (trans == 'c');
-    bool const is_no_transpose = (!is_transpose) && (!is_conj_transpose);
+    bool const is_no_transpose = (trans == 'N') || (trans == 'n');
+    {
+        bool const is_valid_trans = is_transpose || is_conj_transpose || is_no_transpose;
+        assert(is_valid_trans);
+    }
 
     bool const is_column_Y = (incy == 1);
     bool const is_column_X = (incx == 1);
 
+    {
+        bool const is_valid_incx = ((incx == 1) || (incx == ldx));
+        bool const is_valid_incy = ((incy == 1) || (incy == ldy));
+
+        assert(is_valid_incx);
+        assert(is_valid_incy);
+    }
+
     auto idx2D = [](auto i, auto j, auto ld) { return (i + j * static_cast<int64_t>(ld)); };
 
+    auto const ip_Y = idx2D(iy, jy, ldy);
     auto Yvec = [=](auto i) -> T& {
-        auto const iiy = (is_column_Y) ? iy + i : iy;
-        auto const jjy = (is_column_Y) ? jy : jy + i;
-        return (Y_[idx2D(iiy, jjy, ldy)]);
+        assert((0 <= i) && (i < ((is_no_transpose) ? m : n)));
+        return (Y_[ip_Y + i * static_cast<int64_t>(incy)]);
     };
 
+    auto const ip_X = idx2D(ix, jx, ldx);
     auto Xvec = [=](auto i) {
-        auto const iix = (is_column_X) ? ix + i : ix;
-        auto const jjx = (is_column_X) ? jx : jx + i;
-        return (X_[idx2D(iix, jjx, ldx)]);
+        assert((0 <= i) && (i < ((is_no_transpose) ? n : m)));
+        return (X_[ip_X + i * static_cast<int64_t>(incx)]);
     };
 
-    auto A = [=](auto i, auto j) { return (A_[idx2D(i, j, lda)]); };
+    auto A = [=](auto i, auto j) {
+        assert((ia <= i) && (i <= (ia + m - 1)));
+        assert((ja <= j) && (j <= (ja + n - 1)));
+        return (A_[idx2D(i, j, lda)]);
+    };
 
-    bool const need_atomic_update = (is_no_transpose) ? (npcol > 1) : (nprow > 1);
+    // bool const need_atomic_update = (is_no_transpose) ? (npcol > 1) : (nprow > 1);
+    bool const need_atomic_update = true;
 
     I const itileA_start = first_tile(ia, mb, myprow, nprow);
-    I const jtileA_start = first_tile(ja, nb, mypcol, npcol);
     I const itileA_end = first_tile(ia + m - 1, mb, myprow, nprow);
-    I const jtileA_end = first_tile(ja + n - 1, nb, mypcol, npcol);
     I const itile_inc = nprow;
-    I const jtile_inc = npcol;
 
-    extern __shared__ double lmem[];
-    T* const ytmp = (T*)&(lmem[0]);
+    I const jtileA_start = first_tile(ja, nb, mypcol, npcol);
+    I const jtileA_end = first_tile(ja + n - 1, nb, mypcol, npcol);
+    I const jtile_inc = npcol;
 
     I const tixy = tix + tiy * nx;
     I const nxny = nx * ny;
-    I const mbnb = (is_no_transpose) ? mb : nb;
+    I const mbnb = (is_no_transpose) ? nb : mb;
+
+    extern __shared__ double lmem[];
+    T* const Xvec_sh = (T*)&(lmem[0]);
+    T* const rsum_sh_ = Xvec_sh + mbnb;
+
+    auto is_even = [](auto n) -> bool { return ((n % 2) == 0); };
+
+    auto const ld_rsum_sh = is_even(nx) ? nx + 1 : nx;
+
+    auto rsum_sh = [=](auto tx, auto ty) -> T& { return (rsum_sh_[tx + ty * ld_rsum_sh]); };
+
+    for(auto i = (0 + tixy); i < (ld_rsum_sh)*ny; i += nxny)
+    {
+        rsum_sh_[i] = 0;
+    }
 
     for(auto i = (0 + tixy); i < mbnb; i += nxny)
     {
-        ytmp[i] = 0;
+        Xvec_sh[i] = 0;
     }
+
     __syncthreads();
+
+    auto cgwave = cg::tiled_partition(cg::this_thread_block(), nx);
+
+#if(0)
+    {
+        if(cg::this_grid().thread_rank() == 0)
+        {
+            printf("trans=%c, m=%d, n=%d, ia=%d, ja=%d\n", trans, m, n, ia, ja);
+        }
+    }
+#endif
 
     if(is_no_transpose)
     {
         // -----------------
-        // Y = alpha * A * X
+        // Y += alpha * A * X
         // -----------------
         for(auto jtileA = jtileA_start; jtileA <= jtileA_end; jtileA += jtile_inc)
         {
@@ -334,32 +700,38 @@ static __device__ void Xgemv_body(char const trans,
                 auto const istart = std::max(ia, itileA * mb);
                 auto const iend = std::min(ia + m - 1, itileA * mb + (mb - 1));
 
-                for(auto jja = (jstart + tiy); jja <= jend; jja += ny)
+                for(auto jja = (jstart + tixy); jja <= jend; jja += nxny)
                 {
-                    auto const xj = Xvec((jja - ja));
-                    for(auto iia = (istart + tix); iia <= iend; iia += nx)
-                    {
-                        auto const aij = A(iia, jja);
-                        gatomicAdd(&(ytmp[(iia - istart)]), aij * xj);
-                    }
+                    Xvec_sh[(jja - jstart)] = Xvec(jja - ja);
                 }
+
                 __syncthreads();
 
-                for(auto iia = (istart + tixy); iia <= iend; iia += nxny)
+                for(auto iia = (istart + tiy); iia <= iend; iia += ny)
                 {
-                    auto const iiy = (iia - ia);
-                    auto const ioff = (iia - istart);
-                    auto const alpha_ytmp = alpha * ytmp[ioff];
+                    T rsum = 0;
+                    for(auto jja = (jstart + tix); jja <= jend; jja += nx)
+                    {
+                        auto const xj = Xvec_sh[(jja - jstart)];
+                        auto const aij = A(iia, jja);
+                        rsum += aij * xj;
+                    }
+                    rsum_sh(tix, tiy) = rsum;
+                    rsum = reduce_sum(cgwave, &(rsum_sh(0, tiy)), rsum);
 
-                    if(need_atomic_update)
+                    if(cgwave.thread_rank() == 0)
                     {
-                        gatomicAdd(&(Yvec(iiy)), alpha_ytmp);
+                        auto const alpha_rsum = alpha * rsum;
+                        auto const ioff = (iia - ia);
+                        if(need_atomic_update)
+                        {
+                            gatomicAdd(&(Yvec(ioff)), alpha_rsum);
+                        }
+                        else
+                        {
+                            Yvec(ioff) += alpha_rsum;
+                        }
                     }
-                    else
-                    {
-                        Yvec(iiy) += alpha_ytmp;
-                    }
-                    ytmp[ioff] = 0;
                 }
 
                 __syncthreads();
@@ -370,11 +742,7 @@ static __device__ void Xgemv_body(char const trans,
     else
     {
         // -----------------
-        // Y = alpha * op(A) * X
-        // -----------------
-
-        // -----------------
-        // Y = alpha * A * X
+        // Yvec(0:(n-1)) += alpha * trans(A(0:(m-1),0:(n-1)) * Xvec(0:(m-1))
         // -----------------
         for(auto jtileA = jtileA_start; jtileA <= jtileA_end; jtileA += jtile_inc)
         {
@@ -383,42 +751,54 @@ static __device__ void Xgemv_body(char const trans,
                 // ------------------------------
                 // process tile "(itileA,jtileA)"
                 // ------------------------------
-
                 auto const jstart = std::max(ja, jtileA * nb);
-                auto const jend = std::min(ja + n - 1, jstart + nb - 1);
+                auto const jend = std::min(ja + n - 1, jtileA * nb + (nb - 1));
 
                 auto const istart = std::max(ia, itileA * mb);
-                auto const iend = std::min(ia + m - 1, istart + mb - 1);
+                auto const iend = std::min(ia + m - 1, itileA * mb + (mb - 1));
+
+                for(auto iia = (istart + tixy); iia <= iend; iia += nxny)
+                {
+                    Xvec_sh[(iia - istart)] = Xvec((iia - ia));
+                }
+
+                __syncthreads();
 
                 for(auto jja = (jstart + tiy); jja <= jend; jja += ny)
                 {
+                    T rsum = 0;
                     for(auto iia = (istart + tix); iia <= iend; iia += nx)
                     {
                         T const aij = A(iia, jja);
-                        T const atji = (is_complex && is_conj_transpose) ? conj(aij) : aij;
-                        T const xi = Xvec((iia - ia));
+                        T const xi = Xvec_sh[(iia - istart)];
 
-                        gatomicAdd(&(ytmp[(jja - jstart)]), atji * xi);
+                        if(is_complex && is_conj_transpose)
+                        {
+                            rsum += conj(aij) * xi;
+                        }
+                        else
+                        {
+                            rsum += aij * xi;
+                        }
                     }
-                }
-                __syncthreads();
 
-                for(auto jja = (jstart + tixy); jja <= jend; jja += nxny)
-                {
-                    auto const jjy = (jja - ja);
-                    auto const joff = (jja - jstart);
-                    auto const alpha_ytmp = alpha * ytmp[joff];
+                    rsum_sh(tix, tiy) = rsum;
+                    rsum = reduce_sum(cgwave, &(rsum_sh(0, tiy)), rsum);
 
-                    if(need_atomic_update)
+                    if(cgwave.thread_rank() == 0)
                     {
-                        gatomicAdd(&(Yvec(jjy)), alpha_ytmp);
+                        auto const alpha_rsum = alpha * rsum;
+                        auto const joff = (jja - ja);
+                        if(need_atomic_update)
+                        {
+                            gatomicAdd(&(Yvec(joff)), alpha_rsum);
+                        }
+                        else
+                        {
+                            Yvec(joff) += alpha_rsum;
+                        }
                     }
-                    else
-                    {
-                        Yvec(jjy) += alpha_ytmp;
-                    }
-                    ytmp[joff] = 0;
-                }
+                } // end for jja
 
                 __syncthreads();
 
@@ -476,6 +856,442 @@ static __global__ void Xgemv_batch_kernel(char const trans,
     }
 }
 
+template <typename T, typename I, typename Istride, typename UA, typename UX, typename UY>
+static void rocsolverCall_gemv(rocblas_handle handle,
+                               rocblas_operation trans,
+                               I const mm,
+                               I const nn,
+                               T const* const p_alpha,
+                               Istride const stride_alpha,
+                               UA A,
+                               I const shiftA,
+                               I const ia,
+                               I const ja,
+                               I const lda,
+                               Istride const strideA,
+                               UX X,
+                               I const shiftX,
+                               I const ix,
+                               I const jx,
+                               I const ldx,
+                               I const incx,
+                               Istride const strideX,
+                               T const* const p_beta,
+                               Istride const stride_beta,
+                               UY Y,
+                               I const shiftY,
+                               I const iy,
+                               I const jy,
+                               I const ldy,
+                               I const incy,
+                               Istride const strideY,
+                               I const batch_count,
+                               I const mb,
+                               I const nb,
+                               void* work_Arr)
+{
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    auto const num_cu = get_num_cu();
+    size_t const lds_size = 64 * 1024;
+
+    // -----------------------------
+    // scale output Y vector by beta
+    // -----------------------------
+    auto const nx = 32;
+    auto const ny = 32;
+
+    {
+        bool const is_valid_trans = (trans == rocblas_operation_none)
+            || (trans == rocblas_operation_transpose)
+            || (trans == rocblas_operation_conjugate_transpose);
+        assert(is_valid_trans);
+    }
+
+    char const ctrans = (trans == rocblas_operation_none)  ? 'N'
+        : (trans == rocblas_operation_transpose)           ? 'T'
+        : (trans == rocblas_operation_conjugate_transpose) ? 'C'
+                                                           : '?';
+
+    bool const is_no_transpose = (trans == rocblas_operation_none);
+    auto const len_Yvec = is_no_transpose ? mm : nn;
+
+    Xscale_batch_kernel<T, I, Istride><<<dim3(num_cu, 1, 1), dim3(nx, ny, 1), lds_size, stream>>>(
+        len_Yvec, p_beta, stride_beta, Y, shiftY, iy, jy, ldy, incy, strideY, batch_count, mb, nb);
+
+    Xgemv_batch_kernel<T, I, Istride><<<dim3(num_cu, 1, 1), dim3(nx, ny, 1), lds_size, stream>>>(
+        ctrans, mm, nn, p_alpha, stride_alpha, A, shiftA, ia, ja, lda, strideA, X, shiftX, ix, jx,
+        ldx, incx, strideX, Y, shiftY, iy, jy, ldy, incy, strideY, batch_count, mb, nb);
+}
+
+// ----------------------
+// matrix vector multiple
+// y = alpha * op(A) * x
+// where
+// op(A) can be  A
+//     or transpose(A)
+//     or conj(transpose(A))
+// ----------------------
+template <typename T, typename I>
+static __device__ void Xsymv_body(char const c_uplo,
+                                  I const n,
+                                  T const alpha,
+                                  T const* const A_,
+                                  I const ia,
+                                  I const ja,
+                                  I const lda,
+                                  T const* const X_,
+                                  I const ix,
+                                  I const jx,
+                                  I const ldx,
+                                  I const incx,
+                                  T* const Y_,
+                                  I const iy,
+                                  I const jy,
+                                  I const ldy,
+                                  I const incy,
+                                  I const mb,
+                                  I const nb,
+                                  I const myprow,
+                                  I const mypcol,
+                                  I const nprow,
+                                  I const npcol)
+{
+    bool const is_complex = rocblas_is_complex<T>;
+    auto const m = n;
+
+    auto const tix = hipThreadIdx_x;
+    auto const tiy = hipThreadIdx_y;
+    auto const nx = hipBlockDim_x;
+    auto const ny = hipBlockDim_y;
+
+    bool const is_upper = (c_uplo == 'U') || (c_uplo == 'u');
+    bool const is_lower = (c_uplo == 'L') || (c_uplo == 'l');
+    {
+        bool const is_valid = (is_lower || is_upper);
+        assert(is_valid);
+    }
+
+    bool const is_column_X = (incx == 1);
+    bool const is_column_Y = (incy == 1);
+    assert((incx == 1) || (incx == ldx));
+    assert((incy == 1) || (incy == ldy));
+
+    auto idx2D = [](auto i, auto j, auto ld) { return (i + j * static_cast<int64_t>(ld)); };
+
+    auto const ip_Y = idx2D(iy, jy, ldy);
+    auto Yvec = [=](auto i) -> T& { return (Y_[ip_Y + i * static_cast<int64_t>(incy)]); };
+
+    auto const ip_X = idx2D(ix, jx, ldx);
+    auto Xvec = [=](auto i) { return (X_[ip_X + i * static_cast<int64_t>(incx)]); };
+
+    auto A = [=](auto i, auto j) { return (A_[idx2D(i, j, lda)]); };
+
+    auto const itileA_start = first_tile(ia, mb, myprow, nprow);
+    auto const jtileA_start = first_tile(ja, nb, mypcol, npcol);
+    auto const itileA_end = first_tile(ia + n - 1, mb, myprow, nprow);
+    auto const jtileA_end = first_tile(ja + n - 1, nb, mypcol, npcol);
+    auto const itile_inc = nprow;
+    auto const jtile_inc = npcol;
+
+    extern __shared__ double lmem[];
+    T* const ytmp_row = (T*)&(lmem[0]);
+    T* const ytmp_col = ytmp_row + mb;
+
+    {
+        size_t const lds_size = 64 * 1024;
+        bool const lds_ok = ((sizeof(T) * (mb + nb)) <= lds_size);
+        assert(lds_ok);
+    }
+
+    auto const tixy = tix + tiy * nx;
+    auto const nxny = nx * ny;
+
+    for(auto i = (0 + tixy); i < mb; i += nxny)
+    {
+        ytmp_row[i] = 0;
+    }
+    for(auto i = (0 + tixy); i < nb; i += nxny)
+    {
+        ytmp_col[i] = 0;
+    }
+    __syncthreads();
+
+    // -----------------
+    // Y1 = [D1  L21' ]  * X1
+    // Y2 = [L21   D2 ]    X2
+    //
+    //
+    // Y1 = (D1 * X1) + (L21' * X2)
+    // Y2 = (L21 * X1) + ( D2 * X2 )
+    // -----------------
+    for(auto jtileA = jtileA_start; jtileA <= jtileA_end; jtileA += jtile_inc)
+    {
+        for(auto itileA = itileA_start; itileA <= itileA_end; itileA += itile_inc)
+        {
+            // ------------------------------
+            // process tile "(itileA,jtileA)"
+            // ------------------------------
+
+            auto const jstart = std::max(ja, jtileA * nb);
+            auto const jend = std::min(ja + n - 1, jtileA * nb + (nb - 1));
+
+            auto const istart = std::max(ia, itileA * mb);
+            auto const iend = std::min(ia + m - 1, itileA * mb + (mb - 1));
+
+            bool const is_strictly_lower = ((istart - ia) > (jend - ja));
+            bool const is_strictly_upper = ((jstart - ja) > (iend - ia));
+            bool const can_skip_tile
+                = (is_lower && is_strictly_upper) || (is_upper && is_strictly_lower);
+            if(can_skip_tile)
+            {
+                continue;
+            }
+
+            for(auto jja = (jstart + tiy); jja <= jend; jja += ny)
+            {
+                auto const xj = Xvec((jja - ja));
+                for(auto iia = (istart + tix); iia <= iend; iia += nx)
+                {
+                    auto const ioff = (iia - istart);
+                    auto const joff = (jja - jstart);
+                    bool const is_diagonal = ((iia - ia) == (jja - ja));
+                    bool const is_strictly_lower = ((iia - ia) > (jja - ja));
+                    bool const is_strictly_upper = ((iia - ia) < (jja - ja));
+
+                    bool const can_skip
+                        = (is_lower && is_strictly_upper) || (is_upper && is_strictly_lower);
+
+                    if(can_skip)
+                    {
+                        continue;
+                    };
+
+                    if(is_diagonal)
+                    {
+                        auto const ajj = std::real(A(iia, jja));
+                        gatomicAdd(&(ytmp_row[ioff]), ajj * xj);
+                    }
+                    else
+                    {
+                        // ------------------
+                        // off-diagonal entry
+                        // ------------------
+                        T const aij = A(iia, jja);
+                        T const atji = (is_complex) ? conj(aij) : aij;
+
+                        T const xi = Xvec((iia - ia));
+
+                        gatomicAdd(&(ytmp_row[ioff]), aij * xj);
+                        gatomicAdd(&(ytmp_col[joff]), atji * xi);
+                    }
+                }
+            }
+
+            __syncthreads();
+
+            if(tiy == 0)
+            {
+                for(auto iia = (istart + tix); iia <= iend; iia += nx)
+                {
+                    auto const iiy = (iia - ia);
+                    auto const ioff = (iia - istart);
+                    auto const alpha_ytmp_row = alpha * ytmp_row[ioff];
+
+                    bool const need_atomic_update = true;
+                    if(need_atomic_update)
+                    {
+                        gatomicAdd(&(Yvec(iiy)), alpha_ytmp_row);
+                    }
+                    else
+                    {
+                        Yvec(iiy) += alpha_ytmp_row;
+                    }
+                    ytmp_row[ioff] = 0;
+                }
+
+                for(auto jja = (jstart + tix); jja <= jend; jja += nx)
+                {
+                    auto const jjy = (jja - ja);
+                    auto const joff = (jja - jstart);
+                    auto const alpha_ytmp_col = alpha * ytmp_col[joff];
+
+                    bool const need_atomic_update = true;
+                    if(need_atomic_update)
+                    {
+                        gatomicAdd(&(Yvec(jjy)), alpha_ytmp_col);
+                    }
+                    else
+                    {
+                        Yvec(jjy) += alpha_ytmp_col;
+                    }
+                    ytmp_col[joff] = 0;
+                }
+            }
+            __syncthreads();
+
+        } // end for itileA
+    } // end for jtileA
+
+    __syncthreads();
+}
+
+// compute Yvec(0:(n-1)) += alpha * op(A) * Xvec(0:(n-1))
+// where A is symmetric/hermitian matrix
+// op(A) is lower triangular or upper triangular
+//
+template <typename T, typename I, typename Istride, typename UA, typename UX, typename UY>
+static __global__ void Xsymv_batch_kernel(char c_uplo,
+                                          I const n,
+                                          T const* const p_alpha,
+                                          Istride const stride_alpha,
+                                          UA A_,
+                                          Istride const shiftA,
+                                          I const ia,
+                                          I const ja,
+                                          I const lda,
+                                          Istride const strideA,
+                                          UX X_,
+                                          Istride const shiftX,
+                                          I const ix,
+                                          I const jx,
+                                          I const ldx,
+                                          I const incx,
+                                          Istride const strideX,
+                                          UY Y_,
+                                          Istride const shiftY,
+                                          I const iy,
+                                          I const jy,
+                                          I const ldy,
+                                          I const incy,
+                                          Istride const strideY,
+                                          I const batch_count,
+                                          I const mb,
+                                          I const nb)
+{
+    I const myprow = hipBlockIdx_x;
+    I const mypcol = hipBlockIdx_y;
+    I const nprow = hipGridDim_x;
+    I const npcol = hipGridDim_y;
+
+    for(I bid = 0; bid < batch_count; bid++)
+    {
+        T const alpha = *(p_alpha + bid * stride_alpha);
+        T const* const Ap = load_ptr_batch(A_, bid, shiftA, strideA);
+        T const* const Xp = load_ptr_batch(X_, bid, shiftX, strideX);
+        T* const Yp = load_ptr_batch(Y_, bid, shiftY, strideY);
+
+        Xsymv_body(c_uplo, n, alpha, Ap, ia, ja, lda, Xp, ix, jx, ldx, incx, Yp, iy, jy, ldy, incy,
+                   mb, nb, myprow, mypcol, nprow, npcol);
+    }
+}
+
+template <typename T, typename I, typename Istride, typename UA, typename UX, typename UY>
+rocblas_status rocsolverCall_symv_hemv(rocblas_handle handle,
+                                       rocblas_fill const uplo,
+                                       I const n,
+                                       T const* const p_alpha,
+                                       Istride const stride_alpha,
+                                       UA A,
+                                       Istride const shiftA,
+                                       I const ia,
+                                       I const ja,
+                                       I const lda,
+                                       Istride const strideA,
+                                       UX X,
+                                       Istride const shiftX,
+                                       I const ix,
+                                       I const jx,
+                                       I const ldx,
+                                       I const incx,
+                                       Istride const strideX,
+                                       T const* const p_beta,
+                                       Istride stride_beta,
+                                       UY Y,
+                                       Istride const shiftY,
+                                       I const iy,
+                                       I const jy,
+                                       I const ldy,
+                                       I const incy,
+                                       Istride const strideY,
+                                       I const batch_count,
+                                       I const mb,
+                                       I const nb,
+                                       T* work,
+                                       T** workArr)
+{
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    auto const num_cu = get_num_cu();
+    size_t const lds_size = 64 * 1024;
+
+    // -----------------------------
+    // scale output Y vector by beta
+    // -----------------------------
+    auto const nx = 32;
+    auto const ny = 32;
+
+    Xscale_batch_kernel<T, I, Istride><<<dim3(num_cu, 1, 1), dim3(nx, ny, 1), lds_size, stream>>>(
+        n, p_beta, stride_beta, Y, shiftY, iy, jy, ldy, incy, strideY, batch_count, mb, nb);
+
+    char const c_uplo = (uplo == rocblas_fill_upper) ? 'U'
+        : (uplo == rocblas_fill_lower)               ? 'L'
+                                                     : '?';
+
+    Xsymv_batch_kernel<T, I, Istride><<<dim3(num_cu, 1, 1), dim3(nx, ny, 1), lds_size, stream>>>(
+        c_uplo, n, p_alpha, stride_alpha, A, shiftA, ia, ja, lda, strideA, X, shiftX, ix, jx, ldx,
+        incx, strideX, Y, shiftY, iy, jy, ldy, incy, strideY, batch_count, mb, nb);
+
+    return (rocblas_status_success);
+}
+
+/** set_offdiag kernel copies the off-diagonal element of A, which is the non-zero element
+    resulting by applying the Householder reflector to the working column, to E. Then set it
+    to 1 to prepare for the application of the Householder reflector to the rest of the matrix **/
+
+template <typename T, typename I, typename Istride, typename UA, typename UE>
+static __global__ void set_offdiag_batch_kernel(const rocblas_int batch_count,
+                                                UA A_,
+                                                I const shiftA,
+                                                Istride const strideA,
+                                                UE E_,
+                                                Istride const strideE)
+{
+    I const nthreads_per_block = (hipBlockDim_x * hipBlockDim_y) * hipBlockDim_z;
+    I const nblocks = hipGridDim_x * hipGridDim_y * hipGridDim_z;
+    I const bid_inc = nthreads_per_block * nblocks;
+
+    I const ithread = hipThreadIdx_x + hipThreadIdx_y * hipBlockDim_x
+        + hipThreadIdx_z * (hipBlockDim_x * hipBlockDim_y);
+
+    I const iblock = hipBlockIdx_x + hipBlockIdx_y * hipGridDim_x
+        + hipBlockIdx_z * (hipGridDim_x * hipGridDim_y);
+
+    I const bid_start = ithread + iblock * nthreads_per_block;
+
+    Istride const shiftE = 0;
+
+    bool constexpr is_complex = rocblas_is_complex<T>;
+
+    for(I bid = (0 + bid_start); bid < batch_count; bid += bid_inc)
+    {
+        T* const A = load_ptr_batch(A_, bid, shiftA, strideA);
+        auto const E = load_ptr_batch(E_, bid, shiftE, strideE);
+
+        if constexpr(is_complex)
+        {
+            E[0] = std::real(A[0]);
+        }
+        else
+        {
+            E[0] = A[0];
+        }
+        A[0] = T(1);
+    }
+}
+
 template <typename T, typename S, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
                                              const rocblas_fill uplo,
@@ -521,7 +1337,7 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
     blocks = (n - 1) / BS1 + 1;
     dim3 grid_n(blocks, batch_count);
 
-    bool const use_rocblas = false;
+    bool const use_org = false;
     size_t lds_size = 64 * 1024;
     auto const mb = k;
     auto const nb = k;
@@ -536,10 +1352,21 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
         {
             // update column j of A with reflector computed in step j-1
             if(COMPLEX)
-                rocsolver_lacgv_template<T>(handle, j, W, shiftW + idx2D(j, 0, ldw), ldw, strideW,
-                                            batch_count);
+            {
+                if(use_org)
+                {
+                    rocsolver_lacgv_template<T>(handle, j, W, shiftW + idx2D(j, 0, ldw), ldw,
+                                                strideW, batch_count);
+                }
+                else
+                {
+                    auto const incw = ldw;
+                    rocsolverCall_lacgv_template<T, rocblas_int, rocblas_stride>(
+                        handle, j, W, shiftW, j, 0, ldw, incw, strideW, batch_count, mb, nb);
+                }
+            }
 
-            if(use_rocblas)
+            if(use_org)
             {
                 rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j, j,
                                     cast2constType<T>(scalars), 0, A, shiftA + idx2D(j, 0, lda),
@@ -549,52 +1376,36 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
             }
             else
             {
-                auto const mm = n - j;
-                auto const nn = j;
+                auto const incw = ldw;
                 auto const p_alpha = cast2constType<T>(scalars);
                 rocblas_stride const stride_alpha = 0;
                 auto const p_beta = cast2constType<T>(scalars + 2);
                 rocblas_stride const stride_beta = 0;
 
-                auto const Y = A;
-                auto const shift_Y = shiftA;
-                auto const iy = j;
-                auto const jy = j;
-                auto const ldy = lda;
-                auto const incy = 1;
-                auto const stride_Y = strideA;
-
-                Xscale_batch_kernel<T, rocblas_int, rocblas_stride>
-                    <<<dim3(num_cu, 1, 1), dim3(32, 32, 1), lds_size, stream>>>(
-                        mm, p_beta, stride_beta, Y, shift_Y, iy, jy, ldy, incy, stride_Y,
-                        batch_count, mb, nb);
-
-                // rocblasCall_gemv<T>(handle, rocblas_operation_none, mm, nn,
-                //            cast2constType<T>(scalars), 0, A, shiftA + idx2D(j, 0, lda), lda,
-                //            strideA, W, shiftW + idx2D(j, 0, ldw), ldw, strideW,
-                //            cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j, lda), 1,
-                //            strideA, batch_count, workArr);
-
-                char const ctrans = 'N';
-                auto const ia = j;
-                auto const ja = 0;
-                auto const iw = j;
-                auto const jw = 0;
-                auto const incw = ldw;
-
-                Xgemv_batch_kernel<T, rocblas_int, rocblas_stride>
-                    <<<dim3(num_cu, 1, 1), dim3(32, 32, 1), lds_size, stream>>>(
-                        ctrans, mm, nn, p_alpha, stride_alpha, A, shiftA, ia, ja, lda, strideA, W,
-                        shiftW, iw, jw, ldw, incw, strideW, Y, shift_Y, iy, jy, ldy, incy, stride_Y,
-                        batch_count, mb, nb);
+                rocsolverCall_gemv<T>(handle, rocblas_operation_none, n - j, j, p_alpha,
+                                      stride_alpha, A, shiftA, j, 0, lda, strideA, W, shiftW, j, 0,
+                                      ldw, incw, strideW, p_beta, stride_beta, A, shiftA, j, j, lda,
+                                      1, strideA, batch_count, mb, nb, workArr);
             }
 
             if(COMPLEX)
             {
-                rocsolver_lacgv_template<T>(handle, j, W, shiftW + idx2D(j, 0, ldw), ldw, strideW,
-                                            batch_count);
-                rocsolver_lacgv_template<T>(handle, j, A, shiftA + idx2D(j, 0, lda), lda, strideA,
-                                            batch_count);
+                if(use_org)
+                {
+                    rocsolver_lacgv_template<T>(handle, j, W, shiftW + idx2D(j, 0, ldw), ldw,
+                                                strideW, batch_count);
+                    rocsolver_lacgv_template<T>(handle, j, A, shiftA + idx2D(j, 0, lda), lda,
+                                                strideA, batch_count);
+                }
+                else
+                {
+                    auto const incw = ldw;
+                    rocsolverCall_lacgv_template<T, rocblas_int, rocblas_stride>(
+                        handle, j, W, shiftW, j, 0, ldw, incw, strideW, batch_count, mb, nb);
+                    auto const inca = lda;
+                    rocsolverCall_lacgv_template<T, rocblas_int, rocblas_stride>(
+                        handle, j, A, shiftA, j, 0, lda, inca, strideA, batch_count, mb, nb);
+                }
             }
 
             rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j, j,
@@ -613,20 +1424,65 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
                                      (tau + j), strideP, batch_count, work, norms);
 
             // copy to E(j) the corresponding off-diagonal element of A, which is set to 1
-            ROCSOLVER_LAUNCH_KERNEL(set_offdiag<T>, grid_b, threads, 0, stream, batch_count, A,
-                                    shiftA + idx2D(j + 1, j, lda), strideA, (E + j), strideE);
+            if(use_org)
+            {
+                ROCSOLVER_LAUNCH_KERNEL(set_offdiag<T>, grid_b, threads, 0, stream, batch_count, A,
+                                        shiftA + idx2D(j + 1, j, lda), strideA, (E + j), strideE);
+            }
+            else
+            {
+                set_offdiag_batch_kernel<T, rocblas_int, rocblas_stride>
+                    <<<dim3(num_cu, 1, 1), dim3(32, 32, 1), 0, stream>>>(
+                        batch_count, A, shiftA + idx2D(j + 1, j, lda), strideA, (E + j), strideE);
+            }
 
             // compute/update column j of W
-            rocblasCall_symv_hemv<T>(
-                handle, uplo, n - 1 - j, (scalars + 2), 0, A, shiftA + idx2D(j + 1, j + 1, lda),
-                lda, strideA, A, shiftA + idx2D(j + 1, j, lda), 1, strideA, (scalars + 1), 0, W,
-                shiftW + idx2D(j + 1, j, ldw), 1, strideW, batch_count, work, workArr);
+            if(use_org)
+            {
+                rocblasCall_symv_hemv<T>(
+                    handle, uplo, n - 1 - j, (scalars + 2), 0, A, shiftA + idx2D(j + 1, j + 1, lda),
+                    lda, strideA, A, shiftA + idx2D(j + 1, j, lda), 1, strideA, (scalars + 1), 0, W,
+                    shiftW + idx2D(j + 1, j, ldw), 1, strideW, batch_count, work, workArr);
+            }
+            else
+            {
+                T const* const p_alpha = (scalars + 2);
+                rocblas_stride const stride_alpha = 0;
+                T const* const p_beta = (scalars + 1);
+                rocblas_stride const stride_beta = 0;
 
-            rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, n - j - 1, j,
-                                cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(j + 1, 0, ldw),
-                                ldw, strideW, A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
-                                cast2constType<T>(scalars + 1), 0, W, shiftW + idx2D(0, j, ldw), 1,
-                                strideW, batch_count, workArr);
+                rocblas_int const incx = 1;
+                rocblas_int const incy = 1;
+                rocsolverCall_symv_hemv<T, rocblas_int, rocblas_stride>(
+                    handle, uplo, n - 1 - j, p_alpha, stride_alpha, A, shiftA, j + 1, j + 1, lda,
+                    strideA, A, shiftA, j + 1, j, lda, incx, strideA, p_beta, stride_beta, W,
+                    shiftW, j + 1, j, ldw, incy, strideW, batch_count, mb, nb, work, workArr);
+            }
+
+            if(use_org)
+            {
+                rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, n - j - 1, j,
+                                    cast2constType<T>(scalars + 2), 0, W,
+                                    shiftW + idx2D(j + 1, 0, ldw), ldw, strideW, A,
+                                    shiftA + idx2D(j + 1, j, lda), 1, strideA,
+                                    cast2constType<T>(scalars + 1), 0, W, shiftW + idx2D(0, j, ldw),
+                                    1, strideW, batch_count, workArr);
+            }
+            else
+            {
+                auto const mm = n - j - 1;
+                auto const nn = j;
+                bool const has_work = (mm >= 1) && (nn >= 1);
+                if(has_work)
+                {
+                    rocsolverCall_gemv<T, rocblas_int, rocblas_stride>(
+                        handle, rocblas_operation_conjugate_transpose, mm, nn,
+                        cast2constType<T>(scalars + 2), 0, W, shiftW, j + 1, 0, ldw, strideW, A,
+                        shiftA, j + 1, j, lda, 1, strideA, cast2constType<T>(scalars + 1), 0, W,
+                        shiftW, 0, j, ldw, 1, strideW, batch_count, mb, nb, workArr);
+
+                } // if has_work
+            }
 
             rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j - 1, j,
                                 cast2constType<T>(scalars), 0, A, shiftA + idx2D(j + 1, 0, lda),
@@ -659,9 +1515,8 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
             ROCSOLVER_LAUNCH_KERNEL(scale_axpy<T>, grid_n, threads, 0, stream, n - 1 - j, norms,
                                     tau + j, strideP, A, shiftA + idx2D(j + 1, j, lda), strideA, W,
                                     shiftW + idx2D(j + 1, j, ldw), strideW);
-        }
+        } // end for j
     }
-
     else
     {
         // reduce the last k columns of A
@@ -757,4 +1612,5 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
     rocblas_set_pointer_mode(handle, old_mode);
     return rocblas_status_success;
 }
-#endif
+
+ROCSOLVER_END_NAMESPACE

--- a/library/src/auxiliary/rocauxiliary_latrd_coop.hpp
+++ b/library/src/auxiliary/rocauxiliary_latrd_coop.hpp
@@ -1,0 +1,760 @@
+
+/************************************************************************
+ * Derived from the BSD3-licensed
+ * LAPACK routine (version 3.7.1) --
+ *     Univ. of Tennessee, Univ. of California Berkeley,
+ *     Univ. of Colorado Denver and NAG Ltd..
+ *     June 2017
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ * *************************************************************************/
+
+#pragma once
+
+#ifndef ROCSOLVER_LATRD_COOP_H
+#define ROCSOLVER_LATRD_COOP_H 1
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+
+#include "hip/hip_runtime.h"
+#include "hip/hip_runtime_api.h"
+
+#include "rocblas.hpp"
+#include "rocsolver/rocsolver.h"
+
+static int get_num_cu(int deviceId = 0)
+{
+    int ival = 0;
+    auto const attr = hipDeviceAttributeMultiprocessorCount;
+    HIP_CHECK(hipDeviceGetAttribute(&ival, attr, deviceId));
+    return (ival);
+}
+
+static __device__ void gatomicAdd(double* const ptr, double const val)
+{
+    atomicAdd(ptr, val);
+}
+
+static __device__ void gatomicAdd(float* const ptr, float const val)
+{
+    atomicAdd(ptr, val);
+}
+
+static __device__ void gatomicAdd(rocblas_complex_num<float>* const ptr,
+                                  rocblas_complex_num<float> const val)
+{
+    float* const p_real = (float*)ptr;
+    float* const p_imag = p_real + 1;
+    atomicAdd(p_real, val.real());
+    atomicAdd(p_imag, val.imag());
+}
+
+static __device__ void gatomicAdd(rocblas_complex_num<double>* const ptr,
+                                  rocblas_complex_num<double> const val)
+{
+    double* const p_real = (double*)ptr;
+    double* const p_imag = p_real + 1;
+    atomicAdd(p_real, val.real());
+    atomicAdd(p_imag, val.imag());
+}
+
+template <typename I>
+static __device__ __host__ I indxg2tile(I const ia, I const mb, I const myprow, I const nprow)
+{
+    I const itile = (ia / mb);
+    return (itile);
+}
+
+// ------------------------------------------
+// given a global index
+// return the processor that holds this entry
+// ------------------------------------------
+template <typename I>
+static __device__ __host__ I indxg2proc(I const ia, I const mb, I const myprow, I const nprow)
+{
+    I const itile = indxg2tile(ia, mb, myprow, nprow);
+    I const iproc = (itile % nprow);
+
+    return (iproc);
+}
+
+// --------------------------------------------
+// given a global index
+// return the first tile "jtile" that belongs to myprow
+// --------------------------------------------
+template <typename I>
+static __device__ __host__ I first_tile(I const ia, I const mb, I const myprow, I const nprow)
+{
+    I const itile = (ia / mb);
+    I const iproc = (itile % nprow);
+    I const jtile = (itile + ((myprow + nprow - iproc) % nprow));
+
+    assert((jtile % nprow) == myprow);
+    return (jtile);
+}
+
+template <typename T, typename I>
+__device__ void Xscale_body(I const n,
+                            T const alpha,
+                            T* const X_,
+                            I const ix,
+                            I const jx,
+                            I const ldx,
+                            I const incx,
+                            I const mb,
+                            I const nb,
+                            I const myprow,
+                            I const mypcol,
+                            I const nprow,
+                            I const npcol)
+
+{
+    {
+        bool const has_work = (n >= 1) && (alpha != 1);
+        if(!has_work)
+        {
+            return;
+        }
+    }
+
+    I const tix = hipThreadIdx_x;
+    I const tiy = hipThreadIdx_y;
+    I const nx = hipBlockDim_x;
+    I const ny = hipBlockDim_y;
+
+    T const zero = 0;
+    bool const is_alpha_zero = (alpha == zero);
+
+    auto idx2D = [](auto i, auto j, auto ld) { return (i + j * static_cast<int64_t>(ld)); };
+    // ----------------------------------------
+    // incx can only be 1 (column) or ldx (row)
+    // ----------------------------------------
+    bool const is_column_X = (incx == 1);
+
+    auto X = [=](auto iix, auto jjx) -> T& { return (X_[idx2D(iix, jjx, ldx)]); };
+
+    if(is_column_X)
+    {
+        I const tile_start = first_tile(ix, mb, myprow, nprow);
+        I const tile_end = first_tile(ix + n - 1, mb, myprow, nprow);
+        I const tile_inc = nprow;
+
+        I const ntiles = (tile_end - tile_start) / tile_inc;
+
+        for(auto it = (0 + tiy); it <= ntiles; it += ny)
+        {
+            I const tile = tile_start + it * tile_inc;
+            I const i_start = std::max(ix, tile * mb);
+            I const i_end = std::min(ix + n - 1, tile * mb + (mb - 1));
+
+            for(auto i = (i_start + tix); i <= i_end; i += nx)
+            {
+                X(i, jx) = (is_alpha_zero) ? zero : alpha * X(i, jx);
+            }
+        }
+    }
+    else
+    {
+        auto const tile_start = first_tile(jx, nb, mypcol, npcol);
+        auto const tile_end = first_tile(jx + n - 1, nb, mypcol, npcol);
+        auto const tile_inc = npcol;
+
+        auto const ntiles = (tile_end - tile_start) / tile_inc;
+
+        for(auto it = (0 + tiy); it <= ntiles; it += ny)
+        {
+            auto const tile = tile_start + it * tile_inc;
+
+            auto const j_start = std::max(jx, tile * nb);
+            auto const j_end = std::min(jx + n - 1, tile * nb + (nb - 1));
+
+            for(auto j = (j_start + tix); j <= j_end; j += nx)
+            {
+                X(ix, j) = (is_alpha_zero) ? zero : alpha * X(ix, j);
+            }
+        }
+    }
+}
+
+template <typename T, typename I, typename Istride, typename UX>
+static __global__ void Xscale_batch_kernel(I const n,
+                                           T const* const p_alpha,
+                                           Istride const stride_alpha,
+                                           UX X_,
+                                           Istride const shift_X,
+                                           I const ix,
+                                           I const jx,
+                                           I const ldx,
+                                           I const incx,
+                                           Istride const stride_X,
+                                           I const batch_count,
+                                           I const mb,
+                                           I const nb)
+{
+    I const myprow = hipBlockIdx_x;
+    I const mypcol = hipBlockIdx_y;
+    I const nprow = hipGridDim_x;
+    I const npcol = hipGridDim_y;
+
+    for(I bid = 0; bid < batch_count; bid++)
+    {
+        T const alpha = *(p_alpha + bid * stride_alpha);
+
+        auto const Xp = load_ptr_batch(X_, bid, shift_X, stride_X);
+        Xscale_body(n, alpha, Xp, ix, jx, ldx, incx, mb, nb, myprow, mypcol, nprow, npcol);
+    }
+}
+
+// ----------------------
+// matrix vector multiply
+// Yvec = alpha * op(A(0:(m-1),0:(n-1)) * Xvec
+// where
+// op(A) can be  A or
+//               transpose(A) or
+//               conj(transpose(A))
+// ----------------------
+template <typename T, typename I>
+static __device__ void Xgemv_body(char const trans,
+                                  I const m,
+                                  I const n,
+                                  T const alpha,
+                                  T const* const A_,
+                                  I const ia,
+                                  I const ja,
+                                  I const lda,
+                                  T const* const X_,
+                                  I const ix,
+                                  I const jx,
+                                  I const ldx,
+                                  I const incx,
+                                  T* const Y_,
+                                  I const iy,
+                                  I const jy,
+                                  I const ldy,
+                                  I const incy,
+                                  I const mb,
+                                  I const nb,
+                                  I const myprow,
+                                  I const mypcol,
+                                  I const nprow,
+                                  I const npcol)
+{
+    bool constexpr is_complex = rocblas_is_complex<T>;
+
+    I const tix = hipThreadIdx_x;
+    I const tiy = hipThreadIdx_y;
+    I const nx = hipBlockDim_x;
+    I const ny = hipBlockDim_y;
+
+    bool const is_transpose = (trans == 'T') || (trans == 't');
+    bool const is_conj_transpose = (trans == 'C') || (trans == 'c');
+    bool const is_no_transpose = (!is_transpose) && (!is_conj_transpose);
+
+    bool const is_column_Y = (incy == 1);
+    bool const is_column_X = (incx == 1);
+
+    auto idx2D = [](auto i, auto j, auto ld) { return (i + j * static_cast<int64_t>(ld)); };
+
+    auto Yvec = [=](auto i) -> T& {
+        auto const iiy = (is_column_Y) ? iy + i : iy;
+        auto const jjy = (is_column_Y) ? jy : jy + i;
+        return (Y_[idx2D(iiy, jjy, ldy)]);
+    };
+
+    auto Xvec = [=](auto i) {
+        auto const iix = (is_column_X) ? ix + i : ix;
+        auto const jjx = (is_column_X) ? jx : jx + i;
+        return (X_[idx2D(iix, jjx, ldx)]);
+    };
+
+    auto A = [=](auto i, auto j) { return (A_[idx2D(i, j, lda)]); };
+
+    bool const need_atomic_update = (is_no_transpose) ? (npcol > 1) : (nprow > 1);
+
+    I const itileA_start = first_tile(ia, mb, myprow, nprow);
+    I const jtileA_start = first_tile(ja, nb, mypcol, npcol);
+    I const itileA_end = first_tile(ia + m - 1, mb, myprow, nprow);
+    I const jtileA_end = first_tile(ja + n - 1, nb, mypcol, npcol);
+    I const itile_inc = nprow;
+    I const jtile_inc = npcol;
+
+    extern __shared__ double lmem[];
+    T* const ytmp = (T*)&(lmem[0]);
+
+    I const tixy = tix + tiy * nx;
+    I const nxny = nx * ny;
+    I const mbnb = (is_no_transpose) ? mb : nb;
+
+    for(auto i = (0 + tixy); i < mbnb; i += nxny)
+    {
+        ytmp[i] = 0;
+    }
+    __syncthreads();
+
+    if(is_no_transpose)
+    {
+        // -----------------
+        // Y = alpha * A * X
+        // -----------------
+        for(auto jtileA = jtileA_start; jtileA <= jtileA_end; jtileA += jtile_inc)
+        {
+            for(auto itileA = itileA_start; itileA <= itileA_end; itileA += itile_inc)
+            {
+                // ------------------------------
+                // process tile "(itileA,jtileA)"
+                // ------------------------------
+
+                auto const jstart = std::max(ja, jtileA * nb);
+                auto const jend = std::min(ja + n - 1, jtileA * nb + (nb - 1));
+
+                auto const istart = std::max(ia, itileA * mb);
+                auto const iend = std::min(ia + m - 1, itileA * mb + (mb - 1));
+
+                for(auto jja = (jstart + tiy); jja <= jend; jja += ny)
+                {
+                    auto const xj = Xvec((jja - ja));
+                    for(auto iia = (istart + tix); iia <= iend; iia += nx)
+                    {
+                        auto const aij = A(iia, jja);
+                        gatomicAdd(&(ytmp[(iia - istart)]), aij * xj);
+                    }
+                }
+                __syncthreads();
+
+                for(auto iia = (istart + tixy); iia <= iend; iia += nxny)
+                {
+                    auto const iiy = (iia - ia);
+                    auto const ioff = (iia - istart);
+                    auto const alpha_ytmp = alpha * ytmp[ioff];
+
+                    if(need_atomic_update)
+                    {
+                        gatomicAdd(&(Yvec(iiy)), alpha_ytmp);
+                    }
+                    else
+                    {
+                        Yvec(iiy) += alpha_ytmp;
+                    }
+                    ytmp[ioff] = 0;
+                }
+
+                __syncthreads();
+
+            } // end for itileA
+        } // end for jtileA
+    }
+    else
+    {
+        // -----------------
+        // Y = alpha * op(A) * X
+        // -----------------
+
+        // -----------------
+        // Y = alpha * A * X
+        // -----------------
+        for(auto jtileA = jtileA_start; jtileA <= jtileA_end; jtileA += jtile_inc)
+        {
+            for(auto itileA = itileA_start; itileA <= itileA_end; itileA += itile_inc)
+            {
+                // ------------------------------
+                // process tile "(itileA,jtileA)"
+                // ------------------------------
+
+                auto const jstart = std::max(ja, jtileA * nb);
+                auto const jend = std::min(ja + n - 1, jstart + nb - 1);
+
+                auto const istart = std::max(ia, itileA * mb);
+                auto const iend = std::min(ia + m - 1, istart + mb - 1);
+
+                for(auto jja = (jstart + tiy); jja <= jend; jja += ny)
+                {
+                    for(auto iia = (istart + tix); iia <= iend; iia += nx)
+                    {
+                        T const aij = A(iia, jja);
+                        T const atji = (is_complex && is_conj_transpose) ? conj(aij) : aij;
+                        T const xi = Xvec((iia - ia));
+
+                        gatomicAdd(&(ytmp[(jja - jstart)]), atji * xi);
+                    }
+                }
+                __syncthreads();
+
+                for(auto jja = (jstart + tixy); jja <= jend; jja += nxny)
+                {
+                    auto const jjy = (jja - ja);
+                    auto const joff = (jja - jstart);
+                    auto const alpha_ytmp = alpha * ytmp[joff];
+
+                    if(need_atomic_update)
+                    {
+                        gatomicAdd(&(Yvec(jjy)), alpha_ytmp);
+                    }
+                    else
+                    {
+                        Yvec(jjy) += alpha_ytmp;
+                    }
+                    ytmp[joff] = 0;
+                }
+
+                __syncthreads();
+
+            } // end for itileA
+        } // end for jtileA
+    }
+    __syncthreads();
+}
+
+template <typename T, typename I, typename Istride, typename UA, typename UX, typename UY>
+static __global__ void Xgemv_batch_kernel(char const trans,
+                                          I const m,
+                                          I const n,
+                                          T const* const p_alpha,
+                                          Istride const stride_alpha,
+                                          UA A_,
+                                          Istride const shift_A,
+                                          I const ia,
+                                          I const ja,
+                                          I const lda,
+                                          Istride const stride_A,
+                                          UX X_,
+                                          Istride const shift_X,
+                                          I const ix,
+                                          I const jx,
+                                          I const ldx,
+                                          I const incx,
+                                          Istride const stride_X,
+                                          UY Y_,
+                                          Istride const shift_Y,
+                                          I const iy,
+                                          I const jy,
+                                          I const ldy,
+                                          I const incy,
+                                          Istride const stride_Y,
+                                          I const batch_count,
+                                          I const mb,
+                                          I const nb)
+{
+    I const myprow = hipBlockIdx_x;
+    I const mypcol = hipBlockIdx_y;
+    I const nprow = hipGridDim_x;
+    I const npcol = hipGridDim_y;
+
+    for(I bid = 0; bid < batch_count; bid++)
+    {
+        T const alpha = *(p_alpha + bid * stride_alpha);
+
+        T const* const Ap = load_ptr_batch(A_, bid, shift_A, stride_A);
+        T const* const Xp = load_ptr_batch(X_, bid, shift_X, stride_X);
+        T* const Yp = load_ptr_batch(Y_, bid, shift_Y, stride_Y);
+
+        Xgemv_body(trans, m, n, alpha, Ap, ia, ja, lda, Xp, ix, jx, ldx, incx, Yp, iy, jy, ldy,
+                   incy, mb, nb, myprow, mypcol, nprow, npcol);
+    }
+}
+
+template <typename T, typename S, typename U, bool COMPLEX = rocblas_is_complex<T>>
+rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
+                                             const rocblas_fill uplo,
+                                             const rocblas_int n,
+                                             const rocblas_int k,
+                                             U A,
+                                             const rocblas_int shiftA,
+                                             const rocblas_int lda,
+                                             const rocblas_stride strideA,
+                                             S* E,
+                                             const rocblas_stride strideE,
+                                             T* tau,
+                                             const rocblas_stride strideP,
+                                             T* W,
+                                             const rocblas_int shiftW,
+                                             const rocblas_int ldw,
+                                             const rocblas_stride strideW,
+                                             const rocblas_int batch_count,
+                                             T* scalars,
+                                             T* work,
+                                             T* norms,
+                                             T** workArr)
+{
+    ROCSOLVER_ENTER("latrd", "uplo:", uplo, "n:", n, "k:", k, "shiftA:", shiftA, "lda:", lda,
+                    "shiftW:", shiftW, "ldw:", ldw, "bc:", batch_count);
+
+    // quick return
+    if(n == 0 || k == 0 || batch_count == 0)
+        return rocblas_status_success;
+
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    // everything must be executed with scalars on the device
+    rocblas_pointer_mode old_mode;
+    rocblas_get_pointer_mode(handle, &old_mode);
+    rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
+
+    // configure kernels
+    rocblas_int blocks = (batch_count - 1) / BS1 + 1;
+    dim3 grid_b(blocks, 1);
+    dim3 threads(BS1, 1, 1);
+    blocks = (n - 1) / BS1 + 1;
+    dim3 grid_n(blocks, batch_count);
+
+    bool const use_rocblas = false;
+    size_t lds_size = 64 * 1024;
+    auto const mb = k;
+    auto const nb = k;
+
+    auto const num_cu = get_num_cu();
+
+    if(uplo == rocblas_fill_lower)
+    {
+        // reduce the first k columns of A
+        // main loop running forwards (for each column)
+        for(rocblas_int j = 0; j < k; ++j)
+        {
+            // update column j of A with reflector computed in step j-1
+            if(COMPLEX)
+                rocsolver_lacgv_template<T>(handle, j, W, shiftW + idx2D(j, 0, ldw), ldw, strideW,
+                                            batch_count);
+
+            if(use_rocblas)
+            {
+                rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j, j,
+                                    cast2constType<T>(scalars), 0, A, shiftA + idx2D(j, 0, lda),
+                                    lda, strideA, W, shiftW + idx2D(j, 0, ldw), ldw, strideW,
+                                    cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j, lda),
+                                    1, strideA, batch_count, workArr);
+            }
+            else
+            {
+                auto const mm = n - j;
+                auto const nn = j;
+                auto const p_alpha = cast2constType<T>(scalars);
+                rocblas_stride const stride_alpha = 0;
+                auto const p_beta = cast2constType<T>(scalars + 2);
+                rocblas_stride const stride_beta = 0;
+
+                auto const Y = A;
+                auto const shift_Y = shiftA;
+                auto const iy = j;
+                auto const jy = j;
+                auto const ldy = lda;
+                auto const incy = 1;
+                auto const stride_Y = strideA;
+
+                Xscale_batch_kernel<T, rocblas_int, rocblas_stride>
+                    <<<dim3(num_cu, 1, 1), dim3(32, 32, 1), lds_size, stream>>>(
+                        mm, p_beta, stride_beta, Y, shift_Y, iy, jy, ldy, incy, stride_Y,
+                        batch_count, mb, nb);
+
+                // rocblasCall_gemv<T>(handle, rocblas_operation_none, mm, nn,
+                //            cast2constType<T>(scalars), 0, A, shiftA + idx2D(j, 0, lda), lda,
+                //            strideA, W, shiftW + idx2D(j, 0, ldw), ldw, strideW,
+                //            cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j, lda), 1,
+                //            strideA, batch_count, workArr);
+
+                char const ctrans = 'N';
+                auto const ia = j;
+                auto const ja = 0;
+                auto const iw = j;
+                auto const jw = 0;
+                auto const incw = ldw;
+
+                Xgemv_batch_kernel<T, rocblas_int, rocblas_stride>
+                    <<<dim3(num_cu, 1, 1), dim3(32, 32, 1), lds_size, stream>>>(
+                        ctrans, mm, nn, p_alpha, stride_alpha, A, shiftA, ia, ja, lda, strideA, W,
+                        shiftW, iw, jw, ldw, incw, strideW, Y, shift_Y, iy, jy, ldy, incy, stride_Y,
+                        batch_count, mb, nb);
+            }
+
+            if(COMPLEX)
+            {
+                rocsolver_lacgv_template<T>(handle, j, W, shiftW + idx2D(j, 0, ldw), ldw, strideW,
+                                            batch_count);
+                rocsolver_lacgv_template<T>(handle, j, A, shiftA + idx2D(j, 0, lda), lda, strideA,
+                                            batch_count);
+            }
+
+            rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j, j,
+                                cast2constType<T>(scalars), 0, W, shiftW + idx2D(j, 0, ldw), ldw,
+                                strideW, A, shiftA + idx2D(j, 0, lda), lda, strideA,
+                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j, lda), 1,
+                                strideA, batch_count, workArr);
+
+            if(COMPLEX)
+                rocsolver_lacgv_template<T>(handle, j, A, shiftA + idx2D(j, 0, lda), lda, strideA,
+                                            batch_count);
+
+            // generate Householder reflector to work on column j
+            rocsolver_larfg_template(handle, n - j - 1, A, shiftA + idx2D(j + 1, j, lda), A,
+                                     shiftA + idx2D(std::min(j + 2, n - 1), j, lda), 1, strideA,
+                                     (tau + j), strideP, batch_count, work, norms);
+
+            // copy to E(j) the corresponding off-diagonal element of A, which is set to 1
+            ROCSOLVER_LAUNCH_KERNEL(set_offdiag<T>, grid_b, threads, 0, stream, batch_count, A,
+                                    shiftA + idx2D(j + 1, j, lda), strideA, (E + j), strideE);
+
+            // compute/update column j of W
+            rocblasCall_symv_hemv<T>(
+                handle, uplo, n - 1 - j, (scalars + 2), 0, A, shiftA + idx2D(j + 1, j + 1, lda),
+                lda, strideA, A, shiftA + idx2D(j + 1, j, lda), 1, strideA, (scalars + 1), 0, W,
+                shiftW + idx2D(j + 1, j, ldw), 1, strideW, batch_count, work, workArr);
+
+            rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, n - j - 1, j,
+                                cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(j + 1, 0, ldw),
+                                ldw, strideW, A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
+                                cast2constType<T>(scalars + 1), 0, W, shiftW + idx2D(0, j, ldw), 1,
+                                strideW, batch_count, workArr);
+
+            rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j - 1, j,
+                                cast2constType<T>(scalars), 0, A, shiftA + idx2D(j + 1, 0, lda),
+                                lda, strideA, W, shiftW + idx2D(0, j, ldw), 1, strideW,
+                                cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(j + 1, j, ldw),
+                                1, strideW, batch_count, workArr);
+
+            rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, n - j - 1, j,
+                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j + 1, 0, lda),
+                                lda, strideA, A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
+                                cast2constType<T>(scalars + 1), 0, W, shiftW + idx2D(0, j, ldw), 1,
+                                strideW, batch_count, workArr);
+
+            rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j - 1, j,
+                                cast2constType<T>(scalars), 0, W, shiftW + idx2D(j + 1, 0, ldw),
+                                ldw, strideW, W, shiftW + idx2D(0, j, ldw), 1, strideW,
+                                cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(j + 1, j, ldw),
+                                1, strideW, batch_count, workArr);
+
+            rocblasCall_scal<T>(handle, n - j - 1, (tau + j), strideP, W,
+                                shiftW + idx2D(j + 1, j, ldw), 1, strideW, batch_count);
+
+            rocblasCall_dot<COMPLEX, T>(handle, n - 1 - j, W, shiftW + idx2D(j + 1, j, ldw), 1,
+                                        strideW, A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
+                                        batch_count, norms, work, workArr);
+
+            // (TODO: rocblas_axpy is not yet ready to be used in rocsolver. When it becomes
+            //  available, we can use it instead of the scale_axpy kernel, if it provides
+            //  better performance.)
+            ROCSOLVER_LAUNCH_KERNEL(scale_axpy<T>, grid_n, threads, 0, stream, n - 1 - j, norms,
+                                    tau + j, strideP, A, shiftA + idx2D(j + 1, j, lda), strideA, W,
+                                    shiftW + idx2D(j + 1, j, ldw), strideW);
+        }
+    }
+
+    else
+    {
+        // reduce the last k columns of A
+        // main loop running forwards (for each column)
+        rocblas_int jw;
+        for(rocblas_int j = n - 1; j >= n - k; --j)
+        {
+            jw = j - n + k;
+            // update column j of A with reflector computed in step j-1
+            if(COMPLEX)
+                rocsolver_lacgv_template<T>(handle, n - 1 - j, W, shiftW + idx2D(j, jw + 1, ldw),
+                                            ldw, strideW, batch_count);
+
+            rocblasCall_gemv<T>(handle, rocblas_operation_none, j + 1, n - 1 - j,
+                                cast2constType<T>(scalars), 0, A, shiftA + idx2D(0, j + 1, lda),
+                                lda, strideA, W, shiftW + idx2D(j, jw + 1, ldw), ldw, strideW,
+                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(0, j, lda), 1,
+                                strideA, batch_count, workArr);
+
+            if(COMPLEX)
+            {
+                rocsolver_lacgv_template<T>(handle, n - 1 - j, W, shiftW + idx2D(j, jw + 1, ldw),
+                                            ldw, strideW, batch_count);
+                rocsolver_lacgv_template<T>(handle, n - 1 - j, A, shiftA + idx2D(j, j + 1, lda),
+                                            lda, strideA, batch_count);
+            }
+
+            rocblasCall_gemv<T>(handle, rocblas_operation_none, j + 1, n - 1 - j,
+                                cast2constType<T>(scalars), 0, W, shiftW + idx2D(0, jw + 1, ldw),
+                                ldw, strideW, A, shiftA + idx2D(j, j + 1, lda), lda, strideA,
+                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(0, j, lda), 1,
+                                strideA, batch_count, workArr);
+
+            if(COMPLEX)
+                rocsolver_lacgv_template<T>(handle, n - 1 - j, A, shiftA + idx2D(j, j + 1, lda),
+                                            lda, strideA, batch_count);
+
+            // generate Householder reflector to work on column j
+            rocsolver_larfg_template(handle, j, A, shiftA + idx2D(j - 1, j, lda), A,
+                                     shiftA + idx2D(0, j, lda), 1, strideA, (tau + j - 1), strideP,
+                                     batch_count, work, norms);
+
+            // copy to E(j) the corresponding off-diagonal element of A, which is set to 1
+            ROCSOLVER_LAUNCH_KERNEL(set_offdiag<T>, grid_b, threads, 0, stream, batch_count, A,
+                                    shiftA + idx2D(j - 1, j, lda), strideA, (E + j - 1), strideE);
+
+            // compute/update column j of W
+            rocblasCall_symv_hemv<T>(handle, uplo, j, (scalars + 2), 0, A, shiftA, lda, strideA, A,
+                                     shiftA + idx2D(0, j, lda), 1, strideA, (scalars + 1), 0, W,
+                                     shiftW + idx2D(0, jw, ldw), 1, strideW, batch_count, work,
+                                     workArr);
+
+            rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, j, n - 1 - j,
+                                cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(0, jw + 1, ldw),
+                                ldw, strideW, A, shiftA + idx2D(0, j, lda), 1, strideA,
+                                cast2constType<T>(scalars + 1), 0, W,
+                                shiftW + idx2D(j + 1, jw, ldw), 1, strideW, batch_count, workArr);
+
+            rocblasCall_gemv<T>(handle, rocblas_operation_none, j, n - 1 - j,
+                                cast2constType<T>(scalars), 0, A, shiftA + idx2D(0, j + 1, lda),
+                                lda, strideA, W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW,
+                                cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(0, jw, ldw), 1,
+                                strideW, batch_count, workArr);
+
+            rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, j, n - 1 - j,
+                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(0, j + 1, lda),
+                                lda, strideA, A, shiftA + idx2D(0, j, lda), 1, strideA,
+                                cast2constType<T>(scalars + 1), 0, W,
+                                shiftW + idx2D(j + 1, jw, ldw), 1, strideW, batch_count, workArr);
+
+            rocblasCall_gemv<T>(handle, rocblas_operation_none, j, n - 1 - j,
+                                cast2constType<T>(scalars), 0, W, shiftW + idx2D(0, jw + 1, ldw),
+                                ldw, strideW, W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW,
+                                cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(0, jw, ldw), 1,
+                                strideW, batch_count, workArr);
+
+            rocblasCall_scal<T>(handle, j, (tau + j - 1), strideP, W, shiftW + idx2D(0, jw, ldw), 1,
+                                strideW, batch_count);
+
+            rocblasCall_dot<COMPLEX, T>(handle, j, W, shiftW + idx2D(0, jw, ldw), 1, strideW, A,
+                                        shiftA + idx2D(0, j, lda), 1, strideA, batch_count, norms,
+                                        work, workArr);
+
+            // (TODO: rocblas_axpy is not yet ready to be used in rocsolver. When it becomes
+            //  available, we can use it instead of the scale_axpy kernel, if it provides
+            //  better performance.)
+            ROCSOLVER_LAUNCH_KERNEL(scale_axpy<T>, grid_n, threads, 0, stream, j, norms,
+                                    tau + j - 1, strideP, A, shiftA + idx2D(0, j, lda), strideA, W,
+                                    shiftW + idx2D(0, jw, ldw), strideW);
+        }
+    }
+
+    rocblas_set_pointer_mode(handle, old_mode);
+    return rocblas_status_success;
+}
+#endif

--- a/library/src/auxiliary/rocauxiliary_latrd_coop.hpp
+++ b/library/src/auxiliary/rocauxiliary_latrd_coop.hpp
@@ -2015,6 +2015,209 @@ static __global__ void set_offdiag_batch_kernel(const rocblas_int batch_count,
 }
 
 template <typename T, typename I, typename Istride, typename UA>
+static __global__ void lower_stage1(I const n,
+                                    I const j,
+
+                                    T* scalars,
+
+                                    T* const W_,
+                                    Istride const shiftW,
+                                    I const ldw,
+                                    Istride const strideW,
+
+                                    T* const A_,
+                                    Istride const shiftA,
+                                    I const lda,
+                                    Istride const strideA,
+
+                                    I const batch_count,
+
+                                    I const mb,
+                                    I const nb)
+{
+    bool constexpr is_complex = rocblas_is_complex<T>;
+
+    I const myprow = hipBlockIdx_x;
+    I const mypcol = hipBlockIdx_y;
+    I const nprow = hipGridDim_x;
+    I const npcol = hipGridDim_y;
+
+    auto cg_grid = cg::this_grid();
+
+    for(I bid = 0; bid < batch_count; bid++)
+    {
+        T* const A = load_ptr_batch(A_, bid, shiftA, strideA);
+        T* const W = load_ptr_batch(W_, bid, shiftW, strideW);
+
+#if(0)
+
+        if(COMPLEX)
+        {
+            rocsolver_lacgv_template<T>(handle, j, W, shiftW + idx2D(j, 0, ldw), ldw, strideW,
+                                        batch_count);
+        }
+#else
+        if(is_complex)
+        {
+            I const nn = j;
+            Xlacgv_body(nn,
+
+                        W, j, 0, ldw, ldw,
+
+                        mb, nb, myprow, mypcol, nprow, npcol);
+            cg_grid.sync();
+        }
+
+#endif
+
+#if(0)
+        rocblasCall_gemv<T>(handle, rocblas_operation_none,
+
+                            n - j, j,
+
+                            cast2constType<T>(scalars), 0,
+
+                            A, shiftA + idx2D(j, 0, lda), lda, strideA,
+
+                            W, shiftW + idx2D(j, 0, ldw), ldw, strideW,
+
+                            cast2constType<T>(scalars + 2), 0,
+
+                            A, shiftA + idx2D(j, j, lda), 1, strideA,
+
+                            batch_count, workArr);
+#else
+        {
+            char const trans = 'N';
+            T const alpha = *scalars;
+            T const beta = *(scalars + 2);
+            I const mm = n - j;
+            I const nn = j;
+
+            I const len_Y = mm;
+
+            Xscale_body(mm, beta,
+
+                        A, j, j, lda, 1,
+
+                        mb, nb, myprow, mypcol, nprow, npcol);
+
+            cg_grid.sync();
+
+            Xgemv_body(trans, mm, nn, alpha,
+
+                       A, j, 0, lda,
+
+                       W, j, 0, ldw, ldw,
+
+                       A, j, j, lda, 1,
+
+                       mb, nb, myprow, mypcol, nprow, npcol);
+
+            cg_grid.sync();
+        }
+#endif
+
+#if(0)
+
+        if(COMPLEX)
+        {
+            rocsolver_lacgv_template<T>(handle, j,
+
+                                        W, shiftW + idx2D(j, 0, ldw), ldw, strideW,
+
+                                        batch_count);
+
+            rocsolver_lacgv_template<T>(handle, j,
+
+                                        A, shiftA + idx2D(j, 0, lda), lda, strideA,
+
+                                        batch_count);
+        }
+#else
+        if(is_complex)
+        {
+            I const nn = j;
+            Xlacgv_body(nn, W, j, 0, ldw, ldw,
+
+                        mb, nb, myprow, mypcol, nprow, npcol);
+
+            Xlacgv_body(nn, A, j, 0, lda, lda,
+
+                        mb, nb, myprow, mypcol, nprow, npcol);
+
+            cg_grid.sync();
+        }
+
+#endif
+
+#if(0)
+        rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j, j, cast2constType<T>(scalars), 0,
+
+                            W, shiftW + idx2D(j, 0, ldw), ldw, strideW,
+
+                            A, shiftA + idx2D(j, 0, lda), lda, strideA,
+
+                            cast2constType<T>(scalars + 2), 0,
+
+                            A, shiftA + idx2D(j, j, lda), 1, strideA,
+
+                            batch_count, workArr);
+#else
+        {
+            char trans = 'N';
+            I const mm = n - j;
+            I const nn = j;
+            I const len_Y = mm;
+
+            T const alpha = *scalars;
+            T const beta = *(scalars + 2);
+
+            Xscale_body(len_Y, beta,
+
+                        A, j, j, lda, 1,
+
+                        mb, mb, myprow, mypcol, nprow, npcol);
+            cg_grid.sync();
+
+            Xgemv_body(trans, mm, nn, alpha,
+
+                       W, j, 0, ldw,
+
+                       A, j, 0, lda, lda,
+
+                       A, j, j, lda, 1,
+
+                       mb, nb, myprow, mypcol, nprow, npcol);
+
+            cg_grid.sync();
+        }
+
+#endif
+
+#if(0)
+        if(COMPLEX)
+            rocsolver_lacgv_template<T>(handle, j, A, shiftA + idx2D(j, 0, lda), lda, strideA,
+                                        batch_count);
+
+#else
+        if(is_complex)
+        {
+            I const nn = j;
+            Xlacgv_body(nn,
+
+                        A, j, 0, lda, lda,
+
+                        mb, nb, myprow, mypcol, nprow, npcol);
+
+            cg_grid.sync();
+        }
+
+#endif
+    } // end for bid
+}
+
+template <typename T, typename I, typename Istride, typename UA>
 static __global__ void upper_stage1(I const n,
                                     I const j,
                                     I const jw,
@@ -2526,72 +2729,82 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
         for(rocblas_int j = 0; j < k; ++j)
         {
             // update column j of A with reflector computed in step j-1
-            if(COMPLEX)
+            if(use_coop)
             {
-                if(use_org)
+#if(0)
+
+                template <typename T, typename I, typename Istride, typename UA>
+                static __global__ void lower_stage1(
+                    I const n, I const j,
+
+                    T* scalars,
+
+                    T* const W_, Istride const shiftW, I const ldw, Istride const strideW,
+
+                    T* const A_, Istride const shiftA, I const lda, Istride const strideA,
+
+                    I const batch_count,
+
+                    I const mb, I const nb)
+#else
+                rocblas_stride const lshiftW = shiftW;
+                rocblas_stride const lshiftA = shiftA;
+
+                void* args[]
+                    = {(void*)&n,           (void*)&j,       (void*)&scalars,
+
+                       (void*)&W,           (void*)&lshiftW, (void*)&ldw,     (void*)&strideW,
+
+                       (void*)&A,           (void*)&lshiftA, (void*)&lda,     (void*)&strideA,
+
+                       (void*)&batch_count,
+
+                       (void*)&mb,          (void*)&nb};
+
+                auto const nx = 32;
+                auto const ny = 32;
+                auto const lds_size = 64 * 1024;
+
+                LAUNCH_CHECK(hipLaunchCooperativeKernel(
+                    (void*)(lower_stage1<T, rocblas_int, rocblas_stride, U>), dim3(num_cu, 1, 1),
+                    dim3(nx, ny, 1), args, lds_size, stream));
+
+#endif
+            }
+            else
+            {
+                if(COMPLEX)
                 {
                     rocsolver_lacgv_template<T>(handle, j, W, shiftW + idx2D(j, 0, ldw), ldw,
                                                 strideW, batch_count);
                 }
-                else
-                {
-                    auto const incw = ldw;
-                    rocsolverCall_lacgv_template<T, rocblas_int, rocblas_stride>(
-                        handle, j, W, shiftW, j, 0, ldw, incw, strideW, batch_count, mb, nb);
-                }
-            }
 
-            if(use_org)
-            {
                 rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j, j,
                                     cast2constType<T>(scalars), 0, A, shiftA + idx2D(j, 0, lda),
                                     lda, strideA, W, shiftW + idx2D(j, 0, ldw), ldw, strideW,
                                     cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j, lda),
                                     1, strideA, batch_count, workArr);
-            }
-            else
-            {
-                auto const incw = ldw;
-                auto const p_alpha = cast2constType<T>(scalars);
-                rocblas_stride const stride_alpha = 0;
-                auto const p_beta = cast2constType<T>(scalars + 2);
-                rocblas_stride const stride_beta = 0;
 
-                rocsolverCall_gemv<T>(handle, rocblas_operation_none, n - j, j, p_alpha,
-                                      stride_alpha, A, shiftA, j, 0, lda, strideA, W, shiftW, j, 0,
-                                      ldw, incw, strideW, p_beta, stride_beta, A, shiftA, j, j, lda,
-                                      1, strideA, batch_count, mb, nb, workArr);
-            }
-
-            if(COMPLEX)
-            {
-                if(use_org)
+                if(COMPLEX)
                 {
                     rocsolver_lacgv_template<T>(handle, j, W, shiftW + idx2D(j, 0, ldw), ldw,
                                                 strideW, batch_count);
                     rocsolver_lacgv_template<T>(handle, j, A, shiftA + idx2D(j, 0, lda), lda,
                                                 strideA, batch_count);
                 }
-                else
+
+                rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j, j,
+                                    cast2constType<T>(scalars), 0, W, shiftW + idx2D(j, 0, ldw),
+                                    ldw, strideW, A, shiftA + idx2D(j, 0, lda), lda, strideA,
+                                    cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j, lda),
+                                    1, strideA, batch_count, workArr);
+
+                if(COMPLEX)
                 {
-                    auto const incw = ldw;
-                    rocsolverCall_lacgv_template<T, rocblas_int, rocblas_stride>(
-                        handle, j, W, shiftW, j, 0, ldw, incw, strideW, batch_count, mb, nb);
-                    auto const inca = lda;
-                    rocsolverCall_lacgv_template<T, rocblas_int, rocblas_stride>(
-                        handle, j, A, shiftA, j, 0, lda, inca, strideA, batch_count, mb, nb);
+                    rocsolver_lacgv_template<T>(handle, j, A, shiftA + idx2D(j, 0, lda), lda,
+                                                strideA, batch_count);
                 }
             }
-
-            rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j, j,
-                                cast2constType<T>(scalars), 0, W, shiftW + idx2D(j, 0, ldw), ldw,
-                                strideW, A, shiftA + idx2D(j, 0, lda), lda, strideA,
-                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j, lda), 1,
-                                strideA, batch_count, workArr);
-
-            if(COMPLEX)
-                rocsolver_lacgv_template<T>(handle, j, A, shiftA + idx2D(j, 0, lda), lda, strideA,
-                                            batch_count);
 
             // generate Householder reflector to work on column j
             rocsolver_larfg_template(handle, n - j - 1, A, shiftA + idx2D(j + 1, j, lda), A,
@@ -2634,30 +2847,11 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
                     shiftW, j + 1, j, ldw, incy, strideW, batch_count, mb, nb, work, workArr);
             }
 
-            if(use_org)
-            {
-                rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, n - j - 1, j,
-                                    cast2constType<T>(scalars + 2), 0, W,
-                                    shiftW + idx2D(j + 1, 0, ldw), ldw, strideW, A,
-                                    shiftA + idx2D(j + 1, j, lda), 1, strideA,
-                                    cast2constType<T>(scalars + 1), 0, W, shiftW + idx2D(0, j, ldw),
-                                    1, strideW, batch_count, workArr);
-            }
-            else
-            {
-                auto const mm = n - j - 1;
-                auto const nn = j;
-                bool const has_work = (mm >= 1) && (nn >= 1);
-                if(has_work)
-                {
-                    rocsolverCall_gemv<T, rocblas_int, rocblas_stride>(
-                        handle, rocblas_operation_conjugate_transpose, mm, nn,
-                        cast2constType<T>(scalars + 2), 0, W, shiftW, j + 1, 0, ldw, strideW, A,
-                        shiftA, j + 1, j, lda, 1, strideA, cast2constType<T>(scalars + 1), 0, W,
-                        shiftW, 0, j, ldw, 1, strideW, batch_count, mb, nb, workArr);
-
-                } // if has_work
-            }
+            rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, n - j - 1, j,
+                                cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(j + 1, 0, ldw),
+                                ldw, strideW, A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
+                                cast2constType<T>(scalars + 1), 0, W, shiftW + idx2D(0, j, ldw), 1,
+                                strideW, batch_count, workArr);
 
             rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j - 1, j,
                                 cast2constType<T>(scalars), 0, A, shiftA + idx2D(j + 1, 0, lda),
@@ -2680,18 +2874,9 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
             rocblasCall_scal<T>(handle, n - j - 1, (tau + j), strideP, W,
                                 shiftW + idx2D(j + 1, j, ldw), 1, strideW, batch_count);
 
-            if(use_org)
-            {
-                rocblasCall_dot<COMPLEX, T>(handle, n - 1 - j, W, shiftW + idx2D(j + 1, j, ldw), 1,
-                                            strideW, A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
-                                            batch_count, norms, work, workArr);
-            }
-            else
-            {
-                rocsolverCall_dot<T, rocblas_int, rocblas_stride>(
-                    handle, n - 1 - j, W, shiftW, j + 1, j, ldw, 1, strideW, A, shiftA, j + 1, j,
-                    lda, 1, strideA, batch_count, norms, mb, nb, work, workArr);
-            }
+            rocblasCall_dot<COMPLEX, T>(handle, n - 1 - j, W, shiftW + idx2D(j + 1, j, ldw), 1,
+                                        strideW, A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
+                                        batch_count, norms, work, workArr);
 
             // (TODO: rocblas_axpy is not yet ready to be used in rocsolver. When it becomes
             //  available, we can use it instead of the scale_axpy kernel, if it provides
@@ -2743,9 +2928,6 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
                 auto const nx = 32;
                 auto const ny = 32;
                 auto const lds_size = 64 * 1024;
-
-                hipStream_t stream;
-                rocblas_get_stream(handle, &stream);
 
                 LAUNCH_CHECK(hipLaunchCooperativeKernel(
                     (void*)(upper_stage1<T, rocblas_int, rocblas_stride, U>), dim3(num_cu, 1, 1),

--- a/library/src/auxiliary/rocauxiliary_latrd_coop.hpp
+++ b/library/src/auxiliary/rocauxiliary_latrd_coop.hpp
@@ -2014,6 +2014,202 @@ static __global__ void set_offdiag_batch_kernel(const rocblas_int batch_count,
     }
 }
 
+template <typename T, typename I, typename Istride, typename UA>
+static __global__ void upper_stage1(I const n,
+                                    I const j,
+                                    I const jw,
+
+                                    T* const scalars,
+
+                                    T* const W_,
+                                    Istride const shiftW,
+                                    I const ldw,
+                                    Istride const strideW,
+
+                                    UA A_,
+                                    Istride const shiftA,
+                                    I const lda,
+                                    Istride const strideA,
+
+                                    I const batch_count,
+                                    I const mb,
+                                    I const nb)
+{
+    bool constexpr is_complex = rocblas_is_complex<T>;
+
+    I const myprow = hipBlockIdx_x;
+    I const mypcol = hipBlockIdx_y;
+    I const nprow = hipGridDim_x;
+    I const npcol = hipGridDim_y;
+
+    auto cg_grid = cg::this_grid();
+
+    for(I bid = 0; bid < batch_count; bid++)
+    {
+        T* const A = load_ptr_batch(A_, bid, shiftA, strideA);
+        T* const W = load_ptr_batch(W_, bid, shiftW, strideW);
+
+#if(0)
+        // update column j of A with reflector computed in step j-1
+        if(COMPLEX)
+            rocsolver_lacgv_template<T>(handle, n - 1 - j, W, shiftW + idx2D(j, jw + 1, ldw), ldw,
+                                        strideW, batch_count);
+#else
+        if(is_complex)
+        {
+            I const nn = n - 1 - j;
+            Xlacgv_body<T>(nn,
+
+                           W, j, jw + 1, ldw, ldw,
+
+                           mb, nb, myprow, mypcol, nprow, npcol);
+
+            cg_grid.sync();
+        }
+#endif
+
+#if(0)
+        rocblasCall_gemv<T>(handle, rocblas_operation_none, j + 1, n - 1 - j,
+
+                            cast2constType<T>(scalars), 0,
+
+                            A, shiftA + idx2D(0, j + 1, lda), lda, strideA,
+
+                            W, shiftW + idx2D(j, jw + 1, ldw), ldw, strideW,
+
+                            cast2constType<T>(scalars + 2), 0,
+
+                            A, shiftA + idx2D(0, j, lda), 1, strideA,
+
+                            batch_count, workArr);
+#else
+        {
+            char const trans = 'N';
+            I const mm = j + 1;
+            I const nn = n - 1 - j;
+            auto const alpha = *scalars;
+            auto const beta = *(scalars + 2);
+
+            I const len_Y = mm;
+            Xscale_body(len_Y, beta,
+
+                        A, 0, j, lda, 1,
+
+                        mb, nb, myprow, mypcol, nprow, npcol);
+
+            cg_grid.sync();
+
+            Xgemv_body(trans, mm, nn, alpha,
+
+                       A, 0, j + 1, lda,
+
+                       W, j, jw + 1, ldw, ldw,
+
+                       A, 0, j, lda, 1,
+
+                       mb, nb, myprow, mypcol, nprow, npcol);
+
+            cg_grid.sync();
+        }
+
+#endif
+
+#if(0)
+        if(COMPLEX)
+        {
+            rocsolver_lacgv_template<T>(handle, n - 1 - j,
+
+                                        W, shiftW + idx2D(j, jw + 1, ldw), ldw, strideW,
+
+                                        batch_count);
+            rocsolver_lacgv_template<T>(handle, n - 1 - j,
+
+                                        A, shiftA + idx2D(j, j + 1, lda), lda, strideA,
+
+                                        batch_count);
+        }
+#else
+        if(is_complex)
+        {
+            auto const nn = n - 1 - j;
+
+            Xlacgv_body(nn,
+
+                        W, j, jw + 1, ldw, ldw,
+
+                        mb, nb, myprow, mypcol, nprow, npcol);
+
+            Xlacgv_body(nn, A, j, j + 1, lda, lda,
+
+                        mb, nb, myprow, mypcol, nprow, npcol);
+
+            cg_grid.sync();
+        }
+#endif
+
+#if(0)
+        rocblasCall_gemv<T>(handle, rocblas_operation_none, j + 1, n - 1 - j,
+                            cast2constType<T>(scalars), 0,
+
+                            W, shiftW + idx2D(0, jw + 1, ldw), ldw, strideW,
+
+                            A, shiftA + idx2D(j, j + 1, lda), lda, strideA,
+
+                            cast2constType<T>(scalars + 2), 0,
+
+                            A, shiftA + idx2D(0, j, lda), 1, strideA,
+
+                            batch_count, workArr);
+#else
+        {
+            char const trans = 'N';
+            I const mm = j + 1;
+            I const nn = n - 1 - j;
+            auto const len_Y = mm;
+
+            auto const alpha = *scalars;
+            auto const beta = *(scalars + 2);
+
+            Xscale_body(len_Y, beta, A, 0, j, lda, 1, mb, nb, myprow, mypcol, nprow, npcol);
+
+            cg_grid.sync();
+
+            Xgemv_body(trans, mm, nn, alpha,
+
+                       W, 0, jw + 1, ldw,
+
+                       A, j, j + 1, lda, lda,
+
+                       A, 0, j, lda, 1,
+
+                       mb, nb, myprow, mypcol, nprow, npcol);
+
+            cg_grid.sync();
+        }
+
+#endif
+
+#if(0)
+        if(COMPLEX)
+            rocsolver_lacgv_template<T>(handle, n - 1 - j,
+
+                                        A, shiftA + idx2D(j, j + 1, lda), lda, strideA,
+
+                                        batch_count);
+#else
+        if(is_complex)
+        {
+            auto const nn = n - 1 - j;
+            Xlacgv_body(nn, A, j, j + 1, lda, lda,
+
+                        mb, nb, myprow, mypcol, nprow, npcol);
+
+            cg_grid.sync();
+        }
+#endif
+    } // end for bid
+}
+
 template <typename T, typename I, typename Istride, typename UA, typename UW>
 static __global__ void upper_stage2(I const n,
                                     I const j,
@@ -2514,63 +2710,113 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
         {
             jw = j - n + k;
             // update column j of A with reflector computed in step j-1
-            if(COMPLEX)
-                rocsolver_lacgv_template<T>(handle, n - 1 - j, W, shiftW + idx2D(j, jw + 1, ldw),
-                                            ldw, strideW, batch_count);
-
-            rocblasCall_gemv<T>(handle, rocblas_operation_none, j + 1, n - 1 - j,
-                                cast2constType<T>(scalars), 0, A, shiftA + idx2D(0, j + 1, lda),
-                                lda, strideA, W, shiftW + idx2D(j, jw + 1, ldw), ldw, strideW,
-                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(0, j, lda), 1,
-                                strideA, batch_count, workArr);
-
-            if(COMPLEX)
-            {
-                rocsolver_lacgv_template<T>(handle, n - 1 - j, W, shiftW + idx2D(j, jw + 1, ldw),
-                                            ldw, strideW, batch_count);
-                rocsolver_lacgv_template<T>(handle, n - 1 - j, A, shiftA + idx2D(j, j + 1, lda),
-                                            lda, strideA, batch_count);
-            }
-
-            rocblasCall_gemv<T>(handle, rocblas_operation_none, j + 1, n - 1 - j,
-                                cast2constType<T>(scalars), 0, W, shiftW + idx2D(0, jw + 1, ldw),
-                                ldw, strideW, A, shiftA + idx2D(j, j + 1, lda), lda, strideA,
-                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(0, j, lda), 1,
-                                strideA, batch_count, workArr);
-
-            if(COMPLEX)
-                rocsolver_lacgv_template<T>(handle, n - 1 - j, A, shiftA + idx2D(j, j + 1, lda),
-                                            lda, strideA, batch_count);
-
-            // generate Householder reflector to work on column j
-            rocsolver_larfg_template(handle, j, A, shiftA + idx2D(j - 1, j, lda), A,
-                                     shiftA + idx2D(0, j, lda), 1, strideA, (tau + j - 1), strideP,
-                                     batch_count, work, norms);
-
-            // copy to E(j) the corresponding off-diagonal element of A, which is set to 1
-            ROCSOLVER_LAUNCH_KERNEL(set_offdiag<T>, grid_b, threads, 0, stream, batch_count, A,
-                                    shiftA + idx2D(j - 1, j, lda), strideA, (E + j - 1), strideE);
-
-            // compute/update column j of W
-            rocblasCall_symv_hemv<T>(handle, uplo, j, (scalars + 2), 0, A, shiftA, lda, strideA, A,
-                                     shiftA + idx2D(0, j, lda), 1, strideA, (scalars + 1), 0, W,
-                                     shiftW + idx2D(0, jw, ldw), 1, strideW, batch_count, work,
-                                     workArr);
-
             if(use_coop)
             {
 #if(0)
-                template <typename T, typename I, typename Istride, typename UA, typename UW>
-                static __device__ void upper_stage2(
+                template <typename T, typename I, typename Istride, typename UA>
+                static __global__ void upper_stage1(
                     I const n, I const j, I const jw,
 
-                    T const* const scalars, T* const tau, Istride const strideP, T* const norms,
+                    T* const scalars,
 
-                    UW W_, Istride const shiftW, I const ldw, Istride const strideW,
+                    T* const W_, Istride const shiftW, I const ldw, Istride const strideW,
 
                     UA A_, Istride const shiftA, I const lda, Istride const strideA,
 
                     I const batch_count, I const mb, I const nb)
+                {
+#else
+                rocblas_stride lshiftW = shiftW;
+                rocblas_stride lshiftA = shiftA;
+                void* args[] = {
+
+                    (void*)&n,           (void*)&j,       (void*)&jw,
+
+                    (void*)&scalars,
+
+                    (void*)&W,           (void*)&lshiftW, (void*)&ldw, (void*)&strideW,
+
+                    (void*)&A,           (void*)&lshiftA, (void*)&lda, (void*)&strideA,
+
+                    (void*)&batch_count, (void*)&mb,      (void*)&nb};
+
+                auto const nx = 32;
+                auto const ny = 32;
+                auto const lds_size = 64 * 1024;
+
+                hipStream_t stream;
+                rocblas_get_stream(handle, &stream);
+
+                LAUNCH_CHECK(hipLaunchCooperativeKernel(
+                    (void*)(upper_stage1<T, rocblas_int, rocblas_stride, U>), dim3(num_cu, 1, 1),
+                    dim3(nx, ny, 1), args, lds_size, stream));
+
+#endif
+                }
+                else
+                {
+                    if(COMPLEX)
+                        rocsolver_lacgv_template<T>(handle, n - 1 - j, W,
+                                                    shiftW + idx2D(j, jw + 1, ldw), ldw, strideW,
+                                                    batch_count);
+
+                    rocblasCall_gemv<T>(handle, rocblas_operation_none, j + 1, n - 1 - j,
+                                        cast2constType<T>(scalars), 0, A,
+                                        shiftA + idx2D(0, j + 1, lda), lda, strideA, W,
+                                        shiftW + idx2D(j, jw + 1, ldw), ldw, strideW,
+                                        cast2constType<T>(scalars + 2), 0, A,
+                                        shiftA + idx2D(0, j, lda), 1, strideA, batch_count, workArr);
+
+                    if(COMPLEX)
+                    {
+                        rocsolver_lacgv_template<T>(handle, n - 1 - j, W,
+                                                    shiftW + idx2D(j, jw + 1, ldw), ldw, strideW,
+                                                    batch_count);
+                        rocsolver_lacgv_template<T>(handle, n - 1 - j, A,
+                                                    shiftA + idx2D(j, j + 1, lda), lda, strideA,
+                                                    batch_count);
+                    }
+
+                    rocblasCall_gemv<T>(
+                        handle, rocblas_operation_none, j + 1, n - 1 - j, cast2constType<T>(scalars),
+                        0, W, shiftW + idx2D(0, jw + 1, ldw), ldw, strideW, A,
+                        shiftA + idx2D(j, j + 1, lda), lda, strideA, cast2constType<T>(scalars + 2),
+                        0, A, shiftA + idx2D(0, j, lda), 1, strideA, batch_count, workArr);
+
+                    if(COMPLEX)
+                        rocsolver_lacgv_template<T>(handle, n - 1 - j, A,
+                                                    shiftA + idx2D(j, j + 1, lda), lda, strideA,
+                                                    batch_count);
+                }
+                // generate Householder reflector to work on column j
+                rocsolver_larfg_template(handle, j, A, shiftA + idx2D(j - 1, j, lda), A,
+                                         shiftA + idx2D(0, j, lda), 1, strideA, (tau + j - 1),
+                                         strideP, batch_count, work, norms);
+
+                // copy to E(j) the corresponding off-diagonal element of A, which is set to 1
+                ROCSOLVER_LAUNCH_KERNEL(set_offdiag<T>, grid_b, threads, 0, stream, batch_count, A,
+                                        shiftA + idx2D(j - 1, j, lda), strideA, (E + j - 1), strideE);
+
+                // compute/update column j of W
+                rocblasCall_symv_hemv<T>(handle, uplo, j, (scalars + 2), 0, A, shiftA, lda, strideA,
+                                         A, shiftA + idx2D(0, j, lda), 1, strideA, (scalars + 1), 0,
+                                         W, shiftW + idx2D(0, jw, ldw), 1, strideW, batch_count,
+                                         work, workArr);
+
+                if(use_coop)
+                {
+#if(0)
+                    template <typename T, typename I, typename Istride, typename UA, typename UW>
+                    static __device__ void upper_stage2(
+                        I const n, I const j, I const jw,
+
+                        T const* const scalars, T* const tau, Istride const strideP, T* const norms,
+
+                        UW W_, Istride const shiftW, I const ldw, Istride const strideW,
+
+                        UA A_, Istride const shiftA, I const lda, Istride const strideA,
+
+                        I const batch_count, I const mb, I const nb)
 #else
                 rocblas_stride const lshiftA = shiftA;
                 rocblas_stride const lshiftW = shiftW;
@@ -2591,52 +2837,54 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
                     dim3(num_cu, 1, 1), dim3(nx, ny, 1), args, lds_size, stream));
 
 #endif
-            }
-            else
-            {
-                rocblasCall_gemv<T>(
-                    handle, rocblas_operation_conjugate_transpose, j, n - 1 - j,
-                    cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(0, jw + 1, ldw), ldw,
-                    strideW, A, shiftA + idx2D(0, j, lda), 1, strideA, cast2constType<T>(scalars + 1),
-                    0, W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW, batch_count, workArr);
+                }
+                else
+                {
+                    rocblasCall_gemv<T>(
+                        handle, rocblas_operation_conjugate_transpose, j, n - 1 - j,
+                        cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(0, jw + 1, ldw), ldw,
+                        strideW, A, shiftA + idx2D(0, j, lda), 1, strideA,
+                        cast2constType<T>(scalars + 1), 0, W, shiftW + idx2D(j + 1, jw, ldw), 1,
+                        strideW, batch_count, workArr);
 
-                rocblasCall_gemv<T>(handle, rocblas_operation_none, j, n - 1 - j,
-                                    cast2constType<T>(scalars), 0, A, shiftA + idx2D(0, j + 1, lda),
-                                    lda, strideA, W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW,
-                                    cast2constType<T>(scalars + 2), 0, W,
-                                    shiftW + idx2D(0, jw, ldw), 1, strideW, batch_count, workArr);
+                    rocblasCall_gemv<T>(
+                        handle, rocblas_operation_none, j, n - 1 - j, cast2constType<T>(scalars), 0,
+                        A, shiftA + idx2D(0, j + 1, lda), lda, strideA, W,
+                        shiftW + idx2D(j + 1, jw, ldw), 1, strideW, cast2constType<T>(scalars + 2),
+                        0, W, shiftW + idx2D(0, jw, ldw), 1, strideW, batch_count, workArr);
 
-                rocblasCall_gemv<T>(
-                    handle, rocblas_operation_conjugate_transpose, j, n - 1 - j,
-                    cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(0, j + 1, lda), lda, strideA,
-                    A, shiftA + idx2D(0, j, lda), 1, strideA, cast2constType<T>(scalars + 1), 0, W,
-                    shiftW + idx2D(j + 1, jw, ldw), 1, strideW, batch_count, workArr);
+                    rocblasCall_gemv<T>(
+                        handle, rocblas_operation_conjugate_transpose, j, n - 1 - j,
+                        cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(0, j + 1, lda), lda,
+                        strideA, A, shiftA + idx2D(0, j, lda), 1, strideA,
+                        cast2constType<T>(scalars + 1), 0, W, shiftW + idx2D(j + 1, jw, ldw), 1,
+                        strideW, batch_count, workArr);
 
-                rocblasCall_gemv<T>(handle, rocblas_operation_none, j, n - 1 - j,
-                                    cast2constType<T>(scalars), 0, W, shiftW + idx2D(0, jw + 1, ldw),
-                                    ldw, strideW, W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW,
-                                    cast2constType<T>(scalars + 2), 0, W,
-                                    shiftW + idx2D(0, jw, ldw), 1, strideW, batch_count, workArr);
+                    rocblasCall_gemv<T>(
+                        handle, rocblas_operation_none, j, n - 1 - j, cast2constType<T>(scalars), 0,
+                        W, shiftW + idx2D(0, jw + 1, ldw), ldw, strideW, W,
+                        shiftW + idx2D(j + 1, jw, ldw), 1, strideW, cast2constType<T>(scalars + 2),
+                        0, W, shiftW + idx2D(0, jw, ldw), 1, strideW, batch_count, workArr);
 
-                rocblasCall_scal<T>(handle, j, (tau + j - 1), strideP, W,
-                                    shiftW + idx2D(0, jw, ldw), 1, strideW, batch_count);
+                    rocblasCall_scal<T>(handle, j, (tau + j - 1), strideP, W,
+                                        shiftW + idx2D(0, jw, ldw), 1, strideW, batch_count);
 
-                rocblasCall_dot<COMPLEX, T>(handle, j, W, shiftW + idx2D(0, jw, ldw), 1, strideW, A,
-                                            shiftA + idx2D(0, j, lda), 1, strideA, batch_count,
-                                            norms, work, workArr);
-            }
+                    rocblasCall_dot<COMPLEX, T>(handle, j, W, shiftW + idx2D(0, jw, ldw), 1,
+                                                strideW, A, shiftA + idx2D(0, j, lda), 1, strideA,
+                                                batch_count, norms, work, workArr);
+                }
 
-            // (TODO: rocblas_axpy is not yet ready to be used in rocsolver. When it becomes
-            //  available, we can use it instead of the scale_axpy kernel, if it provides
-            //  better performance.)
-            ROCSOLVER_LAUNCH_KERNEL(scale_axpy<T>, grid_n, threads, 0, stream, j, norms,
-                                    tau + j - 1, strideP, A, shiftA + idx2D(0, j, lda), strideA, W,
-                                    shiftW + idx2D(0, jw, ldw), strideW);
-        } // end for  j
+                // (TODO: rocblas_axpy is not yet ready to be used in rocsolver. When it becomes
+                //  available, we can use it instead of the scale_axpy kernel, if it provides
+                //  better performance.)
+                ROCSOLVER_LAUNCH_KERNEL(scale_axpy<T>, grid_n, threads, 0, stream, j, norms,
+                                        tau + j - 1, strideP, A, shiftA + idx2D(0, j, lda), strideA,
+                                        W, shiftW + idx2D(0, jw, ldw), strideW);
+            } // end for  j
+        }
+
+        rocblas_set_pointer_mode(handle, old_mode);
+        return rocblas_status_success;
     }
 
-    rocblas_set_pointer_mode(handle, old_mode);
-    return rocblas_status_success;
-}
-
-ROCSOLVER_END_NAMESPACE
+    ROCSOLVER_END_NAMESPACE

--- a/library/src/auxiliary/rocauxiliary_latrd_coop.hpp
+++ b/library/src/auxiliary/rocauxiliary_latrd_coop.hpp
@@ -2052,10 +2052,17 @@ static __global__ void upper_stage2(I const n,
 
 #if(0)
         rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, j, n - 1 - j,
-                            cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(0, jw + 1, ldw),
-                            ldw, strideW, A, shiftA + idx2D(0, j, lda), 1, strideA,
-                            cast2constType<T>(scalars + 1), 0, W, shiftW + idx2D(j + 1, jw, ldw), 1,
-                            strideW, batch_count, workArr);
+                            cast2constType<T>(scalars + 2), 0,
+
+                            W, shiftW + idx2D(0, jw + 1, ldw), ldw, strideW,
+
+                            A, shiftA + idx2D(0, j, lda), 1, strideA,
+
+                            cast2constType<T>(scalars + 1), 0,
+
+                            W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW,
+
+                            batch_count, workArr);
 #else
         {
             char const trans = 'C';
@@ -2071,18 +2078,32 @@ static __global__ void upper_stage2(I const n,
 
             cg_grid.sync();
 
-            Xgemv_body<T, I>(trans, mm, nn, alpha, W, 0, jw + 1, ldw, A, 0, j, lda, 1, W, j + 1, jw,
-                             ldw, 1, mb, nb, myprow, mypcol, nprow, npcol);
+            Xgemv_body<T, I>(trans, mm, nn, alpha,
+
+                             W, 0, jw + 1, ldw,
+
+                             A, 0, j, lda, 1,
+
+                             W, j + 1, jw, ldw, 1,
+
+                             mb, nb, myprow, mypcol, nprow, npcol);
             cg_grid.sync();
         }
 #endif
 
 #if(0)
         rocblasCall_gemv<T>(handle, rocblas_operation_none, j, n - 1 - j,
-                            cast2constType<T>(scalars), 0, A, shiftA + idx2D(0, j + 1, lda), lda,
-                            strideA, W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW,
-                            cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(0, jw, ldw), 1,
-                            strideW, batch_count, workArr);
+                            cast2constType<T>(scalars), 0,
+
+                            A, shiftA + idx2D(0, j + 1, lda), lda, strideA,
+
+                            W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW,
+
+                            cast2constType<T>(scalars + 2), 0,
+
+                            W, shiftW + idx2D(0, jw, ldw), 1, strideW,
+
+                            batch_count, workArr);
 #else
         {
             char const trans = 'N';
@@ -2093,22 +2114,40 @@ static __global__ void upper_stage2(I const n,
             T const alpha = *scalars;
             T const beta = *(scalars + 2);
 
-            Xscale_body<T, I>(len_Y, alpha, W, 0, jw, ldw, 1, mb, nb, myprow, mypcol, nprow, npcol);
+            Xscale_body<T, I>(len_Y, beta,
+
+                              W, 0, jw, ldw, 1,
+
+                              mb, nb, myprow, mypcol, nprow, npcol);
 
             cg_grid.sync();
 
-            Xgemv_body<T, I>(trans, mm, nn, alpha, A, 0, j + 1, lda, W, j + 1, jw, ldw, 1, W, 0, jw,
-                             ldw, 1, mb, nb, myprow, mypcol, nprow, npcol);
+            Xgemv_body<T, I>(trans, mm, nn, alpha,
+
+                             A, 0, j + 1, lda,
+
+                             W, j + 1, jw, ldw, 1,
+
+                             W, 0, jw, ldw, 1,
+
+                             mb, nb, myprow, mypcol, nprow, npcol);
             cg_grid.sync();
         }
 #endif
 
 #if(0)
         rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, j, n - 1 - j,
-                            cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(0, j + 1, lda),
-                            lda, strideA, A, shiftA + idx2D(0, j, lda), 1, strideA,
-                            cast2constType<T>(scalars + 1), 0, W, shiftW + idx2D(j + 1, jw, ldw), 1,
-                            strideW, batch_count, workArr);
+                            cast2constType<T>(scalars + 2), 0,
+
+                            A, shiftA + idx2D(0, j + 1, lda), lda, strideA,
+
+                            A, shiftA + idx2D(0, j, lda), 1, strideA,
+
+                            cast2constType<T>(scalars + 1), 0,
+
+                            W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW,
+
+                            batch_count, workArr);
 #else
         {
             char const trans = 'C';
@@ -2123,8 +2162,15 @@ static __global__ void upper_stage2(I const n,
                               npcol);
             cg_grid.sync();
 
-            Xgemv_body<T, I>(trans, mm, nn, alpha, A, 0, j + 1, lda, A, 0, j, lda, 1, W, j + 1, jw,
-                             ldw, 1, mb, nb, myprow, mypcol, nprow, npcol);
+            Xgemv_body<T, I>(trans, mm, nn, alpha,
+
+                             A, 0, j + 1, lda,
+
+                             A, 0, j, lda, 1,
+
+                             W, j + 1, jw, ldw, 1,
+
+                             mb, nb, myprow, mypcol, nprow, npcol);
 
             cg_grid.sync();
         }
@@ -2132,10 +2178,17 @@ static __global__ void upper_stage2(I const n,
 
 #if(0)
         rocblasCall_gemv<T>(handle, rocblas_operation_none, j, n - 1 - j,
-                            cast2constType<T>(scalars), 0, W, shiftW + idx2D(0, jw + 1, ldw), ldw,
-                            strideW, W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW,
-                            cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(0, jw, ldw), 1,
-                            strideW, batch_count, workArr);
+                            cast2constType<T>(scalars), 0,
+
+                            W, shiftW + idx2D(0, jw + 1, ldw), ldw, strideW,
+
+                            W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW,
+
+                            cast2constType<T>(scalars + 2), 0,
+
+                            W, shiftW + idx2D(0, jw, ldw), 1, strideW,
+
+                            batch_count, workArr);
 #else
         {
             char const trans = 'N';
@@ -2146,12 +2199,23 @@ static __global__ void upper_stage2(I const n,
             T const alpha = *(scalars);
             T const beta = *(scalars + 2);
 
-            Xscale_body<T, I>(len_Y, beta, W, 0, jw, ldw, 1, mb, nb, myprow, mypcol, nprow, npcol);
+            Xscale_body<T, I>(len_Y, beta,
+
+                              W, 0, jw, ldw, 1,
+
+                              mb, nb, myprow, mypcol, nprow, npcol);
 
             cg_grid.sync();
 
-            Xgemv_body<T, I>(trans, mm, nn, alpha, W, 0, jw + 1, ldw, W, j + 1, jw, ldw, 1, W, 0,
-                             jw, ldw, 1, mb, nb, myprow, mypcol, nprow, npcol);
+            Xgemv_body<T, I>(trans, mm, nn, alpha,
+
+                             W, 0, jw + 1, ldw,
+
+                             W, j + 1, jw, ldw, 1,
+
+                             W, 0, jw, ldw, 1,
+
+                             mb, nb, myprow, mypcol, nprow, npcol);
 
             cg_grid.sync();
         }
@@ -2167,21 +2231,36 @@ static __global__ void upper_stage2(I const n,
             T const* const p_alpha = (tau + j - 1);
             T const alpha = *(p_alpha + bid * strideP);
 
-            Xscale_body<T, I>(nn, alpha, W, 0, jw, ldw, 1, mb, nb, myprow, mypcol, nprow, npcol);
+            Xscale_body<T, I>(nn, alpha,
+
+                              W, 0, jw, ldw, 1,
+
+                              mb, nb, myprow, mypcol, nprow, npcol);
 
             cg_grid.sync();
         }
 #endif
 
 #if(0)
-        rocblasCall_dot<COMPLEX, T>(handle, j, W, shiftW + idx2D(0, jw, ldw), 1, strideW, A,
-                                    shiftA + idx2D(0, j, lda), 1, strideA, batch_count, norms, work,
-                                    workArr);
+        rocblasCall_dot<COMPLEX, T>(handle, j,
+
+                                    W, shiftW + idx2D(0, jw, ldw), 1, strideW,
+
+                                    A, shiftA + idx2D(0, j, lda), 1, strideA,
+
+                                    batch_count, norms, work, workArr);
 #else
         {
             I const nn = j;
-            Xdot_body<T, I>(nn, W, 0, jw, ldw, 1, A, 0, j, lda, 1, &(norms[bid]), mb, nb, myprow,
-                            mypcol, nprow, npcol);
+            Xdot_body<T, I>(nn,
+
+                            W, 0, jw, ldw, 1,
+
+                            A, 0, j, lda, 1,
+
+                            &(norms[bid]),
+
+                            mb, nb, myprow, mypcol, nprow, npcol);
             cg_grid.sync();
         }
 #endif
@@ -2485,7 +2564,7 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
                 static __device__ void upper_stage2(
                     I const n, I const j, I const jw,
 
-                    T const* const scalars, T* const tau, Istride const strideP,
+                    T const* const scalars, T* const tau, Istride const strideP, T* const norms,
 
                     UW W_, Istride const shiftW, I const ldw, Istride const strideW,
 
@@ -2493,8 +2572,8 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
 
                     I const batch_count, I const mb, I const nb)
 #else
-                rocblas_stride lshiftA = shiftA;
-                rocblas_stride lshiftW = shiftW;
+                rocblas_stride const lshiftA = shiftA;
+                rocblas_stride const lshiftW = shiftW;
 
                 void* args[]
                     = {(void*)&n,           (void*)&j,       (void*)&jw,

--- a/library/src/auxiliary/rocauxiliary_latrd_coop.hpp
+++ b/library/src/auxiliary/rocauxiliary_latrd_coop.hpp
@@ -1129,8 +1129,7 @@ static __device__ void Xgemv_body(char const trans,
         return (A_[idx2D(i, j, lda)]);
     };
 
-    // bool const need_atomic_update = (is_no_transpose) ? (npcol > 1) : (nprow > 1);
-    bool const need_atomic_update = true;
+    bool const need_atomic_update = (is_no_transpose) ? (npcol > 1) : (nprow > 1);
 
     I const itileA_start = first_tile(ia, mb, myprow, nprow);
     I const itileA_end = first_tile(ia + m - 1, mb, myprow, nprow);
@@ -1154,28 +1153,9 @@ static __device__ void Xgemv_body(char const trans,
 
     auto rsum_sh = [=](auto tx, auto ty) -> T& { return (rsum_sh_[tx + ty * ld_rsum_sh]); };
 
-    for(auto i = (0 + tixy); i < (ld_rsum_sh)*ny; i += nxny)
-    {
-        rsum_sh_[i] = 0;
-    }
-
-    for(auto i = (0 + tixy); i < mbnb; i += nxny)
-    {
-        Xvec_sh[i] = 0;
-    }
-
-    __syncthreads();
+    bool constexpr use_Xvec_sh = false;
 
     auto cgwave = cg::tiled_partition(cg::this_thread_block(), nx);
-
-#if(0)
-    {
-        if(cg::this_grid().thread_rank() == 0)
-        {
-            printf("trans=%c, m=%d, n=%d, ia=%d, ja=%d\n", trans, m, n, ia, ja);
-        }
-    }
-#endif
 
     if(is_no_transpose)
     {
@@ -1196,19 +1176,22 @@ static __device__ void Xgemv_body(char const trans,
                 auto const istart = std::max(ia, itileA * mb);
                 auto const iend = std::min(ia + m - 1, itileA * mb + (mb - 1));
 
-                for(auto jja = (jstart + tixy); jja <= jend; jja += nxny)
+                if(use_Xvec_sh)
                 {
-                    Xvec_sh[(jja - jstart)] = Xvec(jja - ja);
-                }
+                    for(auto jja = (jstart + tixy); jja <= jend; jja += nxny)
+                    {
+                        Xvec_sh[(jja - jstart)] = Xvec(jja - ja);
+                    }
 
-                __syncthreads();
+                    __syncthreads();
+                }
 
                 for(auto iia = (istart + tiy); iia <= iend; iia += ny)
                 {
                     T rsum = 0;
                     for(auto jja = (jstart + tix); jja <= jend; jja += nx)
                     {
-                        auto const xj = Xvec_sh[(jja - jstart)];
+                        auto const xj = (use_Xvec_sh) ? Xvec_sh[(jja - jstart)] : Xvec(jja - ja);
                         auto const aij = A(iia, jja);
                         rsum += aij * xj;
                     }
@@ -1253,12 +1236,15 @@ static __device__ void Xgemv_body(char const trans,
                 auto const istart = std::max(ia, itileA * mb);
                 auto const iend = std::min(ia + m - 1, itileA * mb + (mb - 1));
 
-                for(auto iia = (istart + tixy); iia <= iend; iia += nxny)
+                if(use_Xvec_sh)
                 {
-                    Xvec_sh[(iia - istart)] = Xvec((iia - ia));
-                }
+                    for(auto iia = (istart + tixy); iia <= iend; iia += nxny)
+                    {
+                        Xvec_sh[(iia - istart)] = Xvec((iia - ia));
+                    }
 
-                __syncthreads();
+                    __syncthreads();
+                }
 
                 for(auto jja = (jstart + tiy); jja <= jend; jja += ny)
                 {
@@ -1266,7 +1252,7 @@ static __device__ void Xgemv_body(char const trans,
                     for(auto iia = (istart + tix); iia <= iend; iia += nx)
                     {
                         T const aij = A(iia, jja);
-                        T const xi = Xvec_sh[(iia - istart)];
+                        T const xi = (use_Xvec_sh) ? Xvec_sh[(iia - istart)] : Xvec(iia - ia);
 
                         if(is_complex && is_conj_transpose)
                         {
@@ -2025,7 +2011,7 @@ static __global__ void lower_stage1(I const n,
                                     I const ldw,
                                     Istride const strideW,
 
-                                    T* const A_,
+                                    UA A_,
                                     Istride const shiftA,
                                     I const lda,
                                     Istride const strideA,
@@ -2096,13 +2082,17 @@ static __global__ void lower_stage1(I const n,
 
             I const len_Y = mm;
 
-            Xscale_body(mm, beta,
+            bool const has_work = (len_Y >= 1) && (beta != 1);
+            if(has_work)
+            {
+                Xscale_body(len_Y, beta,
 
-                        A, j, j, lda, 1,
+                            A, j, j, lda, 1,
 
-                        mb, nb, myprow, mypcol, nprow, npcol);
+                            mb, nb, myprow, mypcol, nprow, npcol);
 
-            cg_grid.sync();
+                cg_grid.sync();
+            }
 
             Xgemv_body(trans, mm, nn, alpha,
 
@@ -2173,12 +2163,17 @@ static __global__ void lower_stage1(I const n,
             T const alpha = *scalars;
             T const beta = *(scalars + 2);
 
-            Xscale_body(len_Y, beta,
+            bool const has_work = (len_Y >= 1) && (beta != 1);
+            if(has_work)
+            {
+                Xscale_body(len_Y, beta,
 
-                        A, j, j, lda, 1,
+                            A, j, j, lda, 1,
 
-                        mb, mb, myprow, mypcol, nprow, npcol);
-            cg_grid.sync();
+                            mb, mb, myprow, mypcol, nprow, npcol);
+
+                cg_grid.sync();
+            }
 
             Xgemv_body(trans, mm, nn, alpha,
 
@@ -2294,13 +2289,17 @@ static __global__ void upper_stage1(I const n,
             auto const beta = *(scalars + 2);
 
             I const len_Y = mm;
-            Xscale_body(len_Y, beta,
+            bool const has_work = (len_Y >= 1) && (beta != 1);
+            if(has_work)
+            {
+                Xscale_body(len_Y, beta,
 
-                        A, 0, j, lda, 1,
+                            A, 0, j, lda, 1,
 
-                        mb, nb, myprow, mypcol, nprow, npcol);
+                            mb, nb, myprow, mypcol, nprow, npcol);
 
-            cg_grid.sync();
+                cg_grid.sync();
+            }
 
             Xgemv_body(trans, mm, nn, alpha,
 
@@ -2373,9 +2372,13 @@ static __global__ void upper_stage1(I const n,
             auto const alpha = *scalars;
             auto const beta = *(scalars + 2);
 
-            Xscale_body(len_Y, beta, A, 0, j, lda, 1, mb, nb, myprow, mypcol, nprow, npcol);
+            bool const has_work = (len_Y >= 1) && (beta != 1);
+            if(has_work)
+            {
+                Xscale_body(len_Y, beta, A, 0, j, lda, 1, mb, nb, myprow, mypcol, nprow, npcol);
 
-            cg_grid.sync();
+                cg_grid.sync();
+            }
 
             Xgemv_body(trans, mm, nn, alpha,
 
@@ -2409,6 +2412,274 @@ static __global__ void upper_stage1(I const n,
 
             cg_grid.sync();
         }
+#endif
+    } // end for bid
+}
+
+template <typename T, typename I, typename Istride, typename UA>
+static __global__ void lower_stage2(I const n,
+                                    I const j,
+
+                                    T* const scalars,
+                                    T* const tau,
+                                    Istride const strideP,
+                                    T* const norms,
+
+                                    T* const W_,
+                                    Istride const shiftW,
+                                    I const ldw,
+                                    Istride const strideW,
+
+                                    UA A_,
+                                    Istride const shiftA,
+                                    I const lda,
+                                    Istride const strideA,
+
+                                    I const batch_count,
+                                    I const mb,
+                                    I const nb)
+{
+    bool constexpr is_complex = rocblas_is_complex<T>;
+
+    I const myprow = hipBlockIdx_x;
+    I const mypcol = hipBlockIdx_y;
+    I const nprow = hipGridDim_x;
+    I const npcol = hipGridDim_y;
+
+    auto cg_grid = cg::this_grid();
+
+    for(I bid = 0; bid < batch_count; bid++)
+    {
+        T* const W = load_ptr_batch(W_, bid, shiftW, strideW);
+        T* const A = load_ptr_batch(A_, bid, shiftA, strideA);
+
+#if(0)
+        rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, n - j - 1, j,
+                            cast2constType<T>(scalars + 2), 0,
+
+                            W, shiftW + idx2D(j + 1, 0, ldw), ldw, strideW,
+
+                            A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
+
+                            cast2constType<T>(scalars + 1), 0,
+
+                            W, shiftW + idx2D(0, j, ldw), 1, strideW,
+
+                            batch_count, workArr);
+#else
+        {
+            T const alpha = *(scalars + 2);
+            T const beta = *(scalars + 1);
+            I const mm = n - j - 1;
+            I const nn = j;
+
+            char const trans = 'C';
+            I const len_Y = nn;
+
+            bool const has_work = (len_Y >= 1) && (beta != 1);
+            if(has_work)
+            {
+                Xscale_body(len_Y, beta,
+
+                            W, 0, j, ldw, 1,
+
+                            mb, nb, myprow, mypcol, nprow, npcol);
+                cg_grid.sync();
+            }
+
+            Xgemv_body(trans, mm, nn, alpha,
+
+                       W, j + 1, 0, ldw,
+
+                       A, j + 1, j, lda, 1,
+
+                       W, 0, j, ldw, 1,
+
+                       mb, nb, myprow, mypcol, nprow, npcol);
+
+            cg_grid.sync();
+        }
+#endif
+
+#if(0)
+
+        rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j - 1, j,
+                            cast2constType<T>(scalars), 0,
+
+                            A, shiftA + idx2D(j + 1, 0, lda), lda, strideA,
+
+                            W, shiftW + idx2D(0, j, ldw), 1, strideW,
+
+                            cast2constType<T>(scalars + 2), 0,
+
+                            W, shiftW + idx2D(j + 1, j, ldw), 1, strideW,
+
+                            batch_count, workArr);
+#else
+        {
+            char const trans = 'N';
+            I const mm = n - j - 1;
+            I const nn = j;
+
+            T const alpha = *scalars;
+            T const beta = *(scalars + 2);
+
+            I const len_Y = mm;
+
+            bool const has_work = (len_Y >= 1) && (beta != 1);
+            if(has_work)
+            {
+                Xscale_body(len_Y, beta, W, j + 1, j, ldw, 1, mb, nb, myprow, mypcol, nprow, npcol);
+
+                cg_grid.sync();
+            }
+
+            Xgemv_body(trans, mm, nn, alpha,
+
+                       A, j + 1, 0, lda,
+
+                       W, 0, j, ldw, 1,
+
+                       W, j + 1, j, ldw, 1,
+
+                       mb, nb, myprow, mypcol, nprow, npcol);
+            cg_grid.sync();
+        }
+#endif
+
+#if(0)
+        rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, n - j - 1, j,
+                            cast2constType<T>(scalars + 2), 0,
+
+                            A, shiftA + idx2D(j + 1, 0, lda), lda, strideA,
+
+                            A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
+
+                            cast2constType<T>(scalars + 1), 0,
+
+                            W, shiftW + idx2D(0, j, ldw), 1, strideW,
+
+                            batch_count, workArr);
+#else
+        {
+            char const trans = 'C';
+            I const mm = n - j - 1;
+            I const nn = j;
+            T const alpha = *(scalars + 2);
+            T const beta = *(scalars + 1);
+
+            I const len_Y = nn;
+
+            bool const has_work = (len_Y >= 1) && (beta != 1);
+            if(has_work)
+            {
+                Xscale_body(len_Y, beta, W, 0, j, ldw, 1, mb, nb, myprow, mypcol, nprow, npcol);
+
+                cg_grid.sync();
+            }
+
+            Xgemv_body(trans, mm, nn, alpha,
+
+                       A, j + 1, 0, lda,
+
+                       A, j + 1, j, lda, 1,
+
+                       W, 0, j, ldw, 1,
+
+                       mb, nb, myprow, mypcol, nprow, npcol);
+
+            cg_grid.sync();
+        }
+#endif
+
+#if(0)
+
+        rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j - 1, j,
+                            cast2constType<T>(scalars), 0,
+
+                            W, shiftW + idx2D(j + 1, 0, ldw), ldw, strideW,
+
+                            W, shiftW + idx2D(0, j, ldw), 1, strideW,
+
+                            cast2constType<T>(scalars + 2), 0,
+
+                            W, shiftW + idx2D(j + 1, j, ldw), 1, strideW,
+
+                            batch_count, workArr);
+#else
+        {
+            char const trans = 'N';
+            I const mm = n - j - 1;
+            I const nn = j;
+            T const alpha = *scalars;
+            T const beta = *(scalars + 2);
+
+            I const len_Y = mm;
+
+            bool const has_work = (len_Y >= 1) && (beta != 1);
+            if(has_work)
+            {
+                Xscale_body(len_Y, beta,
+
+                            W, j + 1, j, ldw, 1,
+
+                            mb, nb, myprow, mypcol, nprow, npcol);
+
+                cg_grid.sync();
+            }
+
+            Xgemv_body(trans, mm, nn, alpha,
+
+                       W, j + 1, 0, ldw,
+
+                       W, 0, j, ldw, 1,
+
+                       W, j + 1, j, ldw, 1,
+
+                       mb, nb, myprow, mypcol, nprow, npcol);
+
+            cg_grid.sync();
+        }
+#endif
+
+#if(0)
+        rocblasCall_scal<T>(handle, n - j - 1, (tau + j), strideP, W, shiftW + idx2D(j + 1, j, ldw),
+                            1, strideW, batch_count);
+#else
+        {
+            I const nn = n - j - 1;
+            T* const p_alpha = (tau + j);
+            T const alpha = *(p_alpha + bid * strideP);
+
+            Xscale_body(nn, alpha, W, j + 1, j, ldw, 1, mb, nb, myprow, mypcol, nprow, npcol);
+
+            cg_grid.sync();
+        }
+#endif
+
+#if(0)
+        rocblasCall_dot<COMPLEX, T>(handle, n - 1 - j,
+
+                                    W, shiftW + idx2D(j + 1, j, ldw), 1, strideW,
+
+                                    A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
+
+                                    batch_count, norms, work, workArr);
+
+#else
+        {
+            I const nn = n - 1 - j;
+            Xdot_body(nn, W, j + 1, j, ldw, 1,
+
+                      A, j + 1, j, lda, 1,
+
+                      &(norms[bid]),
+
+                      mb, nb, myprow, mypcol, nprow, npcol);
+
+            cg_grid.sync();
+        }
+
 #endif
     } // end for bid
 }
@@ -2472,10 +2743,14 @@ static __global__ void upper_stage2(I const n,
             T const alpha = *(scalars + 2);
             T const beta = *(scalars + 1);
 
-            Xscale_body<T, I>(len_Y, beta, W, j + 1, jw, ldw, 1, mb, nb, myprow, mypcol, nprow,
-                              npcol);
+            bool const has_work = (len_Y >= 1) && (beta != 1);
+            if(has_work)
+            {
+                Xscale_body<T, I>(len_Y, beta, W, j + 1, jw, ldw, 1, mb, nb, myprow, mypcol, nprow,
+                                  npcol);
 
-            cg_grid.sync();
+                cg_grid.sync();
+            }
 
             Xgemv_body<T, I>(trans, mm, nn, alpha,
 
@@ -2513,13 +2788,17 @@ static __global__ void upper_stage2(I const n,
             T const alpha = *scalars;
             T const beta = *(scalars + 2);
 
-            Xscale_body<T, I>(len_Y, beta,
+            bool const has_work = (len_Y >= 1) && (beta != 1);
+            if(has_work)
+            {
+                Xscale_body<T, I>(len_Y, beta,
 
-                              W, 0, jw, ldw, 1,
+                                  W, 0, jw, ldw, 1,
 
-                              mb, nb, myprow, mypcol, nprow, npcol);
+                                  mb, nb, myprow, mypcol, nprow, npcol);
 
-            cg_grid.sync();
+                cg_grid.sync();
+            }
 
             Xgemv_body<T, I>(trans, mm, nn, alpha,
 
@@ -2557,9 +2836,13 @@ static __global__ void upper_stage2(I const n,
             T const alpha = *(scalars + 2);
             T const beta = *(scalars + 1);
 
-            Xscale_body<T, I>(len_Y, beta, W, j + 1, jw, ldw, 1, mb, nb, myprow, mypcol, nprow,
-                              npcol);
-            cg_grid.sync();
+            bool const has_work = (len_Y >= 1) && (beta != 1);
+            if(has_work)
+            {
+                Xscale_body<T, I>(len_Y, beta, W, j + 1, jw, ldw, 1, mb, nb, myprow, mypcol, nprow,
+                                  npcol);
+                cg_grid.sync();
+            }
 
             Xgemv_body<T, I>(trans, mm, nn, alpha,
 
@@ -2598,13 +2881,17 @@ static __global__ void upper_stage2(I const n,
             T const alpha = *(scalars);
             T const beta = *(scalars + 2);
 
-            Xscale_body<T, I>(len_Y, beta,
+            bool const has_work = (len_Y >= 1) && (beta != 1);
+            if(has_work)
+            {
+                Xscale_body<T, I>(len_Y, beta,
 
-                              W, 0, jw, ldw, 1,
+                                  W, 0, jw, ldw, 1,
 
-                              mb, nb, myprow, mypcol, nprow, npcol);
+                                  mb, nb, myprow, mypcol, nprow, npcol);
 
-            cg_grid.sync();
+                cg_grid.sync();
+            }
 
             Xgemv_body<T, I>(trans, mm, nn, alpha,
 
@@ -2729,7 +3016,8 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
         for(rocblas_int j = 0; j < k; ++j)
         {
             // update column j of A with reflector computed in step j-1
-            if(use_coop)
+            bool const use_lower_stage1 = true;
+            if(use_lower_stage1)
             {
 #if(0)
 
@@ -2741,14 +3029,14 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
 
                     T* const W_, Istride const shiftW, I const ldw, Istride const strideW,
 
-                    T* const A_, Istride const shiftA, I const lda, Istride const strideA,
+                    U A_, Istride const shiftA, I const lda, Istride const strideA,
 
                     I const batch_count,
 
                     I const mb, I const nb)
 #else
-                rocblas_stride const lshiftW = shiftW;
-                rocblas_stride const lshiftA = shiftA;
+                rocblas_stride lshiftW = shiftW;
+                rocblas_stride lshiftA = shiftA;
 
                 void* args[]
                     = {(void*)&n,           (void*)&j,       (void*)&scalars,
@@ -2825,58 +3113,88 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
             }
 
             // compute/update column j of W
-            if(use_org)
             {
                 rocblasCall_symv_hemv<T>(
                     handle, uplo, n - 1 - j, (scalars + 2), 0, A, shiftA + idx2D(j + 1, j + 1, lda),
                     lda, strideA, A, shiftA + idx2D(j + 1, j, lda), 1, strideA, (scalars + 1), 0, W,
                     shiftW + idx2D(j + 1, j, ldw), 1, strideW, batch_count, work, workArr);
             }
+
+            bool use_lower_stage2 = true;
+            if(use_lower_stage2)
+            {
+#if(0)
+
+                template <typename T, typename I, typename Istride, typename UA>
+                static __global__ void lower_stage2(
+                    I const n, I const j,
+
+                    T* const scalars, T* const tau, Istride const strideP,
+
+                    T* const W_, Istride const shiftW, I const ldw, Istride const strideW,
+
+                    UA A_, Istride const shiftA, I const lda, Istride const strideA,
+
+                    I const batch_count, I const mb, I const nb)
+#else
+                rocblas_stride lshiftA = shiftA;
+                rocblas_stride lshiftW = shiftW;
+
+                void* args[]
+                    = {(void*)&n,           (void*)&j,
+
+                       (void*)&scalars,     (void*)&tau,     (void*)&strideP, (void*)&norms,
+
+                       (void*)&W,           (void*)&lshiftW, (void*)&ldw,     (void*)&strideW,
+
+                       (void*)&A,           (void*)&lshiftA, (void*)&lda,     (void*)&strideA,
+
+                       (void*)&batch_count, (void*)&mb,      (void*)&nb};
+
+                auto const nx = 32;
+                auto const ny = 32;
+                auto const lds_size = 64 * 1024;
+
+                LAUNCH_CHECK(hipLaunchCooperativeKernel(
+                    (void*)(lower_stage2<T, rocblas_int, rocblas_stride, U>), dim3(num_cu, 1, 1),
+                    dim3(nx, ny, 1), args, lds_size, stream));
+#endif
+            }
             else
             {
-                T const* const p_alpha = (scalars + 2);
-                rocblas_stride const stride_alpha = 0;
-                T const* const p_beta = (scalars + 1);
-                rocblas_stride const stride_beta = 0;
+                rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, n - j - 1, j,
+                                    cast2constType<T>(scalars + 2), 0, W,
+                                    shiftW + idx2D(j + 1, 0, ldw), ldw, strideW, A,
+                                    shiftA + idx2D(j + 1, j, lda), 1, strideA,
+                                    cast2constType<T>(scalars + 1), 0, W, shiftW + idx2D(0, j, ldw),
+                                    1, strideW, batch_count, workArr);
 
-                rocblas_int const incx = 1;
-                rocblas_int const incy = 1;
-                rocsolverCall_symv_hemv<T, rocblas_int, rocblas_stride>(
-                    handle, uplo, n - 1 - j, p_alpha, stride_alpha, A, shiftA, j + 1, j + 1, lda,
-                    strideA, A, shiftA, j + 1, j, lda, incx, strideA, p_beta, stride_beta, W,
-                    shiftW, j + 1, j, ldw, incy, strideW, batch_count, mb, nb, work, workArr);
+                rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j - 1, j,
+                                    cast2constType<T>(scalars), 0, A, shiftA + idx2D(j + 1, 0, lda),
+                                    lda, strideA, W, shiftW + idx2D(0, j, ldw), 1, strideW,
+                                    cast2constType<T>(scalars + 2), 0, W,
+                                    shiftW + idx2D(j + 1, j, ldw), 1, strideW, batch_count, workArr);
+
+                rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, n - j - 1, j,
+                                    cast2constType<T>(scalars + 2), 0, A,
+                                    shiftA + idx2D(j + 1, 0, lda), lda, strideA, A,
+                                    shiftA + idx2D(j + 1, j, lda), 1, strideA,
+                                    cast2constType<T>(scalars + 1), 0, W, shiftW + idx2D(0, j, ldw),
+                                    1, strideW, batch_count, workArr);
+
+                rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j - 1, j,
+                                    cast2constType<T>(scalars), 0, W, shiftW + idx2D(j + 1, 0, ldw),
+                                    ldw, strideW, W, shiftW + idx2D(0, j, ldw), 1, strideW,
+                                    cast2constType<T>(scalars + 2), 0, W,
+                                    shiftW + idx2D(j + 1, j, ldw), 1, strideW, batch_count, workArr);
+
+                rocblasCall_scal<T>(handle, n - j - 1, (tau + j), strideP, W,
+                                    shiftW + idx2D(j + 1, j, ldw), 1, strideW, batch_count);
+
+                rocblasCall_dot<COMPLEX, T>(handle, n - 1 - j, W, shiftW + idx2D(j + 1, j, ldw), 1,
+                                            strideW, A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
+                                            batch_count, norms, work, workArr);
             }
-
-            rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, n - j - 1, j,
-                                cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(j + 1, 0, ldw),
-                                ldw, strideW, A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
-                                cast2constType<T>(scalars + 1), 0, W, shiftW + idx2D(0, j, ldw), 1,
-                                strideW, batch_count, workArr);
-
-            rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j - 1, j,
-                                cast2constType<T>(scalars), 0, A, shiftA + idx2D(j + 1, 0, lda),
-                                lda, strideA, W, shiftW + idx2D(0, j, ldw), 1, strideW,
-                                cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(j + 1, j, ldw),
-                                1, strideW, batch_count, workArr);
-
-            rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, n - j - 1, j,
-                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j + 1, 0, lda),
-                                lda, strideA, A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
-                                cast2constType<T>(scalars + 1), 0, W, shiftW + idx2D(0, j, ldw), 1,
-                                strideW, batch_count, workArr);
-
-            rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j - 1, j,
-                                cast2constType<T>(scalars), 0, W, shiftW + idx2D(j + 1, 0, ldw),
-                                ldw, strideW, W, shiftW + idx2D(0, j, ldw), 1, strideW,
-                                cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(j + 1, j, ldw),
-                                1, strideW, batch_count, workArr);
-
-            rocblasCall_scal<T>(handle, n - j - 1, (tau + j), strideP, W,
-                                shiftW + idx2D(j + 1, j, ldw), 1, strideW, batch_count);
-
-            rocblasCall_dot<COMPLEX, T>(handle, n - 1 - j, W, shiftW + idx2D(j + 1, j, ldw), 1,
-                                        strideW, A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
-                                        batch_count, norms, work, workArr);
 
             // (TODO: rocblas_axpy is not yet ready to be used in rocsolver. When it becomes
             //  available, we can use it instead of the scale_axpy kernel, if it provides
@@ -3000,8 +3318,8 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
 
                         I const batch_count, I const mb, I const nb)
 #else
-                rocblas_stride const lshiftA = shiftA;
-                rocblas_stride const lshiftW = shiftW;
+                rocblas_stride lshiftA = shiftA;
+                rocblas_stride lshiftW = shiftW;
 
                 void* args[]
                     = {(void*)&n,           (void*)&j,       (void*)&jw,

--- a/library/src/auxiliary/rocauxiliary_latrd_coop.hpp
+++ b/library/src/auxiliary/rocauxiliary_latrd_coop.hpp
@@ -47,6 +47,19 @@
 
 ROCSOLVER_BEGIN_NAMESPACE
 
+#ifndef LAUNCH_CHECK
+#define LAUNCH_CHECK(fcn)                                                                  \
+    {                                                                                      \
+        auto const istat = (fcn);                                                          \
+        bool const isok = (istat == hipSuccess);                                           \
+        if(!isok)                                                                          \
+        {                                                                                  \
+            std::cerr << "Kernel launch error: " << hipGetErrorString(istat) << std::endl; \
+        }                                                                                  \
+        assert(isok);                                                                      \
+    }
+#endif
+
 namespace cg = cooperative_groups;
 
 template <typename T>
@@ -1032,20 +1045,24 @@ static __device__ void Xgemv_body(char const trans,
                                   I const m,
                                   I const n,
                                   T const alpha,
+
                                   T const* const A_,
                                   I const ia,
                                   I const ja,
                                   I const lda,
+
                                   T const* const X_,
                                   I const ix,
                                   I const jx,
                                   I const ldx,
                                   I const incx,
+
                                   T* const Y_,
                                   I const iy,
                                   I const jy,
                                   I const ldy,
                                   I const incy,
+
                                   I const mb,
                                   I const nb,
                                   I const myprow,
@@ -1416,20 +1433,24 @@ template <typename T, typename I>
 static __device__ void Xsymv_body(char const c_uplo,
                                   I const n,
                                   T const alpha,
+
                                   T const* const A_,
                                   I const ia,
                                   I const ja,
                                   I const lda,
+
                                   T const* const X_,
                                   I const ix,
                                   I const jx,
                                   I const ldx,
                                   I const incx,
+
                                   T* const Y_,
                                   I const iy,
                                   I const jy,
                                   I const ldy,
                                   I const incy,
+
                                   I const mb,
                                   I const nb,
                                   I const myprow,
@@ -1618,6 +1639,226 @@ static __device__ void Xsymv_body(char const c_uplo,
     __syncthreads();
 }
 
+// ----------------------
+// matrix vector multiple
+// y = alpha * op(A) * x
+// where
+// op(A) can be  A
+//     or transpose(A)
+//     or conj(transpose(A))
+// ----------------------
+template <typename T, typename I>
+static __device__ void Xsymv_body_v2(char const c_uplo,
+                                     I const n,
+                                     T const alpha,
+
+                                     T const* const A_,
+                                     I const ia,
+                                     I const ja,
+                                     I const lda,
+
+                                     T const* const X_,
+                                     I const ix,
+                                     I const jx,
+                                     I const ldx,
+                                     I const incx,
+
+                                     T* const Y_,
+                                     I const iy,
+                                     I const jy,
+                                     I const ldy,
+                                     I const incy,
+
+                                     I const mb,
+                                     I const nb,
+                                     I const myprow,
+                                     I const mypcol,
+                                     I const nprow,
+                                     I const npcol)
+{
+    bool const is_complex = rocblas_is_complex<T>;
+    auto const m = n;
+    {
+        // assume operate on symmetric diagonal
+        // (ia == ja)
+        assert((ia == ja));
+        assert((mb == nb));
+    }
+
+    auto const tix = hipThreadIdx_x;
+    auto const tiy = hipThreadIdx_y;
+    auto const nx = hipBlockDim_x;
+    auto const ny = hipBlockDim_y;
+
+    bool const is_upper = (c_uplo == 'U') || (c_uplo == 'u');
+    bool const is_lower = (c_uplo == 'L') || (c_uplo == 'l');
+
+    bool const is_column_X = (incx == 1);
+    bool const is_column_Y = (incy == 1);
+    {
+        assert((is_lower) || (is_upper));
+        assert((incx == 1) || (incx == ldx));
+        assert((incy == 1) || (incy == ldy));
+    }
+
+    auto idx2D = [](auto i, auto j, auto ld) { return (i + j * static_cast<int64_t>(ld)); };
+
+    auto const ip_Y = idx2D(iy, jy, ldy);
+    auto Yvec = [=](auto i) -> T& { return (Y_[ip_Y + i * static_cast<int64_t>(incy)]); };
+
+    auto const ip_X = idx2D(ix, jx, ldx);
+    auto Xvec = [=](auto i) { return (X_[ip_X + i * static_cast<int64_t>(incx)]); };
+
+    auto A = [=](auto i, auto j) { return (A_[idx2D(i, j, lda)]); };
+
+    auto const itileA_start = first_tile(ia, mb, myprow, nprow);
+    auto const jtileA_start = first_tile(ja, nb, mypcol, npcol);
+    auto const itileA_end = first_tile(ia + n - 1, mb, myprow, nprow);
+    auto const jtileA_end = first_tile(ja + n - 1, nb, mypcol, npcol);
+    auto const itile_inc = nprow;
+    auto const jtile_inc = npcol;
+
+    auto is_even = [](auto n) -> bool { return ((n % 2) == 0); };
+    auto const ldtmp = (is_even(nx)) ? nx + 1 : nx;
+
+    extern __shared__ double lmem[];
+    T* pfree = (T*)&(lmem[0]);
+
+    size_t total_len = 0;
+    T* const tmp_ = pfree;
+    pfree += ldtmp * ny;
+    total_len += ldtmp * ny;
+    T* const ysh_j = pfree;
+    pfree += nb;
+    total_len += nb;
+    T* const xsh_j = pfree;
+    pfree += nb;
+    total_len += nb;
+
+    auto tmp = [=](auto tx, auto ty) -> T& { return (tmp_[tx + ty * ldtmp]); };
+
+    {
+        size_t const lds_size = 64 * 1024;
+        bool const lds_ok = (sizeof(T) * total_len <= lds_size);
+        assert(lds_ok);
+    }
+
+    auto const tixy = tix + tiy * nx;
+    auto const nxny = nx * ny;
+
+    // -----------------
+    // Y1 = [D1  L21' ]  * X1
+    // Y2 = [L21   D2 ]    X2
+    //
+    //
+    // Y1 = (D1 * X1) + (L21' * X2)
+    // Y2 = (L21 * X1) + ( D2 * X2 )
+    // -----------------
+
+    auto const cg_wave = cg::tiled_partition(cg::this_thread_block(), nx);
+
+    for(auto jtileA = jtileA_start; jtileA <= jtileA_end; jtileA += jtile_inc)
+    {
+        auto const jstart = std::max(ja, jtileA * nb);
+        auto const jend = std::min(ja + n - 1, jtileA * nb + (nb - 1));
+
+        for(auto jja = (jstart + tixy); jja <= jend; jja += nxny)
+        {
+            ysh_j[(jja - jstart)] = 0;
+            xsh_j[(jja - jstart)] = Xvec((jja - ja));
+        }
+
+        __syncthreads();
+
+        for(auto itileA = itileA_start; itileA <= itileA_end; itileA += itile_inc)
+        {
+            auto const istart = std::max(ia, itileA * mb);
+            auto const iend = std::min(ia + m - 1, itileA * mb + (mb - 1));
+
+            bool const is_lower_tile = (istart > jend);
+            bool const is_upper_tile = (jstart > iend);
+
+            bool const do_work = (is_lower && is_lower_tile) || (is_upper && is_upper_tile);
+            if(!do_work)
+            {
+                continue;
+            }
+
+            // ------------------------------
+            // process tile "(itileA,jtileA)"
+            // ------------------------------
+
+            for(auto iia = (istart + tiy); iia <= iend; iia += ny)
+            {
+                auto const ioff = (iia - istart);
+                auto const xi = Xvec((iia - ia));
+
+                T y_i = 0;
+                for(auto jja = (jstart + tix); jja <= jend; jja += nx)
+                {
+                    auto const joff = (jja - jstart);
+                    auto const xj = xsh_j[joff];
+
+                    bool const is_diagonal = (iia == jja);
+                    bool const is_strictly_lower = (iia > jja);
+                    bool const is_strictly_upper = (jja > iia);
+
+                    if(is_diagonal)
+                    {
+                        auto const aii = std::real(A(iia, iia));
+                        y_i += aii * xi;
+                    }
+                    else
+                    {
+                        // ------------------
+                        // off-diagonal entry
+                        // ------------------
+
+                        bool const do_work
+                            = (is_lower && is_strictly_lower) || (is_upper && is_strictly_upper);
+
+                        if(!do_work)
+                        {
+                            continue;
+                        };
+
+                        T const aij = A(iia, jja);
+                        y_i += aij * xj;
+
+                        if constexpr(is_complex)
+                        {
+                            T const atji = conj(aij);
+                            gatomicAdd(&(ysh_j[joff]), atji * xi);
+                        }
+                        else
+                        {
+                            T const atji = aij;
+                            gatomicAdd(&(ysh_j[joff]), atji * xi);
+                        }
+                    }
+                } // end for jja
+
+                y_i = reduce_sum(cg_wave, &(tmp(0, tiy)), y_i);
+                if(cg_wave.thread_rank() == 0)
+                {
+                    gatomicAdd(&(Yvec(iia - ia)), alpha * y_i);
+                }
+            } // end for iia
+        } // end for itileA
+
+        __syncthreads();
+
+        for(auto jja = (jstart + tixy); jja <= jend; jja += nxny)
+        {
+            auto const joff = (jja - jstart);
+            gatomicAdd(&(Yvec((jja - ja))), alpha * ysh_j[joff]);
+            ysh_j[joff] = 0;
+        }
+        __syncthreads();
+
+    } // end for jtileA
+}
+
 // compute Yvec(0:(n-1)) += alpha * op(A) * Xvec(0:(n-1))
 // where A is symmetric/hermitian matrix
 // op(A) is lower triangular or upper triangular
@@ -1773,6 +2014,181 @@ static __global__ void set_offdiag_batch_kernel(const rocblas_int batch_count,
     }
 }
 
+template <typename T, typename I, typename Istride, typename UA, typename UW>
+static __global__ void upper_stage2(I const n,
+                                    I const j,
+                                    I const jw,
+
+                                    T const* const scalars,
+                                    T* const tau,
+                                    Istride const strideP,
+                                    T* const norms,
+
+                                    UW W_,
+                                    Istride const shiftW,
+                                    I const ldw,
+                                    Istride const strideW,
+
+                                    UA A_,
+                                    Istride const shiftA,
+                                    I const lda,
+                                    Istride const strideA,
+
+                                    I const batch_count,
+                                    I const mb,
+                                    I const nb)
+{
+    auto const myprow = hipBlockIdx_x;
+    auto const mypcol = hipBlockIdx_y;
+    auto const nprow = hipGridDim_x;
+    auto const npcol = hipGridDim_y;
+
+    auto cg_grid = cg::this_grid();
+
+    for(I bid = 0; bid < batch_count; bid++)
+    {
+        T* const A = load_ptr_batch(A_, bid, shiftA, strideA);
+        T* const W = load_ptr_batch(W_, bid, shiftW, strideW);
+
+#if(0)
+        rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, j, n - 1 - j,
+                            cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(0, jw + 1, ldw),
+                            ldw, strideW, A, shiftA + idx2D(0, j, lda), 1, strideA,
+                            cast2constType<T>(scalars + 1), 0, W, shiftW + idx2D(j + 1, jw, ldw), 1,
+                            strideW, batch_count, workArr);
+#else
+        {
+            char const trans = 'C';
+            I const mm = j;
+            I const nn = n - 1 - j;
+            I const len_Y = nn;
+
+            T const alpha = *(scalars + 2);
+            T const beta = *(scalars + 1);
+
+            Xscale_body<T, I>(len_Y, beta, W, j + 1, jw, ldw, 1, mb, nb, myprow, mypcol, nprow,
+                              npcol);
+
+            cg_grid.sync();
+
+            Xgemv_body<T, I>(trans, mm, nn, alpha, W, 0, jw + 1, ldw, A, 0, j, lda, 1, W, j + 1, jw,
+                             ldw, 1, mb, nb, myprow, mypcol, nprow, npcol);
+            cg_grid.sync();
+        }
+#endif
+
+#if(0)
+        rocblasCall_gemv<T>(handle, rocblas_operation_none, j, n - 1 - j,
+                            cast2constType<T>(scalars), 0, A, shiftA + idx2D(0, j + 1, lda), lda,
+                            strideA, W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW,
+                            cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(0, jw, ldw), 1,
+                            strideW, batch_count, workArr);
+#else
+        {
+            char const trans = 'N';
+            I const mm = j;
+            I const nn = n - 1 - j;
+            I const len_Y = mm;
+
+            T const alpha = *scalars;
+            T const beta = *(scalars + 2);
+
+            Xscale_body<T, I>(len_Y, alpha, W, 0, jw, ldw, 1, mb, nb, myprow, mypcol, nprow, npcol);
+
+            cg_grid.sync();
+
+            Xgemv_body<T, I>(trans, mm, nn, alpha, A, 0, j + 1, lda, W, j + 1, jw, ldw, 1, W, 0, jw,
+                             ldw, 1, mb, nb, myprow, mypcol, nprow, npcol);
+            cg_grid.sync();
+        }
+#endif
+
+#if(0)
+        rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, j, n - 1 - j,
+                            cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(0, j + 1, lda),
+                            lda, strideA, A, shiftA + idx2D(0, j, lda), 1, strideA,
+                            cast2constType<T>(scalars + 1), 0, W, shiftW + idx2D(j + 1, jw, ldw), 1,
+                            strideW, batch_count, workArr);
+#else
+        {
+            char const trans = 'C';
+            I const mm = j;
+            I const nn = n - 1 - j;
+            I const len_Y = nn;
+
+            T const alpha = *(scalars + 2);
+            T const beta = *(scalars + 1);
+
+            Xscale_body<T, I>(len_Y, beta, W, j + 1, jw, ldw, 1, mb, nb, myprow, mypcol, nprow,
+                              npcol);
+            cg_grid.sync();
+
+            Xgemv_body<T, I>(trans, mm, nn, alpha, A, 0, j + 1, lda, A, 0, j, lda, 1, W, j + 1, jw,
+                             ldw, 1, mb, nb, myprow, mypcol, nprow, npcol);
+
+            cg_grid.sync();
+        }
+#endif
+
+#if(0)
+        rocblasCall_gemv<T>(handle, rocblas_operation_none, j, n - 1 - j,
+                            cast2constType<T>(scalars), 0, W, shiftW + idx2D(0, jw + 1, ldw), ldw,
+                            strideW, W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW,
+                            cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(0, jw, ldw), 1,
+                            strideW, batch_count, workArr);
+#else
+        {
+            char const trans = 'N';
+            I const mm = j;
+            I const nn = n - 1 - j;
+            I const len_Y = mm;
+
+            T const alpha = *(scalars);
+            T const beta = *(scalars + 2);
+
+            Xscale_body<T, I>(len_Y, beta, W, 0, jw, ldw, 1, mb, nb, myprow, mypcol, nprow, npcol);
+
+            cg_grid.sync();
+
+            Xgemv_body<T, I>(trans, mm, nn, alpha, W, 0, jw + 1, ldw, W, j + 1, jw, ldw, 1, W, 0,
+                             jw, ldw, 1, mb, nb, myprow, mypcol, nprow, npcol);
+
+            cg_grid.sync();
+        }
+
+#endif
+
+#if(0)
+        rocblasCall_scal<T>(handle, j, (tau + j - 1), strideP, W, shiftW + idx2D(0, jw, ldw), 1,
+                            strideW, batch_count);
+#else
+        {
+            I const nn = j;
+            T const* const p_alpha = (tau + j - 1);
+            T const alpha = *(p_alpha + bid * strideP);
+
+            Xscale_body<T, I>(nn, alpha, W, 0, jw, ldw, 1, mb, nb, myprow, mypcol, nprow, npcol);
+
+            cg_grid.sync();
+        }
+#endif
+
+#if(0)
+        rocblasCall_dot<COMPLEX, T>(handle, j, W, shiftW + idx2D(0, jw, ldw), 1, strideW, A,
+                                    shiftA + idx2D(0, j, lda), 1, strideA, batch_count, norms, work,
+                                    workArr);
+#else
+        {
+            I const nn = j;
+            Xdot_body<T, I>(nn, W, 0, jw, ldw, 1, A, 0, j, lda, 1, &(norms[bid]), mb, nb, myprow,
+                            mypcol, nprow, npcol);
+            cg_grid.sync();
+        }
+#endif
+
+    } // end for bid
+}
+
 template <typename T, typename S, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
                                              const rocblas_fill uplo,
@@ -1818,7 +2234,10 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
     blocks = (n - 1) / BS1 + 1;
     dim3 grid_n(blocks, batch_count);
 
-    bool const use_org = false;
+    auto const nx = 32;
+    auto const ny = 32;
+    bool const use_org = true;
+    bool const use_coop = true;
     size_t lds_size = 64 * 1024;
     auto const mb = k;
     auto const nb = k;
@@ -2059,36 +2478,74 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
                                      shiftW + idx2D(0, jw, ldw), 1, strideW, batch_count, work,
                                      workArr);
 
-            rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, j, n - 1 - j,
-                                cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(0, jw + 1, ldw),
-                                ldw, strideW, A, shiftA + idx2D(0, j, lda), 1, strideA,
-                                cast2constType<T>(scalars + 1), 0, W,
-                                shiftW + idx2D(j + 1, jw, ldw), 1, strideW, batch_count, workArr);
+            if(use_coop)
+            {
+#if(0)
+                template <typename T, typename I, typename Istride, typename UA, typename UW>
+                static __device__ void upper_stage2(
+                    I const n, I const j, I const jw,
 
-            rocblasCall_gemv<T>(handle, rocblas_operation_none, j, n - 1 - j,
-                                cast2constType<T>(scalars), 0, A, shiftA + idx2D(0, j + 1, lda),
-                                lda, strideA, W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW,
-                                cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(0, jw, ldw), 1,
-                                strideW, batch_count, workArr);
+                    T const* const scalars, T* const tau, Istride const strideP,
 
-            rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, j, n - 1 - j,
-                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(0, j + 1, lda),
-                                lda, strideA, A, shiftA + idx2D(0, j, lda), 1, strideA,
-                                cast2constType<T>(scalars + 1), 0, W,
-                                shiftW + idx2D(j + 1, jw, ldw), 1, strideW, batch_count, workArr);
+                    UW W_, Istride const shiftW, I const ldw, Istride const strideW,
 
-            rocblasCall_gemv<T>(handle, rocblas_operation_none, j, n - 1 - j,
-                                cast2constType<T>(scalars), 0, W, shiftW + idx2D(0, jw + 1, ldw),
-                                ldw, strideW, W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW,
-                                cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(0, jw, ldw), 1,
-                                strideW, batch_count, workArr);
+                    UA A_, Istride const shiftA, I const lda, Istride const strideA,
 
-            rocblasCall_scal<T>(handle, j, (tau + j - 1), strideP, W, shiftW + idx2D(0, jw, ldw), 1,
-                                strideW, batch_count);
+                    I const batch_count, I const mb, I const nb)
+#else
+                rocblas_stride lshiftA = shiftA;
+                rocblas_stride lshiftW = shiftW;
 
-            rocblasCall_dot<COMPLEX, T>(handle, j, W, shiftW + idx2D(0, jw, ldw), 1, strideW, A,
-                                        shiftA + idx2D(0, j, lda), 1, strideA, batch_count, norms,
-                                        work, workArr);
+                void* args[]
+                    = {(void*)&n,           (void*)&j,       (void*)&jw,
+
+                       (void*)&scalars,     (void*)&tau,     (void*)&strideP, (void*)&norms,
+
+                       (void*)&W,           (void*)&lshiftW, (void*)&ldw,     (void*)&strideW,
+
+                       (void*)&A,           (void*)&lshiftA, (void*)&lda,     (void*)&strideA,
+
+                       (void*)&batch_count, (void*)&mb,      (void*)&nb};
+
+                LAUNCH_CHECK(hipLaunchCooperativeKernel(
+                    (void*)(upper_stage2<T, rocblas_int, rocblas_stride, U, T*>),
+                    dim3(num_cu, 1, 1), dim3(nx, ny, 1), args, lds_size, stream));
+
+#endif
+            }
+            else
+            {
+                rocblasCall_gemv<T>(
+                    handle, rocblas_operation_conjugate_transpose, j, n - 1 - j,
+                    cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(0, jw + 1, ldw), ldw,
+                    strideW, A, shiftA + idx2D(0, j, lda), 1, strideA, cast2constType<T>(scalars + 1),
+                    0, W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW, batch_count, workArr);
+
+                rocblasCall_gemv<T>(handle, rocblas_operation_none, j, n - 1 - j,
+                                    cast2constType<T>(scalars), 0, A, shiftA + idx2D(0, j + 1, lda),
+                                    lda, strideA, W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW,
+                                    cast2constType<T>(scalars + 2), 0, W,
+                                    shiftW + idx2D(0, jw, ldw), 1, strideW, batch_count, workArr);
+
+                rocblasCall_gemv<T>(
+                    handle, rocblas_operation_conjugate_transpose, j, n - 1 - j,
+                    cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(0, j + 1, lda), lda, strideA,
+                    A, shiftA + idx2D(0, j, lda), 1, strideA, cast2constType<T>(scalars + 1), 0, W,
+                    shiftW + idx2D(j + 1, jw, ldw), 1, strideW, batch_count, workArr);
+
+                rocblasCall_gemv<T>(handle, rocblas_operation_none, j, n - 1 - j,
+                                    cast2constType<T>(scalars), 0, W, shiftW + idx2D(0, jw + 1, ldw),
+                                    ldw, strideW, W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW,
+                                    cast2constType<T>(scalars + 2), 0, W,
+                                    shiftW + idx2D(0, jw, ldw), 1, strideW, batch_count, workArr);
+
+                rocblasCall_scal<T>(handle, j, (tau + j - 1), strideP, W,
+                                    shiftW + idx2D(0, jw, ldw), 1, strideW, batch_count);
+
+                rocblasCall_dot<COMPLEX, T>(handle, j, W, shiftW + idx2D(0, jw, ldw), 1, strideW, A,
+                                            shiftA + idx2D(0, j, lda), 1, strideA, batch_count,
+                                            norms, work, workArr);
+            }
 
             // (TODO: rocblas_axpy is not yet ready to be used in rocsolver. When it becomes
             //  available, we can use it instead of the scale_axpy kernel, if it provides
@@ -2096,7 +2553,7 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
             ROCSOLVER_LAUNCH_KERNEL(scale_axpy<T>, grid_n, threads, 0, stream, j, norms,
                                     tau + j - 1, strideP, A, shiftA + idx2D(0, j, lda), strideA, W,
                                     shiftW + idx2D(0, jw, ldw), strideW);
-        }
+        } // end for  j
     }
 
     rocblas_set_pointer_mode(handle, old_mode);

--- a/library/src/auxiliary/rocauxiliary_latrd_coop.hpp
+++ b/library/src/auxiliary/rocauxiliary_latrd_coop.hpp
@@ -267,6 +267,123 @@ static __device__ S sign(S const a, S const b)
     return (std::abs(a) * ((b < 0) ? -1 : 1));
 }
 
+// -------------------------------------------
+// compute complex division in real arithmetic
+// p + I * q = (a + I * b)/( c + I * d )
+// -------------------------------------------
+template <typename S>
+static __device__ __host__ void ladiv(S const a, S const b, S const c, S const d, S& p, S& q)
+{
+    {
+        assert(!rocblas_is_complex<S>);
+    }
+
+    S const bs = 2.0;
+    S const half = 0.5;
+    S const two = 2.0;
+    S const one = 1.0;
+
+    auto ladiv2 = [](S const a, S const b, S const c, S const d, S const r, S const t) -> S {
+        S dladiv2 = 0;
+        if(r != 0)
+        {
+            auto const br = b * r;
+            if(br != 0)
+            {
+                dladiv2 = (a + br) * t;
+            }
+            else
+            {
+                dladiv2 = a * t + (b * t) * r;
+            }
+        }
+        else
+        {
+            dladiv2 = (a + d * (b / c)) * t;
+        }
+        return (dladiv2);
+    };
+
+    auto ladiv1 = [](S& a, S& b, S& c, S& d, S& p, S& q) {
+        S const one = 1.0;
+        auto r = d / c;
+        auto t = one / (c + d * r);
+        p = ladiv2(a, b, c, d, r, t);
+        a = -a;
+        q = ladiv2(b, a, c, d, r, t);
+    };
+
+    S aa = a;
+    S bb = b;
+    S cc = c;
+    S dd = d;
+
+    S const ab = std::max(std::abs(a), std::abs(b));
+    S const cd = std::max(std::abs(c), std::abs(d));
+    S s = one;
+
+    auto const ov = lamch<S>('O'); // overflow
+    auto const un = lamch<S>('S'); // safe min
+    auto const eps = lamch<S>('E'); // epsilon
+    auto const be = bs / (eps * eps);
+
+    if(cd >= half * ov)
+    {
+        cc = half * cc;
+        dd = half * dd;
+        s = half * s;
+    }
+
+    if(ab <= un * bs / eps)
+    {
+        aa *= be;
+        bb *= be;
+        s = s / be;
+    }
+
+    if(cd <= un * bs / eps)
+    {
+        cc *= be;
+        dd *= be;
+        s *= be;
+    }
+
+    if(std::abs(d) <= std::abs(c))
+    {
+        ladiv1(aa, bb, cc, dd, p, q);
+    }
+    else
+    {
+        ladiv1(bb, aa, dd, cc, p, q);
+        q = -q;
+    }
+
+    p *= s;
+    q *= s;
+
+#ifdef NDEBUG
+#else
+    {
+        // -------------------------------------
+        // extra check
+        //
+        // p + I * q = (a + I * b)/( c + I * d )
+        //
+        // or
+        //
+        // (p + I * q) * (c + I * d ) == (a + I * b )
+        // -------------------------------------
+        double const tol = 20 * eps;
+        auto const zpq = rocblas_complex_num<double>{double{p}, double{q}};
+        auto const zcd = rocblas_complex_num<double>{double{c}, double{d}};
+        auto const zab = rocblas_complex_num<double>{double{a}, double{b}};
+
+        bool const isok = (std::abs(zpq * zcd - zab) <= tol * std::abs(zpq));
+        assert(isok);
+    }
+#endif
+}
+
 template <typename T, typename I>
 __device__ void Xscale_body(I const n,
                             T const alpha,
@@ -403,6 +520,145 @@ static __global__ void Xscale_batch_kernel(I const n,
         auto const Xp = load_ptr_batch(X_, bid, shift_X, stride_X);
         Xscale_body(n, alpha, Xp, ix, jx, ldx, incx, mb, nb, myprow, mypcol, nprow, npcol);
     }
+}
+
+// -------------------------------
+// compute the L2 norm of a vector
+// and return in "ans"
+// -------------------------------
+template <typename T, typename I, typename S>
+static void __device__ Xnrm2_body(cg::grid_group cg_grid,
+                                  I const n,
+                                  T const* const X_,
+                                  I const ix,
+                                  I const jx,
+                                  I const ldx,
+                                  I const incx,
+                                  I const mb,
+                                  I const nb,
+                                  I const myprow,
+                                  I const mypcol,
+                                  I const nprow,
+                                  I const npcol,
+                                  S* const ans)
+{
+    if(n <= 0)
+    {
+        return;
+    };
+
+    bool constexpr is_complex = rocblas_is_complex<T>;
+
+    {
+        assert(cg_grid.is_valid());
+    }
+
+    if(cg_grid.thread_rank() == 0)
+    {
+        *ans = 0;
+    }
+    cg_grid.sync();
+
+    I const tix = hipThreadIdx_x;
+    I const tiy = hipThreadIdx_y;
+    I const nx = hipBlockDim_x;
+    I const ny = hipBlockDim_y;
+
+    auto idx2D = [](auto i, auto j, auto ld) { return (i + j * static_cast<int64_t>(ld)); };
+
+    bool const is_column_X = (incx == 1);
+    {
+        assert((incx == 1) || (incx == ldx));
+    }
+
+    auto const ip_X = idx2D(ix, jx, ldx);
+    auto Xvec = [=](auto const i) -> T& { return (X_[ip_X + i * static_cast<int64_t>(incx)]); };
+
+    extern __shared__ double lmem[];
+
+    double* dnorm_sh = (double*)&(lmem[0]);
+
+    double dnorm = 0;
+    if(is_column_X)
+    {
+        auto const itile_start = find_next_tile(ix, mb, myprow, nprow);
+        auto const itile_end = find_next_tile(ix + n - 1, mb, myprow, nprow);
+        auto const ntiles = (itile_end - itile_start) / nprow;
+
+        {
+            assert(itile_start <= itile_end);
+            assert(ntiles * nprow == (itile_end - itile_start));
+        }
+
+        for(auto it = (0 + tiy); it <= ntiles; it += ny)
+        {
+            auto const itile = itile_start + it * nprow;
+            auto const istart = std::max(ix, itile * mb);
+            auto const iend = std::min(ix + n - 1, itile * mb + (mb - 1));
+
+            for(auto iix = (istart + tix); iix <= iend; iix += nx)
+            {
+                T const xi = Xvec((iix - ix));
+                if(is_complex)
+                {
+                    dnorm += std::norm(xi);
+                }
+                else
+                {
+                    dnorm += xi * xi;
+                }
+            }
+        }
+    }
+    else
+    {
+        auto const jtile_start = find_next_tile(jx, nb, mypcol, npcol);
+        auto const jtile_end = find_next_tile(jx + n - 1, nb, mypcol, npcol);
+        auto const ntiles = (jtile_end - jtile_start) / npcol;
+
+        {
+            assert(jtile_start <= jtile_end);
+            assert(ntiles * npcol == (jtile_end - jtile_start));
+        }
+
+        for(auto it = (0 + tiy); it <= ntiles; it += ny)
+        {
+            auto const jtile = jtile_start + it * npcol;
+            auto const jstart = std::max(jx, it * nb);
+            auto const jend = std::min(jx + n - 1, it * nb + (nb - 1));
+
+            for(auto jjx = (jstart + tix); jjx <= jend; jjx += nx)
+            {
+                T const xj = Xvec((jjx - jx));
+                if(is_complex)
+                {
+                    dnorm += std::norm(xj);
+                }
+                else
+                {
+                    dnorm += xj * xj;
+                }
+            }
+        }
+    }
+
+    auto const cg_block = cg::this_thread_block();
+    dnorm = reduce_sum(cg_block, dnorm_sh, dnorm);
+
+    bool const need_atomic_update = (is_column_X) ? (nprow > 1) : (npcol > 1);
+    if(cg_block.thread_rank() == 0)
+    {
+        if(need_atomic_update)
+        {
+            atomicAdd(ans, static_cast<S>(dnorm));
+        }
+        else
+        {
+            *ans += static_cast<S>(dnorm);
+        }
+    }
+
+    cg_grid.sync();
 }
 
 template <typename T, typename I>

--- a/library/src/auxiliary/rocauxiliary_latrd_coop.hpp
+++ b/library/src/auxiliary/rocauxiliary_latrd_coop.hpp
@@ -38,7 +38,11 @@
 #include <complex>
 #include <limits>
 
+#include "hip/amd_detail/amd_warp_sync_functions.h"
+#include "hip/device_functions.h"
+#include "hip/hip_common.h"
 #include "hip/hip_cooperative_groups.h"
+
 #include "hip/hip_runtime.h"
 #include "hip/hip_runtime_api.h"
 
@@ -46,6 +50,13 @@
 #include "rocsolver/rocsolver.h"
 
 ROCSOLVER_BEGIN_NAMESPACE
+
+#define PRINT_PROFILE
+#ifdef PRINT_PROFILE
+#define CLOCK64() clock64()
+#else
+#define CLOCK64() (0)
+#endif
 
 #ifndef LAUNCH_CHECK
 #define LAUNCH_CHECK(fcn)                                                                  \
@@ -62,45 +73,55 @@ ROCSOLVER_BEGIN_NAMESPACE
 
 namespace cg = cooperative_groups;
 
-template <typename T>
-__device__ T reduce_sum(cg::thread_group g, T* temp, T val)
+template <typename T, typename I>
+__device__ T reduce_sum_shfl_wsize(I const wsize, T val)
 {
-    auto const lane = g.thread_rank();
-    g.sync();
-
     // Each iteration halves the number of active threads
     // Each thread adds its partial sum[i] to sum[lane+i]
-    for(auto i = g.size() / 2; i > 0; i /= 2)
+    for(auto offset = wsize / 2; offset > 0; offset /= 2)
     {
-        temp[lane] = val;
-        g.sync(); // wait for all threads to store
-        if(lane < i)
-            val += temp[lane + i];
-        g.sync(); // wait for all threads to load
+        val += __shfl_down(val, offset);
+        // g.sync();
     }
     return val; // note: only thread 0 will return full sum
 }
 
-#if(0)
-template <typename T>
-__device__ int reduce_sum_shfl(cg::thread_block g, T const val)
+static bool get_cooperative_launch(int deviceId = 0)
 {
-    g.sync();
-    // Each iteration halves the number of active threads
-    // Each thread adds its partial sum[i] to sum[lane+i]
-    for(auto i = g.size() / 2; i > 0; i /= 2)
-    {
-        val += __shfl_down(val, i);
-        g.sync();
-    }
-    return val; // note: only thread 0 will return full sum
+    int ival = 0;
+    auto const attr = hipDeviceAttributeCooperativeLaunch;
+    HIP_CHECK(hipDeviceGetAttribute(&ival, attr, deviceId));
+    return (ival);
 }
-#endif
+
+static int get_lds_size(int deviceId = 0)
+{
+    int ival = 0;
+    auto const attr = hipDeviceAttributeMaxSharedMemoryPerBlock;
+    HIP_CHECK(hipDeviceGetAttribute(&ival, attr, deviceId));
+    return (ival);
+}
 
 static int get_num_cu(int deviceId = 0)
 {
     int ival = 0;
     auto const attr = hipDeviceAttributeMultiprocessorCount;
+    HIP_CHECK(hipDeviceGetAttribute(&ival, attr, deviceId));
+    return (ival);
+}
+
+static int get_warp_size(int deviceId = 0)
+{
+    int ival = 0;
+    auto const attr = hipDeviceAttributeWarpSize;
+    HIP_CHECK(hipDeviceGetAttribute(&ival, attr, deviceId));
+    return (ival);
+}
+
+static int get_max_threads_per_block(int deviceId = 0)
+{
+    int ival = 0;
+    auto const attr = hipDeviceAttributeMaxThreadsPerBlock;
     HIP_CHECK(hipDeviceGetAttribute(&ival, attr, deviceId));
     return (ival);
 }
@@ -133,1826 +154,247 @@ static __device__ void gatomicAdd(rocblas_complex_num<double>* const ptr,
     atomicAdd(p_imag, val.imag());
 }
 
-template <typename I>
-static __device__ __host__ I indxg2tile(I const ia, I const mb, I const myprow, I const nprow)
-{
-    I const itile = (ia / mb);
-    return (itile);
-}
-
-// ------------------------------------------
-// given a global index
-// return the processor that holds this entry
-// ------------------------------------------
-template <typename I>
-static __device__ __host__ I indxg2proc(I const ia, I const mb, I const myprow, I const nprow)
-{
-    I const itile = indxg2tile(ia, mb, myprow, nprow);
-    I const iproc = (itile % nprow);
-
-    return (iproc);
-}
-
-// --------------------------------------------
-// given a global index
-// return the first tile "jtile" that belongs to myprow
-// --------------------------------------------
-template <typename I>
-static __device__ __host__ I first_tile(I const ia, I const mb, I const myprow, I const nprow)
-{
-    I const itile = (ia / mb);
-    I const iproc = (itile % nprow);
-    I const jtile = (itile + ((myprow + nprow - iproc) % nprow));
-
-    assert((jtile % nprow) == myprow);
-
-    return (jtile);
-}
-
-template <typename S>
-static __device__ __host__ S lamch(char const ctype)
-{
-    if((ctype == 'E') || (ctype == 'e'))
-    {
-        return (std::numeric_limits<S>::epsilon() / 2);
-    }
-    if((ctype == 'S') || (ctype == 's'))
-    {
-        return (std::numeric_limits<S>::min());
-    }
-    if((ctype == 'B') || (ctype == 'b'))
-    {
-        return (std::numeric_limits<S>::base());
-    }
-    if((ctype == 'P') || (ctype == 'p'))
-    {
-        S const eps = std::numeric_limits<S>::epsilon() / 2;
-        S const base = std::numeric_limits<S>::base();
-        return (eps * base);
-    }
-    if((ctype == 'O') || (ctype == 'o'))
-    {
-        return (std::numeric_limits<S>::max());
-    }
-    return (0);
-}
-
-// --------------------------------------------------------------
-// computes  sqrt( x^2 + y^2 + z^2 ) without unnecessary overflow
-// assume x, y, z are not complex types
-// --------------------------------------------------------------
-template <typename S>
-static __device__ S lapy3(S const x, S const y, S const z)
-{
-    assert(!rocblas_is_complex<S>);
-
-    auto square = [](auto d) { return (d * d); };
-
-    auto const xabs = std::abs(x);
-    auto const yabs = std::abs(y);
-    auto const zabs = std::abs(z);
-    auto const w = std::max(xabs, std::max(yabs, zabs));
-    auto const ans = (w == 0)
-        ? (xabs + yabs + zabs)
-        : w * std::sqrt(square(xabs / w) + square(yabs / w) + square(zabs / w));
-    return (ans);
-}
-
-// -------------------------------------------------------
-// computes sqrt( x^2 + y^2 ) without unnecessary overflow
-// assume x, y are not complex types
-// -------------------------------------------------------
-template <typename S>
-static __device__ S lapy2(S const x, S const y)
-{
-    S const one = 1;
-    S const zero = 0;
-    bool const x_is_nan = std::isnan(x);
-    bool const y_is_nan = std::isnan(y);
-    S dlapy2 = zero;
-    if(x_is_nan)
-    {
-        dlapy2 = x;
-    }
-    if(y_is_nan)
-    {
-        dlapy2 = y;
-    }
-
-    auto const hugeval = lamch<S>('O'); // overflow
-
-    auto square = [](auto d) { return (d * d); };
-
-    if(!(x_is_nan || y_is_nan))
-    {
-        auto const xabs = std::abs(x);
-        auto const yabs = std::abs(y);
-        auto const w = std::max(xabs, yabs);
-        auto const z = std::min(xabs, yabs);
-        if((z == zero) || (w > hugeval))
-        {
-            dlapy2 = w;
-        }
-        else
-        {
-            dlapy2 = w * std::sqrt(one + square(z / w));
-        }
-    }
-    return (dlapy2);
-}
-
-// ---------------------------------------
-// Fortran sign intrinsic
-// return  abs value of a times  sign of b
-// ---------------------------------------
-template <typename S>
-static __device__ S sign(S const a, S const b)
-{
-    return (std::abs(a) * ((b < 0) ? -1 : 1));
-}
-
-// -------------------------------------------
-// compute complex division in real arithmetic
-// p + I * q = (a + I * b)/( c + I * d )
-// -------------------------------------------
-template <typename S>
-static __device__ __host__ void ladiv(S const a, S const b, S const c, S const d, S& p, S& q)
-{
-    {
-        assert(!rocblas_is_complex<S>);
-    }
-
-    S const bs = 2.0;
-    S const half = 0.5;
-    S const two = 2.0;
-    S const one = 1.0;
-
-    auto ladiv2 = [](S const a, S const b, S const c, S const d, S const r, S const t) -> S {
-        S dladiv2 = 0;
-        if(r != 0)
-        {
-            auto const br = b * r;
-            if(br != 0)
-            {
-                dladiv2 = (a + br) * t;
-            }
-            else
-            {
-                dladiv2 = a * t + (b * t) * r;
-            }
-        }
-        else
-        {
-            dladiv2 = (a + d * (b / c)) * t;
-        }
-        return (dladiv2);
-    };
-
-    auto ladiv1 = [](S& a, S& b, S& c, S& d, S& p, S& q) {
-        S const one = 1.0;
-        auto r = d / c;
-        auto t = one / (c + d * r);
-        p = ladiv2(a, b, c, d, r, t);
-        a = -a;
-        q = ladiv2(b, a, c, d, r, t);
-    };
-
-    S aa = a;
-    S bb = b;
-    S cc = c;
-    S dd = d;
-
-    S const ab = std::max(std::abs(a), std::abs(b));
-    S const cd = std::max(std::abs(c), std::abs(d));
-    S s = one;
-
-    auto const ov = lamch<S>('O'); // overflow
-    auto const un = lamch<S>('S'); // safe min
-    auto const eps = lamch<S>('E'); // epsilon
-    auto const be = bs / (eps * eps);
-
-    if(cd >= half * ov)
-    {
-        cc = half * cc;
-        dd = half * dd;
-        s = half * s;
-    }
-
-    if(ab <= un * bs / eps)
-    {
-        aa *= be;
-        bb *= be;
-        s = s / be;
-    }
-
-    if(cd <= un * bs / eps)
-    {
-        cc *= be;
-        dd *= be;
-        s *= be;
-    }
-
-    if(std::abs(d) <= std::abs(c))
-    {
-        ladiv1(aa, bb, cc, dd, p, q);
-    }
-    else
-    {
-        ladiv1(bb, aa, dd, cc, p, q);
-        q = -q;
-    }
-
-    p *= s;
-    q *= s;
-
-#ifdef NDEBUG
-#else
-    {
-        // -------------------------------------
-        // extra check
-        //
-        // p + I * q = (a + I * b)/( c + I * d )
-        //
-        // or
-        //
-        // (p + I * q) * (c + I * d ) == (a + I * b )
-        // -------------------------------------
-        double const tol = 20 * eps;
-        auto const zpq = rocblas_complex_num<double>{double{p}, double{q}};
-        auto const zcd = rocblas_complex_num<double>{double{c}, double{d}};
-        auto const zab = rocblas_complex_num<double>{double{a}, double{b}};
-
-        bool const isok = (std::abs(zpq * zcd - zab) <= tol * std::abs(zpq));
-        assert(isok);
-    }
-#endif
-}
-
+// -------------------------------------------------
+// assume launch as dim3( num_cu,1,1), dim3(nx,ny,1)
+// -------------------------------------------------
 template <typename T, typename I>
-__device__ void Xscale_body(I const n,
-                            T const alpha,
-                            T* const X_,
-                            I const ix,
-                            I const jx,
-                            I const ldx,
-                            I const incx,
-                            I const mb,
-                            I const nb,
-                            I const myprow,
-                            I const mypcol,
-                            I const nprow,
-                            I const npcol)
-
+static __device__ void Xscale_coop_body(I const n, T const alpha, T* const X, I const incx)
 {
     {
-        bool const has_work = (n >= 1);
+        bool const has_work = (n >= 1) && (alpha != 1);
         if(!has_work)
         {
             return;
         }
     }
 
-    I const tix = hipThreadIdx_x;
-    I const tiy = hipThreadIdx_y;
-    I const nx = hipBlockDim_x;
-    I const ny = hipBlockDim_y;
+    auto ceil = [](auto m, auto n) { return (1 + (m - 1) / n); };
 
-    T const zero = 0;
-    bool const is_alpha_zero = (alpha == zero);
+    I const nblocks = (hipGridDim_x * hipGridDim_y * hipGridDim_z);
+    I const nthreads_per_block = (hipBlockDim_x * hipBlockDim_y * hipBlockDim_z);
 
-    auto idx2D = [](auto i, auto j, auto ld) { return (i + j * static_cast<int64_t>(ld)); };
-    // ----------------------------------------
-    // incx can only be 1 (column) or ldx (row)
-    // ----------------------------------------
-    bool const is_column_X = (incx == 1);
+    I const nx = nthreads_per_block;
+
+    I const tix = (hipThreadIdx_x + hipThreadIdx_y * hipBlockDim_x
+                   + hipThreadIdx_z * (hipBlockDim_x * hipBlockDim_y));
+
+    I const bix = (hipBlockIdx_x + hipBlockIdx_y * hipGridDim_x
+                   + hipBlockIdx_z * (hipGridDim_x * hipGridDim_y));
+
+    I const mb = ceil(n, nblocks);
+    I const ix_start = bix * mb;
+    I const ix_end = std::min(n, ix_start + mb);
+
+    if(incx == 1)
     {
-        assert((incx == 1) || (incx == ldx));
-    }
-
-    auto const ip_X = idx2D(ix, jx, ldx);
-    auto Xvec = [=](auto i) -> T& { return (X_[ip_X + i * static_cast<int64_t>(incx)]); };
-
-    if(is_column_X)
-    {
-        I const tile_start = first_tile(ix, mb, myprow, nprow);
-        I const tile_end = first_tile(ix + n - 1, mb, myprow, nprow);
-        I const tile_inc = nprow;
-
-        I const ntiles = (tile_end - tile_start) / tile_inc;
-        assert((ntiles * tile_inc) == (tile_end - tile_start));
-
-        for(auto it = (0 + tiy); it <= ntiles; it += ny)
+        for(I ix = (ix_start + tix); ix < ix_end; ix += nx)
         {
-            I const tile = tile_start + it * tile_inc;
-            I const i_start = std::max(ix, tile * mb);
-            I const i_end = std::min(ix + n - 1, tile * mb + (mb - 1));
-
-            if(is_alpha_zero)
+            if(alpha == 0)
             {
-                for(auto i = (i_start + tix); i <= i_end; i += nx)
-                {
-                    Xvec(i - ix) = zero;
-                }
+                X[ix] = 0;
             }
             else
             {
-                for(auto i = (i_start + tix); i <= i_end; i += nx)
-                {
-                    Xvec(i - ix) *= alpha;
-                }
+                X[ix] *= alpha;
             }
         }
     }
     else
     {
-        auto const tile_start = first_tile(jx, nb, mypcol, npcol);
-        auto const tile_end = first_tile(jx + n - 1, nb, mypcol, npcol);
-        auto const tile_inc = npcol;
-
-        auto const ntiles = (tile_end - tile_start) / tile_inc;
-        assert((ntiles * tile_inc) == (tile_end - tile_start));
-
-        for(auto it = (0 + tiy); it <= ntiles; it += ny)
+        for(I ix = (ix_start + tix); ix < ix_end; ix += nx)
         {
-            auto const tile = tile_start + it * tile_inc;
-
-            auto const j_start = std::max(jx, tile * nb);
-            auto const j_end = std::min(jx + n - 1, tile * nb + (nb - 1));
-
-            if(is_alpha_zero)
+            if(alpha == 0)
             {
-                for(auto j = (j_start + tix); j <= j_end; j += nx)
-                {
-                    Xvec(j - jx) = zero;
-                }
+                X[ix * static_cast<int64_t>(incx)] = 0;
             }
             else
             {
-                for(auto j = (j_start + tix); j <= j_end; j += nx)
-                {
-                    Xvec(j - jx) *= alpha;
-                }
+                X[ix * static_cast<int64_t>(incx)] *= alpha;
             }
         }
     }
-}
-
-template <typename T, typename I, typename Istride, typename UX>
-static __global__ void Xscale_batch_kernel(I const n,
-                                           T const* const p_alpha,
-                                           Istride const stride_alpha,
-                                           UX X_,
-                                           Istride const shift_X,
-                                           I const ix,
-                                           I const jx,
-                                           I const ldx,
-                                           I const incx,
-                                           Istride const stride_X,
-                                           I const batch_count,
-                                           I const mb,
-                                           I const nb)
-{
-    I const myprow = hipBlockIdx_x;
-    I const mypcol = hipBlockIdx_y;
-    I const nprow = hipGridDim_x;
-    I const npcol = hipGridDim_y;
-
-    for(I bid = 0; bid < batch_count; bid++)
-    {
-        T const alpha = *(p_alpha + bid * stride_alpha);
-
-        auto const Xp = load_ptr_batch(X_, bid, shift_X, stride_X);
-        Xscale_body(n, alpha, Xp, ix, jx, ldx, incx, mb, nb, myprow, mypcol, nprow, npcol);
-    }
-}
-
-// -------------------------------
-// compute the L2 norm of a vector
-// and return in "ans"
-// -------------------------------
-template <typename T, typename I, typename S>
-static void __device__ Xnrm2_body(cg::grid_group cg_grid,
-                                  I const n,
-                                  T const* const X_,
-                                  I const ix,
-                                  I const jx,
-                                  I const ldx,
-                                  I const incx,
-                                  I const mb,
-                                  I const nb,
-                                  I const myprow,
-                                  I const mypcol,
-                                  I const nprow,
-                                  I const npcol,
-                                  S* const ans)
-{
-    if(n <= 0)
-    {
-        return;
-    };
-
-    bool constexpr is_complex = rocblas_is_complex<T>;
-
-    {
-        assert(cg_grid.is_valid());
-    }
-
-    if(cg_grid.thread_rank() == 0)
-    {
-        *ans = 0;
-    }
-    cg_grid.sync();
-
-    I const tix = hipThreadIdx_x;
-    I const tiy = hipThreadIdx_y;
-    I const nx = hipBlockDim_x;
-    I const ny = hipBlockDim_y;
-
-    auto idx2D = [](auto i, auto j, auto ld) { return (i + j * static_cast<int64_t>(ld)); };
-
-    bool const is_column_X = (incx == 1);
-    {
-        assert((incx == 1) || (incx == ldx));
-    }
-
-    auto const ip_X = idx2D(ix, jx, ldx);
-    auto Xvec = [=](auto const i) -> T& { return (X_[ip_X + i * static_cast<int64_t>(incx)]); };
-
-    extern __shared__ double lmem[];
-
-    double* dnorm_sh = (double*)&(lmem[0]);
-
-    double dnorm = 0;
-    if(is_column_X)
-    {
-        auto const itile_start = first_tile(ix, mb, myprow, nprow);
-        auto const itile_end = first_tile(ix + n - 1, mb, myprow, nprow);
-        auto const ntiles = (itile_end - itile_start) / nprow;
-
-        {
-            assert(itile_start <= itile_end);
-            assert(ntiles * nprow == (itile_end - itile_start));
-        }
-
-        for(auto it = (0 + tiy); it <= ntiles; it += ny)
-        {
-            auto const itile = itile_start + it * nprow;
-            auto const istart = std::max(ix, itile * mb);
-            auto const iend = std::min(ix + n - 1, itile * mb + (mb - 1));
-
-            for(auto iix = (istart + tix); iix <= iend; iix += nx)
-            {
-                T const xi = Xvec((iix - ix));
-                if(is_complex)
-                {
-                    dnorm += std::norm(xi);
-                }
-                else
-                {
-                    dnorm += xi * xi;
-                }
-            }
-        }
-    }
-    else
-    {
-        auto const jtile_start = first_tile(jx, nb, mypcol, npcol);
-        auto const jtile_end = first_tile(jx + n - 1, nb, mypcol, npcol);
-        auto const ntiles = (jtile_end - jtile_start) / npcol;
-
-        {
-            assert(jtile_start <= jtile_end);
-            assert(ntiles * npcol == (jtile_end - jtile_start));
-        }
-
-        for(auto it = (0 + tiy); it <= ntiles; it += ny)
-        {
-            auto const jtile = jtile_start + it * npcol;
-            auto const jstart = std::max(jx, it * nb);
-            auto const jend = std::min(jx + n - 1, it * nb + (nb - 1));
-
-            for(auto jjx = (jstart + tix); jjx <= jend; jjx += nx)
-            {
-                T const xj = Xvec((jjx - jx));
-                if(is_complex)
-                {
-                    dnorm += std::norm(xj);
-                }
-                else
-                {
-                    dnorm += xj * xj;
-                }
-            }
-        }
-    }
-
-    auto const cg_block = cg::this_thread_block();
-    dnorm = reduce_sum(cg_block, dnorm_sh, dnorm);
-
-    bool const need_atomic_update = (is_column_X) ? (nprow > 1) : (npcol > 1);
-    if(cg_block.thread_rank() == 0)
-    {
-        if(need_atomic_update)
-        {
-            atomicAdd(ans, static_cast<S>(dnorm));
-        }
-        else
-        {
-            *ans += static_cast<S>(dnorm);
-        }
-    }
-
-    cg_grid.sync();
-}
-
-// -------------------------------
-// compute the dot product
-// and return in "ans"
-//
-//
-// NOTE: assume *ans has been set to zero
-// -------------------------------
-template <typename T, typename I>
-static void __device__ Xdot_body(I const n,
-
-                                 T const* const X_,
-                                 I const ix,
-                                 I const jx,
-                                 I const ldx,
-                                 I const incx,
-
-                                 T const* const Y_,
-                                 I const iy,
-                                 I const jy,
-                                 I const ldy,
-                                 I const incy,
-
-                                 T* const ans,
-
-                                 I const mb,
-                                 I const nb,
-                                 I const myprow,
-                                 I const mypcol,
-                                 I const nprow,
-                                 I const npcol)
-{
-    if(n <= 0)
-    {
-        return;
-    };
-
-    bool constexpr is_complex = rocblas_is_complex<T>;
-
-    I const tix = hipThreadIdx_x;
-    I const tiy = hipThreadIdx_y;
-    I const nx = hipBlockDim_x;
-    I const ny = hipBlockDim_y;
-
-    auto idx2D = [](auto i, auto j, auto ld) { return (i + j * static_cast<int64_t>(ld)); };
-
-    bool const is_column_X = (incx == 1);
-    bool const is_column_Y = (incy == 1);
-    {
-        assert((incx == 1) || (incx == ldx));
-        assert((incy == 1) || (incy == ldy));
-    }
-
-    auto const ip_X = idx2D(ix, jx, ldx);
-    auto Xvec = [=](auto const i) -> T { return (X_[ip_X + i * static_cast<int64_t>(incx)]); };
-
-    auto const ip_Y = idx2D(iy, jy, ldy);
-    auto Yvec = [=](auto const i) -> T { return (Y_[ip_Y + i * static_cast<int64_t>(incy)]); };
-
-    extern __shared__ double lmem[];
-
-    T* dsum_sh = (T*)&(lmem[0]);
-
-    T dsum = 0;
-    if(is_column_X)
-    {
-        auto const itile_start = first_tile(ix, mb, myprow, nprow);
-        auto const itile_end = first_tile(ix + n - 1, mb, myprow, nprow);
-        auto const ntiles = (itile_end - itile_start) / nprow;
-
-        {
-            assert(itile_start <= itile_end);
-            assert(ntiles * nprow == (itile_end - itile_start));
-        }
-
-        for(auto it = (0 + tiy); it <= ntiles; it += ny)
-        {
-            auto const itile = itile_start + it * nprow;
-            auto const istart = std::max(ix, itile * mb);
-            auto const iend = std::min(ix + n - 1, itile * mb + (mb - 1));
-
-            for(auto iix = (istart + tix); iix <= iend; iix += nx)
-            {
-                T const xi = Xvec((iix - ix));
-                T const yi = Yvec((iix - ix));
-                if constexpr(is_complex)
-                {
-                    dsum += conj(xi) * yi;
-                }
-                else
-                {
-                    dsum += xi * yi;
-                }
-            }
-        }
-    }
-    else
-    {
-        auto const jtile_start = first_tile(jx, nb, mypcol, npcol);
-        auto const jtile_end = first_tile(jx + n - 1, nb, mypcol, npcol);
-        auto const ntiles = (jtile_end - jtile_start) / npcol;
-
-        {
-            assert(jtile_start <= jtile_end);
-            assert(ntiles * npcol == (jtile_end - jtile_start));
-        }
-
-        for(auto it = (0 + tiy); it <= ntiles; it += ny)
-        {
-            auto const jtile = jtile_start + it * npcol;
-            auto const jstart = std::max(jx, it * nb);
-            auto const jend = std::min(jx + n - 1, it * nb + (nb - 1));
-
-            for(auto jjx = (jstart + tix); jjx <= jend; jjx += nx)
-            {
-                T const xj = Xvec((jjx - jx));
-                T const yj = Yvec((jjx - jx));
-                if constexpr(is_complex)
-                {
-                    dsum += conj(xj) * yj;
-                }
-                else
-                {
-                    dsum += xj * yj;
-                }
-            }
-        }
-    }
-
-    auto const cg_block = cg::this_thread_block();
-    dsum = reduce_sum(cg_block, dsum_sh, dsum);
-
-    bool const need_atomic_update = (is_column_X) ? (nprow > 1) : (npcol > 1);
-    if(cg_block.thread_rank() == 0)
-    {
-        if(need_atomic_update)
-        {
-            atomicAdd(ans, (dsum));
-        }
-        else
-        {
-            *ans += (dsum);
-        }
-    }
-}
-
-template <typename T, typename I, typename Istride, typename UX, typename UY>
-__global__ static void Xdot_batch_kernel(I const n,
-
-                                         UX X_,
-                                         Istride const shiftX,
-                                         I const ix,
-                                         I const jx,
-                                         I const ldx,
-                                         I const incx,
-                                         Istride const strideX,
-
-                                         UY Y_,
-                                         Istride const shiftY,
-                                         I const iy,
-                                         I const jy,
-                                         I const ldy,
-                                         I const incy,
-                                         Istride const strideY,
-
-                                         I const batch_count,
-                                         I const mb,
-                                         I const nb,
-                                         T* const ans,
-                                         T* const work)
-{
-    I const myprow = hipBlockIdx_x;
-    I const mypcol = hipBlockIdx_y;
-    I const nprow = hipGridDim_x;
-    I const npcol = hipGridDim_y;
-
-    for(I bid = 0; bid < batch_count; bid++)
-    {
-        T const* const Xp = load_ptr_batch(X_, bid, shiftX, strideX);
-        T const* const Yp = load_ptr_batch(Y_, bid, shiftY, strideY);
-        T* const ansp = ans + bid;
-
-        Xdot_body<T, I>(n, Xp, ix, jx, ldx, incx, Yp, iy, jy, ldy, incy, ansp,
-
-                        mb, nb, myprow, mypcol, nprow, npcol);
-    }
-}
-
-template <typename T, typename I, typename Istride, typename UX, typename UY, typename Tex>
-static void rocsolverCall_dot(rocblas_handle handle,
-                              I const n,
-
-                              UX X_,
-                              Istride const shiftX,
-                              I const ix,
-                              I const jx,
-                              I const ldx,
-                              I const incx,
-                              Istride const strideX,
-
-                              UY Y_,
-                              Istride const shiftY,
-                              I const iy,
-                              I const jy,
-                              I const ldy,
-                              I const incy,
-                              Istride const strideY,
-
-                              I const batch_count,
-                              T* const norms,
-                              I const mb,
-                              I const nb,
-                              Tex* const workspace,
-                              T** const workArr)
-{
-    hipStream_t stream;
-    rocblas_get_stream(handle, &stream);
-
-    auto const nx = 32;
-    auto const ny = 32;
-    auto const num_cu = get_num_cu();
-    size_t const ld_size = 64 * 1024;
-
-    {
-        auto const istat = hipMemset(norms, 0, sizeof(T) * batch_count);
-        assert(istat == hipSuccess);
-    }
-
-    Xdot_batch_kernel<T, I, Istride><<<dim3(num_cu, 1, 1), dim3(nx, ny, 1), ld_size, stream>>>(
-        n, X_, shiftX, ix, jx, ldx, incx, strideX, Y_, shiftY, iy, jy, ldy, incy, strideY,
-        batch_count, mb, nb, norms, workspace);
 }
 
 template <typename T, typename I>
-__device__ void Xlacgv_body(I const n,
-                            T* const X_,
-                            I const ix,
-                            I const jx,
-                            I const ldx,
-                            I const incx,
-                            I const mb,
-                            I const nb,
-                            I const myprow,
-                            I const mypcol,
-                            I const nprow,
-                            I const npcol)
+static __device__ void Xgemv_sh(char const trans,
+                                I const mm,
+                                I const nn,
 
+                                T const alpha,
+
+                                T const* const A_sh_,
+                                I const ldAsh,
+
+                                T const* const X_,
+                                I const incx,
+
+                                T* const Y_,
+                                I const incy)
 {
+    bool constexpr is_complex = rocblas_is_complex<T>;
+
+    I nx = hipBlockDim_x;
+    I ny = hipBlockDim_y;
+    I tix = hipThreadIdx_x;
+    I tiy = hipThreadIdx_y;
+
+    I const myprow = hipBlockIdx_x;
+    I const nprow = hipGridDim_x;
+
     {
-        bool const has_work = (n >= 1);
+        bool const has_work = (mm >= 1) && (nn >= 1) && (alpha != 0);
         if(!has_work)
         {
             return;
         }
     }
 
-    I const tix = hipThreadIdx_x;
-    I const tiy = hipThreadIdx_y;
-    I const nx = hipBlockDim_x;
-    I const ny = hipBlockDim_y;
+    auto ceil = [](auto m, auto n) { return (1 + (m - 1) / n); };
 
-    auto idx2D = [](auto i, auto j, auto ld) { return (i + j * static_cast<int64_t>(ld)); };
-    // ----------------------------------------
-    // incx can only be 1 (column) or ldx (row)
-    // ----------------------------------------
-    bool const is_column_X = (incx == 1);
-    assert((incx == 1) || (incx == ldx));
-
-    auto const ip_X = idx2D(ix, jx, ldx);
-    auto Xvec = [=](auto i) -> T& { return (X_[ip_X + i * static_cast<int64_t>(incx)]); };
-
-    if(is_column_X)
-    {
-        I const tile_start = first_tile(ix, mb, myprow, nprow);
-        I const tile_end = first_tile(ix + n - 1, mb, myprow, nprow);
-        I const tile_inc = nprow;
-
-        I const ntiles = (tile_end - tile_start) / tile_inc;
-
-        for(auto it = (0 + tiy); it <= ntiles; it += ny)
-        {
-            I const tile = tile_start + it * tile_inc;
-            I const i_start = std::max(ix, tile * mb);
-            I const i_end = std::min(ix + n - 1, tile * mb + (mb - 1));
-
-            {
-                for(auto i = (i_start + tix); i <= i_end; i += nx)
-                {
-                    Xvec(i - ix) = conj(Xvec(i - ix));
-                }
-            }
-        }
-    }
-    else
-    {
-        auto const tile_start = first_tile(jx, nb, mypcol, npcol);
-        auto const tile_end = first_tile(jx + n - 1, nb, mypcol, npcol);
-        auto const tile_inc = npcol;
-
-        auto const ntiles = (tile_end - tile_start) / tile_inc;
-
-        for(auto it = (0 + tiy); it <= ntiles; it += ny)
-        {
-            auto const tile = tile_start + it * tile_inc;
-
-            auto const j_start = std::max(jx, tile * nb);
-            auto const j_end = std::min(jx + n - 1, tile * nb + (nb - 1));
-
-            {
-                for(auto j = (j_start + tix); j <= j_end; j += nx)
-                {
-                    Xvec(j - jx) = conj(Xvec(j - jx));
-                }
-            }
-        }
-    }
-}
-
-template <typename T, typename I, typename Istride, typename UX>
-static __global__ void Xlacgv_batch_kernel(I const n,
-                                           UX X_,
-                                           Istride const shift_X,
-                                           I const ix,
-                                           I const jx,
-                                           I const ldx,
-                                           I const incx,
-                                           Istride const stride_X,
-                                           I const batch_count,
-                                           I const mb,
-                                           I const nb)
-{
-    I const myprow = hipBlockIdx_x;
-    I const mypcol = hipBlockIdx_y;
-    I const nprow = hipGridDim_x;
-    I const npcol = hipGridDim_y;
-
-    for(I bid = 0; bid < batch_count; bid++)
-    {
-        auto const Xp = load_ptr_batch(X_, bid, shift_X, stride_X);
-        Xlacgv_body(n, Xp, ix, jx, ldx, incx, mb, nb, myprow, mypcol, nprow, npcol);
-    }
-}
-
-template <typename T, typename I, typename Istride, typename UX>
-static void rocsolverCall_lacgv_template(rocblas_handle handle,
-                                         I const n,
-                                         UX X_,
-                                         Istride const shiftX,
-                                         I const ix,
-                                         I const jx,
-                                         I const ldx,
-                                         I const incx,
-                                         Istride strideX,
-                                         I const batch_count,
-                                         I const mb,
-                                         I const nb)
-{
-    hipStream_t stream;
-    rocblas_get_stream(handle, &stream);
-    size_t const lds_size = 64 * 1024;
-    auto const NX = 32;
-    auto const NY = 32;
-    auto const num_cu = get_num_cu();
-
-    Xlacgv_batch_kernel<T, I, Istride><<<dim3(num_cu, 1, 1), dim3(NX, NY, 1), lds_size, stream>>>(
-        n, X_, shiftX, ix, jx, ldx, incx, strideX, batch_count, mb, nb);
-}
-
-// ----------------------
-// matrix vector multiply
-// Yvec = alpha * op(A(0:(m-1),0:(n-1)) * Xvec
-// where
-// op(A) can be  A or
-//               transpose(A) or
-//               conj(transpose(A))
-// ----------------------
-template <typename T, typename I>
-static __device__ void Xgemv_body(char const trans,
-                                  I const m,
-                                  I const n,
-                                  T const alpha,
-
-                                  T const* const A_,
-                                  I const ia,
-                                  I const ja,
-                                  I const lda,
-
-                                  T const* const X_,
-                                  I const ix,
-                                  I const jx,
-                                  I const ldx,
-                                  I const incx,
-
-                                  T* const Y_,
-                                  I const iy,
-                                  I const jy,
-                                  I const ldy,
-                                  I const incy,
-
-                                  I const mb,
-                                  I const nb,
-                                  I const myprow,
-                                  I const mypcol,
-                                  I const nprow,
-                                  I const npcol)
-{
-    bool constexpr is_complex = rocblas_is_complex<T>;
-
-    {
-        bool const has_work = (m >= 1) && (n >= 1) && (alpha != 0);
-        if(!has_work)
-        {
-            return;
-        }
-    }
-
-    {
-        bool const is_valid_lda = (lda >= 1) && (lda >= m);
-        assert(is_valid_lda);
-    }
-
-    I const tix = hipThreadIdx_x;
-    I const tiy = hipThreadIdx_y;
-    I const nx = hipBlockDim_x;
-    I const ny = hipBlockDim_y;
+    auto const mb = ceil(mm, nprow);
 
     bool const is_transpose = (trans == 'T') || (trans == 't');
     bool const is_conj_transpose = (trans == 'C') || (trans == 'c');
-    bool const is_no_transpose = (trans == 'N') || (trans == 'n');
-    {
-        bool const is_valid_trans = is_transpose || is_conj_transpose || is_no_transpose;
-        assert(is_valid_trans);
-    }
+    bool const is_no_transpose = (!is_transpose) && (!is_conj_transpose);
 
-    bool const is_column_Y = (incy == 1);
-    bool const is_column_X = (incx == 1);
+    I const nthreads = (hipBlockDim_x * hipBlockDim_y) * hipBlockDim_z;
+    I const warp_size = hipBlockDim_x;
 
-    {
-        bool const is_valid_incx = ((incx == 1) || (incx == ldx));
-        bool const is_valid_incy = ((incy == 1) || (incy == ldy));
+    auto setup_nxny
+        = [=](bool const is_no_transpose, auto const mm, auto const nn, auto& nx, auto& ny) {
+              if(is_no_transpose)
+              {
+                  nx = (nn >= warp_size)       ? warp_size
+                      : (nn >= warp_size / 2)  ? warp_size / 2
+                      : (nn >= warp_size / 4)  ? warp_size / 4
+                      : (nn >= warp_size / 8)  ? warp_size / 8
+                      : (nn >= warp_size / 16) ? warp_size / 16
+                      : (nn >= warp_size / 32) ? warp_size / 32
+                                               : 1;
+                  ny = nthreads / nx;
+                  assert((nx * ny) == nthreads);
+              }
+              else
+              {
+                  auto const lny = nthreads / warp_size;
+                  ny = (nn >= lny)       ? lny
+                      : (nn >= lny / 2)  ? lny / 2
+                      : (nn >= lny / 4)  ? lny / 4
+                      : (nn >= lny / 8)  ? lny / 8
+                      : (nn >= lny / 16) ? lny / 16
+                      : (nn >= lny / 32) ? lny / 32
+                                         : 1;
 
-        assert(is_valid_incx);
-        assert(is_valid_incy);
-    }
+                  nx = nthreads / ny;
+                  assert((nx * ny) == nthreads);
+              }
+          };
 
-    auto idx2D = [](auto i, auto j, auto ld) { return (i + j * static_cast<int64_t>(ld)); };
+    I const wsize = std::min(warp_size, nx);
 
-    auto const ip_Y = idx2D(iy, jy, ldy);
+    I const tixy = hipThreadIdx_x + hipThreadIdx_y * hipBlockDim_x
+        + hipThreadIdx_z * (hipBlockDim_x * hipBlockDim_y);
+    //  ---------------------
+    //  tixy = tix + tiy * nx
+    //  ---------------------
+    tix = (tixy % nx);
+    tiy = (tixy - tix) / nx;
+    bool const is_wave_rank0 = ((tixy % nx) == 0);
+
+    auto A_sh = [=](auto i, auto j) {
+        assert((0 <= i) && (i < mb));
+        assert((0 <= j) && (j < nn));
+        return (A_sh_[i + j * ldAsh]);
+    };
+
+    auto const len_X = (is_no_transpose) ? nn : mm;
+    auto const len_Y = (is_no_transpose) ? mm : nn;
+
+    auto Xvec = [=](auto i) -> T {
+        assert((0 <= i) && (i < len_X));
+        if(incx == 1)
+        {
+            return (X_[i]);
+        }
+        else
+        {
+            return (X_[i * static_cast<int64_t>(incx)]);
+        }
+    };
+
     auto Yvec = [=](auto i) -> T& {
-        assert((0 <= i) && (i < ((is_no_transpose) ? m : n)));
-        return (Y_[ip_Y + i * static_cast<int64_t>(incy)]);
+        assert((0 <= i) && (i < len_Y));
+        if(incy == 1)
+        {
+            return (Y_[i]);
+        }
+        else
+        {
+            return (Y_[i * static_cast<int64_t>(incy)]);
+        }
     };
 
-    auto const ip_X = idx2D(ix, jx, ldx);
-    auto Xvec = [=](auto i) {
-        assert((0 <= i) && (i < ((is_no_transpose) ? n : m)));
-        return (X_[ip_X + i * static_cast<int64_t>(incx)]);
-    };
-
-    auto A = [=](auto i, auto j) {
-        assert((ia <= i) && (i <= (ia + m - 1)));
-        assert((ja <= j) && (j <= (ja + n - 1)));
-        return (A_[idx2D(i, j, lda)]);
-    };
-
-    bool const need_atomic_update = (is_no_transpose) ? (npcol > 1) : (nprow > 1);
-
-    I const itileA_start = first_tile(ia, mb, myprow, nprow);
-    I const itileA_end = first_tile(ia + m - 1, mb, myprow, nprow);
-    I const itile_inc = nprow;
-
-    I const jtileA_start = first_tile(ja, nb, mypcol, npcol);
-    I const jtileA_end = first_tile(ja + n - 1, nb, mypcol, npcol);
-    I const jtile_inc = npcol;
-
-    I const tixy = tix + tiy * nx;
-    I const nxny = nx * ny;
-    I const mbnb = (is_no_transpose) ? nb : mb;
-
-    extern __shared__ double lmem[];
-    T* const Xvec_sh = (T*)&(lmem[0]);
-    T* const rsum_sh_ = Xvec_sh + mbnb;
-
-    auto is_even = [](auto n) -> bool { return ((n % 2) == 0); };
-
-    auto const ld_rsum_sh = is_even(nx) ? nx + 1 : nx;
-
-    auto rsum_sh = [=](auto tx, auto ty) -> T& { return (rsum_sh_[tx + ty * ld_rsum_sh]); };
-
-    bool constexpr use_Xvec_sh = false;
-
-    auto cgwave = cg::tiled_partition(cg::this_thread_block(), nx);
+    I const ia_start = myprow * mb;
+    I const ia_end = std::min(mm, (myprow + 1) * mb);
 
     if(is_no_transpose)
     {
-        // -----------------
-        // Y += alpha * A * X
-        // -----------------
-        for(auto jtileA = jtileA_start; jtileA <= jtileA_end; jtileA += jtile_inc)
+        //  ------------------------------------------
+        //  Y(1:mm) += alpha * A(1:mm, 1:nn) * X(1:nn)
+        //  ------------------------------------------
+
+        for(auto ia = (ia_start + tiy); ia < ia_end; ia += ny)
         {
-            for(auto itileA = itileA_start; itileA <= itileA_end; itileA += itile_inc)
+            T y_i = 0;
+            for(auto ja = (0 + tix); ja < nn; ja += nx)
             {
-                // ------------------------------
-                // process tile "(itileA,jtileA)"
-                // ------------------------------
+                T const xj = Xvec(ja);
+                T const aij = A_sh(ia - ia_start, ja);
+                y_i += aij * xj;
+            }
+            if(wsize > 1)
+            {
+                y_i = reduce_sum_shfl_wsize(wsize, y_i);
+            }
 
-                auto const jstart = std::max(ja, jtileA * nb);
-                auto const jend = std::min(ja + n - 1, jtileA * nb + (nb - 1));
-
-                auto const istart = std::max(ia, itileA * mb);
-                auto const iend = std::min(ia + m - 1, itileA * mb + (mb - 1));
-
-                if(use_Xvec_sh)
-                {
-                    for(auto jja = (jstart + tixy); jja <= jend; jja += nxny)
-                    {
-                        Xvec_sh[(jja - jstart)] = Xvec(jja - ja);
-                    }
-
-                    __syncthreads();
-                }
-
-                for(auto iia = (istart + tiy); iia <= iend; iia += ny)
-                {
-                    T rsum = 0;
-                    for(auto jja = (jstart + tix); jja <= jend; jja += nx)
-                    {
-                        auto const xj = (use_Xvec_sh) ? Xvec_sh[(jja - jstart)] : Xvec(jja - ja);
-                        auto const aij = A(iia, jja);
-                        rsum += aij * xj;
-                    }
-                    rsum_sh(tix, tiy) = rsum;
-                    rsum = reduce_sum(cgwave, &(rsum_sh(0, tiy)), rsum);
-
-                    if(cgwave.thread_rank() == 0)
-                    {
-                        auto const alpha_rsum = alpha * rsum;
-                        auto const ioff = (iia - ia);
-                        if(need_atomic_update)
-                        {
-                            gatomicAdd(&(Yvec(ioff)), alpha_rsum);
-                        }
-                        else
-                        {
-                            Yvec(ioff) += alpha_rsum;
-                        }
-                    }
-                }
-
-                __syncthreads();
-
-            } // end for itileA
-        } // end for jtileA
+            // ------------------------------
+            // note: assume atomicAdd not required
+            // ------------------------------
+            if(is_wave_rank0 && (y_i != 0))
+            {
+                gatomicAdd(&(Yvec(ia)), alpha * y_i);
+            }
+        }
     }
     else
     {
-        // -----------------
-        // Yvec(0:(n-1)) += alpha * trans(A(0:(m-1),0:(n-1)) * Xvec(0:(m-1))
-        // -----------------
-        for(auto jtileA = jtileA_start; jtileA <= jtileA_end; jtileA += jtile_inc)
+        // ------------------------------------------------------
+        // Y(1:nn) += alpha * tranpose( A(1:mm, 1:nn) ) * X(1:mm)
+        // ------------------------------------------------------
+
+        for(auto ja = (0 + tiy); ja < nn; ja += ny)
         {
-            for(auto itileA = itileA_start; itileA <= itileA_end; itileA += itile_inc)
+            T y_j = 0;
+            for(auto ia = (ia_start + tix); ia < ia_end; ia += nx)
             {
-                // ------------------------------
-                // process tile "(itileA,jtileA)"
-                // ------------------------------
-                auto const jstart = std::max(ja, jtileA * nb);
-                auto const jend = std::min(ja + n - 1, jtileA * nb + (nb - 1));
-
-                auto const istart = std::max(ia, itileA * mb);
-                auto const iend = std::min(ia + m - 1, itileA * mb + (mb - 1));
-
-                if(use_Xvec_sh)
+                T const xi = Xvec(ia);
+                T const aij = A_sh(ia - ia_start, ja);
+                if(is_complex && is_conj_transpose)
                 {
-                    for(auto iia = (istart + tixy); iia <= iend; iia += nxny)
-                    {
-                        Xvec_sh[(iia - istart)] = Xvec((iia - ia));
-                    }
-
-                    __syncthreads();
+                    y_j += xi * conj(aij);
                 }
-
-                for(auto jja = (jstart + tiy); jja <= jend; jja += ny)
+                else
                 {
-                    T rsum = 0;
-                    for(auto iia = (istart + tix); iia <= iend; iia += nx)
-                    {
-                        T const aij = A(iia, jja);
-                        T const xi = (use_Xvec_sh) ? Xvec_sh[(iia - istart)] : Xvec(iia - ia);
-
-                        if(is_complex && is_conj_transpose)
-                        {
-                            rsum += conj(aij) * xi;
-                        }
-                        else
-                        {
-                            rsum += aij * xi;
-                        }
-                    }
-
-                    rsum_sh(tix, tiy) = rsum;
-                    rsum = reduce_sum(cgwave, &(rsum_sh(0, tiy)), rsum);
-
-                    if(cgwave.thread_rank() == 0)
-                    {
-                        auto const alpha_rsum = alpha * rsum;
-                        auto const joff = (jja - ja);
-                        if(need_atomic_update)
-                        {
-                            gatomicAdd(&(Yvec(joff)), alpha_rsum);
-                        }
-                        else
-                        {
-                            Yvec(joff) += alpha_rsum;
-                        }
-                    }
-                } // end for jja
-
-                __syncthreads();
-
-            } // end for itileA
-        } // end for jtileA
-    }
-    __syncthreads();
-}
-
-template <typename T, typename I, typename Istride, typename UA, typename UX, typename UY>
-static __global__ void Xgemv_batch_kernel(char const trans,
-                                          I const m,
-                                          I const n,
-                                          T const* const p_alpha,
-                                          Istride const stride_alpha,
-                                          UA A_,
-                                          Istride const shift_A,
-                                          I const ia,
-                                          I const ja,
-                                          I const lda,
-                                          Istride const stride_A,
-                                          UX X_,
-                                          Istride const shift_X,
-                                          I const ix,
-                                          I const jx,
-                                          I const ldx,
-                                          I const incx,
-                                          Istride const stride_X,
-                                          UY Y_,
-                                          Istride const shift_Y,
-                                          I const iy,
-                                          I const jy,
-                                          I const ldy,
-                                          I const incy,
-                                          Istride const stride_Y,
-                                          I const batch_count,
-                                          I const mb,
-                                          I const nb)
-{
-    I const myprow = hipBlockIdx_x;
-    I const mypcol = hipBlockIdx_y;
-    I const nprow = hipGridDim_x;
-    I const npcol = hipGridDim_y;
-
-    for(I bid = 0; bid < batch_count; bid++)
-    {
-        T const alpha = *(p_alpha + bid * stride_alpha);
-
-        T const* const Ap = load_ptr_batch(A_, bid, shift_A, stride_A);
-        T const* const Xp = load_ptr_batch(X_, bid, shift_X, stride_X);
-        T* const Yp = load_ptr_batch(Y_, bid, shift_Y, stride_Y);
-
-        Xgemv_body(trans, m, n, alpha, Ap, ia, ja, lda, Xp, ix, jx, ldx, incx, Yp, iy, jy, ldy,
-                   incy, mb, nb, myprow, mypcol, nprow, npcol);
-    }
-}
-
-template <typename T, typename I, typename Istride, typename UA, typename UX, typename UY>
-static void rocsolverCall_gemv(rocblas_handle handle,
-                               rocblas_operation trans,
-                               I const mm,
-                               I const nn,
-                               T const* const p_alpha,
-                               Istride const stride_alpha,
-                               UA A,
-                               I const shiftA,
-                               I const ia,
-                               I const ja,
-                               I const lda,
-                               Istride const strideA,
-                               UX X,
-                               I const shiftX,
-                               I const ix,
-                               I const jx,
-                               I const ldx,
-                               I const incx,
-                               Istride const strideX,
-                               T const* const p_beta,
-                               Istride const stride_beta,
-                               UY Y,
-                               I const shiftY,
-                               I const iy,
-                               I const jy,
-                               I const ldy,
-                               I const incy,
-                               Istride const strideY,
-                               I const batch_count,
-                               I const mb,
-                               I const nb,
-                               void* work_Arr)
-{
-    hipStream_t stream;
-    rocblas_get_stream(handle, &stream);
-
-    auto const num_cu = get_num_cu();
-    size_t const lds_size = 64 * 1024;
-
-    // -----------------------------
-    // scale output Y vector by beta
-    // -----------------------------
-    auto const nx = 32;
-    auto const ny = 32;
-
-    {
-        bool const is_valid_trans = (trans == rocblas_operation_none)
-            || (trans == rocblas_operation_transpose)
-            || (trans == rocblas_operation_conjugate_transpose);
-        assert(is_valid_trans);
-    }
-
-    char const ctrans = (trans == rocblas_operation_none)  ? 'N'
-        : (trans == rocblas_operation_transpose)           ? 'T'
-        : (trans == rocblas_operation_conjugate_transpose) ? 'C'
-                                                           : '?';
-
-    bool const is_no_transpose = (trans == rocblas_operation_none);
-    auto const len_Yvec = is_no_transpose ? mm : nn;
-
-    Xscale_batch_kernel<T, I, Istride><<<dim3(num_cu, 1, 1), dim3(nx, ny, 1), lds_size, stream>>>(
-        len_Yvec, p_beta, stride_beta, Y, shiftY, iy, jy, ldy, incy, strideY, batch_count, mb, nb);
-
-    Xgemv_batch_kernel<T, I, Istride><<<dim3(num_cu, 1, 1), dim3(nx, ny, 1), lds_size, stream>>>(
-        ctrans, mm, nn, p_alpha, stride_alpha, A, shiftA, ia, ja, lda, strideA, X, shiftX, ix, jx,
-        ldx, incx, strideX, Y, shiftY, iy, jy, ldy, incy, strideY, batch_count, mb, nb);
-}
-
-// ----------------------
-// matrix vector multiple
-// y = alpha * op(A) * x
-// where
-// op(A) can be  A
-//     or transpose(A)
-//     or conj(transpose(A))
-// ----------------------
-template <typename T, typename I>
-static __device__ void Xsymv_body(char const c_uplo,
-                                  I const n,
-                                  T const alpha,
-
-                                  T const* const A_,
-                                  I const ia,
-                                  I const ja,
-                                  I const lda,
-
-                                  T const* const X_,
-                                  I const ix,
-                                  I const jx,
-                                  I const ldx,
-                                  I const incx,
-
-                                  T* const Y_,
-                                  I const iy,
-                                  I const jy,
-                                  I const ldy,
-                                  I const incy,
-
-                                  I const mb,
-                                  I const nb,
-                                  I const myprow,
-                                  I const mypcol,
-                                  I const nprow,
-                                  I const npcol)
-{
-    bool const is_complex = rocblas_is_complex<T>;
-    auto const m = n;
-
-    auto const tix = hipThreadIdx_x;
-    auto const tiy = hipThreadIdx_y;
-    auto const nx = hipBlockDim_x;
-    auto const ny = hipBlockDim_y;
-
-    bool const is_upper = (c_uplo == 'U') || (c_uplo == 'u');
-    bool const is_lower = (c_uplo == 'L') || (c_uplo == 'l');
-    {
-        bool const is_valid = (is_lower || is_upper);
-        assert(is_valid);
-    }
-
-    bool const is_column_X = (incx == 1);
-    bool const is_column_Y = (incy == 1);
-    {
-        assert((incx == 1) || (incx == ldx));
-        assert((incy == 1) || (incy == ldy));
-    }
-
-    auto idx2D = [](auto i, auto j, auto ld) { return (i + j * static_cast<int64_t>(ld)); };
-
-    auto const ip_Y = idx2D(iy, jy, ldy);
-    auto Yvec = [=](auto i) -> T& { return (Y_[ip_Y + i * static_cast<int64_t>(incy)]); };
-
-    auto const ip_X = idx2D(ix, jx, ldx);
-    auto Xvec = [=](auto i) { return (X_[ip_X + i * static_cast<int64_t>(incx)]); };
-
-    auto A = [=](auto i, auto j) { return (A_[idx2D(i, j, lda)]); };
-
-    auto const itileA_start = first_tile(ia, mb, myprow, nprow);
-    auto const jtileA_start = first_tile(ja, nb, mypcol, npcol);
-    auto const itileA_end = first_tile(ia + n - 1, mb, myprow, nprow);
-    auto const jtileA_end = first_tile(ja + n - 1, nb, mypcol, npcol);
-    auto const itile_inc = nprow;
-    auto const jtile_inc = npcol;
-
-    extern __shared__ double lmem[];
-    T* const ytmp_row = (T*)&(lmem[0]);
-    T* const ytmp_col = ytmp_row + mb;
-
-    {
-        size_t const lds_size = 64 * 1024;
-        bool const lds_ok = ((sizeof(T) * (mb + nb)) <= lds_size);
-        assert(lds_ok);
-    }
-
-    auto const tixy = tix + tiy * nx;
-    auto const nxny = nx * ny;
-
-    for(auto i = (0 + tixy); i < mb; i += nxny)
-    {
-        ytmp_row[i] = 0;
-    }
-    for(auto i = (0 + tixy); i < nb; i += nxny)
-    {
-        ytmp_col[i] = 0;
-    }
-    __syncthreads();
-
-    // -----------------
-    // Y1 = [D1  L21' ]  * X1
-    // Y2 = [L21   D2 ]    X2
-    //
-    //
-    // Y1 = (D1 * X1) + (L21' * X2)
-    // Y2 = (L21 * X1) + ( D2 * X2 )
-    // -----------------
-    for(auto jtileA = jtileA_start; jtileA <= jtileA_end; jtileA += jtile_inc)
-    {
-        for(auto itileA = itileA_start; itileA <= itileA_end; itileA += itile_inc)
-        {
-            // ------------------------------
-            // process tile "(itileA,jtileA)"
-            // ------------------------------
-
-            auto const jstart = std::max(ja, jtileA * nb);
-            auto const jend = std::min(ja + n - 1, jtileA * nb + (nb - 1));
-
-            auto const istart = std::max(ia, itileA * mb);
-            auto const iend = std::min(ia + m - 1, itileA * mb + (mb - 1));
-
-            bool const is_strictly_lower = ((istart - ia) > (jend - ja));
-            bool const is_strictly_upper = ((jstart - ja) > (iend - ia));
-            bool const can_skip_tile
-                = (is_lower && is_strictly_upper) || (is_upper && is_strictly_lower);
-            if(can_skip_tile)
-            {
-                continue;
-            }
-
-            for(auto jja = (jstart + tiy); jja <= jend; jja += ny)
-            {
-                auto const xj = Xvec((jja - ja));
-                for(auto iia = (istart + tix); iia <= iend; iia += nx)
-                {
-                    auto const ioff = (iia - istart);
-                    auto const joff = (jja - jstart);
-                    bool const is_diagonal = ((iia - ia) == (jja - ja));
-                    bool const is_strictly_lower = ((iia - ia) > (jja - ja));
-                    bool const is_strictly_upper = ((iia - ia) < (jja - ja));
-
-                    bool const can_skip
-                        = (is_lower && is_strictly_upper) || (is_upper && is_strictly_lower);
-
-                    if(can_skip)
-                    {
-                        continue;
-                    };
-
-                    if(is_diagonal)
-                    {
-                        auto const ajj = std::real(A(iia, jja));
-                        gatomicAdd(&(ytmp_row[ioff]), ajj * xj);
-                    }
-                    else
-                    {
-                        // ------------------
-                        // off-diagonal entry
-                        // ------------------
-                        T const aij = A(iia, jja);
-                        T const atji = (is_complex) ? conj(aij) : aij;
-
-                        T const xi = Xvec((iia - ia));
-
-                        gatomicAdd(&(ytmp_row[ioff]), aij * xj);
-                        gatomicAdd(&(ytmp_col[joff]), atji * xi);
-                    }
+                    y_j += xi * aij;
                 }
             }
-
-            __syncthreads();
-
-            if(tiy == 0)
+            y_j = reduce_sum_shfl_wsize(wsize, y_j);
+            if(is_wave_rank0)
             {
-                for(auto iia = (istart + tix); iia <= iend; iia += nx)
-                {
-                    auto const iiy = (iia - ia);
-                    auto const ioff = (iia - istart);
-                    auto const alpha_ytmp_row = alpha * ytmp_row[ioff];
-
-                    bool const need_atomic_update = true;
-                    if(need_atomic_update)
-                    {
-                        gatomicAdd(&(Yvec(iiy)), alpha_ytmp_row);
-                    }
-                    else
-                    {
-                        Yvec(iiy) += alpha_ytmp_row;
-                    }
-                    ytmp_row[ioff] = 0;
-                }
-
-                for(auto jja = (jstart + tix); jja <= jend; jja += nx)
-                {
-                    auto const jjy = (jja - ja);
-                    auto const joff = (jja - jstart);
-                    auto const alpha_ytmp_col = alpha * ytmp_col[joff];
-
-                    bool const need_atomic_update = true;
-                    if(need_atomic_update)
-                    {
-                        gatomicAdd(&(Yvec(jjy)), alpha_ytmp_col);
-                    }
-                    else
-                    {
-                        Yvec(jjy) += alpha_ytmp_col;
-                    }
-                    ytmp_col[joff] = 0;
-                }
+                gatomicAdd(&(Yvec(ja)), alpha * y_j);
             }
-            __syncthreads();
-
-        } // end for itileA
-    } // end for jtileA
-
-    __syncthreads();
-}
-
-// ----------------------
-// matrix vector multiple
-// y = alpha * op(A) * x
-// where
-// op(A) can be  A
-//     or transpose(A)
-//     or conj(transpose(A))
-// ----------------------
-template <typename T, typename I>
-static __device__ void Xsymv_body_v2(char const c_uplo,
-                                     I const n,
-                                     T const alpha,
-
-                                     T const* const A_,
-                                     I const ia,
-                                     I const ja,
-                                     I const lda,
-
-                                     T const* const X_,
-                                     I const ix,
-                                     I const jx,
-                                     I const ldx,
-                                     I const incx,
-
-                                     T* const Y_,
-                                     I const iy,
-                                     I const jy,
-                                     I const ldy,
-                                     I const incy,
-
-                                     I const mb,
-                                     I const nb,
-                                     I const myprow,
-                                     I const mypcol,
-                                     I const nprow,
-                                     I const npcol)
-{
-    bool const is_complex = rocblas_is_complex<T>;
-    auto const m = n;
-    {
-        // assume operate on symmetric diagonal
-        // (ia == ja)
-        assert((ia == ja));
-        assert((mb == nb));
-    }
-
-    auto const tix = hipThreadIdx_x;
-    auto const tiy = hipThreadIdx_y;
-    auto const nx = hipBlockDim_x;
-    auto const ny = hipBlockDim_y;
-
-    bool const is_upper = (c_uplo == 'U') || (c_uplo == 'u');
-    bool const is_lower = (c_uplo == 'L') || (c_uplo == 'l');
-
-    bool const is_column_X = (incx == 1);
-    bool const is_column_Y = (incy == 1);
-    {
-        assert((is_lower) || (is_upper));
-        assert((incx == 1) || (incx == ldx));
-        assert((incy == 1) || (incy == ldy));
-    }
-
-    auto idx2D = [](auto i, auto j, auto ld) { return (i + j * static_cast<int64_t>(ld)); };
-
-    auto const ip_Y = idx2D(iy, jy, ldy);
-    auto Yvec = [=](auto i) -> T& { return (Y_[ip_Y + i * static_cast<int64_t>(incy)]); };
-
-    auto const ip_X = idx2D(ix, jx, ldx);
-    auto Xvec = [=](auto i) { return (X_[ip_X + i * static_cast<int64_t>(incx)]); };
-
-    auto A = [=](auto i, auto j) { return (A_[idx2D(i, j, lda)]); };
-
-    auto const itileA_start = first_tile(ia, mb, myprow, nprow);
-    auto const jtileA_start = first_tile(ja, nb, mypcol, npcol);
-    auto const itileA_end = first_tile(ia + n - 1, mb, myprow, nprow);
-    auto const jtileA_end = first_tile(ja + n - 1, nb, mypcol, npcol);
-    auto const itile_inc = nprow;
-    auto const jtile_inc = npcol;
-
-    auto is_even = [](auto n) -> bool { return ((n % 2) == 0); };
-    auto const ldtmp = (is_even(nx)) ? nx + 1 : nx;
-
-    extern __shared__ double lmem[];
-    T* pfree = (T*)&(lmem[0]);
-
-    size_t total_len = 0;
-    T* const tmp_ = pfree;
-    pfree += ldtmp * ny;
-    total_len += ldtmp * ny;
-    T* const ysh_j = pfree;
-    pfree += nb;
-    total_len += nb;
-    T* const xsh_j = pfree;
-    pfree += nb;
-    total_len += nb;
-
-    auto tmp = [=](auto tx, auto ty) -> T& { return (tmp_[tx + ty * ldtmp]); };
-
-    {
-        size_t const lds_size = 64 * 1024;
-        bool const lds_ok = (sizeof(T) * total_len <= lds_size);
-        assert(lds_ok);
-    }
-
-    auto const tixy = tix + tiy * nx;
-    auto const nxny = nx * ny;
-
-    // -----------------
-    // Y1 = [D1  L21' ]  * X1
-    // Y2 = [L21   D2 ]    X2
-    //
-    //
-    // Y1 = (D1 * X1) + (L21' * X2)
-    // Y2 = (L21 * X1) + ( D2 * X2 )
-    // -----------------
-
-    auto const cg_wave = cg::tiled_partition(cg::this_thread_block(), nx);
-
-    for(auto jtileA = jtileA_start; jtileA <= jtileA_end; jtileA += jtile_inc)
-    {
-        auto const jstart = std::max(ja, jtileA * nb);
-        auto const jend = std::min(ja + n - 1, jtileA * nb + (nb - 1));
-
-        for(auto jja = (jstart + tixy); jja <= jend; jja += nxny)
-        {
-            ysh_j[(jja - jstart)] = 0;
-            xsh_j[(jja - jstart)] = Xvec((jja - ja));
         }
-
-        __syncthreads();
-
-        for(auto itileA = itileA_start; itileA <= itileA_end; itileA += itile_inc)
-        {
-            auto const istart = std::max(ia, itileA * mb);
-            auto const iend = std::min(ia + m - 1, itileA * mb + (mb - 1));
-
-            bool const is_lower_tile = (istart > jend);
-            bool const is_upper_tile = (jstart > iend);
-
-            bool const do_work = (is_lower && is_lower_tile) || (is_upper && is_upper_tile);
-            if(!do_work)
-            {
-                continue;
-            }
-
-            // ------------------------------
-            // process tile "(itileA,jtileA)"
-            // ------------------------------
-
-            for(auto iia = (istart + tiy); iia <= iend; iia += ny)
-            {
-                auto const ioff = (iia - istart);
-                auto const xi = Xvec((iia - ia));
-
-                T y_i = 0;
-                for(auto jja = (jstart + tix); jja <= jend; jja += nx)
-                {
-                    auto const joff = (jja - jstart);
-                    auto const xj = xsh_j[joff];
-
-                    bool const is_diagonal = (iia == jja);
-                    bool const is_strictly_lower = (iia > jja);
-                    bool const is_strictly_upper = (jja > iia);
-
-                    if(is_diagonal)
-                    {
-                        auto const aii = std::real(A(iia, iia));
-                        y_i += aii * xi;
-                    }
-                    else
-                    {
-                        // ------------------
-                        // off-diagonal entry
-                        // ------------------
-
-                        bool const do_work
-                            = (is_lower && is_strictly_lower) || (is_upper && is_strictly_upper);
-
-                        if(!do_work)
-                        {
-                            continue;
-                        };
-
-                        T const aij = A(iia, jja);
-                        y_i += aij * xj;
-
-                        if constexpr(is_complex)
-                        {
-                            T const atji = conj(aij);
-                            gatomicAdd(&(ysh_j[joff]), atji * xi);
-                        }
-                        else
-                        {
-                            T const atji = aij;
-                            gatomicAdd(&(ysh_j[joff]), atji * xi);
-                        }
-                    }
-                } // end for jja
-
-                y_i = reduce_sum(cg_wave, &(tmp(0, tiy)), y_i);
-                if(cg_wave.thread_rank() == 0)
-                {
-                    gatomicAdd(&(Yvec(iia - ia)), alpha * y_i);
-                }
-            } // end for iia
-        } // end for itileA
-
-        __syncthreads();
-
-        for(auto jja = (jstart + tixy); jja <= jend; jja += nxny)
-        {
-            auto const joff = (jja - jstart);
-            gatomicAdd(&(Yvec((jja - ja))), alpha * ysh_j[joff]);
-            ysh_j[joff] = 0;
-        }
-        __syncthreads();
-
-    } // end for jtileA
-}
-
-// compute Yvec(0:(n-1)) += alpha * op(A) * Xvec(0:(n-1))
-// where A is symmetric/hermitian matrix
-// op(A) is lower triangular or upper triangular
-//
-template <typename T, typename I, typename Istride, typename UA, typename UX, typename UY>
-static __global__ void Xsymv_batch_kernel(char c_uplo,
-                                          I const n,
-                                          T const* const p_alpha,
-                                          Istride const stride_alpha,
-                                          UA A_,
-                                          Istride const shiftA,
-                                          I const ia,
-                                          I const ja,
-                                          I const lda,
-                                          Istride const strideA,
-                                          UX X_,
-                                          Istride const shiftX,
-                                          I const ix,
-                                          I const jx,
-                                          I const ldx,
-                                          I const incx,
-                                          Istride const strideX,
-                                          UY Y_,
-                                          Istride const shiftY,
-                                          I const iy,
-                                          I const jy,
-                                          I const ldy,
-                                          I const incy,
-                                          Istride const strideY,
-                                          I const batch_count,
-                                          I const mb,
-                                          I const nb)
-{
-    I const myprow = hipBlockIdx_x;
-    I const mypcol = hipBlockIdx_y;
-    I const nprow = hipGridDim_x;
-    I const npcol = hipGridDim_y;
-
-    for(I bid = 0; bid < batch_count; bid++)
-    {
-        T const alpha = *(p_alpha + bid * stride_alpha);
-        T const* const Ap = load_ptr_batch(A_, bid, shiftA, strideA);
-        T const* const Xp = load_ptr_batch(X_, bid, shiftX, strideX);
-        T* const Yp = load_ptr_batch(Y_, bid, shiftY, strideY);
-
-        Xsymv_body(c_uplo, n, alpha, Ap, ia, ja, lda, Xp, ix, jx, ldx, incx, Yp, iy, jy, ldy, incy,
-                   mb, nb, myprow, mypcol, nprow, npcol);
     }
-}
-
-template <typename T, typename I, typename Istride, typename UA, typename UX, typename UY>
-rocblas_status rocsolverCall_symv_hemv(rocblas_handle handle,
-                                       rocblas_fill const uplo,
-                                       I const n,
-                                       T const* const p_alpha,
-                                       Istride const stride_alpha,
-                                       UA A,
-                                       Istride const shiftA,
-                                       I const ia,
-                                       I const ja,
-                                       I const lda,
-                                       Istride const strideA,
-                                       UX X,
-                                       Istride const shiftX,
-                                       I const ix,
-                                       I const jx,
-                                       I const ldx,
-                                       I const incx,
-                                       Istride const strideX,
-                                       T const* const p_beta,
-                                       Istride stride_beta,
-                                       UY Y,
-                                       Istride const shiftY,
-                                       I const iy,
-                                       I const jy,
-                                       I const ldy,
-                                       I const incy,
-                                       Istride const strideY,
-                                       I const batch_count,
-                                       I const mb,
-                                       I const nb,
-                                       T* work,
-                                       T** workArr)
-{
-    hipStream_t stream;
-    rocblas_get_stream(handle, &stream);
-
-    auto const num_cu = get_num_cu();
-    size_t const lds_size = 64 * 1024;
-
-    // -----------------------------
-    // scale output Y vector by beta
-    // -----------------------------
-    auto const nx = 32;
-    auto const ny = 32;
-
-    Xscale_batch_kernel<T, I, Istride><<<dim3(num_cu, 1, 1), dim3(nx, ny, 1), lds_size, stream>>>(
-        n, p_beta, stride_beta, Y, shiftY, iy, jy, ldy, incy, strideY, batch_count, mb, nb);
-
-    char const c_uplo = (uplo == rocblas_fill_upper) ? 'U'
-        : (uplo == rocblas_fill_lower)               ? 'L'
-                                                     : '?';
-
-    Xsymv_batch_kernel<T, I, Istride><<<dim3(num_cu, 1, 1), dim3(nx, ny, 1), lds_size, stream>>>(
-        c_uplo, n, p_alpha, stride_alpha, A, shiftA, ia, ja, lda, strideA, X, shiftX, ix, jx, ldx,
-        incx, strideX, Y, shiftY, iy, jy, ldy, incy, strideY, batch_count, mb, nb);
-
-    return (rocblas_status_success);
 }
 
 /** set_offdiag kernel copies the off-diagonal element of A, which is the non-zero element
@@ -2001,422 +443,6 @@ static __global__ void set_offdiag_batch_kernel(const rocblas_int batch_count,
 }
 
 template <typename T, typename I, typename Istride, typename UA>
-static __global__ void lower_stage1(I const n,
-                                    I const j,
-
-                                    T* scalars,
-
-                                    T* const W_,
-                                    Istride const shiftW,
-                                    I const ldw,
-                                    Istride const strideW,
-
-                                    UA A_,
-                                    Istride const shiftA,
-                                    I const lda,
-                                    Istride const strideA,
-
-                                    I const batch_count,
-
-                                    I const mb,
-                                    I const nb)
-{
-    bool constexpr is_complex = rocblas_is_complex<T>;
-
-    I const myprow = hipBlockIdx_x;
-    I const mypcol = hipBlockIdx_y;
-    I const nprow = hipGridDim_x;
-    I const npcol = hipGridDim_y;
-
-    auto cg_grid = cg::this_grid();
-
-    for(I bid = 0; bid < batch_count; bid++)
-    {
-        T* const A = load_ptr_batch(A_, bid, shiftA, strideA);
-        T* const W = load_ptr_batch(W_, bid, shiftW, strideW);
-
-#if(0)
-
-        if(COMPLEX)
-        {
-            rocsolver_lacgv_template<T>(handle, j, W, shiftW + idx2D(j, 0, ldw), ldw, strideW,
-                                        batch_count);
-        }
-#else
-        if(is_complex)
-        {
-            I const nn = j;
-            Xlacgv_body(nn,
-
-                        W, j, 0, ldw, ldw,
-
-                        mb, nb, myprow, mypcol, nprow, npcol);
-            cg_grid.sync();
-        }
-
-#endif
-
-#if(0)
-        rocblasCall_gemv<T>(handle, rocblas_operation_none,
-
-                            n - j, j,
-
-                            cast2constType<T>(scalars), 0,
-
-                            A, shiftA + idx2D(j, 0, lda), lda, strideA,
-
-                            W, shiftW + idx2D(j, 0, ldw), ldw, strideW,
-
-                            cast2constType<T>(scalars + 2), 0,
-
-                            A, shiftA + idx2D(j, j, lda), 1, strideA,
-
-                            batch_count, workArr);
-#else
-        {
-            char const trans = 'N';
-            T const alpha = *scalars;
-            T const beta = *(scalars + 2);
-            I const mm = n - j;
-            I const nn = j;
-
-            I const len_Y = mm;
-
-            bool const has_work = (len_Y >= 1) && (beta != 1);
-            if(has_work)
-            {
-                Xscale_body(len_Y, beta,
-
-                            A, j, j, lda, 1,
-
-                            mb, nb, myprow, mypcol, nprow, npcol);
-
-                cg_grid.sync();
-            }
-
-            Xgemv_body(trans, mm, nn, alpha,
-
-                       A, j, 0, lda,
-
-                       W, j, 0, ldw, ldw,
-
-                       A, j, j, lda, 1,
-
-                       mb, nb, myprow, mypcol, nprow, npcol);
-
-            cg_grid.sync();
-        }
-#endif
-
-#if(0)
-
-        if(COMPLEX)
-        {
-            rocsolver_lacgv_template<T>(handle, j,
-
-                                        W, shiftW + idx2D(j, 0, ldw), ldw, strideW,
-
-                                        batch_count);
-
-            rocsolver_lacgv_template<T>(handle, j,
-
-                                        A, shiftA + idx2D(j, 0, lda), lda, strideA,
-
-                                        batch_count);
-        }
-#else
-        if(is_complex)
-        {
-            I const nn = j;
-            Xlacgv_body(nn, W, j, 0, ldw, ldw,
-
-                        mb, nb, myprow, mypcol, nprow, npcol);
-
-            Xlacgv_body(nn, A, j, 0, lda, lda,
-
-                        mb, nb, myprow, mypcol, nprow, npcol);
-
-            cg_grid.sync();
-        }
-
-#endif
-
-#if(0)
-        rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j, j, cast2constType<T>(scalars), 0,
-
-                            W, shiftW + idx2D(j, 0, ldw), ldw, strideW,
-
-                            A, shiftA + idx2D(j, 0, lda), lda, strideA,
-
-                            cast2constType<T>(scalars + 2), 0,
-
-                            A, shiftA + idx2D(j, j, lda), 1, strideA,
-
-                            batch_count, workArr);
-#else
-        {
-            char trans = 'N';
-            I const mm = n - j;
-            I const nn = j;
-            I const len_Y = mm;
-
-            T const alpha = *scalars;
-            T const beta = *(scalars + 2);
-
-            bool const has_work = (len_Y >= 1) && (beta != 1);
-            if(has_work)
-            {
-                Xscale_body(len_Y, beta,
-
-                            A, j, j, lda, 1,
-
-                            mb, mb, myprow, mypcol, nprow, npcol);
-
-                cg_grid.sync();
-            }
-
-            Xgemv_body(trans, mm, nn, alpha,
-
-                       W, j, 0, ldw,
-
-                       A, j, 0, lda, lda,
-
-                       A, j, j, lda, 1,
-
-                       mb, nb, myprow, mypcol, nprow, npcol);
-
-            cg_grid.sync();
-        }
-
-#endif
-
-#if(0)
-        if(COMPLEX)
-            rocsolver_lacgv_template<T>(handle, j, A, shiftA + idx2D(j, 0, lda), lda, strideA,
-                                        batch_count);
-
-#else
-        if(is_complex)
-        {
-            I const nn = j;
-            Xlacgv_body(nn,
-
-                        A, j, 0, lda, lda,
-
-                        mb, nb, myprow, mypcol, nprow, npcol);
-
-            cg_grid.sync();
-        }
-
-#endif
-    } // end for bid
-}
-
-template <typename T, typename I, typename Istride, typename UA>
-static __global__ void upper_stage1(I const n,
-                                    I const j,
-                                    I const jw,
-
-                                    T* const scalars,
-
-                                    T* const W_,
-                                    Istride const shiftW,
-                                    I const ldw,
-                                    Istride const strideW,
-
-                                    UA A_,
-                                    Istride const shiftA,
-                                    I const lda,
-                                    Istride const strideA,
-
-                                    I const batch_count,
-                                    I const mb,
-                                    I const nb)
-{
-    bool constexpr is_complex = rocblas_is_complex<T>;
-
-    I const myprow = hipBlockIdx_x;
-    I const mypcol = hipBlockIdx_y;
-    I const nprow = hipGridDim_x;
-    I const npcol = hipGridDim_y;
-
-    auto cg_grid = cg::this_grid();
-
-    for(I bid = 0; bid < batch_count; bid++)
-    {
-        T* const A = load_ptr_batch(A_, bid, shiftA, strideA);
-        T* const W = load_ptr_batch(W_, bid, shiftW, strideW);
-
-#if(0)
-        // update column j of A with reflector computed in step j-1
-        if(COMPLEX)
-            rocsolver_lacgv_template<T>(handle, n - 1 - j, W, shiftW + idx2D(j, jw + 1, ldw), ldw,
-                                        strideW, batch_count);
-#else
-        if(is_complex)
-        {
-            I const nn = n - 1 - j;
-            Xlacgv_body<T>(nn,
-
-                           W, j, jw + 1, ldw, ldw,
-
-                           mb, nb, myprow, mypcol, nprow, npcol);
-
-            cg_grid.sync();
-        }
-#endif
-
-#if(0)
-        rocblasCall_gemv<T>(handle, rocblas_operation_none, j + 1, n - 1 - j,
-
-                            cast2constType<T>(scalars), 0,
-
-                            A, shiftA + idx2D(0, j + 1, lda), lda, strideA,
-
-                            W, shiftW + idx2D(j, jw + 1, ldw), ldw, strideW,
-
-                            cast2constType<T>(scalars + 2), 0,
-
-                            A, shiftA + idx2D(0, j, lda), 1, strideA,
-
-                            batch_count, workArr);
-#else
-        {
-            char const trans = 'N';
-            I const mm = j + 1;
-            I const nn = n - 1 - j;
-            auto const alpha = *scalars;
-            auto const beta = *(scalars + 2);
-
-            I const len_Y = mm;
-            bool const has_work = (len_Y >= 1) && (beta != 1);
-            if(has_work)
-            {
-                Xscale_body(len_Y, beta,
-
-                            A, 0, j, lda, 1,
-
-                            mb, nb, myprow, mypcol, nprow, npcol);
-
-                cg_grid.sync();
-            }
-
-            Xgemv_body(trans, mm, nn, alpha,
-
-                       A, 0, j + 1, lda,
-
-                       W, j, jw + 1, ldw, ldw,
-
-                       A, 0, j, lda, 1,
-
-                       mb, nb, myprow, mypcol, nprow, npcol);
-
-            cg_grid.sync();
-        }
-
-#endif
-
-#if(0)
-        if(COMPLEX)
-        {
-            rocsolver_lacgv_template<T>(handle, n - 1 - j,
-
-                                        W, shiftW + idx2D(j, jw + 1, ldw), ldw, strideW,
-
-                                        batch_count);
-            rocsolver_lacgv_template<T>(handle, n - 1 - j,
-
-                                        A, shiftA + idx2D(j, j + 1, lda), lda, strideA,
-
-                                        batch_count);
-        }
-#else
-        if(is_complex)
-        {
-            auto const nn = n - 1 - j;
-
-            Xlacgv_body(nn,
-
-                        W, j, jw + 1, ldw, ldw,
-
-                        mb, nb, myprow, mypcol, nprow, npcol);
-
-            Xlacgv_body(nn, A, j, j + 1, lda, lda,
-
-                        mb, nb, myprow, mypcol, nprow, npcol);
-
-            cg_grid.sync();
-        }
-#endif
-
-#if(0)
-        rocblasCall_gemv<T>(handle, rocblas_operation_none, j + 1, n - 1 - j,
-                            cast2constType<T>(scalars), 0,
-
-                            W, shiftW + idx2D(0, jw + 1, ldw), ldw, strideW,
-
-                            A, shiftA + idx2D(j, j + 1, lda), lda, strideA,
-
-                            cast2constType<T>(scalars + 2), 0,
-
-                            A, shiftA + idx2D(0, j, lda), 1, strideA,
-
-                            batch_count, workArr);
-#else
-        {
-            char const trans = 'N';
-            I const mm = j + 1;
-            I const nn = n - 1 - j;
-            auto const len_Y = mm;
-
-            auto const alpha = *scalars;
-            auto const beta = *(scalars + 2);
-
-            bool const has_work = (len_Y >= 1) && (beta != 1);
-            if(has_work)
-            {
-                Xscale_body(len_Y, beta, A, 0, j, lda, 1, mb, nb, myprow, mypcol, nprow, npcol);
-
-                cg_grid.sync();
-            }
-
-            Xgemv_body(trans, mm, nn, alpha,
-
-                       W, 0, jw + 1, ldw,
-
-                       A, j, j + 1, lda, lda,
-
-                       A, 0, j, lda, 1,
-
-                       mb, nb, myprow, mypcol, nprow, npcol);
-
-            cg_grid.sync();
-        }
-
-#endif
-
-#if(0)
-        if(COMPLEX)
-            rocsolver_lacgv_template<T>(handle, n - 1 - j,
-
-                                        A, shiftA + idx2D(j, j + 1, lda), lda, strideA,
-
-                                        batch_count);
-#else
-        if(is_complex)
-        {
-            auto const nn = n - 1 - j;
-            Xlacgv_body(nn, A, j, j + 1, lda, lda,
-
-                        mb, nb, myprow, mypcol, nprow, npcol);
-
-            cg_grid.sync();
-        }
-#endif
-    } // end for bid
-}
-
-template <typename T, typename I, typename Istride, typename UA>
 static __global__ void lower_stage2(I const n,
                                     I const j,
 
@@ -2436,42 +462,181 @@ static __global__ void lower_stage2(I const n,
                                     Istride const strideA,
 
                                     I const batch_count,
-                                    I const mb,
-                                    I const nb)
+                                    I const lds_size)
 {
     bool constexpr is_complex = rocblas_is_complex<T>;
+
+    I tix = hipThreadIdx_x;
+    I tiy = hipThreadIdx_y;
+    I nx = hipBlockDim_x;
+    I ny = hipBlockDim_y;
+    I const tixy = hipThreadIdx_x + hipThreadIdx_y * hipBlockDim_x
+        + hipThreadIdx_z * (hipBlockDim_x * hipBlockDim_y);
+    I const nthreads = (hipBlockDim_x * hipBlockDim_y) * hipBlockDim_z;
+
+    // ----------------------------------------
+    // assume launch dimension encode warp_size
+    // ----------------------------------------
+    I const warp_size = hipBlockDim_x;
 
     I const myprow = hipBlockIdx_x;
     I const mypcol = hipBlockIdx_y;
     I const nprow = hipGridDim_x;
     I const npcol = hipGridDim_y;
 
+    auto time_gemv_c1 = CLOCK64() * 0;
+    auto time_gemv_n1 = CLOCK64() * 0;
+    auto time_gemv_c2 = CLOCK64() * 0;
+    auto time_gemv_n2 = CLOCK64() * 0;
+
+    auto time_scale = CLOCK64() * 0;
+    auto time_load = CLOCK64() * 0;
+    auto tic = CLOCK64();
+
     auto cg_grid = cg::this_grid();
+
+    I const mm = (n - j - 1);
+    I const nn = j;
+
+    auto ceil = [](auto m, auto n) { return (1 + (m - 1) / n); };
+    auto is_even = [](auto n) -> bool { return ((n % 2) == 0); };
+
+    auto setup_nxny = [=](auto mb, auto nn, auto& nx, auto& ny) {
+        auto const lny = (nn >= warp_size) ? warp_size
+            : (nn >= warp_size / 2)        ? warp_size / 2
+            : (nn >= warp_size / 4)        ? warp_size / 4
+            : (nn >= warp_size / 8)        ? warp_size / 8
+            : (nn >= warp_size / 16)       ? warp_size / 16
+                                           : 1;
+        if((nthreads % lny) == 0)
+        {
+            ny = lny;
+            nx = nthreads / ny;
+        }
+    };
+
+    // ------------------------------------
+    // repartition configuration of threads
+    // ------------------------------------
+    bool const use_setup_nxny = true;
+    if(use_setup_nxny)
+    {
+        setup_nxny(mm, nn, nx, ny);
+        // ---------------------
+        // tixy = tix + tiy * nx
+        // ---------------------
+        tix = (tixy % nx);
+        tiy = (tixy - tix) / nx;
+        assert(nx * ny == nthreads);
+    }
+
+    I const mb = ceil(mm, nprow);
+    I const ldAWsh = is_even(mb) ? mb + 1 : mb;
+    I const nb = nn;
+
+    extern __shared__ double lmem[];
+
+    size_t total_bytes = 0;
+    std::byte* pfree = (std::byte*)&(lmem[0]);
+    T* const W_sh_ = (T*)pfree;
+
+    size_t const size_mat = sizeof(T) * ldAWsh * nn;
+
+    pfree += size_mat;
+    total_bytes += size_mat;
+
+    T* const A_sh_ = (T*)pfree;
+    pfree += size_mat;
+    total_bytes += size_mat;
+
+    {
+        assert(total_bytes <= lds_size);
+    }
+
+    auto W_sh = [=](auto i, auto j) -> T& {
+        assert((0 <= i) && (i < mb));
+        assert((0 <= j) && (j < nn));
+        return (W_sh_[i + j * ldAWsh]);
+    };
+
+    auto A_sh = [=](auto i, auto j) -> T& {
+        assert((0 <= i) && (i < mb));
+        assert((0 <= j) && (j < nn));
+        return (A_sh_[i + j * ldAWsh]);
+    };
 
     for(I bid = 0; bid < batch_count; bid++)
     {
-        T* const W = load_ptr_batch(W_, bid, shiftW, strideW);
-        T* const A = load_ptr_batch(A_, bid, shiftA, strideA);
+        T* const __restrict__ W = load_ptr_batch(W_, bid, shiftW, strideW);
+        T* const __restrict__ A = load_ptr_batch(A_, bid, shiftA, strideA);
 
-#if(0)
-        rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, n - j - 1, j,
-                            cast2constType<T>(scalars + 2), 0,
+        // --------------------------------
+        // load data into LDS shared memory
+        // --------------------------------
 
-                            W, shiftW + idx2D(j + 1, 0, ldw), ldw, strideW,
+        I const iw = j + 1;
+        I const jw = 0;
+        I const ia = j + 1;
+        I const ja = 0;
 
-                            A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
+        auto Amat = [=](auto i, auto j) -> T& {
+            assert((0 <= i) && (i < mm));
+            assert((0 <= i) && (j < nn));
+            assert((ia + i) < lda);
 
-                            cast2constType<T>(scalars + 1), 0,
+            return (A[idx2D(ia + i, ja + j, lda)]);
+        };
 
-                            W, shiftW + idx2D(0, j, ldw), 1, strideW,
+        auto Wmat = [=](auto i, auto j) -> T& {
+            assert((0 <= i) && (i < mm));
+            assert((0 <= i) && (j < nn));
+            assert((iw + i) < ldw);
 
-                            batch_count, workArr);
-#else
+            return (W[idx2D(iw + i, jw + j, ldw)]);
+        };
+
+        I const ii_start = (myprow)*mb;
+        I const ii_end = std::min(mm, (myprow + 1) * mb);
+
+        __syncthreads();
+        tic = CLOCK64();
+
+        bool const use_load_2D = false;
+        if(use_load_2D)
+        {
+            for(I jj = (0 + tiy); jj < nn; jj += ny)
+            {
+                for(I ii = (ii_start + tix); ii < ii_end; ii += nx)
+                {
+                    A_sh((ii - ii_start), jj) = Amat(ii, jj);
+                    W_sh((ii - ii_start), jj) = Wmat(ii, jj);
+                }
+            }
+        }
+        else
+        {
+            // ----------------------------
+            // use one-dimensional indexing
+            // ----------------------------
+
+            I const ii_size = ii_end - ii_start;
+            for(I ixy = (0 + tixy); ixy < (ii_size * nn); ixy += nthreads)
+            {
+                // ixy = ii + jj * ii_size
+                I const jj = ixy / ii_size;
+                I const ii = ixy % ii_size;
+
+                A_sh(ii, jj) = Amat(ii + ii_start, jj);
+                W_sh(ii, jj) = Wmat(ii + ii_start, jj);
+            }
+        }
+
+        __syncthreads();
+        time_load += CLOCK64() - tic;
+
         {
             T const alpha = *(scalars + 2);
             T const beta = *(scalars + 1);
-            I const mm = n - j - 1;
-            I const nn = j;
 
             char const trans = 'C';
             I const len_Y = nn;
@@ -2479,47 +644,38 @@ static __global__ void lower_stage2(I const n,
             bool const has_work = (len_Y >= 1) && (beta != 1);
             if(has_work)
             {
-                Xscale_body(len_Y, beta,
+                tic = CLOCK64();
+                Xscale_coop_body(len_Y, beta,
 
-                            W, 0, j, ldw, 1,
-
-                            mb, nb, myprow, mypcol, nprow, npcol);
+                                 W + idx2D(0, j, ldw), 1);
                 cg_grid.sync();
+                time_scale += CLOCK64() - tic;
             }
 
-            Xgemv_body(trans, mm, nn, alpha,
+            if(alpha == 0)
+            {
+                Xscale_coop_body(len_Y, alpha, W + idx2D(0, j, ldw), 1);
+            }
+            else
+            {
+                tic = CLOCK64();
+                Xgemv_sh<T, I>(trans, mm, nn, alpha,
 
-                       W, j + 1, 0, ldw,
+                               W_sh_, ldAWsh,
 
-                       A, j + 1, j, lda, 1,
+                               A + idx2D(j + 1, j, lda), 1,
 
-                       W, 0, j, ldw, 1,
+                               W + idx2D(0, j, ldw), 1);
 
-                       mb, nb, myprow, mypcol, nprow, npcol);
+                tic = CLOCK64();
 
-            cg_grid.sync();
+                cg_grid.sync();
+                time_gemv_c1 += CLOCK64() - tic;
+            }
         }
-#endif
 
-#if(0)
-
-        rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j - 1, j,
-                            cast2constType<T>(scalars), 0,
-
-                            A, shiftA + idx2D(j + 1, 0, lda), lda, strideA,
-
-                            W, shiftW + idx2D(0, j, ldw), 1, strideW,
-
-                            cast2constType<T>(scalars + 2), 0,
-
-                            W, shiftW + idx2D(j + 1, j, ldw), 1, strideW,
-
-                            batch_count, workArr);
-#else
         {
             char const trans = 'N';
-            I const mm = n - j - 1;
-            I const nn = j;
 
             T const alpha = *scalars;
             T const beta = *(scalars + 2);
@@ -2529,42 +685,41 @@ static __global__ void lower_stage2(I const n,
             bool const has_work = (len_Y >= 1) && (beta != 1);
             if(has_work)
             {
-                Xscale_body(len_Y, beta, W, j + 1, j, ldw, 1, mb, nb, myprow, mypcol, nprow, npcol);
+                tic = CLOCK64();
+                Xscale_coop_body(len_Y, beta,
 
-                cg_grid.sync();
+                                 W + idx2D(j + 1, j, ldw), 1);
+
+                // cg_grid.sync();
+                // NOTE: grid sync is not needed since the part of vector
+                // is updated by the same thread block
+                __syncthreads();
+
+                time_scale += CLOCK64() - tic;
             }
 
-            Xgemv_body(trans, mm, nn, alpha,
+            if(alpha == 0)
+            {
+                Xscale_coop_body(len_Y, alpha, W + idx2D(j + 1, j, ldw), 1);
+            }
+            else
+            {
+                tic = CLOCK64();
+                Xgemv_sh<T, I>(trans, mm, nn, alpha,
 
-                       A, j + 1, 0, lda,
+                               A_sh_, ldAWsh,
 
-                       W, 0, j, ldw, 1,
+                               W + idx2D(0, j, ldw), 1,
 
-                       W, j + 1, j, ldw, 1,
+                               W + idx2D(j + 1, j, ldw), 1);
 
-                       mb, nb, myprow, mypcol, nprow, npcol);
-            cg_grid.sync();
+                cg_grid.sync();
+                time_gemv_n1 += CLOCK64() - tic;
+            }
         }
-#endif
 
-#if(0)
-        rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, n - j - 1, j,
-                            cast2constType<T>(scalars + 2), 0,
-
-                            A, shiftA + idx2D(j + 1, 0, lda), lda, strideA,
-
-                            A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
-
-                            cast2constType<T>(scalars + 1), 0,
-
-                            W, shiftW + idx2D(0, j, ldw), 1, strideW,
-
-                            batch_count, workArr);
-#else
         {
             char const trans = 'C';
-            I const mm = n - j - 1;
-            I const nn = j;
             T const alpha = *(scalars + 2);
             T const beta = *(scalars + 1);
 
@@ -2573,44 +728,33 @@ static __global__ void lower_stage2(I const n,
             bool const has_work = (len_Y >= 1) && (beta != 1);
             if(has_work)
             {
-                Xscale_body(len_Y, beta, W, 0, j, ldw, 1, mb, nb, myprow, mypcol, nprow, npcol);
+                tic = CLOCK64();
+
+                Xscale_coop_body(len_Y, beta,
+
+                                 W + idx2D(0, j, ldw), 1);
 
                 cg_grid.sync();
+
+                time_scale += CLOCK64() - tic;
             }
 
-            Xgemv_body(trans, mm, nn, alpha,
+            tic = CLOCK64();
+            Xgemv_sh<T, I>(trans, mm, nn, alpha,
 
-                       A, j + 1, 0, lda,
+                           A_sh_, ldAWsh,
 
-                       A, j + 1, j, lda, 1,
+                           A + idx2D(j + 1, j, lda), 1,
 
-                       W, 0, j, ldw, 1,
-
-                       mb, nb, myprow, mypcol, nprow, npcol);
+                           W + idx2D(0, j, ldw), 1);
 
             cg_grid.sync();
+
+            time_gemv_c2 += CLOCK64() - tic;
         }
-#endif
 
-#if(0)
-
-        rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j - 1, j,
-                            cast2constType<T>(scalars), 0,
-
-                            W, shiftW + idx2D(j + 1, 0, ldw), ldw, strideW,
-
-                            W, shiftW + idx2D(0, j, ldw), 1, strideW,
-
-                            cast2constType<T>(scalars + 2), 0,
-
-                            W, shiftW + idx2D(j + 1, j, ldw), 1, strideW,
-
-                            batch_count, workArr);
-#else
         {
             char const trans = 'N';
-            I const mm = n - j - 1;
-            I const nn = j;
             T const alpha = *scalars;
             T const beta = *(scalars + 2);
 
@@ -2619,69 +763,43 @@ static __global__ void lower_stage2(I const n,
             bool const has_work = (len_Y >= 1) && (beta != 1);
             if(has_work)
             {
-                Xscale_body(len_Y, beta,
+                tic = CLOCK64();
+                Xscale_coop_body(len_Y, beta,
 
-                            W, j + 1, j, ldw, 1,
+                                 W + idx2D(j + 1, j, ldw), 1);
 
-                            mb, nb, myprow, mypcol, nprow, npcol);
+                // cg_grid.sync();
+                // NOTE: grid sync is not needed since the part of vector
+                // is updated by the same thread block
+                __syncthreads();
 
-                cg_grid.sync();
+                time_scale += CLOCK64() - tic;
             }
 
-            Xgemv_body(trans, mm, nn, alpha,
+            tic = CLOCK64();
+            Xgemv_sh<T, I>(trans, mm, nn, alpha,
 
-                       W, j + 1, 0, ldw,
+                           W_sh_, ldAWsh,
 
-                       W, 0, j, ldw, 1,
+                           W + idx2D(0, j, ldw), 1,
 
-                       W, j + 1, j, ldw, 1,
-
-                       mb, nb, myprow, mypcol, nprow, npcol);
-
-            cg_grid.sync();
-        }
-#endif
-
-#if(0)
-        rocblasCall_scal<T>(handle, n - j - 1, (tau + j), strideP, W, shiftW + idx2D(j + 1, j, ldw),
-                            1, strideW, batch_count);
-#else
-        {
-            I const nn = n - j - 1;
-            T* const p_alpha = (tau + j);
-            T const alpha = *(p_alpha + bid * strideP);
-
-            Xscale_body(nn, alpha, W, j + 1, j, ldw, 1, mb, nb, myprow, mypcol, nprow, npcol);
+                           W + idx2D(j + 1, j, ldw), 1);
 
             cg_grid.sync();
-        }
-#endif
-
-#if(0)
-        rocblasCall_dot<COMPLEX, T>(handle, n - 1 - j,
-
-                                    W, shiftW + idx2D(j + 1, j, ldw), 1, strideW,
-
-                                    A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
-
-                                    batch_count, norms, work, workArr);
-
-#else
-        {
-            I const nn = n - 1 - j;
-            Xdot_body(nn, W, j + 1, j, ldw, 1,
-
-                      A, j + 1, j, lda, 1,
-
-                      &(norms[bid]),
-
-                      mb, nb, myprow, mypcol, nprow, npcol);
-
-            cg_grid.sync();
+            time_gemv_n2 += CLOCK64() - tic;
         }
 
-#endif
     } // end for bid
+
+#ifdef PRINT_PROFILE
+    if(cg_grid.thread_rank() == 0)
+    {
+        printf("mm=%d, nn=%d, time_scale=%le, time_load=%le, time_gemv_c1=%le, time_gemv_c2=%le, "
+               "time_gemv_n1=%le, time_gemv_n2=%le\n",
+               (int)mm, (int)nn, (double)time_scale, (double)time_load, (double)time_gemv_c1,
+               (double)time_gemv_c2, (double)time_gemv_n1, (double)time_gemv_n2);
+    }
+#endif
 }
 
 template <typename T, typename I, typename Istride, typename UA, typename UW>
@@ -2705,39 +823,145 @@ static __global__ void upper_stage2(I const n,
                                     Istride const strideA,
 
                                     I const batch_count,
-                                    I const mb,
-                                    I const nb)
+                                    I const lds_size)
 {
-    auto const myprow = hipBlockIdx_x;
-    auto const mypcol = hipBlockIdx_y;
-    auto const nprow = hipGridDim_x;
-    auto const npcol = hipGridDim_y;
+    I const myprow = hipBlockIdx_x;
+    I const mypcol = hipBlockIdx_y;
+    I const nprow = hipGridDim_x;
+    I const npcol = hipGridDim_y;
 
     auto cg_grid = cg::this_grid();
 
+    I const nthreads = (hipBlockDim_x * hipBlockDim_y) * hipBlockDim_z;
+
+    auto ceil = [](auto m, auto n) { return (1 + (m - 1) / n); };
+
+    auto is_even = [](auto n) -> bool { return ((n % 2) == 0); };
+
+    I const mm = j;
+    I const nn = n - 1 - j;
+
+    I const mb = ceil(mm, nprow);
+    I const ldAWsh = is_even(mb) ? mb + 1 : mb;
+
+    I nx = hipBlockDim_x;
+    I ny = hipBlockDim_y;
+    I tix = hipThreadIdx_x;
+    I tiy = hipThreadIdx_y;
+    I const tixy = hipThreadIdx_x + hipThreadIdx_y * hipBlockDim_x
+        + hipThreadIdx_z * (hipBlockDim_x * hipBlockDim_y);
+
+    // ----------------------------------------
+    // assume warp_size in launch configuration
+    // ----------------------------------------
+    I const warp_size = hipBlockDim_x;
+
+    bool const use_setup_nxny = true;
+    if(use_setup_nxny)
+    {
+        auto setup_nxny = [=](auto mb, auto nn, auto& nx, auto& ny) {
+            auto const lny = (nn >= ny) ? ny
+                : (nn >= ny / 2)        ? ny / 2
+                : (nn >= ny / 4)        ? ny / 4
+                : (nn >= ny / 8)        ? ny / 8
+                : (nn >= ny / 16)       ? ny / 16
+                : (nn >= ny / 32)       ? ny / 32
+                                        : 1;
+            if((nthreads % lny) == 0)
+            {
+                ny = lny;
+                nx = nthreads / ny;
+            }
+
+            assert((nx * ny) == nthreads);
+        };
+
+        //  ----------------------
+        //  tixy = tix + tiy * nx
+        //  ----------------------
+        tix = (tixy % nx);
+        tiy = (tixy - tix) / nx;
+    }
+
+    extern __shared__ double lmem[];
+    std::byte* pfree = (std::byte*)&(lmem[0]);
+
+    size_t const mat_size = sizeof(T) * ldAWsh * nn;
+    size_t total_bytes = 0;
+
+    T* const A_sh_ = (T*)pfree;
+    pfree += mat_size;
+    total_bytes += mat_size;
+
+    T* const W_sh_ = (T*)pfree;
+    pfree += mat_size;
+    total_bytes += mat_size;
+
+    {
+        size_t const ld_size = 64 * 1024;
+        assert(total_bytes <= ld_size);
+    }
+
+    auto A_sh = [=](auto i, auto j) -> T& { return (A_sh_[i + j * ldAWsh]); };
+
+    auto W_sh = [=](auto i, auto j) -> T& { return (W_sh_[i + j * ldAWsh]); };
+
+    I const iiw = 0;
+    I const jjw = jw + 1;
+    I const ia = 0;
+    I const ja = j + 1;
+
     for(I bid = 0; bid < batch_count; bid++)
     {
-        T* const A = load_ptr_batch(A_, bid, shiftA, strideA);
-        T* const W = load_ptr_batch(W_, bid, shiftW, strideW);
+        T* const __restrict__ A = load_ptr_batch(A_, bid, shiftA, strideA);
+        T* const __restrict__ W = load_ptr_batch(W_, bid, shiftW, strideW);
 
-#if(0)
-        rocblasCall_gemv<T>(handle, rocblas_operation_conjugate_transpose, j, n - 1 - j,
-                            cast2constType<T>(scalars + 2), 0,
+        auto Amat = [=](auto i, auto j) -> T& { return (A[idx2D(ia + i, ja + j, lda)]); };
 
-                            W, shiftW + idx2D(0, jw + 1, ldw), ldw, strideW,
+        auto Wmat = [=](auto i, auto j) -> T& { return (W[idx2D(iiw + i, jjw + j, ldw)]); };
 
-                            A, shiftA + idx2D(0, j, lda), 1, strideA,
+        // -----------------------
+        // load into shared memory
+        // -----------------------
 
-                            cast2constType<T>(scalars + 1), 0,
+        I const ia_start = myprow * mb;
+        I const ia_end = std::min(mm, (myprow + 1) * mb);
 
-                            W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW,
+        __syncthreads();
 
-                            batch_count, workArr);
-#else
+        bool const use_load_2D = false;
+        if(use_load_2D)
+        {
+            for(I jj = (0 + tiy); jj < nn; jj += ny)
+            {
+                for(I ii = (ia_start + tix); ii < ia_end; ii += nx)
+                {
+                    A_sh((ii - ia_start), jj) = Amat(ii, jj);
+                    W_sh((ii - ia_start), jj) = Wmat(ii, jj);
+                }
+            }
+        }
+        else
+        {
+            I const ia_size = ia_end - ia_start;
+
+            for(I ixy = (0 + tixy); ixy < (ia_size * nn); ixy += nthreads)
+            {
+                // ------------------
+                // ixy = ii + jj * ia_size
+                // ------------------
+                I const jj = ixy / ia_size;
+                I const ii = ixy % ia_size;
+
+                A_sh(ii, jj) = Amat(ii + ia_start, jj);
+                W_sh(ii, jj) = Wmat(ii + ia_start, jj);
+            }
+        }
+
+        __syncthreads();
+
         {
             char const trans = 'C';
-            I const mm = j;
-            I const nn = n - 1 - j;
             I const len_Y = nn;
 
             T const alpha = *(scalars + 2);
@@ -2746,24 +970,22 @@ static __global__ void upper_stage2(I const n,
             bool const has_work = (len_Y >= 1) && (beta != 1);
             if(has_work)
             {
-                Xscale_body<T, I>(len_Y, beta, W, j + 1, jw, ldw, 1, mb, nb, myprow, mypcol, nprow,
-                                  npcol);
+                Xscale_coop_body(len_Y, beta,
+
+                                 W + idx2D(j + 1, jw, ldw), 1);
 
                 cg_grid.sync();
             }
 
-            Xgemv_body<T, I>(trans, mm, nn, alpha,
+            Xgemv_sh(trans, mm, nn, alpha,
 
-                             W, 0, jw + 1, ldw,
+                     W_sh_, ldAWsh,
 
-                             A, 0, j, lda, 1,
+                     A + idx2D(0, j, lda), 1,
 
-                             W, j + 1, jw, ldw, 1,
-
-                             mb, nb, myprow, mypcol, nprow, npcol);
+                     W + idx2D(j + 1, jw, ldw), 1);
             cg_grid.sync();
         }
-#endif
 
 #if(0)
         rocblasCall_gemv<T>(handle, rocblas_operation_none, j, n - 1 - j,
@@ -2781,8 +1003,6 @@ static __global__ void upper_stage2(I const n,
 #else
         {
             char const trans = 'N';
-            I const mm = j;
-            I const nn = n - 1 - j;
             I const len_Y = mm;
 
             T const alpha = *scalars;
@@ -2791,24 +1011,23 @@ static __global__ void upper_stage2(I const n,
             bool const has_work = (len_Y >= 1) && (beta != 1);
             if(has_work)
             {
-                Xscale_body<T, I>(len_Y, beta,
+                Xscale_coop_body(len_Y, beta,
 
-                                  W, 0, jw, ldw, 1,
+                                 W + idx2D(0, jw, ldw), 1);
 
-                                  mb, nb, myprow, mypcol, nprow, npcol);
-
-                cg_grid.sync();
+                // cg_grid.sync();
+                // NOTE: grid sync is not needed since the part of vector
+                // is updated by the same thread block
+                __syncthreads();
             }
 
-            Xgemv_body<T, I>(trans, mm, nn, alpha,
+            Xgemv_sh(trans, mm, nn, alpha,
 
-                             A, 0, j + 1, lda,
+                     A_sh_, ldAWsh,
 
-                             W, j + 1, jw, ldw, 1,
+                     W + idx2D(j + 1, jw, ldw), 1,
 
-                             W, 0, jw, ldw, 1,
-
-                             mb, nb, myprow, mypcol, nprow, npcol);
+                     W + idx2D(0, jw, ldw), 1);
             cg_grid.sync();
         }
 #endif
@@ -2829,8 +1048,6 @@ static __global__ void upper_stage2(I const n,
 #else
         {
             char const trans = 'C';
-            I const mm = j;
-            I const nn = n - 1 - j;
             I const len_Y = nn;
 
             T const alpha = *(scalars + 2);
@@ -2839,20 +1056,19 @@ static __global__ void upper_stage2(I const n,
             bool const has_work = (len_Y >= 1) && (beta != 1);
             if(has_work)
             {
-                Xscale_body<T, I>(len_Y, beta, W, j + 1, jw, ldw, 1, mb, nb, myprow, mypcol, nprow,
-                                  npcol);
+                Xscale_coop_body(len_Y, beta,
+
+                                 W + idx2D(j + 1, jw, ldw), 1);
                 cg_grid.sync();
             }
 
-            Xgemv_body<T, I>(trans, mm, nn, alpha,
+            Xgemv_sh(trans, mm, nn, alpha,
 
-                             A, 0, j + 1, lda,
+                     A_sh_, ldAWsh,
 
-                             A, 0, j, lda, 1,
+                     A + idx2D(0, j, lda), 1,
 
-                             W, j + 1, jw, ldw, 1,
-
-                             mb, nb, myprow, mypcol, nprow, npcol);
+                     W + idx2D(j + 1, jw, ldw), 1);
 
             cg_grid.sync();
         }
@@ -2874,8 +1090,6 @@ static __global__ void upper_stage2(I const n,
 #else
         {
             char const trans = 'N';
-            I const mm = j;
-            I const nn = n - 1 - j;
             I const len_Y = mm;
 
             T const alpha = *(scalars);
@@ -2884,72 +1098,40 @@ static __global__ void upper_stage2(I const n,
             bool const has_work = (len_Y >= 1) && (beta != 1);
             if(has_work)
             {
-                Xscale_body<T, I>(len_Y, beta,
+                Xscale_coop_body(len_Y, beta,
 
-                                  W, 0, jw, ldw, 1,
+                                 W + idx2D(0, jw, ldw), 1);
 
-                                  mb, nb, myprow, mypcol, nprow, npcol);
-
-                cg_grid.sync();
+                // cg_grid.sync();
+                // NOTE: grid sync is not needed since the part of vector
+                // is updated by the same thread block
+                __syncthreads();
             }
 
-            Xgemv_body<T, I>(trans, mm, nn, alpha,
+            Xgemv_sh(trans, mm, nn, alpha,
 
-                             W, 0, jw + 1, ldw,
+                     W_sh_, ldAWsh,
 
-                             W, j + 1, jw, ldw, 1,
+                     W + idx2D(j + 1, jw, ldw), 1,
 
-                             W, 0, jw, ldw, 1,
-
-                             mb, nb, myprow, mypcol, nprow, npcol);
+                     W + idx2D(0, jw, ldw), 1);
 
             cg_grid.sync();
         }
 
 #endif
 
-#if(0)
-        rocblasCall_scal<T>(handle, j, (tau + j - 1), strideP, W, shiftW + idx2D(0, jw, ldw), 1,
-                            strideW, batch_count);
-#else
         {
             I const nn = j;
             T const* const p_alpha = (tau + j - 1);
             T const alpha = *(p_alpha + bid * strideP);
 
-            Xscale_body<T, I>(nn, alpha,
+            Xscale_coop_body(nn, alpha,
 
-                              W, 0, jw, ldw, 1,
-
-                              mb, nb, myprow, mypcol, nprow, npcol);
+                             W + idx2D(0, jw, ldw), 1);
 
             cg_grid.sync();
         }
-#endif
-
-#if(0)
-        rocblasCall_dot<COMPLEX, T>(handle, j,
-
-                                    W, shiftW + idx2D(0, jw, ldw), 1, strideW,
-
-                                    A, shiftA + idx2D(0, j, lda), 1, strideA,
-
-                                    batch_count, norms, work, workArr);
-#else
-        {
-            I const nn = j;
-            Xdot_body<T, I>(nn,
-
-                            W, 0, jw, ldw, 1,
-
-                            A, 0, j, lda, 1,
-
-                            &(norms[bid]),
-
-                            mb, nb, myprow, mypcol, nprow, npcol);
-            cg_grid.sync();
-        }
-#endif
 
     } // end for bid
 }
@@ -2993,21 +1175,35 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
     rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
 
     // configure kernels
+    auto const num_cu = get_num_cu();
+    auto const warp_size = get_warp_size();
+    auto const max_threads_per_block = get_max_threads_per_block();
+    rocblas_int const lds_size = get_lds_size();
+
     rocblas_int blocks = (batch_count - 1) / BS1 + 1;
     dim3 grid_b(blocks, 1);
     dim3 threads(BS1, 1, 1);
     blocks = (n - 1) / BS1 + 1;
     dim3 grid_n(blocks, batch_count);
 
-    auto const nx = 32;
-    auto const ny = 32;
+    auto const nx = warp_size;
+    auto const ny = max_threads_per_block / nx;
+
     bool const use_org = true;
     bool const use_coop = true;
-    size_t lds_size = 64 * 1024;
     auto const mb = k;
     auto const nb = k;
 
-    auto const num_cu = get_num_cu();
+    auto is_even = [](auto n) -> bool { return ((n % 2) == 0); };
+
+    auto ceil = [](auto m, auto n) { return (1 + (m - 1) / n); };
+
+    auto need_lds_size = [=](auto mm, auto nn, auto sizeof_T) {
+        auto const mb = ceil(mm, num_cu);
+
+        auto ld = is_even(mb) ? mb + 1 : mb;
+        return (sizeof_T * (ld * nn) * 2);
+    };
 
     if(uplo == rocblas_fill_lower)
     {
@@ -3016,82 +1212,36 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
         for(rocblas_int j = 0; j < k; ++j)
         {
             // update column j of A with reflector computed in step j-1
-            bool const use_lower_stage1 = true;
-            if(use_lower_stage1)
+            if(COMPLEX)
             {
-#if(0)
-
-                template <typename T, typename I, typename Istride, typename UA>
-                static __global__ void lower_stage1(
-                    I const n, I const j,
-
-                    T* scalars,
-
-                    T* const W_, Istride const shiftW, I const ldw, Istride const strideW,
-
-                    U A_, Istride const shiftA, I const lda, Istride const strideA,
-
-                    I const batch_count,
-
-                    I const mb, I const nb)
-#else
-                rocblas_stride lshiftW = shiftW;
-                rocblas_stride lshiftA = shiftA;
-
-                void* args[]
-                    = {(void*)&n,           (void*)&j,       (void*)&scalars,
-
-                       (void*)&W,           (void*)&lshiftW, (void*)&ldw,     (void*)&strideW,
-
-                       (void*)&A,           (void*)&lshiftA, (void*)&lda,     (void*)&strideA,
-
-                       (void*)&batch_count,
-
-                       (void*)&mb,          (void*)&nb};
-
-                auto const nx = 32;
-                auto const ny = 32;
-                auto const lds_size = 64 * 1024;
-
-                LAUNCH_CHECK(hipLaunchCooperativeKernel(
-                    (void*)(lower_stage1<T, rocblas_int, rocblas_stride, U>), dim3(num_cu, 1, 1),
-                    dim3(nx, ny, 1), args, lds_size, stream));
-
-#endif
+                rocsolver_lacgv_template<T>(handle, j, W, shiftW + idx2D(j, 0, ldw), ldw, strideW,
+                                            batch_count);
             }
-            else
+
+            rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j, j,
+                                cast2constType<T>(scalars), 0, A, shiftA + idx2D(j, 0, lda), lda,
+                                strideA, W, shiftW + idx2D(j, 0, ldw), ldw, strideW,
+                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j, lda), 1,
+                                strideA, batch_count, workArr);
+
+            if(COMPLEX)
             {
-                if(COMPLEX)
-                {
-                    rocsolver_lacgv_template<T>(handle, j, W, shiftW + idx2D(j, 0, ldw), ldw,
-                                                strideW, batch_count);
-                }
+                rocsolver_lacgv_template<T>(handle, j, W, shiftW + idx2D(j, 0, ldw), ldw, strideW,
+                                            batch_count);
+                rocsolver_lacgv_template<T>(handle, j, A, shiftA + idx2D(j, 0, lda), lda, strideA,
+                                            batch_count);
+            }
 
-                rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j, j,
-                                    cast2constType<T>(scalars), 0, A, shiftA + idx2D(j, 0, lda),
-                                    lda, strideA, W, shiftW + idx2D(j, 0, ldw), ldw, strideW,
-                                    cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j, lda),
-                                    1, strideA, batch_count, workArr);
+            rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j, j,
+                                cast2constType<T>(scalars), 0, W, shiftW + idx2D(j, 0, ldw), ldw,
+                                strideW, A, shiftA + idx2D(j, 0, lda), lda, strideA,
+                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j, lda), 1,
+                                strideA, batch_count, workArr);
 
-                if(COMPLEX)
-                {
-                    rocsolver_lacgv_template<T>(handle, j, W, shiftW + idx2D(j, 0, ldw), ldw,
-                                                strideW, batch_count);
-                    rocsolver_lacgv_template<T>(handle, j, A, shiftA + idx2D(j, 0, lda), lda,
-                                                strideA, batch_count);
-                }
-
-                rocblasCall_gemv<T>(handle, rocblas_operation_none, n - j, j,
-                                    cast2constType<T>(scalars), 0, W, shiftW + idx2D(j, 0, ldw),
-                                    ldw, strideW, A, shiftA + idx2D(j, 0, lda), lda, strideA,
-                                    cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(j, j, lda),
-                                    1, strideA, batch_count, workArr);
-
-                if(COMPLEX)
-                {
-                    rocsolver_lacgv_template<T>(handle, j, A, shiftA + idx2D(j, 0, lda), lda,
-                                                strideA, batch_count);
-                }
+            if(COMPLEX)
+            {
+                rocsolver_lacgv_template<T>(handle, j, A, shiftA + idx2D(j, 0, lda), lda, strideA,
+                                            batch_count);
             }
 
             // generate Householder reflector to work on column j
@@ -3100,17 +1250,8 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
                                      (tau + j), strideP, batch_count, work, norms);
 
             // copy to E(j) the corresponding off-diagonal element of A, which is set to 1
-            if(use_org)
-            {
-                ROCSOLVER_LAUNCH_KERNEL(set_offdiag<T>, grid_b, threads, 0, stream, batch_count, A,
-                                        shiftA + idx2D(j + 1, j, lda), strideA, (E + j), strideE);
-            }
-            else
-            {
-                set_offdiag_batch_kernel<T, rocblas_int, rocblas_stride>
-                    <<<dim3(num_cu, 1, 1), dim3(32, 32, 1), 0, stream>>>(
-                        batch_count, A, shiftA + idx2D(j + 1, j, lda), strideA, (E + j), strideE);
-            }
+            ROCSOLVER_LAUNCH_KERNEL(set_offdiag<T>, grid_b, threads, 0, stream, batch_count, A,
+                                    shiftA + idx2D(j + 1, j, lda), strideA, (E + j), strideE);
 
             // compute/update column j of W
             {
@@ -3120,23 +1261,16 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
                     shiftW + idx2D(j + 1, j, ldw), 1, strideW, batch_count, work, workArr);
             }
 
-            bool use_lower_stage2 = true;
+            bool use_lower_stage2
+                = get_cooperative_launch() && (need_lds_size(n - j - 1, j, sizeof(T)) <= lds_size);
+#ifdef NDEBUG
+#else
+            printf("use_lower_stage2=%d, mm=%d, nn=%d\n", (int)use_lower_stage2, (int)(n - j - 1),
+                   (int)j);
+#endif
+
             if(use_lower_stage2)
             {
-#if(0)
-
-                template <typename T, typename I, typename Istride, typename UA>
-                static __global__ void lower_stage2(
-                    I const n, I const j,
-
-                    T* const scalars, T* const tau, Istride const strideP,
-
-                    T* const W_, Istride const shiftW, I const ldw, Istride const strideW,
-
-                    UA A_, Istride const shiftA, I const lda, Istride const strideA,
-
-                    I const batch_count, I const mb, I const nb)
-#else
                 rocblas_stride lshiftA = shiftA;
                 rocblas_stride lshiftW = shiftW;
 
@@ -3149,16 +1283,15 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
 
                        (void*)&A,           (void*)&lshiftA, (void*)&lda,     (void*)&strideA,
 
-                       (void*)&batch_count, (void*)&mb,      (void*)&nb};
+                       (void*)&batch_count, (void*)&lds_size};
 
-                auto const nx = 32;
-                auto const ny = 32;
+                auto const nx = warp_size;
+                auto const ny = max_threads_per_block / nx;
                 auto const lds_size = 64 * 1024;
 
                 LAUNCH_CHECK(hipLaunchCooperativeKernel(
                     (void*)(lower_stage2<T, rocblas_int, rocblas_stride, U>), dim3(num_cu, 1, 1),
                     dim3(nx, ny, 1), args, lds_size, stream));
-#endif
             }
             else
             {
@@ -3187,14 +1320,14 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
                                     ldw, strideW, W, shiftW + idx2D(0, j, ldw), 1, strideW,
                                     cast2constType<T>(scalars + 2), 0, W,
                                     shiftW + idx2D(j + 1, j, ldw), 1, strideW, batch_count, workArr);
-
-                rocblasCall_scal<T>(handle, n - j - 1, (tau + j), strideP, W,
-                                    shiftW + idx2D(j + 1, j, ldw), 1, strideW, batch_count);
-
-                rocblasCall_dot<COMPLEX, T>(handle, n - 1 - j, W, shiftW + idx2D(j + 1, j, ldw), 1,
-                                            strideW, A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
-                                            batch_count, norms, work, workArr);
             }
+
+            rocblasCall_scal<T>(handle, n - j - 1, (tau + j), strideP, W,
+                                shiftW + idx2D(j + 1, j, ldw), 1, strideW, batch_count);
+
+            rocblasCall_dot<COMPLEX, T>(handle, n - 1 - j, W, shiftW + idx2D(j + 1, j, ldw), 1,
+                                        strideW, A, shiftA + idx2D(j + 1, j, lda), 1, strideA,
+                                        batch_count, norms, work, workArr);
 
             // (TODO: rocblas_axpy is not yet ready to be used in rocsolver. When it becomes
             //  available, we can use it instead of the scale_axpy kernel, if it provides
@@ -3213,111 +1346,58 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
         {
             jw = j - n + k;
             // update column j of A with reflector computed in step j-1
-            if(use_coop)
+            if(COMPLEX)
+                rocsolver_lacgv_template<T>(handle, n - 1 - j, W, shiftW + idx2D(j, jw + 1, ldw),
+                                            ldw, strideW, batch_count);
+
+            rocblasCall_gemv<T>(handle, rocblas_operation_none, j + 1, n - 1 - j,
+                                cast2constType<T>(scalars), 0, A, shiftA + idx2D(0, j + 1, lda),
+                                lda, strideA, W, shiftW + idx2D(j, jw + 1, ldw), ldw, strideW,
+                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(0, j, lda), 1,
+                                strideA, batch_count, workArr);
+
+            if(COMPLEX)
             {
-#if(0)
-                template <typename T, typename I, typename Istride, typename UA>
-                static __global__ void upper_stage1(
-                    I const n, I const j, I const jw,
+                rocsolver_lacgv_template<T>(handle, n - 1 - j, W, shiftW + idx2D(j, jw + 1, ldw),
+                                            ldw, strideW, batch_count);
+                rocsolver_lacgv_template<T>(handle, n - 1 - j, A, shiftA + idx2D(j, j + 1, lda),
+                                            lda, strideA, batch_count);
+            }
 
-                    T* const scalars,
+            rocblasCall_gemv<T>(handle, rocblas_operation_none, j + 1, n - 1 - j,
+                                cast2constType<T>(scalars), 0, W, shiftW + idx2D(0, jw + 1, ldw),
+                                ldw, strideW, A, shiftA + idx2D(j, j + 1, lda), lda, strideA,
+                                cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(0, j, lda), 1,
+                                strideA, batch_count, workArr);
 
-                    T* const W_, Istride const shiftW, I const ldw, Istride const strideW,
+            if(COMPLEX)
+                rocsolver_lacgv_template<T>(handle, n - 1 - j, A, shiftA + idx2D(j, j + 1, lda),
+                                            lda, strideA, batch_count);
+            // generate Householder reflector to work on column j
+            rocsolver_larfg_template(handle, j, A, shiftA + idx2D(j - 1, j, lda), A,
+                                     shiftA + idx2D(0, j, lda), 1, strideA, (tau + j - 1), strideP,
+                                     batch_count, work, norms);
 
-                    UA A_, Istride const shiftA, I const lda, Istride const strideA,
+            // copy to E(j) the corresponding off-diagonal element of A, which is set to 1
+            ROCSOLVER_LAUNCH_KERNEL(set_offdiag<T>, grid_b, threads, 0, stream, batch_count, A,
+                                    shiftA + idx2D(j - 1, j, lda), strideA, (E + j - 1), strideE);
 
-                    I const batch_count, I const mb, I const nb)
-                {
+            // compute/update column j of W
+            rocblasCall_symv_hemv<T>(handle, uplo, j, (scalars + 2), 0, A, shiftA, lda, strideA, A,
+                                     shiftA + idx2D(0, j, lda), 1, strideA, (scalars + 1), 0, W,
+                                     shiftW + idx2D(0, jw, ldw), 1, strideW, batch_count, work,
+                                     workArr);
+
+            bool const use_upper_stage2
+                = get_cooperative_launch() && (need_lds_size(j, n - 1 - j, sizeof(T)) <= lds_size);
+#ifdef NDEBUG
 #else
-                rocblas_stride lshiftW = shiftW;
-                rocblas_stride lshiftA = shiftA;
-                void* args[] = {
-
-                    (void*)&n,           (void*)&j,       (void*)&jw,
-
-                    (void*)&scalars,
-
-                    (void*)&W,           (void*)&lshiftW, (void*)&ldw, (void*)&strideW,
-
-                    (void*)&A,           (void*)&lshiftA, (void*)&lda, (void*)&strideA,
-
-                    (void*)&batch_count, (void*)&mb,      (void*)&nb};
-
-                auto const nx = 32;
-                auto const ny = 32;
-                auto const lds_size = 64 * 1024;
-
-                LAUNCH_CHECK(hipLaunchCooperativeKernel(
-                    (void*)(upper_stage1<T, rocblas_int, rocblas_stride, U>), dim3(num_cu, 1, 1),
-                    dim3(nx, ny, 1), args, lds_size, stream));
-
+            printf("use_upper_stage2=%d, mm=%d, nn=%d\n", (int)use_upper_stage2, (int)j,
+                   (int)n - 1 - j);
 #endif
-                }
-                else
-                {
-                    if(COMPLEX)
-                        rocsolver_lacgv_template<T>(handle, n - 1 - j, W,
-                                                    shiftW + idx2D(j, jw + 1, ldw), ldw, strideW,
-                                                    batch_count);
 
-                    rocblasCall_gemv<T>(handle, rocblas_operation_none, j + 1, n - 1 - j,
-                                        cast2constType<T>(scalars), 0, A,
-                                        shiftA + idx2D(0, j + 1, lda), lda, strideA, W,
-                                        shiftW + idx2D(j, jw + 1, ldw), ldw, strideW,
-                                        cast2constType<T>(scalars + 2), 0, A,
-                                        shiftA + idx2D(0, j, lda), 1, strideA, batch_count, workArr);
-
-                    if(COMPLEX)
-                    {
-                        rocsolver_lacgv_template<T>(handle, n - 1 - j, W,
-                                                    shiftW + idx2D(j, jw + 1, ldw), ldw, strideW,
-                                                    batch_count);
-                        rocsolver_lacgv_template<T>(handle, n - 1 - j, A,
-                                                    shiftA + idx2D(j, j + 1, lda), lda, strideA,
-                                                    batch_count);
-                    }
-
-                    rocblasCall_gemv<T>(
-                        handle, rocblas_operation_none, j + 1, n - 1 - j, cast2constType<T>(scalars),
-                        0, W, shiftW + idx2D(0, jw + 1, ldw), ldw, strideW, A,
-                        shiftA + idx2D(j, j + 1, lda), lda, strideA, cast2constType<T>(scalars + 2),
-                        0, A, shiftA + idx2D(0, j, lda), 1, strideA, batch_count, workArr);
-
-                    if(COMPLEX)
-                        rocsolver_lacgv_template<T>(handle, n - 1 - j, A,
-                                                    shiftA + idx2D(j, j + 1, lda), lda, strideA,
-                                                    batch_count);
-                }
-                // generate Householder reflector to work on column j
-                rocsolver_larfg_template(handle, j, A, shiftA + idx2D(j - 1, j, lda), A,
-                                         shiftA + idx2D(0, j, lda), 1, strideA, (tau + j - 1),
-                                         strideP, batch_count, work, norms);
-
-                // copy to E(j) the corresponding off-diagonal element of A, which is set to 1
-                ROCSOLVER_LAUNCH_KERNEL(set_offdiag<T>, grid_b, threads, 0, stream, batch_count, A,
-                                        shiftA + idx2D(j - 1, j, lda), strideA, (E + j - 1), strideE);
-
-                // compute/update column j of W
-                rocblasCall_symv_hemv<T>(handle, uplo, j, (scalars + 2), 0, A, shiftA, lda, strideA,
-                                         A, shiftA + idx2D(0, j, lda), 1, strideA, (scalars + 1), 0,
-                                         W, shiftW + idx2D(0, jw, ldw), 1, strideW, batch_count,
-                                         work, workArr);
-
-                if(use_coop)
-                {
-#if(0)
-                    template <typename T, typename I, typename Istride, typename UA, typename UW>
-                    static __device__ void upper_stage2(
-                        I const n, I const j, I const jw,
-
-                        T const* const scalars, T* const tau, Istride const strideP, T* const norms,
-
-                        UW W_, Istride const shiftW, I const ldw, Istride const strideW,
-
-                        UA A_, Istride const shiftA, I const lda, Istride const strideA,
-
-                        I const batch_count, I const mb, I const nb)
-#else
+            if(use_upper_stage2)
+            {
                 rocblas_stride lshiftA = shiftA;
                 rocblas_stride lshiftW = shiftW;
 
@@ -3330,61 +1410,56 @@ rocblas_status rocsolver_latrd_coop_template(rocblas_handle handle,
 
                        (void*)&A,           (void*)&lshiftA, (void*)&lda,     (void*)&strideA,
 
-                       (void*)&batch_count, (void*)&mb,      (void*)&nb};
+                       (void*)&batch_count, (void*)&lds_size};
 
                 LAUNCH_CHECK(hipLaunchCooperativeKernel(
                     (void*)(upper_stage2<T, rocblas_int, rocblas_stride, U, T*>),
                     dim3(num_cu, 1, 1), dim3(nx, ny, 1), args, lds_size, stream));
+            }
+            else
+            {
+                rocblasCall_gemv<T>(
+                    handle, rocblas_operation_conjugate_transpose, j, n - 1 - j,
+                    cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(0, jw + 1, ldw), ldw,
+                    strideW, A, shiftA + idx2D(0, j, lda), 1, strideA, cast2constType<T>(scalars + 1),
+                    0, W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW, batch_count, workArr);
 
-#endif
-                }
-                else
-                {
-                    rocblasCall_gemv<T>(
-                        handle, rocblas_operation_conjugate_transpose, j, n - 1 - j,
-                        cast2constType<T>(scalars + 2), 0, W, shiftW + idx2D(0, jw + 1, ldw), ldw,
-                        strideW, A, shiftA + idx2D(0, j, lda), 1, strideA,
-                        cast2constType<T>(scalars + 1), 0, W, shiftW + idx2D(j + 1, jw, ldw), 1,
-                        strideW, batch_count, workArr);
+                rocblasCall_gemv<T>(handle, rocblas_operation_none, j, n - 1 - j,
+                                    cast2constType<T>(scalars), 0, A, shiftA + idx2D(0, j + 1, lda),
+                                    lda, strideA, W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW,
+                                    cast2constType<T>(scalars + 2), 0, W,
+                                    shiftW + idx2D(0, jw, ldw), 1, strideW, batch_count, workArr);
 
-                    rocblasCall_gemv<T>(
-                        handle, rocblas_operation_none, j, n - 1 - j, cast2constType<T>(scalars), 0,
-                        A, shiftA + idx2D(0, j + 1, lda), lda, strideA, W,
-                        shiftW + idx2D(j + 1, jw, ldw), 1, strideW, cast2constType<T>(scalars + 2),
-                        0, W, shiftW + idx2D(0, jw, ldw), 1, strideW, batch_count, workArr);
+                rocblasCall_gemv<T>(
+                    handle, rocblas_operation_conjugate_transpose, j, n - 1 - j,
+                    cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(0, j + 1, lda), lda, strideA,
+                    A, shiftA + idx2D(0, j, lda), 1, strideA, cast2constType<T>(scalars + 1), 0, W,
+                    shiftW + idx2D(j + 1, jw, ldw), 1, strideW, batch_count, workArr);
 
-                    rocblasCall_gemv<T>(
-                        handle, rocblas_operation_conjugate_transpose, j, n - 1 - j,
-                        cast2constType<T>(scalars + 2), 0, A, shiftA + idx2D(0, j + 1, lda), lda,
-                        strideA, A, shiftA + idx2D(0, j, lda), 1, strideA,
-                        cast2constType<T>(scalars + 1), 0, W, shiftW + idx2D(j + 1, jw, ldw), 1,
-                        strideW, batch_count, workArr);
+                rocblasCall_gemv<T>(handle, rocblas_operation_none, j, n - 1 - j,
+                                    cast2constType<T>(scalars), 0, W, shiftW + idx2D(0, jw + 1, ldw),
+                                    ldw, strideW, W, shiftW + idx2D(j + 1, jw, ldw), 1, strideW,
+                                    cast2constType<T>(scalars + 2), 0, W,
+                                    shiftW + idx2D(0, jw, ldw), 1, strideW, batch_count, workArr);
 
-                    rocblasCall_gemv<T>(
-                        handle, rocblas_operation_none, j, n - 1 - j, cast2constType<T>(scalars), 0,
-                        W, shiftW + idx2D(0, jw + 1, ldw), ldw, strideW, W,
-                        shiftW + idx2D(j + 1, jw, ldw), 1, strideW, cast2constType<T>(scalars + 2),
-                        0, W, shiftW + idx2D(0, jw, ldw), 1, strideW, batch_count, workArr);
+                rocblasCall_scal<T>(handle, j, (tau + j - 1), strideP, W,
+                                    shiftW + idx2D(0, jw, ldw), 1, strideW, batch_count);
+            }
+            rocblasCall_dot<COMPLEX, T>(handle, j, W, shiftW + idx2D(0, jw, ldw), 1, strideW, A,
+                                        shiftA + idx2D(0, j, lda), 1, strideA, batch_count, norms,
+                                        work, workArr);
 
-                    rocblasCall_scal<T>(handle, j, (tau + j - 1), strideP, W,
-                                        shiftW + idx2D(0, jw, ldw), 1, strideW, batch_count);
-
-                    rocblasCall_dot<COMPLEX, T>(handle, j, W, shiftW + idx2D(0, jw, ldw), 1,
-                                                strideW, A, shiftA + idx2D(0, j, lda), 1, strideA,
-                                                batch_count, norms, work, workArr);
-                }
-
-                // (TODO: rocblas_axpy is not yet ready to be used in rocsolver. When it becomes
-                //  available, we can use it instead of the scale_axpy kernel, if it provides
-                //  better performance.)
-                ROCSOLVER_LAUNCH_KERNEL(scale_axpy<T>, grid_n, threads, 0, stream, j, norms,
-                                        tau + j - 1, strideP, A, shiftA + idx2D(0, j, lda), strideA,
-                                        W, shiftW + idx2D(0, jw, ldw), strideW);
-            } // end for  j
-        }
-
-        rocblas_set_pointer_mode(handle, old_mode);
-        return rocblas_status_success;
+            // (TODO: rocblas_axpy is not yet ready to be used in rocsolver. When it becomes
+            //  available, we can use it instead of the scale_axpy kernel, if it provides
+            //  better performance.)
+            ROCSOLVER_LAUNCH_KERNEL(scale_axpy<T>, grid_n, threads, 0, stream, j, norms,
+                                    tau + j - 1, strideP, A, shiftA + idx2D(0, j, lda), strideA, W,
+                                    shiftW + idx2D(0, jw, ldw), strideW);
+        } // end for  j
     }
 
-    ROCSOLVER_END_NAMESPACE
+    rocblas_set_pointer_mode(handle, old_mode);
+    return rocblas_status_success;
+}
+
+ROCSOLVER_END_NAMESPACE


### PR DESCRIPTION
Here is an attempt to optimize latrd by storing the 2 narrow column panels "A" and "W" in LDS shared memory and using Cooperative  Kernel Launch to synchronize all thread blocks in computing the 4 GEMV matrix vector multiplications.

However, there is no  improvement in the performance. 

Creating this PR in case there can be further improvements later.