### PR TITLE
Set test timeout to 300min

### DIFF
--- a/.jenkins/debug.groovy
+++ b/.jenkins/debug.groovy
@@ -17,7 +17,7 @@ def runCI =
     def prj = new rocProject('rocSOLVER', 'Debug')
 
     prj.timeout.compile = 600
-    prj.timeout.test = 45
+    prj.timeout.test = 300
     prj.defaults.ccache = true
 
     // customize for project
@@ -92,4 +92,3 @@ ci: {
         }
     }
 }
-


### PR DESCRIPTION
Currently times out at 45min before tests complete