### PR TITLE
LU factorization (GETRF) to use  64bit arithmetic for index address calculations

### DIFF
--- a/clients/common/auxiliary/testing_lacgv.hpp
+++ b/clients/common/auxiliary/testing_lacgv.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -106,7 +106,7 @@ void lacgv_getError(const rocblas_handle handle,
     // error |hA - hAr| (elements must be identical)
     *max_err = 0;
     double diff;
-    for(int j = 0; j < n; j++)
+    for(int64_t j = 0; j < n; j++)
     {
         diff = std::abs(hAr[0][j * abs(inc)] - hA[0][j * abs(inc)]);
         *max_err = diff > *max_err ? diff : *max_err;
@@ -139,7 +139,7 @@ void lacgv_getPerfData(const rocblas_handle handle,
     lacgv_initData<true, false, T>(handle, n, dA, inc, hA);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         lacgv_initData<false, true, T>(handle, n, dA, inc, hA);
 
@@ -161,7 +161,7 @@ void lacgv_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         lacgv_initData<false, true, T>(handle, n, dA, inc, hA);
 

--- a/clients/common/auxiliary/testing_laswp.hpp
+++ b/clients/common/auxiliary/testing_laswp.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -104,7 +104,7 @@ void laswp_initData(const rocblas_handle handle,
 
         // put indices in range [1, x]
         // for simplicity, consider x = lda as this is the number of rows
-        for(rocblas_int i = 0; i < hIpiv.n(); ++i)
+        for(int64_t i = 0; i < hIpiv.n(); ++i)
             hIpiv[0][i] = hIpiv[0][i] * lda < 10 ? 1 : hIpiv[0][i] * lda / 10;
     }
 
@@ -144,9 +144,9 @@ void laswp_getError(const rocblas_handle handle,
     // error |hA - hAr| (elements must be identical)
     *max_err = 0;
     double diff;
-    for(int i = 0; i < lda; i++)
+    for(int64_t i = 0; i < lda; i++)
     {
-        for(int j = 0; j < n; j++)
+        for(int64_t j = 0; j < n; j++)
         {
             diff = std::abs(hAr[0][i + j * lda] - hA[0][i + j * lda]);
             *max_err = diff > *max_err ? diff : *max_err;

--- a/clients/common/auxiliary/testing_latrd.hpp
+++ b/clients/common/auxiliary/testing_latrd.hpp
@@ -112,9 +112,9 @@ void latrd_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
 
         // scale A to avoid singularities
-        for(rocblas_int i = 0; i < n; i++)
+        for(int64_t i = 0; i < n; i++)
         {
-            for(rocblas_int j = 0; j < n; j++)
+            for(int64_t j = 0; j < n; j++)
             {
                 if(i == j || (i == j + 1) || (i == j - 1))
                     hA[0][i + j * lda] += 400;
@@ -143,9 +143,9 @@ void latrd_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
 
         // scale A to avoid singularities
-        for(rocblas_int i = 0; i < n; i++)
+        for(int64_t i = 0; i < n; i++)
         {
-            for(rocblas_int j = 0; j < n; j++)
+            for(int64_t j = 0; j < n; j++)
             {
                 if(i == j)
                     hA[0][i + j * lda] = hA[0][i + j * lda].real() + 400;
@@ -244,7 +244,7 @@ void latrd_getPerfData(const rocblas_handle handle,
     latrd_initData<true, false, T>(handle, n, dA, lda, hA);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         latrd_initData<false, true, T>(handle, n, dA, lda, hA);
 
@@ -267,7 +267,7 @@ void latrd_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         latrd_initData<false, true, T>(handle, n, dA, lda, hA);
 
@@ -308,10 +308,10 @@ void testing_latrd(Arguments& argus)
     }
 
     // determine sizes
-    size_t size_A = lda * n;
+    size_t size_A = size_t(lda) * n;
     size_t size_E = n;
     size_t size_tau = n;
-    size_t size_W = ldw * k;
+    size_t size_W = size_t(ldw) * k;
     double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
 
     size_t size_ARes = (argus.unit_check || argus.norm_check) ? size_A : 0;

--- a/clients/common/containers/rocblas_vector.hpp
+++ b/clients/common/containers/rocblas_vector.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -71,7 +71,7 @@ void rocblas_init_template(U& that, bool seedReset = false)
         auto n = that.n();
         if(inc < 0)
         {
-            batched_data -= (n - 1) * inc;
+            batched_data -= int64_t(n - 1) * inc;
         }
 
         for(int64_t i = 0; i < n; ++i)
@@ -102,7 +102,7 @@ void rocblas_init_nan_template(U& that, bool seedReset = false)
         auto n = that.n();
         if(inc < 0)
         {
-            batched_data -= (n - 1) * inc;
+            batched_data -= int64_t(n - 1) * inc;
         }
 
         for(int64_t i = 0; i < n; ++i)

--- a/clients/common/lapack/testing_gebd2_gebrd.hpp
+++ b/clients/common/lapack/testing_gebd2_gebrd.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -184,11 +184,11 @@ void gebd2_gebrd_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
 
         // scale A to avoid singularities
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < m; i++)
+            for(int64_t i = 0; i < m; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j || (m >= n && j == i + 1) || (m < n && i == j + 1))
                         hA[b][i + j * lda] += 400;
@@ -255,7 +255,7 @@ void gebd2_gebrd_getError(const rocblas_handle handle,
     else
     {
         // CPU lapack
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             memcpy(hARes[b], hA[b], lda * n * sizeof(T));
             GEBRD
@@ -268,7 +268,7 @@ void gebd2_gebrd_getError(const rocblas_handle handle,
     // reconstruct A from the factorization for implicit testing
     std::vector<T> vec(std::max(m, n));
     vec[0] = 1;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         T* a = hARes[b];
         T* tauq = hTauq[b];
@@ -276,7 +276,7 @@ void gebd2_gebrd_getError(const rocblas_handle handle,
 
         if(m >= n)
         {
-            for(int j = n - 1; j >= 0; j--)
+            for(int64_t j = n - 1; j >= 0; j--)
             {
                 if(j < n - 1)
                 {
@@ -285,7 +285,7 @@ void gebd2_gebrd_getError(const rocblas_handle handle,
                         cpu_lacgv(1, taup + j, 1);
                         cpu_lacgv(n - j - 1, a + j + (j + 1) * lda, lda);
                     }
-                    for(int i = 1; i < n - j - 1; i++)
+                    for(int64_t i = 1; i < n - j - 1; i++)
                     {
                         vec[i] = a[j + (j + i + 1) * lda];
                         a[j + (j + i + 1) * lda] = 0;
@@ -296,7 +296,7 @@ void gebd2_gebrd_getError(const rocblas_handle handle,
                         cpu_lacgv(1, taup + j, 1);
                 }
 
-                for(int i = 1; i < m - j; i++)
+                for(int64_t i = 1; i < m - j; i++)
                 {
                     vec[i] = a[(j + i) + j * lda];
                     a[(j + i) + j * lda] = 0;
@@ -307,11 +307,11 @@ void gebd2_gebrd_getError(const rocblas_handle handle,
         }
         else
         {
-            for(int j = m - 1; j >= 0; j--)
+            for(int64_t j = m - 1; j >= 0; j--)
             {
                 if(j < m - 1)
                 {
-                    for(int i = 1; i < m - j - 1; i++)
+                    for(int64_t i = 1; i < m - j - 1; i++)
                     {
                         vec[i] = a[(j + i + 1) + j * lda];
                         a[(j + i + 1) + j * lda] = 0;
@@ -325,7 +325,7 @@ void gebd2_gebrd_getError(const rocblas_handle handle,
                     cpu_lacgv(1, taup + j, 1);
                     cpu_lacgv(n - j, a + j + j * lda, lda);
                 }
-                for(int i = 1; i < n - j; i++)
+                for(int64_t i = 1; i < n - j; i++)
                 {
                     vec[i] = a[j + (j + i) * lda];
                     a[j + (j + i) * lda] = 0;
@@ -342,7 +342,7 @@ void gebd2_gebrd_getError(const rocblas_handle handle,
     // using frobenius norm
     double err;
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         err = norm_error('F', m, n, lda, hA[b], hARes[b]);
         *max_err = err > *max_err ? err : *max_err;
@@ -386,7 +386,7 @@ void gebd2_gebrd_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             GEBRD
             ? cpu_gebrd(m, n, hA[b], lda, hD[b], hE[b], hTauq[b], hTaup[b], hW.data(), std::max(m, n))
@@ -399,7 +399,7 @@ void gebd2_gebrd_getPerfData(const rocblas_handle handle,
                                          dTaup, stP, bc, hA, hD, hE, hTauq, hTaup);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         gebd2_gebrd_initData<false, true, T>(handle, m, n, dA, lda, stA, dD, stD, dE, stE, dTauq,
                                              stQ, dTaup, stP, bc, hA, hD, hE, hTauq, hTaup);
@@ -424,7 +424,7 @@ void gebd2_gebrd_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         gebd2_gebrd_initData<false, true, T>(handle, m, n, dA, lda, stA, dD, stD, dE, stE, dTauq,
                                              stQ, dTaup, stP, bc, hA, hD, hE, hTauq, hTaup);
@@ -447,7 +447,7 @@ void testing_gebd2_gebrd(Arguments& argus)
     rocblas_int m = argus.get<rocblas_int>("m");
     rocblas_int n = argus.get<rocblas_int>("n", m);
     rocblas_int lda = argus.get<rocblas_int>("lda", m);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stD = argus.get<rocblas_stride>("strideD", std::min(m, n));
     rocblas_stride stE = argus.get<rocblas_stride>("strideE", std::min(m, n) - 1);
     rocblas_stride stQ = argus.get<rocblas_stride>("strideQ", std::min(m, n));

--- a/clients/common/lapack/testing_geblttrf_npvt.hpp
+++ b/clients/common/lapack/testing_geblttrf_npvt.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -169,15 +169,15 @@ void geblttrf_npvt_initData(const rocblas_handle handle,
 
         rocblas_int n = nb * nblocks;
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             // scale to avoid singularities
             // leaving matrix as diagonal dominant so that pivoting is not required
-            for(rocblas_int i = 0; i < nb; i++)
+            for(int64_t i = 0; i < nb; i++)
             {
-                for(rocblas_int j = 0; j < nb; j++)
+                for(int64_t j = 0; j < nb; j++)
                 {
-                    for(rocblas_int k = 0; k < nblocks; k++)
+                    for(int64_t k = 0; k < nblocks; k++)
                     {
                         if(i == j)
                             hB[b][i + j * ldb + k * ldb * nb] += 400;
@@ -185,7 +185,7 @@ void geblttrf_npvt_initData(const rocblas_handle handle,
                             hB[b][i + j * ldb + k * ldb * nb] -= 4;
                     }
 
-                    for(rocblas_int k = 0; k < nblocks - 1; k++)
+                    for(int64_t k = 0; k < nblocks - 1; k++)
                     {
                         hA[b][i + j * lda + k * lda * nb] -= 4;
                         hC[b][i + j * ldc + k * ldc * nb] -= 4;
@@ -202,7 +202,7 @@ void geblttrf_npvt_initData(const rocblas_handle handle,
                 jj -= (jj / n) * n;
                 rocblas_int j = jj % nb;
                 rocblas_int k = jj / nb;
-                for(rocblas_int i = 0; i < nb; i++)
+                for(int64_t i = 0; i < nb; i++)
                 {
                     // zero the jj-th column
                     hB[b][i + j * ldb + k * ldb * nb] = 0;
@@ -216,7 +216,7 @@ void geblttrf_npvt_initData(const rocblas_handle handle,
                 jj -= (jj / n) * n;
                 j = jj % nb;
                 k = jj / nb;
-                for(rocblas_int i = 0; i < nb; i++)
+                for(int64_t i = 0; i < nb; i++)
                 {
                     // zero the jj-th column
                     hB[b][i + j * ldb + k * ldb * nb] = 0;
@@ -230,7 +230,7 @@ void geblttrf_npvt_initData(const rocblas_handle handle,
                 jj -= (jj / n) * n;
                 j = jj % nb;
                 k = jj / nb;
-                for(rocblas_int i = 0; i < nb; i++)
+                for(int64_t i = 0; i < nb; i++)
                 {
                     // zero the jj-th column
                     hB[b][i + j * ldb + k * ldb * nb] = 0;
@@ -299,7 +299,7 @@ void geblttrf_npvt_getError(const rocblas_handle handle,
     // check info for singularities
     double err = 0;
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(singular && (b == bc / 4 || b == bc / 2 || b == bc - 1))
         {
@@ -316,16 +316,16 @@ void geblttrf_npvt_getError(const rocblas_handle handle,
     }
     *max_err += err;
 
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(hInfoRes[b][0] == 0)
         {
             // compute diagonal blocks and store in full matrix L
-            for(rocblas_int k = 0; k < nblocks; k++)
+            for(int64_t k = 0; k < nblocks; k++)
             {
-                for(rocblas_int i = 0; i < nb; i++)
+                for(int64_t i = 0; i < nb; i++)
                 {
-                    for(rocblas_int j = 0; j < nb; j++)
+                    for(int64_t j = 0; j < nb; j++)
                     {
                         if(i <= j)
                             L[i + j * n + k * (n + 1) * nb] = hBRes[b][i + j * ldb + k * ldb * nb];
@@ -340,13 +340,13 @@ void geblttrf_npvt_getError(const rocblas_handle handle,
             }
 
             // move blocks A, updated C, and I into full matrices L and U
-            for(rocblas_int k = 0; k < nblocks; k++)
+            for(int64_t k = 0; k < nblocks; k++)
             {
-                for(rocblas_int i = 0; i < nb; i++)
+                for(int64_t i = 0; i < nb; i++)
                 {
                     if(k < nblocks - 1)
                     {
-                        for(rocblas_int j = 0; j < nb; j++)
+                        for(int64_t j = 0; j < nb; j++)
                         {
                             U[i + (j + nb) * n + k * (n + 1) * nb]
                                 = hCRes[b][i + j * ldc + k * ldc * nb];
@@ -364,11 +364,11 @@ void geblttrf_npvt_getError(const rocblas_handle handle,
                      U.data(), n, T(0), MRes.data(), n);
 
             // form original matrix from original blocks
-            for(rocblas_int k = 0; k < nblocks; k++)
+            for(int64_t k = 0; k < nblocks; k++)
             {
-                for(rocblas_int i = 0; i < nb; i++)
+                for(int64_t i = 0; i < nb; i++)
                 {
-                    for(rocblas_int j = 0; j < nb; j++)
+                    for(int64_t j = 0; j < nb; j++)
                     {
                         M[i + j * n + k * (n + 1) * nb] = hB[b][i + j * ldb + k * ldb * nb];
 
@@ -430,7 +430,7 @@ void geblttrf_npvt_getPerfData(const rocblas_handle handle,
                                            hB, hC, singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         geblttrf_npvt_initData<false, true, T>(handle, nb, nblocks, dA, lda, dB, ldb, dC, ldc, bc,
                                                hA, hB, hC, singular);
@@ -455,7 +455,7 @@ void geblttrf_npvt_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         geblttrf_npvt_initData<false, true, T>(handle, nb, nblocks, dA, lda, dB, ldb, dC, ldc, bc,
                                                hA, hB, hC, singular);

--- a/clients/common/lapack/testing_geblttrf_npvt_interleaved.hpp
+++ b/clients/common/lapack/testing_geblttrf_npvt_interleaved.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -168,7 +168,7 @@ void geblttrf_npvt_interleaved_initData(const rocblas_handle handle,
 
         rocblas_int n = nb * nblocks;
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             T* A = hA[0] + b * stA;
             T* B = hB[0] + b * stB;
@@ -176,11 +176,11 @@ void geblttrf_npvt_interleaved_initData(const rocblas_handle handle,
 
             // scale to avoid singularities
             // leaving matrix as diagonal dominant so that pivoting is not required
-            for(rocblas_int i = 0; i < nb; i++)
+            for(int64_t i = 0; i < nb; i++)
             {
-                for(rocblas_int j = 0; j < nb; j++)
+                for(int64_t j = 0; j < nb; j++)
                 {
-                    for(rocblas_int k = 0; k < nblocks; k++)
+                    for(int64_t k = 0; k < nblocks; k++)
                     {
                         if(i == j)
                             B[i * incb + j * ldb + k * ldb * nb] += 400;
@@ -188,7 +188,7 @@ void geblttrf_npvt_interleaved_initData(const rocblas_handle handle,
                             B[i * incb + j * ldb + k * ldb * nb] -= 4;
                     }
 
-                    for(rocblas_int k = 0; k < nblocks - 1; k++)
+                    for(int64_t k = 0; k < nblocks - 1; k++)
                     {
                         A[i * inca + j * lda + k * lda * nb] -= 4;
                         C[i * incc + j * ldc + k * ldc * nb] -= 4;
@@ -205,7 +205,7 @@ void geblttrf_npvt_interleaved_initData(const rocblas_handle handle,
                 jj -= (jj / n) * n;
                 rocblas_int j = jj % nb;
                 rocblas_int k = jj / nb;
-                for(rocblas_int i = 0; i < nb; i++)
+                for(int64_t i = 0; i < nb; i++)
                 {
                     // zero the jj-th column
                     B[i * incb + j * ldb + k * ldb * nb] = 0;
@@ -219,7 +219,7 @@ void geblttrf_npvt_interleaved_initData(const rocblas_handle handle,
                 jj -= (jj / n) * n;
                 j = jj % nb;
                 k = jj / nb;
-                for(rocblas_int i = 0; i < nb; i++)
+                for(int64_t i = 0; i < nb; i++)
                 {
                     // zero the jj-th column
                     B[i * incb + j * ldb + k * ldb * nb] = 0;
@@ -233,7 +233,7 @@ void geblttrf_npvt_interleaved_initData(const rocblas_handle handle,
                 jj -= (jj / n) * n;
                 j = jj % nb;
                 k = jj / nb;
-                for(rocblas_int i = 0; i < nb; i++)
+                for(int64_t i = 0; i < nb; i++)
                 {
                     // zero the jj-th column
                     B[i * incb + j * ldb + k * ldb * nb] = 0;
@@ -307,7 +307,7 @@ void geblttrf_npvt_interleaved_getError(const rocblas_handle handle,
     // check info for singularities
     double err = 0;
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(singular && (b == bc / 4 || b == bc / 2 || b == bc - 1))
         {
@@ -324,16 +324,16 @@ void geblttrf_npvt_interleaved_getError(const rocblas_handle handle,
     }
     *max_err += err;
 
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(hInfoRes[b][0] == 0)
         {
             // compute diagonal blocks and store in full matrix L
-            for(rocblas_int k = 0; k < nblocks; k++)
+            for(int64_t k = 0; k < nblocks; k++)
             {
-                for(rocblas_int i = 0; i < nb; i++)
+                for(int64_t i = 0; i < nb; i++)
                 {
-                    for(rocblas_int j = 0; j < nb; j++)
+                    for(int64_t j = 0; j < nb; j++)
                     {
                         Btmp[i + j * nb + k * nb * nb]
                             = hBRes[0][i * incb + j * ldb + k * ldb * nb + b * stB];
@@ -351,13 +351,13 @@ void geblttrf_npvt_interleaved_getError(const rocblas_handle handle,
             }
 
             // move blocks A, updated C, and I into full matrices L and U
-            for(rocblas_int k = 0; k < nblocks; k++)
+            for(int64_t k = 0; k < nblocks; k++)
             {
-                for(rocblas_int i = 0; i < nb; i++)
+                for(int64_t i = 0; i < nb; i++)
                 {
                     if(k < nblocks - 1)
                     {
-                        for(rocblas_int j = 0; j < nb; j++)
+                        for(int64_t j = 0; j < nb; j++)
                         {
                             U[i + (j + nb) * n + k * (n + 1) * nb]
                                 = hCRes[0][i * incc + j * ldc + k * ldc * nb + b * stC];
@@ -375,11 +375,11 @@ void geblttrf_npvt_interleaved_getError(const rocblas_handle handle,
                      U.data(), n, T(0), MRes.data(), n);
 
             // form original matrix from original blocks
-            for(rocblas_int k = 0; k < nblocks; k++)
+            for(int64_t k = 0; k < nblocks; k++)
             {
-                for(rocblas_int i = 0; i < nb; i++)
+                for(int64_t i = 0; i < nb; i++)
                 {
-                    for(rocblas_int j = 0; j < nb; j++)
+                    for(int64_t j = 0; j < nb; j++)
                     {
                         M[i + j * n + k * (n + 1) * nb]
                             = hB[0][i * incb + j * ldb + k * ldb * nb + b * stB];
@@ -446,7 +446,7 @@ void geblttrf_npvt_interleaved_getPerfData(const rocblas_handle handle,
                                                        hB, hC, singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         geblttrf_npvt_interleaved_initData<false, true, T>(handle, nb, nblocks, dA, inca, lda, stA,
                                                            dB, incb, ldb, stB, dC, incc, ldc, stC,
@@ -472,7 +472,7 @@ void geblttrf_npvt_interleaved_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         geblttrf_npvt_interleaved_initData<false, true, T>(handle, nb, nblocks, dA, inca, lda, stA,
                                                            dB, incb, ldb, stB, dC, incc, ldc, stC,
@@ -500,9 +500,9 @@ void testing_geblttrf_npvt_interleaved(Arguments& argus)
     rocblas_int lda = argus.get<rocblas_int>("lda", nb);
     rocblas_int ldb = argus.get<rocblas_int>("ldb", nb);
     rocblas_int ldc = argus.get<rocblas_int>("ldc", nb);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * nb * nblocks);
-    rocblas_stride stB = argus.get<rocblas_stride>("strideB", ldb * nb * nblocks);
-    rocblas_stride stC = argus.get<rocblas_stride>("strideC", ldc * nb * nblocks);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * nb * nblocks);
+    rocblas_stride stB = argus.get<rocblas_stride>("strideB", rocblas_stride(ldb) * nb * nblocks);
+    rocblas_stride stC = argus.get<rocblas_stride>("strideC", rocblas_stride(ldc) * nb * nblocks);
 
     rocblas_int bc = argus.batch_count;
     rocblas_int hot_calls = argus.iters;

--- a/clients/common/lapack/testing_geblttrs_npvt.hpp
+++ b/clients/common/lapack/testing_geblttrs_npvt.hpp
@@ -179,9 +179,9 @@ void geblttrs_npvt_initData(const rocblas_handle handle,
     {
         int info;
         int n = nb * nblocks;
-        std::vector<T> M(n * n);
-        std::vector<T> XX(n * nrhs);
-        std::vector<T> XB(n * nrhs);
+        std::vector<T> M(size_t(n) * n);
+        std::vector<T> XX(size_t(n) * nrhs);
+        std::vector<T> XB(size_t(n) * nrhs);
         std::vector<rocblas_int> ipiv(nb);
 
         // initialize blocks of the original matrix

--- a/clients/common/lapack/testing_geblttrs_npvt.hpp
+++ b/clients/common/lapack/testing_geblttrs_npvt.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -192,14 +192,14 @@ void geblttrs_npvt_initData(const rocblas_handle handle,
         // initialize solution vectors
         rocblas_init<T>(hX, false);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             // form original matrix M and scale to avoid singularities
-            for(rocblas_int k = 0; k < nblocks; k++)
+            for(int64_t k = 0; k < nblocks; k++)
             {
-                for(rocblas_int i = 0; i < nb; i++)
+                for(int64_t i = 0; i < nb; i++)
                 {
-                    for(rocblas_int j = 0; j < nb; j++)
+                    for(int64_t j = 0; j < nb; j++)
                     {
                         if(i == j)
                             M[i + j * n + k * (n + 1) * nb] = hB[b][i + j * ldb + k * ldb * nb] + 400;
@@ -218,9 +218,9 @@ void geblttrs_npvt_initData(const rocblas_handle handle,
             }
 
             // move blocks of X to full matrix XX
-            for(rocblas_int k = 0; k < nblocks; k++)
-                for(rocblas_int i = 0; i < nb; i++)
-                    for(rocblas_int j = 0; j < nrhs; j++)
+            for(int64_t k = 0; k < nblocks; k++)
+                for(int64_t i = 0; i < nb; i++)
+                    for(int64_t j = 0; j < nrhs; j++)
                         XX[i + j * n + k * nb] = hX[b][i + j * ldx + k * ldx * nrhs];
 
             // generate the full matrix of right-hand-side vectors XB by computing M * XX
@@ -228,14 +228,14 @@ void geblttrs_npvt_initData(const rocblas_handle handle,
                      XX.data(), n, T(0), XB.data(), n);
 
             // move XB to block format in hRHS
-            for(rocblas_int k = 0; k < nblocks; k++)
-                for(rocblas_int i = 0; i < nb; i++)
-                    for(rocblas_int j = 0; j < nrhs; j++)
+            for(int64_t k = 0; k < nblocks; k++)
+                for(int64_t i = 0; i < nb; i++)
+                    for(int64_t j = 0; j < nrhs; j++)
                         hRHS[b][i + j * ldx + k * ldx * nrhs] = XB[i + j * n + k * nb];
 
             // factorize M
             cpu_getrf(nb, nb, M.data(), n, ipiv.data(), &info);
-            for(rocblas_int k = 0; k < nblocks - 1; k++)
+            for(int64_t k = 0; k < nblocks - 1; k++)
             {
                 cpu_getrs(rocblas_operation_none, nb, nb, M.data() + k * (n + 1) * nb, n,
                           ipiv.data(), M.data() + nb * n + k * (n + 1) * nb, n);
@@ -248,11 +248,11 @@ void geblttrs_npvt_initData(const rocblas_handle handle,
             }
 
             // move factorized blocks from M into hA, hB, and hC
-            for(rocblas_int k = 0; k < nblocks; k++)
+            for(int64_t k = 0; k < nblocks; k++)
             {
-                for(rocblas_int i = 0; i < nb; i++)
+                for(int64_t i = 0; i < nb; i++)
                 {
-                    for(rocblas_int j = 0; j < nb; j++)
+                    for(int64_t j = 0; j < nb; j++)
                     {
                         hB[b][i + j * ldb + k * ldb * nb] = M[i + j * n + k * (n + 1) * nb];
 
@@ -322,7 +322,7 @@ void geblttrs_npvt_getError(const rocblas_handle handle,
     // (THIS DOES NOT ACCOUNT FOR NUMERICAL REPRODUCIBILITY ISSUES.
     // IT MIGHT BE REVISITED IN THE FUTURE)
     // using frobenius norm
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         err = norm_error('F', nb, nrhs * nblocks, ldx, hX[b], hXRes[b]);
         *max_err = err > *max_err ? err : *max_err;
@@ -370,7 +370,7 @@ void geblttrs_npvt_getPerfData(const rocblas_handle handle,
                                            ldx, bc, hA, hB, hC, hX, hXRes);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         geblttrs_npvt_initData<false, true, T>(handle, nb, nblocks, nrhs, dA, lda, dB, ldb, dC, ldc,
                                                dX, ldx, bc, hA, hB, hC, hX, hXRes);
@@ -395,7 +395,7 @@ void geblttrs_npvt_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         geblttrs_npvt_initData<false, true, T>(handle, nb, nblocks, nrhs, dA, lda, dB, ldb, dC, ldc,
                                                dX, ldx, bc, hA, hB, hC, hX, hXRes);
@@ -420,10 +420,10 @@ void testing_geblttrs_npvt(Arguments& argus)
     rocblas_int ldb = argus.get<rocblas_int>("ldb", nb);
     rocblas_int ldc = argus.get<rocblas_int>("ldc", nb);
     rocblas_int ldx = argus.get<rocblas_int>("ldx", nb);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * nb * nblocks);
-    rocblas_stride stB = argus.get<rocblas_stride>("strideB", ldb * nb * nblocks);
-    rocblas_stride stC = argus.get<rocblas_stride>("strideC", ldc * nb * nblocks);
-    rocblas_stride stX = argus.get<rocblas_stride>("strideX", ldx * nrhs * nblocks);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * nb * nblocks);
+    rocblas_stride stB = argus.get<rocblas_stride>("strideB", rocblas_stride(ldb) * nb * nblocks);
+    rocblas_stride stC = argus.get<rocblas_stride>("strideC", rocblas_stride(ldc) * nb * nblocks);
+    rocblas_stride stX = argus.get<rocblas_stride>("strideX", rocblas_stride(ldx) * nrhs * nblocks);
 
     rocblas_int bc = argus.batch_count;
     rocblas_int hot_calls = argus.iters;

--- a/clients/common/lapack/testing_geblttrs_npvt_interleaved.hpp
+++ b/clients/common/lapack/testing_geblttrs_npvt_interleaved.hpp
@@ -184,9 +184,9 @@ void geblttrs_npvt_interleaved_initData(const rocblas_handle handle,
     {
         int info;
         int n = nb * nblocks;
-        std::vector<T> M(n * n);
-        std::vector<T> XX(n * nrhs);
-        std::vector<T> XB(n * nrhs);
+        std::vector<T> M(size_t(n) * n);
+        std::vector<T> XX(size_t(n) * nrhs);
+        std::vector<T> XB(size_t(n) * nrhs);
         std::vector<rocblas_int> ipiv(nb);
 
         // initialize blocks of the original matrix

--- a/clients/common/lapack/testing_geblttrs_npvt_interleaved.hpp
+++ b/clients/common/lapack/testing_geblttrs_npvt_interleaved.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -197,7 +197,7 @@ void geblttrs_npvt_interleaved_initData(const rocblas_handle handle,
         // initialize solution vectors
         rocblas_init<T>(hX, false);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             T* A = hA[0] + b * stA;
             T* B = hB[0] + b * stB;
@@ -206,11 +206,11 @@ void geblttrs_npvt_interleaved_initData(const rocblas_handle handle,
             T* RHS = hRHS[0] + b * stX;
 
             // form original matrix M and scale to avoid singularities
-            for(rocblas_int k = 0; k < nblocks; k++)
+            for(int64_t k = 0; k < nblocks; k++)
             {
-                for(rocblas_int i = 0; i < nb; i++)
+                for(int64_t i = 0; i < nb; i++)
                 {
-                    for(rocblas_int j = 0; j < nb; j++)
+                    for(int64_t j = 0; j < nb; j++)
                     {
                         if(i == j)
                             M[i + j * n + k * (n + 1) * nb]
@@ -231,9 +231,9 @@ void geblttrs_npvt_interleaved_initData(const rocblas_handle handle,
             }
 
             // move blocks of X to full matrix XX
-            for(rocblas_int k = 0; k < nblocks; k++)
-                for(rocblas_int i = 0; i < nb; i++)
-                    for(rocblas_int j = 0; j < nrhs; j++)
+            for(int64_t k = 0; k < nblocks; k++)
+                for(int64_t i = 0; i < nb; i++)
+                    for(int64_t j = 0; j < nrhs; j++)
                         XX[i + j * n + k * nb] = X[i * incx + j * ldx + k * ldx * nrhs];
 
             // generate the full matrix of right-hand-side vectors XB by computing M * XX
@@ -241,14 +241,14 @@ void geblttrs_npvt_interleaved_initData(const rocblas_handle handle,
                      XX.data(), n, T(0), XB.data(), n);
 
             // move XB to block format in hRHS
-            for(rocblas_int k = 0; k < nblocks; k++)
-                for(rocblas_int i = 0; i < nb; i++)
-                    for(rocblas_int j = 0; j < nrhs; j++)
+            for(int64_t k = 0; k < nblocks; k++)
+                for(int64_t i = 0; i < nb; i++)
+                    for(int64_t j = 0; j < nrhs; j++)
                         RHS[i * incx + j * ldx + k * ldx * nrhs] = XB[i + j * n + k * nb];
 
             // factorize M
             cpu_getrf(nb, nb, M.data(), n, ipiv.data(), &info);
-            for(rocblas_int k = 0; k < nblocks - 1; k++)
+            for(int64_t k = 0; k < nblocks - 1; k++)
             {
                 cpu_getrs(rocblas_operation_none, nb, nb, M.data() + k * (n + 1) * nb, n,
                           ipiv.data(), M.data() + nb * n + k * (n + 1) * nb, n);
@@ -261,11 +261,11 @@ void geblttrs_npvt_interleaved_initData(const rocblas_handle handle,
             }
 
             // move factorized blocks from M into hA, hB, and hC
-            for(rocblas_int k = 0; k < nblocks; k++)
+            for(int64_t k = 0; k < nblocks; k++)
             {
-                for(rocblas_int i = 0; i < nb; i++)
+                for(int64_t i = 0; i < nb; i++)
                 {
-                    for(rocblas_int j = 0; j < nb; j++)
+                    for(int64_t j = 0; j < nb; j++)
                     {
                         B[i * incb + j * ldb + k * ldb * nb] = M[i + j * n + k * (n + 1) * nb];
 
@@ -343,14 +343,14 @@ void geblttrs_npvt_interleaved_getError(const rocblas_handle handle,
     // (THIS DOES NOT ACCOUNT FOR NUMERICAL REPRODUCIBILITY ISSUES.
     // IT MIGHT BE REVISITED IN THE FUTURE)
     // using frobenius norm
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         // put X and XRes into Xtmp and XtmpRes in column-major format
-        for(rocblas_int k = 0; k < nblocks; k++)
+        for(int64_t k = 0; k < nblocks; k++)
         {
-            for(rocblas_int i = 0; i < nb; i++)
+            for(int64_t i = 0; i < nb; i++)
             {
-                for(rocblas_int j = 0; j < nrhs; j++)
+                for(int64_t j = 0; j < nrhs; j++)
                 {
                     Xtmp[i + j * nb + k * nb * nrhs]
                         = hX[0][i * incx + j * ldx + k * ldx * nrhs + b * stX];
@@ -411,7 +411,7 @@ void geblttrs_npvt_interleaved_getPerfData(const rocblas_handle handle,
                                                        incx, ldx, stX, bc, hA, hB, hC, hX, hXRes);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         geblttrs_npvt_interleaved_initData<false, true, T>(
             handle, nb, nblocks, nrhs, dA, inca, lda, stA, dB, incb, ldb, stB, dC, incc, ldc, stC,
@@ -437,7 +437,7 @@ void geblttrs_npvt_interleaved_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         geblttrs_npvt_interleaved_initData<false, true, T>(
             handle, nb, nblocks, nrhs, dA, inca, lda, stA, dB, incb, ldb, stB, dC, incc, ldc, stC,
@@ -468,10 +468,10 @@ void testing_geblttrs_npvt_interleaved(Arguments& argus)
     rocblas_int ldb = argus.get<rocblas_int>("ldb", nb);
     rocblas_int ldc = argus.get<rocblas_int>("ldc", nb);
     rocblas_int ldx = argus.get<rocblas_int>("ldx", nb);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * nb * nblocks);
-    rocblas_stride stB = argus.get<rocblas_stride>("strideB", ldb * nb * nblocks);
-    rocblas_stride stC = argus.get<rocblas_stride>("strideC", ldc * nb * nblocks);
-    rocblas_stride stX = argus.get<rocblas_stride>("strideX", ldx * nrhs * nblocks);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * nb * nblocks);
+    rocblas_stride stB = argus.get<rocblas_stride>("strideB", rocblas_stride(ldb) * nb * nblocks);
+    rocblas_stride stC = argus.get<rocblas_stride>("strideC", rocblas_stride(ldc) * nb * nblocks);
+    rocblas_stride stX = argus.get<rocblas_stride>("strideX", rocblas_stride(ldx) * nrhs * nblocks);
 
     rocblas_int bc = argus.batch_count;
     rocblas_int hot_calls = argus.iters;

--- a/clients/common/lapack/testing_gelq2_gelqf.hpp
+++ b/clients/common/lapack/testing_gelq2_gelqf.hpp
@@ -289,7 +289,7 @@ void testing_gelq2_gelqf(Arguments& argus)
     rocblas_int n = argus.get<rocblas_int>("n", m);
     rocblas_int lda = argus.get<rocblas_int>("lda", m);
     rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
-    rocblas_stride stP = argus.get<rocblas_stride>("strideP", min(m, n));
+    rocblas_stride stP = argus.get<rocblas_stride>("strideP", std::min(m, n));
 
     rocblas_int bc = argus.batch_count;
     rocblas_int hot_calls = argus.iters;
@@ -301,7 +301,7 @@ void testing_gelq2_gelqf(Arguments& argus)
 
     // determine sizes
     size_t size_A = size_t(lda) * n;
-    size_t size_P = size_t(min(m, n));
+    size_t size_P = size_t(std::min(m, n));
     double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
 
     size_t size_ARes = (argus.unit_check || argus.norm_check) ? size_A : 0;

--- a/clients/common/lapack/testing_gelq2_gelqf.hpp
+++ b/clients/common/lapack/testing_gelq2_gelqf.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -139,11 +139,11 @@ void gelq2_gelqf_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
 
         // scale A to avoid singularities
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < m; i++)
+            for(int64_t i = 0; i < m; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] += 400;
@@ -188,7 +188,7 @@ void gelq2_gelqf_getError(const rocblas_handle handle,
     CHECK_HIP_ERROR(hARes.transfer_from(dA));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         GELQF ? cpu_gelqf(m, n, hA[b], lda, hIpiv[b], hW.data(), m)
               : cpu_gelq2(m, n, hA[b], lda, hIpiv[b], hW.data());
@@ -200,7 +200,7 @@ void gelq2_gelqf_getError(const rocblas_handle handle,
     // using frobenius norm
     double err;
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         err = norm_error('F', m, n, lda, hA[b], hARes[b]);
         *max_err = err > *max_err ? err : *max_err;
@@ -234,7 +234,7 @@ void gelq2_gelqf_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             GELQF ? cpu_gelqf(m, n, hA[b], lda, hIpiv[b], hW.data(), m)
                   : cpu_gelq2(m, n, hA[b], lda, hIpiv[b], hW.data());
@@ -245,7 +245,7 @@ void gelq2_gelqf_getPerfData(const rocblas_handle handle,
     gelq2_gelqf_initData<true, false, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         gelq2_gelqf_initData<false, true, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
 
@@ -268,7 +268,7 @@ void gelq2_gelqf_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         gelq2_gelqf_initData<false, true, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
 
@@ -288,7 +288,7 @@ void testing_gelq2_gelqf(Arguments& argus)
     rocblas_int m = argus.get<rocblas_int>("m");
     rocblas_int n = argus.get<rocblas_int>("n", m);
     rocblas_int lda = argus.get<rocblas_int>("lda", m);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stP = argus.get<rocblas_stride>("strideP", min(m, n));
 
     rocblas_int bc = argus.batch_count;

--- a/clients/common/lapack/testing_gels.hpp
+++ b/clients/common/lapack/testing_gels.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -185,11 +185,11 @@ void gels_initData(const rocblas_handle handle,
         std::bernoulli_distribution coinflip(0.5);
 
         // scale A to avoid singularities
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < m; i++)
+            for(int64_t i = 0; i < m; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] += 400;
@@ -207,15 +207,15 @@ void gels_initData(const rocblas_handle handle,
                     if(n <= m)
                     {
                         // zero random col
-                        rocblas_int j = sample_index(rocblas_rng);
-                        for(rocblas_int i = 0; i < m; i++)
+                        int64_t j = sample_index(rocblas_rng);
+                        for(int64_t i = 0; i < m; i++)
                             hA[b][i + j * lda] = 0;
                     }
                     else
                     {
                         // zero random row
-                        rocblas_int i = sample_index(rocblas_rng);
-                        for(rocblas_int j = 0; j < n; j++)
+                        int64_t i = sample_index(rocblas_rng);
+                        for(int64_t j = 0; j < n; j++)
                             hA[b][i + j * lda] = 0;
                     }
                 } while(coinflip(rocblas_rng));
@@ -268,7 +268,7 @@ void gels_getError(const rocblas_handle handle,
     CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         cpu_gels(trans, m, n, nrhs, hA[b], lda, hB[b], ldb, hW.data(), sizeW, hInfo[b]);
     }
@@ -279,7 +279,7 @@ void gels_getError(const rocblas_handle handle,
     // using vector-induced infinity norm
     double err;
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         err = norm_error('I', std::max(m, n), nrhs, ldb, hB[b], hBRes[b]);
         *max_err = err > *max_err ? err : *max_err;
@@ -287,7 +287,7 @@ void gels_getError(const rocblas_handle handle,
 
     // also check info for singularities
     err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
@@ -330,7 +330,7 @@ void gels_getPerfData(const rocblas_handle handle,
                                       bc, hA, hB, hInfo, singular);
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             cpu_gels(trans, m, n, nrhs, hA[b], lda, hB[b], ldb, hW.data(), sizeW, hInfo[b]);
         }
@@ -339,7 +339,7 @@ void gels_getPerfData(const rocblas_handle handle,
     gels_initData<true, false, T>(handle, trans, m, n, nrhs, dA, lda, stA, dB, ldb, stB, dInfo, bc,
                                   hA, hB, hInfo, singular);
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         gels_initData<false, true, T>(handle, trans, m, n, nrhs, dA, lda, stA, dB, ldb, stB, dInfo,
                                       bc, hA, hB, hInfo, singular);
@@ -362,7 +362,7 @@ void gels_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         gels_initData<false, true, T>(handle, trans, m, n, nrhs, dA, lda, stA, dB, ldb, stB, dInfo,
                                       bc, hA, hB, hInfo, singular);
@@ -386,8 +386,8 @@ void testing_gels(Arguments& argus)
     rocblas_int nrhs = argus.get<rocblas_int>("nrhs", n);
     rocblas_int lda = argus.get<rocblas_int>("lda", m);
     rocblas_int ldb = argus.get<rocblas_int>("ldb", std::max(m, n));
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
-    rocblas_stride stB = argus.get<rocblas_stride>("strideB", ldb * nrhs);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
+    rocblas_stride stB = argus.get<rocblas_stride>("strideB", rocblas_stride(ldb) * nrhs);
 
     rocblas_operation trans = char2rocblas_operation(transC);
     rocblas_int bc = argus.batch_count;

--- a/clients/common/lapack/testing_gels_outofplace.hpp
+++ b/clients/common/lapack/testing_gels_outofplace.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -205,12 +205,12 @@ void gels_outofplace_initData(const rocblas_handle handle,
         const rocblas_int rowsB = (trans == rocblas_operation_none) ? m : n;
         const rocblas_int ldx = std::max(m, n);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             // scale A to avoid singularities
-            for(rocblas_int i = 0; i < m; i++)
+            for(int64_t i = 0; i < m; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] += 400;
@@ -220,8 +220,8 @@ void gels_outofplace_initData(const rocblas_handle handle,
             }
 
             // populate hX with values from hB
-            for(rocblas_int i = 0; i < rowsB; i++)
-                for(rocblas_int j = 0; j < nrhs; j++)
+            for(int64_t i = 0; i < rowsB; i++)
+                for(int64_t j = 0; j < nrhs; j++)
                     hX[b][i + j * ldx] = hB[b][i + j * ldb];
 
             // add some singularities
@@ -234,14 +234,14 @@ void gels_outofplace_initData(const rocblas_handle handle,
                     {
                         // zero random col
                         rocblas_int j = sample_index(rocblas_rng);
-                        for(rocblas_int i = 0; i < m; i++)
+                        for(int64_t i = 0; i < m; i++)
                             hA[b][i + j * lda] = 0;
                     }
                     else
                     {
                         // zero random row
                         rocblas_int i = sample_index(rocblas_rng);
-                        for(rocblas_int j = 0; j < n; j++)
+                        for(int64_t j = 0; j < n; j++)
                             hA[b][i + j * lda] = 0;
                     }
                 } while(coinflip(rocblas_rng));
@@ -301,7 +301,7 @@ void gels_outofplace_getError(const rocblas_handle handle,
     CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         cpu_gels(trans, m, n, nrhs, hA[b], lda, hX[b], std::max(m, n), hW.data(), sizeW, hInfo[b]);
     }
@@ -312,7 +312,7 @@ void gels_outofplace_getError(const rocblas_handle handle,
     // using vector-induced infinity norm
     double err;
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         const rocblas_int rowsB = (trans == rocblas_operation_none) ? m : n;
         err = norm_error('F', rowsB, nrhs, ldb, hB[b], hBRes[b]);
@@ -328,7 +328,7 @@ void gels_outofplace_getError(const rocblas_handle handle,
 
     // also check info for singularities
     err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
@@ -376,7 +376,7 @@ void gels_outofplace_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             cpu_gels(trans, m, n, nrhs, hA[b], lda, hX[b], std::max(m, n), hW.data(), sizeW,
                      hInfo[b]);
@@ -388,7 +388,7 @@ void gels_outofplace_getPerfData(const rocblas_handle handle,
                                              dInfo, bc, hA, hB, hX, hInfo, singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         gels_outofplace_initData<false, true, T>(handle, trans, m, n, nrhs, dA, lda, stA, dB, ldb,
                                                  stB, dInfo, bc, hA, hB, hX, hInfo, singular);
@@ -413,7 +413,7 @@ void gels_outofplace_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         gels_outofplace_initData<false, true, T>(handle, trans, m, n, nrhs, dA, lda, stA, dB, ldb,
                                                  stB, dInfo, bc, hA, hB, hX, hInfo, singular);
@@ -438,9 +438,9 @@ void testing_gels_outofplace(Arguments& argus)
     rocblas_int lda = argus.get<rocblas_int>("lda", m);
     rocblas_int ldb = argus.get<rocblas_int>("ldb", transC == 'N' ? m : n);
     rocblas_int ldx = argus.get<rocblas_int>("ldx", transC == 'N' ? n : m);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
-    rocblas_stride stB = argus.get<rocblas_stride>("strideB", ldb * nrhs);
-    rocblas_stride stX = argus.get<rocblas_stride>("strideX", ldx * nrhs);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
+    rocblas_stride stB = argus.get<rocblas_stride>("strideB", rocblas_stride(ldb) * nrhs);
+    rocblas_stride stX = argus.get<rocblas_stride>("strideX", rocblas_stride(ldx) * nrhs);
 
     rocblas_operation trans = char2rocblas_operation(transC);
     rocblas_int bc = argus.batch_count;

--- a/clients/common/lapack/testing_geql2_geqlf.hpp
+++ b/clients/common/lapack/testing_geql2_geqlf.hpp
@@ -289,7 +289,7 @@ void testing_geql2_geqlf(Arguments& argus)
     rocblas_int n = argus.get<rocblas_int>("n", m);
     rocblas_int lda = argus.get<rocblas_int>("lda", m);
     rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
-    rocblas_stride stP = argus.get<rocblas_stride>("strideP", min(m, n));
+    rocblas_stride stP = argus.get<rocblas_stride>("strideP", std::min(m, n));
 
     rocblas_int bc = argus.batch_count;
     rocblas_int hot_calls = argus.iters;
@@ -301,7 +301,7 @@ void testing_geql2_geqlf(Arguments& argus)
 
     // determine sizes
     size_t size_A = size_t(lda) * n;
-    size_t size_P = size_t(min(m, n));
+    size_t size_P = size_t(std::min(m, n));
     double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
 
     size_t size_ARes = (argus.unit_check || argus.norm_check) ? size_A : 0;

--- a/clients/common/lapack/testing_geql2_geqlf.hpp
+++ b/clients/common/lapack/testing_geql2_geqlf.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -139,11 +139,11 @@ void geql2_geqlf_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
 
         // scale A to avoid singularities
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < m; i++)
+            for(int64_t i = 0; i < m; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(m - i == n - j)
                         hA[b][i + j * lda] += 400;
@@ -188,7 +188,7 @@ void geql2_geqlf_getError(const rocblas_handle handle,
     CHECK_HIP_ERROR(hARes.transfer_from(dA));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         GEQLF ? cpu_geqlf(m, n, hA[b], lda, hIpiv[b], hW.data(), n)
               : cpu_geql2(m, n, hA[b], lda, hIpiv[b], hW.data());
@@ -200,7 +200,7 @@ void geql2_geqlf_getError(const rocblas_handle handle,
     // using frobenius norm
     double err;
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         err = norm_error('F', m, n, lda, hA[b], hARes[b]);
         *max_err = err > *max_err ? err : *max_err;
@@ -234,7 +234,7 @@ void geql2_geqlf_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             GEQLF ? cpu_geqlf(m, n, hA[b], lda, hIpiv[b], hW.data(), n)
                   : cpu_geql2(m, n, hA[b], lda, hIpiv[b], hW.data());
@@ -245,7 +245,7 @@ void geql2_geqlf_getPerfData(const rocblas_handle handle,
     geql2_geqlf_initData<true, false, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         geql2_geqlf_initData<false, true, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
 
@@ -268,7 +268,7 @@ void geql2_geqlf_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         geql2_geqlf_initData<false, true, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
 
@@ -288,7 +288,7 @@ void testing_geql2_geqlf(Arguments& argus)
     rocblas_int m = argus.get<rocblas_int>("m");
     rocblas_int n = argus.get<rocblas_int>("n", m);
     rocblas_int lda = argus.get<rocblas_int>("lda", m);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stP = argus.get<rocblas_stride>("strideP", min(m, n));
 
     rocblas_int bc = argus.batch_count;

--- a/clients/common/lapack/testing_geqr2_geqrf.hpp
+++ b/clients/common/lapack/testing_geqr2_geqrf.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -139,11 +139,11 @@ void geqr2_geqrf_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
 
         // scale A to avoid singularities
-        for(I b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(I i = 0; i < m; i++)
+            for(int64_t i = 0; i < m; i++)
             {
-                for(I j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] += 400;
@@ -188,7 +188,7 @@ void geqr2_geqrf_getError(const rocblas_handle handle,
     CHECK_HIP_ERROR(hARes.transfer_from(dA));
 
     // CPU lapack
-    for(I b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         GEQRF ? cpu_geqrf(m, n, hA[b], lda, hIpiv[b], hW.data(), n)
               : cpu_geqr2(m, n, hA[b], lda, hIpiv[b], hW.data());
@@ -200,7 +200,7 @@ void geqr2_geqrf_getError(const rocblas_handle handle,
     // using frobenius norm
     double err;
     *max_err = 0;
-    for(I b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         err = norm_error('F', m, n, lda, hA[b], hARes[b]);
         *max_err = err > *max_err ? err : *max_err;
@@ -234,7 +234,7 @@ void geqr2_geqrf_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(I b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             GEQRF ? cpu_geqrf(m, n, hA[b], lda, hIpiv[b], hW.data(), n)
                   : cpu_geqr2(m, n, hA[b], lda, hIpiv[b], hW.data());
@@ -245,7 +245,7 @@ void geqr2_geqrf_getPerfData(const rocblas_handle handle,
     geqr2_geqrf_initData<true, false, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         geqr2_geqrf_initData<false, true, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
 
@@ -268,7 +268,7 @@ void geqr2_geqrf_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         geqr2_geqrf_initData<false, true, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
 
@@ -288,7 +288,7 @@ void testing_geqr2_geqrf(Arguments& argus)
     I m = argus.get<I>("m");
     I n = argus.get<I>("n", m);
     I lda = argus.get<I>("lda", m);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stP = argus.get<rocblas_stride>("strideP", min(m, n));
 
     I bc = argus.batch_count;

--- a/clients/common/lapack/testing_geqr2_geqrf.hpp
+++ b/clients/common/lapack/testing_geqr2_geqrf.hpp
@@ -289,7 +289,7 @@ void testing_geqr2_geqrf(Arguments& argus)
     I n = argus.get<I>("n", m);
     I lda = argus.get<I>("lda", m);
     rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
-    rocblas_stride stP = argus.get<rocblas_stride>("strideP", min(m, n));
+    rocblas_stride stP = argus.get<rocblas_stride>("strideP", std::min(m, n));
 
     I bc = argus.batch_count;
     rocblas_int hot_calls = argus.iters;
@@ -301,7 +301,7 @@ void testing_geqr2_geqrf(Arguments& argus)
 
     // determine sizes
     size_t size_A = size_t(lda) * n;
-    size_t size_P = size_t(min(m, n));
+    size_t size_P = size_t(std::min(m, n));
     double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
 
     size_t size_ARes = (argus.unit_check || argus.norm_check) ? size_A : 0;

--- a/clients/common/lapack/testing_gerq2_gerqf.hpp
+++ b/clients/common/lapack/testing_gerq2_gerqf.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -139,11 +139,11 @@ void gerq2_gerqf_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
 
         // scale A to avoid singularities
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < m; i++)
+            for(int64_t i = 0; i < m; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] += 400;
@@ -188,7 +188,7 @@ void gerq2_gerqf_getError(const rocblas_handle handle,
     CHECK_HIP_ERROR(hARes.transfer_from(dA));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         GERQF ? cpu_gerqf(m, n, hA[b], lda, hIpiv[b], hW.data(), m)
               : cpu_gerq2(m, n, hA[b], lda, hIpiv[b], hW.data());
@@ -200,7 +200,7 @@ void gerq2_gerqf_getError(const rocblas_handle handle,
     // using frobenius norm
     double err;
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         err = norm_error('F', m, n, lda, hA[b], hARes[b]);
         *max_err = err > *max_err ? err : *max_err;
@@ -234,7 +234,7 @@ void gerq2_gerqf_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             GERQF ? cpu_gerqf(m, n, hA[b], lda, hIpiv[b], hW.data(), m)
                   : cpu_gerq2(m, n, hA[b], lda, hIpiv[b], hW.data());
@@ -245,7 +245,7 @@ void gerq2_gerqf_getPerfData(const rocblas_handle handle,
     gerq2_gerqf_initData<true, false, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         gerq2_gerqf_initData<false, true, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
 
@@ -268,7 +268,7 @@ void gerq2_gerqf_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         gerq2_gerqf_initData<false, true, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
 
@@ -288,7 +288,7 @@ void testing_gerq2_gerqf(Arguments& argus)
     rocblas_int m = argus.get<rocblas_int>("m");
     rocblas_int n = argus.get<rocblas_int>("n", m);
     rocblas_int lda = argus.get<rocblas_int>("lda", m);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stP = argus.get<rocblas_stride>("strideP", min(m, n));
 
     rocblas_int bc = argus.batch_count;

--- a/clients/common/lapack/testing_gerq2_gerqf.hpp
+++ b/clients/common/lapack/testing_gerq2_gerqf.hpp
@@ -289,7 +289,7 @@ void testing_gerq2_gerqf(Arguments& argus)
     rocblas_int n = argus.get<rocblas_int>("n", m);
     rocblas_int lda = argus.get<rocblas_int>("lda", m);
     rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
-    rocblas_stride stP = argus.get<rocblas_stride>("strideP", min(m, n));
+    rocblas_stride stP = argus.get<rocblas_stride>("strideP", std::min(m, n));
 
     rocblas_int bc = argus.batch_count;
     rocblas_int hot_calls = argus.iters;
@@ -301,7 +301,7 @@ void testing_gerq2_gerqf(Arguments& argus)
 
     // determine sizes
     size_t size_A = size_t(lda) * n;
-    size_t size_P = size_t(min(m, n));
+    size_t size_P = size_t(std::min(m, n));
     double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
 
     size_t size_ARes = (argus.unit_check || argus.norm_check) ? size_A : 0;

--- a/clients/common/lapack/testing_gesdd.hpp
+++ b/clients/common/lapack/testing_gesdd.hpp
@@ -190,14 +190,14 @@ void gesdd_initData(const rocblas_handle handle,
     {
         rocblas_init<T>(hA, true);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             if(!singular)
             {
                 // scale A to avoid singularities
-                for(rocblas_int i = 0; i < m; i++)
+                for(int64_t i = 0; i < m; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                     {
                         if(i == j)
                             hA[b][i + j * lda] += 400;
@@ -209,9 +209,9 @@ void gesdd_initData(const rocblas_handle handle,
             else
             {
                 // form a singular matrix consisting of all ones
-                for(rocblas_int i = 0; i < m; i++)
+                for(int64_t i = 0; i < m; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                     {
                         hA[b][i + j * lda] = 1;
                     }
@@ -221,9 +221,9 @@ void gesdd_initData(const rocblas_handle handle,
             // make copy of original data to test vectors if required
             if(test && (left_svect != rocblas_svect_none || right_svect != rocblas_svect_none))
             {
-                for(rocblas_int i = 0; i < m; i++)
+                for(int64_t i = 0; i < m; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                         A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
                 }
             }
@@ -333,7 +333,7 @@ void gesdd_getError(const rocblas_handle handle,
     const bool no_singular_vectors
         = (left_svect == rocblas_svect_none) && (right_svect == rocblas_svect_none);
 
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         // We expect gesdd to converge for all input matrices
         EXPECT_EQ(hinfoRes[b][0], 0) << "where b = " << b;
@@ -464,7 +464,7 @@ void gesdd_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
             cpu_gesvd(left_svect, right_svect, m, n, hA[b], lda, hS[b], hU[b], ldu, hV[b], ldv,
                       work.data(), lwork, rwork.data(), hinfo[b]);
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
@@ -473,7 +473,7 @@ void gesdd_getPerfData(const rocblas_handle handle,
     gesdd_initData<true, false, T>(handle, left_svect, right_svect, m, n, dA, lda, bc, hA, A, 0);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         gesdd_initData<false, true, T>(handle, left_svect, right_svect, m, n, dA, lda, bc, hA, A, 0);
 
@@ -497,7 +497,7 @@ void gesdd_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         gesdd_initData<false, true, T>(handle, left_svect, right_svect, m, n, dA, lda, bc, hA, A, 0);
 
@@ -523,11 +523,11 @@ void testing_gesdd(Arguments& argus)
     rocblas_int lda = argus.get<rocblas_int>("lda", m);
     rocblas_int ldu = argus.get<rocblas_int>("ldu", m);
     rocblas_int ldv = argus.get<rocblas_int>("ldv", (rightvC == 'A' ? n : std::min(m, n)));
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stS = argus.get<rocblas_stride>("strideS", std::min(m, n));
-    rocblas_stride stU
-        = argus.get<rocblas_stride>("strideU", (leftvC == 'A' ? ldu * m : ldu * std::min(m, n)));
-    rocblas_stride stV = argus.get<rocblas_stride>("strideV", ldv * n);
+    rocblas_stride stU = argus.get<rocblas_stride>(
+        "strideU", (leftvC == 'A' ? rocblas_stride(ldu) * m : rocblas_stride(ldu) * std::min(m, n)));
+    rocblas_stride stV = argus.get<rocblas_stride>("strideV", rocblas_stride(ldv) * n);
 
     rocblas_svect leftv = char2rocblas_svect(leftvC);
     rocblas_svect rightv = char2rocblas_svect(rightvC);

--- a/clients/common/lapack/testing_gesv.hpp
+++ b/clients/common/lapack/testing_gesv.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -165,11 +165,11 @@ void gesv_initData(const rocblas_handle handle,
         rocblas_init<T>(hB, true);
 
         // scale A to avoid singularities
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] += 400;
@@ -186,15 +186,15 @@ void gesv_initData(const rocblas_handle handle,
                 // diagonal of those matrices in the batch that are singular
                 rocblas_int j = n / 4 + b;
                 j -= (j / n) * n;
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                     hA[b][i + j * lda] = 0;
                 j = n / 2 + b;
                 j -= (j / n) * n;
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                     hA[b][i + j * lda] = 0;
                 j = n - 1 + b;
                 j -= (j / n) * n;
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                     hA[b][i + j * lda] = 0;
             }
         }
@@ -244,7 +244,7 @@ void gesv_getError(const rocblas_handle handle,
     CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         cpu_gesv(n, nrhs, hA[b], lda, hIpiv[b], hB[b], ldb, hInfo[b]);
     }
@@ -255,7 +255,7 @@ void gesv_getError(const rocblas_handle handle,
     // using vector-induced infinity norm
     double err;
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         err = norm_error('I', n, nrhs, ldb, hB[b], hBRes[b]);
         *max_err = err > *max_err ? err : *max_err;
@@ -263,7 +263,7 @@ void gesv_getError(const rocblas_handle handle,
 
     // also check info for singularities
     err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
@@ -305,7 +305,7 @@ void gesv_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             cpu_gesv(n, nrhs, hA[b], lda, hIpiv[b], hB[b], ldb, hInfo[b]);
         }
@@ -316,7 +316,7 @@ void gesv_getPerfData(const rocblas_handle handle,
                                   hIpiv, hB, singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         gesv_initData<false, true, T>(handle, n, nrhs, dA, lda, stA, dIpiv, stP, dB, ldb, stB, bc,
                                       hA, hIpiv, hB, singular);
@@ -340,7 +340,7 @@ void gesv_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         gesv_initData<false, true, T>(handle, n, nrhs, dA, lda, stA, dIpiv, stP, dB, ldb, stB, bc,
                                       hA, hIpiv, hB, singular);
@@ -362,9 +362,9 @@ void testing_gesv(Arguments& argus)
     rocblas_int nrhs = argus.get<rocblas_int>("nrhs", n);
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
     rocblas_int ldb = argus.get<rocblas_int>("ldb", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stP = argus.get<rocblas_stride>("strideP", n);
-    rocblas_stride stB = argus.get<rocblas_stride>("strideB", ldb * nrhs);
+    rocblas_stride stB = argus.get<rocblas_stride>("strideB", rocblas_stride(ldb) * nrhs);
 
     rocblas_int bc = argus.batch_count;
     rocblas_int hot_calls = argus.iters;

--- a/clients/common/lapack/testing_gesv_outofplace.hpp
+++ b/clients/common/lapack/testing_gesv_outofplace.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -181,11 +181,11 @@ void gesv_outofplace_initData(const rocblas_handle handle,
         rocblas_init<T>(hB, true);
 
         // scale A to avoid singularities
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] += 400;
@@ -202,15 +202,15 @@ void gesv_outofplace_initData(const rocblas_handle handle,
                 // diagonal of those matrices in the batch that are singular
                 rocblas_int j = n / 4 + b;
                 j -= (j / n) * n;
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                     hA[b][i + j * lda] = 0;
                 j = n / 2 + b;
                 j -= (j / n) * n;
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                     hA[b][i + j * lda] = 0;
                 j = n - 1 + b;
                 j -= (j / n) * n;
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                     hA[b][i + j * lda] = 0;
             }
         }
@@ -264,7 +264,7 @@ void gesv_outofplace_getError(const rocblas_handle handle,
     CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         cpu_gesv(n, nrhs, hA[b], lda, hIpiv[b], hB[b], ldb, hInfo[b]);
     }
@@ -275,7 +275,7 @@ void gesv_outofplace_getError(const rocblas_handle handle,
     // using vector-induced infinity norm
     double err;
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(hInfoRes[b][0] == 0)
         {
@@ -286,7 +286,7 @@ void gesv_outofplace_getError(const rocblas_handle handle,
 
     // also check info for singularities
     err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
@@ -331,7 +331,7 @@ void gesv_outofplace_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             cpu_gesv(n, nrhs, hA[b], lda, hIpiv[b], hB[b], ldb, hInfo[b]);
         }
@@ -342,7 +342,7 @@ void gesv_outofplace_getPerfData(const rocblas_handle handle,
                                              stB, bc, hA, hIpiv, hB, singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         gesv_outofplace_initData<false, true, T>(handle, n, nrhs, dA, lda, stA, dIpiv, stP, dB, ldb,
                                                  stB, bc, hA, hIpiv, hB, singular);
@@ -367,7 +367,7 @@ void gesv_outofplace_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         gesv_outofplace_initData<false, true, T>(handle, n, nrhs, dA, lda, stA, dIpiv, stP, dB, ldb,
                                                  stB, bc, hA, hIpiv, hB, singular);
@@ -390,10 +390,10 @@ void testing_gesv_outofplace(Arguments& argus)
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
     rocblas_int ldb = argus.get<rocblas_int>("ldb", n);
     rocblas_int ldx = argus.get<rocblas_int>("ldx", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stP = argus.get<rocblas_stride>("strideP", n);
-    rocblas_stride stB = argus.get<rocblas_stride>("strideB", ldb * nrhs);
-    rocblas_stride stX = argus.get<rocblas_stride>("strideX", ldx * nrhs);
+    rocblas_stride stB = argus.get<rocblas_stride>("strideB", rocblas_stride(ldb) * nrhs);
+    rocblas_stride stX = argus.get<rocblas_stride>("strideX", rocblas_stride(ldx) * nrhs);
 
     rocblas_int bc = argus.batch_count;
     rocblas_int hot_calls = argus.iters;

--- a/clients/common/lapack/testing_gesvd.hpp
+++ b/clients/common/lapack/testing_gesvd.hpp
@@ -213,14 +213,14 @@ void gesvd_initData(const rocblas_handle handle,
     {
         rocblas_init<T>(hA, true);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             if(!singular)
             {
                 // scale A to avoid singularities
-                for(rocblas_int i = 0; i < m; i++)
+                for(int64_t i = 0; i < m; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                     {
                         if(i == j)
                             hA[b][i + j * lda] += 400;
@@ -232,9 +232,9 @@ void gesvd_initData(const rocblas_handle handle,
             else
             {
                 // form a singular matrix consisting of all ones
-                for(rocblas_int i = 0; i < m; i++)
+                for(int64_t i = 0; i < m; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                     {
                         hA[b][i + j * lda] = 1;
                     }
@@ -244,9 +244,9 @@ void gesvd_initData(const rocblas_handle handle,
             // make copy of original data to test vectors if required
             if(test && (left_svect != rocblas_svect_none || right_svect != rocblas_svect_none))
             {
-                for(rocblas_int i = 0; i < m; i++)
+                for(int64_t i = 0; i < m; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                         A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
                 }
             }
@@ -336,7 +336,7 @@ void gesvd_getError(const rocblas_handle handle,
                                    singular);
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
         cpu_gesvd(rocblas_svect_none, rocblas_svect_none, m, n, hA[b], lda, hS[b], hU[b], ldu,
                   hV[b], ldv, work.data(), lwork, rwork.data(), hinfo[b]);
 
@@ -356,11 +356,11 @@ void gesvd_getError(const rocblas_handle handle,
     if(left_svect == rocblas_svect_overwrite)
     {
         CHECK_HIP_ERROR(hA.transfer_from(dA));
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < m; i++)
+            for(int64_t i = 0; i < m; i++)
             {
-                for(rocblas_int j = 0; j < std::min(m, n); j++)
+                for(int64_t j = 0; j < std::min(m, n); j++)
                     Ures[b][i + j * ldures] = hA[b][i + j * lda];
             }
         }
@@ -368,11 +368,11 @@ void gesvd_getError(const rocblas_handle handle,
     if(right_svect == rocblas_svect_overwrite)
     {
         CHECK_HIP_ERROR(hA.transfer_from(dA));
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < std::min(m, n); i++)
+            for(int64_t i = 0; i < std::min(m, n); i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                     Vres[b][i + j * ldvres] = hA[b][i + j * lda];
             }
         }
@@ -380,7 +380,7 @@ void gesvd_getError(const rocblas_handle handle,
 
     // Check info for non-convergence
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
@@ -394,7 +394,7 @@ void gesvd_getError(const rocblas_handle handle,
     double err;
     *max_errv = 0;
 
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         // error is ||hS - hSres||
         err = norm_error('F', 1, std::min(m, n), 1, hS[b], hSres[b]);
@@ -405,12 +405,12 @@ void gesvd_getError(const rocblas_handle handle,
         {
             err = 0;
             // check singular vectors implicitly (A*v_k = s_k*u_k)
-            for(rocblas_int k = 0; k < std::min(m, n); ++k)
+            for(int64_t k = 0; k < std::min(m, n); ++k)
             {
-                for(rocblas_int i = 0; i < m; ++i)
+                for(int64_t i = 0; i < m; ++i)
                 {
                     T tmp = 0;
-                    for(rocblas_int j = 0; j < n; ++j)
+                    for(int64_t j = 0; j < n; ++j)
                         tmp += A[b * lda * n + i + j * lda] * sconj(Vres[b][k + j * ldvres]);
                     tmp -= hSres[b][k] * Ures[b][i + k * ldures];
                     err += std::abs(tmp) * std::abs(tmp);
@@ -472,7 +472,7 @@ void gesvd_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
             cpu_gesvd(left_svect, right_svect, m, n, hA[b], lda, hS[b], hU[b], ldu, hV[b], ldv,
                       work.data(), lwork, rwork.data(), hinfo[b]);
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
@@ -482,7 +482,7 @@ void gesvd_getPerfData(const rocblas_handle handle,
                                    singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         gesvd_initData<false, true, T>(handle, left_svect, right_svect, m, n, dA, lda, bc, hA, A,
                                        false, singular);
@@ -507,7 +507,7 @@ void gesvd_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         gesvd_initData<false, true, T>(handle, left_svect, right_svect, m, n, dA, lda, bc, hA, A,
                                        false, singular);
@@ -535,10 +535,10 @@ void testing_gesvd(Arguments& argus)
     rocblas_int lda = argus.get<rocblas_int>("lda", m);
     rocblas_int ldu = argus.get<rocblas_int>("ldu", m);
     rocblas_int ldv = argus.get<rocblas_int>("ldv", (rightvC == 'A' ? n : std::min(m, n)));
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stS = argus.get<rocblas_stride>("strideS", std::min(m, n));
-    rocblas_stride stU = argus.get<rocblas_stride>("strideU", ldu * m);
-    rocblas_stride stV = argus.get<rocblas_stride>("strideV", ldv * n);
+    rocblas_stride stU = argus.get<rocblas_stride>("strideU", rocblas_stride(ldu) * m);
+    rocblas_stride stV = argus.get<rocblas_stride>("strideV", rocblas_stride(ldv) * n);
     rocblas_stride stE = argus.get<rocblas_stride>("strideE", std::min(m, n) - 1);
     char faC = argus.get<char>("fast_alg");
 

--- a/clients/common/lapack/testing_gesvdj.hpp
+++ b/clients/common/lapack/testing_gesvdj.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -220,12 +220,12 @@ void gesvdj_initData(const rocblas_handle handle,
     {
         rocblas_init<T>(hA, true);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             // scale A to avoid singularities
-            for(rocblas_int i = 0; i < m; i++)
+            for(int64_t i = 0; i < m; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] += 400;
@@ -237,9 +237,9 @@ void gesvdj_initData(const rocblas_handle handle,
             // make copy of original data to test vectors if required
             if(test && (left_svect != rocblas_svect_none || right_svect != rocblas_svect_none))
             {
-                for(rocblas_int i = 0; i < m; i++)
+                for(int64_t i = 0; i < m; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                         A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
                 }
             }
@@ -336,7 +336,7 @@ void gesvdj_getError(const rocblas_handle handle,
     gesvdj_initData<false, true, T>(handle, left_svect, right_svect, m, n, dA, lda, bc, hA, A);
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
         cpu_gesvd(rocblas_svect_none, rocblas_svect_none, m, n, hA[b], lda, hS[b], hU[b], ldu,
                   hV[b], ldv, work.data(), lwork, rwork.data(), hinfo[b]);
 
@@ -358,7 +358,7 @@ void gesvdj_getError(const rocblas_handle handle,
 
     // Check info for non-convergence
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
@@ -366,7 +366,7 @@ void gesvdj_getError(const rocblas_handle handle,
     }
 
     // Also check validity of residual
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_GE(hResidualRes[b][0], 0) << "where b = " << b;
         if(hResidualRes[b][0] < 0)
@@ -374,7 +374,7 @@ void gesvdj_getError(const rocblas_handle handle,
     }
 
     // Also check validity of sweeps
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_GE(hResidualRes[b][0], 0) << "where b = " << b;
         EXPECT_LE(hSweepsRes[b][0], max_sweeps) << "where b = " << b;
@@ -389,7 +389,7 @@ void gesvdj_getError(const rocblas_handle handle,
     double err;
     *max_errv = 0;
 
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         // error is ||hS - hSres||
         err = norm_error('F', 1, std::min(m, n), 1, hS[b], hSres[b]);
@@ -400,12 +400,12 @@ void gesvdj_getError(const rocblas_handle handle,
         {
             err = 0;
             // check singular vectors implicitly (A*v_k = s_k*u_k)
-            for(rocblas_int k = 0; k < std::min(m, n); ++k)
+            for(int64_t k = 0; k < std::min(m, n); ++k)
             {
-                for(rocblas_int i = 0; i < m; ++i)
+                for(int64_t i = 0; i < m; ++i)
                 {
                     T tmp = 0;
-                    for(rocblas_int j = 0; j < n; ++j)
+                    for(int64_t j = 0; j < n; ++j)
                         tmp += A[b * lda * n + i + j * lda] * sconj(Vres[b][k + j * ldvres]);
                     tmp -= hSres[b][k] * Ures[b][i + k * ldures];
                     err += std::abs(tmp) * std::abs(tmp);
@@ -474,7 +474,7 @@ void gesvdj_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
             cpu_gesvd(left_svect, right_svect, m, n, hA[b], lda, hS[b], hU[b], ldu, hV[b], ldv,
                       work.data(), lwork, rwork.data(), hinfo[b]);
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
@@ -483,7 +483,7 @@ void gesvdj_getPerfData(const rocblas_handle handle,
     gesvdj_initData<true, false, T>(handle, left_svect, right_svect, m, n, dA, lda, bc, hA, A, 0);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         gesvdj_initData<false, true, T>(handle, left_svect, right_svect, m, n, dA, lda, bc, hA, A, 0);
 
@@ -508,7 +508,7 @@ void gesvdj_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         gesvdj_initData<false, true, T>(handle, left_svect, right_svect, m, n, dA, lda, bc, hA, A, 0);
 
@@ -535,7 +535,7 @@ void testing_gesvdj(Arguments& argus)
     rocblas_int lda = argus.get<rocblas_int>("lda", m);
     rocblas_int ldu = argus.get<rocblas_int>("ldu", m);
     rocblas_int ldv = argus.get<rocblas_int>("ldv", (rightvC == 'A' ? n : std::min(m, n)));
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stS = argus.get<rocblas_stride>("strideS", std::min(m, n));
     rocblas_stride stU
         = argus.get<rocblas_stride>("strideU", (leftvC == 'A' ? ldu * m : ldu * std::min(m, n)));

--- a/clients/common/lapack/testing_gesvdj_notransv.hpp
+++ b/clients/common/lapack/testing_gesvdj_notransv.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -234,12 +234,12 @@ void gesvdj_notransv_initData(const rocblas_handle handle,
     {
         rocblas_init<T>(hA, true);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             // scale A to avoid singularities
-            for(rocblas_int i = 0; i < m; i++)
+            for(int64_t i = 0; i < m; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] += 400;
@@ -251,9 +251,9 @@ void gesvdj_notransv_initData(const rocblas_handle handle,
             // make copy of original data to test vectors if required
             if(test && (left_svect != rocblas_svect_none || right_svect != rocblas_svect_none))
             {
-                for(rocblas_int i = 0; i < m; i++)
+                for(int64_t i = 0; i < m; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                         A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
                 }
             }
@@ -352,7 +352,7 @@ void gesvdj_notransv_getError(const rocblas_handle handle,
                                              A);
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
         cpu_gesvd(rocblas_svect_none, rocblas_svect_none, m, n, hA[b], lda, hS[b], hU[b], ldu,
                   hV[b], ldv, work.data(), lwork, rwork.data(), hinfo[b]);
 
@@ -374,7 +374,7 @@ void gesvdj_notransv_getError(const rocblas_handle handle,
 
     // Check info for non-convergence
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
@@ -382,7 +382,7 @@ void gesvdj_notransv_getError(const rocblas_handle handle,
     }
 
     // Also check validity of residual
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_GE(hResidualRes[b][0], 0) << "where b = " << b;
         if(hResidualRes[b][0] < 0)
@@ -390,7 +390,7 @@ void gesvdj_notransv_getError(const rocblas_handle handle,
     }
 
     // Also check validity of sweeps
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_GE(hResidualRes[b][0], 0) << "where b = " << b;
         EXPECT_LE(hSweepsRes[b][0], max_sweeps) << "where b = " << b;
@@ -405,7 +405,7 @@ void gesvdj_notransv_getError(const rocblas_handle handle,
     double err;
     *max_errv = 0;
 
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         // error is ||hS - hSres||
         err = norm_error('F', 1, std::min(m, n), 1, hS[b], hSres[b]);
@@ -416,12 +416,12 @@ void gesvdj_notransv_getError(const rocblas_handle handle,
         {
             err = 0;
             // check singular vectors implicitly (A*v_k = s_k*u_k)
-            for(rocblas_int k = 0; k < std::min(m, n); ++k)
+            for(int64_t k = 0; k < std::min(m, n); ++k)
             {
-                for(rocblas_int i = 0; i < m; ++i)
+                for(int64_t i = 0; i < m; ++i)
                 {
                     T tmp = 0;
-                    for(rocblas_int j = 0; j < n; ++j)
+                    for(int64_t j = 0; j < n; ++j)
                         tmp += A[b * lda * n + i + j * lda] * Vres[b][j + k * ldvres];
                     tmp -= hSres[b][k] * Ures[b][i + k * ldures];
                     err += std::abs(tmp) * std::abs(tmp);
@@ -491,7 +491,7 @@ void gesvdj_notransv_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
             cpu_gesvd(left_svect, right_svect, m, n, hA[b], lda, hS[b], hU[b], ldu, hV[b], ldv,
                       work.data(), lwork, rwork.data(), hinfo[b]);
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
@@ -501,7 +501,7 @@ void gesvdj_notransv_getPerfData(const rocblas_handle handle,
                                              A, 0);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         gesvdj_notransv_initData<false, true, T>(handle, left_svect, right_svect, m, n, dA, lda, bc,
                                                  hA, A, 0);
@@ -527,7 +527,7 @@ void gesvdj_notransv_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         gesvdj_notransv_initData<false, true, T>(handle, left_svect, right_svect, m, n, dA, lda, bc,
                                                  hA, A, 0);
@@ -555,12 +555,12 @@ void testing_gesvdj_notransv(Arguments& argus)
     rocblas_int lda = argus.get<rocblas_int>("lda", m);
     rocblas_int ldu = argus.get<rocblas_int>("ldu", m);
     rocblas_int ldv = argus.get<rocblas_int>("ldv", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stS = argus.get<rocblas_stride>("strideS", std::min(m, n));
-    rocblas_stride stU
-        = argus.get<rocblas_stride>("strideU", (leftvC == 'A' ? ldu * m : ldu * std::min(m, n)));
-    rocblas_stride stV
-        = argus.get<rocblas_stride>("strideV", (rightvC == 'A' ? ldv * n : ldv * std::min(m, n)));
+    rocblas_stride stU = argus.get<rocblas_stride>(
+        "strideU", (leftvC == 'A' ? rocblas_stride(ldu) * m : rocblas_stride(ldu) * std::min(m, n)));
+    rocblas_stride stV = argus.get<rocblas_stride>(
+        "strideV", (rightvC == 'A' ? rocblas_stride(ldv) * n : rocblas_stride(ldv) * std::min(m, n)));
 
     S abstol = S(argus.get<double>("abstol", 0));
     rocblas_int max_sweeps = argus.get<rocblas_int>("max_sweeps", 100);

--- a/clients/common/lapack/testing_gesvdx.hpp
+++ b/clients/common/lapack/testing_gesvdx.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -224,15 +224,15 @@ void gesvdx_initData(const rocblas_handle handle,
         rocblas_int nn = std::min(m, n);
 
         // construct non singular matrix A such that all singular values are in (0, 20]
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < m; i++)
+            for(int64_t i = 0; i < m; i++)
             {
                 if(i == nn / 4 || i == nn / 2 || i == nn - 1 || i == nn / 7 || i == nn / 5
                    || i == nn / 3)
                     hA[b][i + i * lda] = 0;
 
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] = 2 * std::real(hA[b][i + j * lda]) - 21;
@@ -259,9 +259,9 @@ void gesvdx_initData(const rocblas_handle handle,
             // make copy of original data to test vectors if required
             if(test && (left_svect != rocblas_svect_none || right_svect != rocblas_svect_none))
             {
-                for(rocblas_int i = 0; i < m; i++)
+                for(int64_t i = 0; i < m; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                         A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
                 }
             }
@@ -398,7 +398,7 @@ void gesvdx_getError(const rocblas_handle handle,
     gesvdx_initData<false, true, T>(handle, left_svect, right_svect, m, n, dA, lda, bc, hA, A);
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         //cpu_gesvdx(rocblas_svect_none, rocblas_svect_none, srange, m, n, hA[b], lda, vl, vu, il, iu, hNsv[b], hS[b], hU[b], ldu, hV[b], ldv,
         //               work.data(), lwork, rwork.data(), hifail[b], hinfo[b]);
@@ -415,7 +415,7 @@ void gesvdx_getError(const rocblas_handle handle,
         }
         else if(srange == rocblas_srange_value)
         {
-            for(int j = 0; j < minn; ++j)
+            for(int64_t j = 0; j < minn; ++j)
             {
                 if(hS[b][j] < vu && hS[b][j] >= vl)
                 {
@@ -455,12 +455,12 @@ void gesvdx_getError(const rocblas_handle handle,
     // Check info and ifail for non-convergence
     // (NOTE: With the workaround in place, info and ifail cannot be tested as they have different
     //  meaning in gesvd_, however, We expect the used input matrices to always converge)
-    /*for(rocblas_int b = 0; b < bc; ++b)
+    /*for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
             *max_err += 1;
-        for(int j = 0; j < hNsv[b][0]; ++j)
+        for(int64_t j = 0; j < hNsv[b][0]; ++j)
         {
             EXPECT_EQ(hifail[b][j], hifailRes[b][j]) << "where b = " << b << ", j = " << j;
             if(hifail[b][j] != hifailRes[b][j])
@@ -469,7 +469,7 @@ void gesvdx_getError(const rocblas_handle handle,
     }*/
 
     double err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         // check number of computed singular values
         rocblas_int nn = hNsvRes[b][0];
@@ -490,7 +490,7 @@ void gesvdx_getError(const rocblas_handle handle,
                 std::vector<T> VVres(nn * nn, 0.0);
                 std::vector<T> I(nn * nn, 0.0);
 
-                for(rocblas_int i = 0; i < nn; i++)
+                for(int64_t i = 0; i < nn; i++)
                     I[i + i * nn] = T(1);
 
                 cpu_gemm(rocblas_operation_conjugate_transpose, rocblas_operation_none, nn, nn, m,
@@ -506,7 +506,7 @@ void gesvdx_getError(const rocblas_handle handle,
 
             err = 0;
             // check singular vectors implicitly (A*v_k = s_k*u_k)
-            for(rocblas_int k = 0; k < hNsv[b][0]; ++k)
+            for(int64_t k = 0; k < hNsv[b][0]; ++k)
             {
                 T tmp = 0;
                 double tmp2 = 0;
@@ -514,10 +514,10 @@ void gesvdx_getError(const rocblas_handle handle,
                 // (Comparing absolute values to deal with the fact that the pair of singular vectors (u,-v) or (-u,v) are
                 //  both ok and we could get either one with the complementary or main executions when only
                 //  one side set of vectors is required. May be revisited in the future.)
-                for(rocblas_int i = 0; i < m; ++i)
+                for(int64_t i = 0; i < m; ++i)
                 {
                     tmp = 0;
-                    for(rocblas_int j = 0; j < n; ++j)
+                    for(int64_t j = 0; j < n; ++j)
                         tmp += A[b * lda * n + i + j * lda] * sconj(hVres[b][k + j * ldvres]);
                     tmp2 = std::abs(tmp) - std::abs(hSres[b][k] * hUres[b][i + k * ldures]);
                     err += tmp2 * tmp2;
@@ -609,7 +609,7 @@ void gesvdx_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         //*cpu_time_used = get_time_us_no_sync();
-        //for(rocblas_int b = 0; b < bc; ++b)
+        //for(int64_t b = 0; b < bc; ++b)
         //    cpu_gesvdx(left_svect, right_svect, srange, m, n, hA[b], lda, vl, vu, il, iu, hNsv[b], hS[b], hU[b], ldu, hV[b], ldv,
         //                   work.data(), lwork, rwork.data(), hifail[b], hinfo[b]);
         //*cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
@@ -619,7 +619,7 @@ void gesvdx_getPerfData(const rocblas_handle handle,
     gesvdx_initData<true, false, T>(handle, left_svect, right_svect, m, n, dA, lda, bc, hA, A, 0);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         gesvdx_initData<false, true, T>(handle, left_svect, right_svect, m, n, dA, lda, bc, hA, A, 0);
 
@@ -644,7 +644,7 @@ void gesvdx_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         gesvdx_initData<false, true, T>(handle, left_svect, right_svect, m, n, dA, lda, bc, hA, A, 0);
 
@@ -683,11 +683,11 @@ void testing_gesvdx(Arguments& argus)
     rocblas_int lda = argus.get<rocblas_int>("lda", m);
     rocblas_int ldu = argus.get<rocblas_int>("ldu", m);
     rocblas_int ldv = argus.get<rocblas_int>("ldv", nsv_max);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stS = argus.get<rocblas_stride>("strideS", nsv_max);
     rocblas_stride stF = argus.get<rocblas_stride>("strideF", nn);
-    rocblas_stride stU = argus.get<rocblas_stride>("strideU", ldu * nsv_max);
-    rocblas_stride stV = argus.get<rocblas_stride>("strideV", ldv * n);
+    rocblas_stride stU = argus.get<rocblas_stride>("strideU", rocblas_stride(ldu) * nsv_max);
+    rocblas_stride stV = argus.get<rocblas_stride>("strideV", rocblas_stride(ldv) * n);
 
     rocblas_int bc = argus.batch_count;
     rocblas_int hot_calls = argus.iters;

--- a/clients/common/lapack/testing_gesvdx_notransv.hpp
+++ b/clients/common/lapack/testing_gesvdx_notransv.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -238,15 +238,15 @@ void gesvdx_notransv_initData(const rocblas_handle handle,
         rocblas_int nn = std::min(m, n);
 
         // construct non singular matrix A such that all singular values are in (0, 20]
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < m; i++)
+            for(int64_t i = 0; i < m; i++)
             {
                 if(i == nn / 4 || i == nn / 2 || i == nn - 1 || i == nn / 7 || i == nn / 5
                    || i == nn / 3)
                     hA[b][i + i * lda] = 0;
 
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] = 2 * std::real(hA[b][i + j * lda]) - 21;
@@ -273,9 +273,9 @@ void gesvdx_notransv_initData(const rocblas_handle handle,
             // make copy of original data to test vectors if required
             if(test && (left_svect != rocblas_svect_none || right_svect != rocblas_svect_none))
             {
-                for(rocblas_int i = 0; i < m; i++)
+                for(int64_t i = 0; i < m; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                         A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
                 }
             }
@@ -414,7 +414,7 @@ void gesvdx_notransv_getError(const rocblas_handle handle,
                                              A);
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         //cpu_gesvdx(rocblas_svect_none, rocblas_svect_none, srange, m, n, hA[b], lda, vl, vu, il, iu, hNsv[b], hS[b], hU[b], ldu, hV[b], ldv,
         //               work.data(), lwork, rwork.data(), hifail[b], hinfo[b]);
@@ -431,7 +431,7 @@ void gesvdx_notransv_getError(const rocblas_handle handle,
         }
         else if(srange == rocblas_srange_value)
         {
-            for(int j = 0; j < minn; ++j)
+            for(int64_t j = 0; j < minn; ++j)
             {
                 if(hS[b][j] < vu && hS[b][j] >= vl)
                 {
@@ -471,12 +471,12 @@ void gesvdx_notransv_getError(const rocblas_handle handle,
     // Check info and ifail for non-convergence
     // (NOTE: With the workaround in place, info and ifail cannot be tested as they have different
     //  meaning in gesvd_, however, We expect the used input matrices to always converge)
-    /*for(rocblas_int b = 0; b < bc; ++b)
+    /*for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
             *max_err += 1;
-        for(int j = 0; j < hNsv[b][0]; ++j)
+        for(int64_t j = 0; j < hNsv[b][0]; ++j)
         {
             EXPECT_EQ(hifail[b][j], hifailRes[b][j]) << "where b = " << b << ", j = " << j;
             if(hifail[b][j] != hifailRes[b][j])
@@ -485,7 +485,7 @@ void gesvdx_notransv_getError(const rocblas_handle handle,
     }*/
 
     double err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         // check number of computed singular values
         rocblas_int nn = hNsvRes[b][0];
@@ -506,7 +506,7 @@ void gesvdx_notransv_getError(const rocblas_handle handle,
                 std::vector<T> VVres(nn * nn, 0.0);
                 std::vector<T> I(nn * nn, 0.0);
 
-                for(rocblas_int i = 0; i < nn; i++)
+                for(int64_t i = 0; i < nn; i++)
                     I[i + i * nn] = T(1);
 
                 cpu_gemm(rocblas_operation_conjugate_transpose, rocblas_operation_none, nn, nn, m,
@@ -522,7 +522,7 @@ void gesvdx_notransv_getError(const rocblas_handle handle,
 
             err = 0;
             // check singular vectors implicitly (A*v_k = s_k*u_k)
-            for(rocblas_int k = 0; k < nn; ++k)
+            for(int64_t k = 0; k < nn; ++k)
             {
                 T tmp = 0;
                 double tmp2 = 0;
@@ -530,10 +530,10 @@ void gesvdx_notransv_getError(const rocblas_handle handle,
                 // (Comparing absolute values to deal with the fact that the pair of singular vectors (u,-v) or (-u,v) are
                 //  both ok and we could get either one with the complementary or main executions when only
                 //  one side set of vectors is required. May be revisited in the future.)
-                for(rocblas_int i = 0; i < m; ++i)
+                for(int64_t i = 0; i < m; ++i)
                 {
                     tmp = 0;
-                    for(rocblas_int j = 0; j < n; ++j)
+                    for(int64_t j = 0; j < n; ++j)
                         tmp += A[b * lda * n + i + j * lda] * hVres[b][j + k * ldvres];
                     tmp2 = std::abs(tmp) - std::abs(hSres[b][k] * hUres[b][i + k * ldures]);
                     err += tmp2 * tmp2;
@@ -625,7 +625,7 @@ void gesvdx_notransv_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         //*cpu_time_used = get_time_us_no_sync();
-        //for(rocblas_int b = 0; b < bc; ++b)
+        //for(int64_t b = 0; b < bc; ++b)
         //    cpu_gesvdx(left_svect, right_svect, srange, m, n, hA[b], lda, vl, vu, il, iu, hNsv[b], hS[b], hU[b], ldu, hV[b], ldv,
         //                   work.data(), lwork, rwork.data(), hifail[b], hinfo[b]);
         //*cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
@@ -636,7 +636,7 @@ void gesvdx_notransv_getPerfData(const rocblas_handle handle,
                                              A, 0);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         gesvdx_notransv_initData<false, true, T>(handle, left_svect, right_svect, m, n, dA, lda, bc,
                                                  hA, A, 0);
@@ -662,7 +662,7 @@ void gesvdx_notransv_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         gesvdx_notransv_initData<false, true, T>(handle, left_svect, right_svect, m, n, dA, lda, bc,
                                                  hA, A, 0);
@@ -703,11 +703,11 @@ void testing_gesvdx_notransv(Arguments& argus)
     rocblas_int lda = argus.get<rocblas_int>("lda", m);
     rocblas_int ldu = argus.get<rocblas_int>("ldu", m);
     rocblas_int ldv = argus.get<rocblas_int>("ldv", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stS = argus.get<rocblas_stride>("strideS", nsv_max);
     rocblas_stride stF = argus.get<rocblas_stride>("strideF", nn);
-    rocblas_stride stU = argus.get<rocblas_stride>("strideU", ldu * nsv_max);
-    rocblas_stride stV = argus.get<rocblas_stride>("strideV", ldv * nsv_max);
+    rocblas_stride stU = argus.get<rocblas_stride>("strideU", rocblas_stride(ldu) * nsv_max);
+    rocblas_stride stV = argus.get<rocblas_stride>("strideV", rocblas_stride(ldv) * nsv_max);
 
     rocblas_int bc = argus.batch_count;
     rocblas_int hot_calls = argus.iters;

--- a/clients/common/lapack/testing_getf2_getrf.hpp
+++ b/clients/common/lapack/testing_getf2_getrf.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -138,7 +138,7 @@ void getf2_getrf_initData(const rocblas_handle handle,
                           const I m,
                           const I n,
                           Td& dA,
-                          const I lda,
+                          const I lda_arg,
                           const rocblas_stride stA,
                           Id& dIpiv,
                           const rocblas_stride stP,
@@ -148,17 +148,19 @@ void getf2_getrf_initData(const rocblas_handle handle,
                           Uh& hIpiv,
                           const bool singular)
 {
+#define lda (static_cast<int64_t>(lda_arg))
+
     if(CPU)
     {
         T tmp;
         rocblas_init<T>(hA, true);
 
-        for(I b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             // scale A to avoid singularities
-            for(I i = 0; i < m; i++)
+            for(int64_t i = 0; i < m; i++)
             {
-                for(I j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] += 400;
@@ -169,9 +171,9 @@ void getf2_getrf_initData(const rocblas_handle handle,
 
             // shuffle rows to test pivoting
             // always the same permuation for debugging purposes
-            for(I i = 0; i < m / 2; i++)
+            for(int64_t i = 0; i < m / 2; i++)
             {
-                for(I j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     tmp = hA[b][i + j * lda];
                     hA[b][i + j * lda] = hA[b][m - 1 - i + j * lda];
@@ -187,15 +189,15 @@ void getf2_getrf_initData(const rocblas_handle handle,
                 // matrices in the batch that are singular
                 I j = n / 4 + b;
                 j -= (j / n) * n;
-                for(I i = 0; i < m; i++)
+                for(int64_t i = 0; i < m; i++)
                     hA[b][i + j * lda] = 0;
                 j = n / 2 + b;
                 j -= (j / n) * n;
-                for(I i = 0; i < m; i++)
+                for(int64_t i = 0; i < m; i++)
                     hA[b][i + j * lda] = 0;
                 j = n - 1 + b;
                 j -= (j / n) * n;
-                for(I i = 0; i < m; i++)
+                for(int64_t i = 0; i < m; i++)
                     hA[b][i + j * lda] = 0;
             }
         }
@@ -206,6 +208,7 @@ void getf2_getrf_initData(const rocblas_handle handle,
         // now copy data to the GPU
         CHECK_HIP_ERROR(dA.transfer_from(hA));
     }
+#undef lda
 }
 
 template <bool STRIDED, bool GETRF, typename T, typename I, typename Td, typename Id, typename Th, typename Ih, typename Uh>
@@ -247,7 +250,7 @@ void getf2_getrf_getError(const rocblas_handle handle,
     CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
 
     // CPU lapack
-    for(I b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         GETRF ? cpu_getrf(m, n, hA[b], lda, hIpiv[b], hInfo[b])
               : cpu_getf2(m, n, hA[b], lda, hIpiv[b], hInfo[b]);
@@ -264,14 +267,14 @@ void getf2_getrf_getError(const rocblas_handle handle,
     // using frobenius norm
     double err;
     *max_err = 0;
-    for(I b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         err = norm_error('F', m, n, lda, hA[b], hARes[b]);
         *max_err = err > *max_err ? err : *max_err;
 
         // also check pivoting (count the number of incorrect pivots)
         err = 0;
-        for(I i = 0; i < min(m, n); ++i)
+        for(int64_t i = 0; i < min(m, n); ++i)
         {
             EXPECT_EQ(hIpiv[b][i], hIpivRes[b][i]) << "where b = " << b << ", i = " << i;
             if(hIpiv[b][i] != hIpivRes[b][i])
@@ -282,7 +285,7 @@ void getf2_getrf_getError(const rocblas_handle handle,
 
     // also check info for singularities
     err = 0;
-    for(I b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
@@ -320,7 +323,7 @@ void getf2_getrf_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(I b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             GETRF ? cpu_getrf(m, n, hA[b], lda, hIpiv[b], hInfo[b])
                   : cpu_getf2(m, n, hA[b], lda, hIpiv[b], hInfo[b]);
@@ -332,7 +335,7 @@ void getf2_getrf_getPerfData(const rocblas_handle handle,
                                          hIpiv, singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         getf2_getrf_initData<false, true, T>(handle, m, n, dA, lda, stA, dIpiv, stP, dInfo, bc, hA,
                                              hIpiv, singular);
@@ -356,7 +359,7 @@ void getf2_getrf_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         getf2_getrf_initData<false, true, T>(handle, m, n, dA, lda, stA, dIpiv, stP, dInfo, bc, hA,
                                              hIpiv, singular);
@@ -377,7 +380,7 @@ void testing_getf2_getrf(Arguments& argus)
     I m = argus.get<rocblas_int>("m");
     I n = argus.get<rocblas_int>("n", m);
     I lda = argus.get<rocblas_int>("lda", m);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stP = argus.get<rocblas_stride>("strideP", min(m, n));
 
     I bc = argus.batch_count;

--- a/clients/common/lapack/testing_getf2_getrf.hpp
+++ b/clients/common/lapack/testing_getf2_getrf.hpp
@@ -138,7 +138,7 @@ void getf2_getrf_initData(const rocblas_handle handle,
                           const I m,
                           const I n,
                           Td& dA,
-                          const I lda_arg,
+                          const I lda,
                           const rocblas_stride stA,
                           Id& dIpiv,
                           const rocblas_stride stP,
@@ -148,8 +148,6 @@ void getf2_getrf_initData(const rocblas_handle handle,
                           Uh& hIpiv,
                           const bool singular)
 {
-#define lda (static_cast<int64_t>(lda_arg))
-
     if(CPU)
     {
         T tmp;
@@ -187,7 +185,7 @@ void getf2_getrf_initData(const rocblas_handle handle,
                 // (always the same elements for debugging purposes).
                 // The algorithm must detect the first zero pivot in those
                 // matrices in the batch that are singular
-                I j = n / 4 + b;
+                int64_t j = n / 4 + b;
                 j -= (j / n) * n;
                 for(int64_t i = 0; i < m; i++)
                     hA[b][i + j * lda] = 0;
@@ -208,7 +206,6 @@ void getf2_getrf_initData(const rocblas_handle handle,
         // now copy data to the GPU
         CHECK_HIP_ERROR(dA.transfer_from(hA));
     }
-#undef lda
 }
 
 template <bool STRIDED, bool GETRF, typename T, typename I, typename Td, typename Id, typename Th, typename Ih, typename Uh>
@@ -274,7 +271,7 @@ void getf2_getrf_getError(const rocblas_handle handle,
 
         // also check pivoting (count the number of incorrect pivots)
         err = 0;
-        for(int64_t i = 0; i < min(m, n); ++i)
+        for(int64_t i = 0; i < std::min(m, n); ++i)
         {
             EXPECT_EQ(hIpiv[b][i], hIpivRes[b][i]) << "where b = " << b << ", i = " << i;
             if(hIpiv[b][i] != hIpivRes[b][i])
@@ -381,7 +378,7 @@ void testing_getf2_getrf(Arguments& argus)
     I n = argus.get<rocblas_int>("n", m);
     I lda = argus.get<rocblas_int>("lda", m);
     rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
-    rocblas_stride stP = argus.get<rocblas_stride>("strideP", min(m, n));
+    rocblas_stride stP = argus.get<rocblas_stride>("strideP", std::min(m, n));
 
     I bc = argus.batch_count;
     int hot_calls = argus.iters;
@@ -394,7 +391,7 @@ void testing_getf2_getrf(Arguments& argus)
 
     // determine sizes
     size_t size_A = size_t(lda) * n;
-    size_t size_P = size_t(min(m, n));
+    size_t size_P = size_t(std::min(m, n));
     double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
     size_t hashA = 0, hashARes = 0, hashIpivRes = 0;
 
@@ -534,7 +531,7 @@ void testing_getf2_getrf(Arguments& argus)
     // validate results for rocsolver-test
     // using min(m,n) * machine_precision as tolerance
     if(argus.unit_check)
-        ROCSOLVER_TEST_CHECK(T, max_error, min(m, n));
+        ROCSOLVER_TEST_CHECK(T, max_error, std::min(m, n));
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/clients/common/lapack/testing_getf2_getrf_npvt.hpp
+++ b/clients/common/lapack/testing_getf2_getrf_npvt.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -137,11 +137,11 @@ void getf2_getrf_npvt_initData(const rocblas_handle handle,
 
         // scale A to avoid singularities
         // leaving matrix as diagonal dominant so that pivoting is not required
-        for(I b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(I i = 0; i < m; i++)
+            for(int64_t i = 0; i < m; i++)
             {
-                for(I j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] += 400;
@@ -156,17 +156,17 @@ void getf2_getrf_npvt_initData(const rocblas_handle handle,
                 // (always the same elements for debugging purposes).
                 // The algorithm must detect the first zero element in the
                 // diagonal of those matrices in the batch that are singular
-                I j = n / 4 + b;
+                int64_t j = n / 4 + b;
                 j -= (j / n) * n;
-                for(I i = 0; i < m; i++)
+                for(int64_t i = 0; i < m; i++)
                     hA[b][i + j * lda] = 0;
                 j = n / 2 + b;
                 j -= (j / n) * n;
-                for(I i = 0; i < m; i++)
+                for(int64_t i = 0; i < m; i++)
                     hA[b][i + j * lda] = 0;
                 j = n - 1 + b;
                 j -= (j / n) * n;
-                for(I i = 0; i < m; i++)
+                for(int64_t i = 0; i < m; i++)
                     hA[b][i + j * lda] = 0;
             }
         }
@@ -207,7 +207,7 @@ void getf2_getrf_npvt_getError(const rocblas_handle handle,
     CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
 
     // CPU lapack
-    for(I b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         GETRF ? cpu_getrf(m, n, hA[b], lda, hIpiv[b], hInfo[b])
               : cpu_getf2(m, n, hA[b], lda, hIpiv[b], hInfo[b]);
@@ -220,7 +220,7 @@ void getf2_getrf_npvt_getError(const rocblas_handle handle,
     // using frobenius norm
     double err;
     *max_err = 0;
-    for(I b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         err = norm_error('F', m, n, lda, hA[b], hARes[b]);
         *max_err = err > *max_err ? err : *max_err;
@@ -228,7 +228,7 @@ void getf2_getrf_npvt_getError(const rocblas_handle handle,
 
     // also check info for singularities
     err = 0;
-    for(I b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
@@ -264,7 +264,7 @@ void getf2_getrf_npvt_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if no perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(I b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             GETRF ? cpu_getrf(m, n, hA[b], lda, hIpiv[b], hInfo[b])
                   : cpu_getf2(m, n, hA[b], lda, hIpiv[b], hInfo[b]);
@@ -275,7 +275,7 @@ void getf2_getrf_npvt_getPerfData(const rocblas_handle handle,
     getf2_getrf_npvt_initData<true, false, T>(handle, m, n, dA, lda, stA, dInfo, bc, hA, singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         getf2_getrf_npvt_initData<false, true, T>(handle, m, n, dA, lda, stA, dInfo, bc, hA,
                                                   singular);
@@ -298,7 +298,7 @@ void getf2_getrf_npvt_getPerfData(const rocblas_handle handle,
             rocsolver_log_set_layer_mode(rocblas_layer_mode_log_profile);
         rocsolver_log_set_max_levels(profile);
     }
-    for(int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         getf2_getrf_npvt_initData<false, true, T>(handle, m, n, dA, lda, stA, dInfo, bc, hA,
                                                   singular);
@@ -319,7 +319,7 @@ void testing_getf2_getrf_npvt(Arguments& argus)
     I m = argus.get<rocblas_int>("m");
     I n = argus.get<rocblas_int>("n", m);
     I lda = argus.get<rocblas_int>("lda", m);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stP = argus.get<rocblas_stride>("strideP", min(m, n));
 
     I bc = argus.batch_count;

--- a/clients/common/lapack/testing_getf2_getrf_npvt.hpp
+++ b/clients/common/lapack/testing_getf2_getrf_npvt.hpp
@@ -320,7 +320,7 @@ void testing_getf2_getrf_npvt(Arguments& argus)
     I n = argus.get<rocblas_int>("n", m);
     I lda = argus.get<rocblas_int>("lda", m);
     rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
-    rocblas_stride stP = argus.get<rocblas_stride>("strideP", min(m, n));
+    rocblas_stride stP = argus.get<rocblas_stride>("strideP", std::min(m, n));
 
     I bc = argus.batch_count;
     int hot_calls = argus.iters;
@@ -332,7 +332,7 @@ void testing_getf2_getrf_npvt(Arguments& argus)
 
     // determine sizes
     size_t size_A = size_t(lda) * n;
-    size_t size_P = size_t(min(m, n));
+    size_t size_P = size_t(std::min(m, n));
     double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
 
     size_t size_ARes = (argus.unit_check || argus.norm_check) ? size_A : 0;
@@ -462,7 +462,7 @@ void testing_getf2_getrf_npvt(Arguments& argus)
     // validate results for rocsolver-test
     // using min(m,n) * machine_precision as tolerance
     if(argus.unit_check)
-        ROCSOLVER_TEST_CHECK(T, max_error, min(m, n));
+        ROCSOLVER_TEST_CHECK(T, max_error, std::min(m, n));
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/clients/common/lapack/testing_getrf_large.hpp
+++ b/clients/common/lapack/testing_getrf_large.hpp
@@ -110,7 +110,7 @@ void getrf_large_initData(const rocblas_handle handle,
                 // (always the same elements for debugging purposes).
                 // The algorithm must detect the first zero pivot in those
                 // matrices in the batch that are singular
-                rocblas_int j = n / 4 + b;
+                int64_t j = n / 4 + b;
                 j -= (j / n) * n;
                 for(int64_t i = 0; i < n; i++)
                     hA[b][i + j * lda] = 0;
@@ -201,7 +201,7 @@ void getrf_large_initData(const rocblas_handle handle,
                 // (always the same elements for debugging purposes).
                 // The algorithm must detect the first zero pivot in those
                 // matrices in the batch that are singular
-                rocblas_int j = n / 4 + b;
+                int64_t j = n / 4 + b;
                 j -= (j / n) * n;
                 for(int64_t i = 0; i < n; i++)
                     hA[b][i + j * lda] = 0;
@@ -469,7 +469,7 @@ void testing_getrf_large(Arguments& argus)
     // validate results for rocsolver-test
     // using min(m,n) * machine_precision as tolerance
     if(argus.unit_check)
-        ROCSOLVER_TEST_CHECK(T, max_error, min(n, n));
+        ROCSOLVER_TEST_CHECK(T, max_error, std::min(n, n));
     // output results for rocsolver-bench
     if(argus.timing)
     {

--- a/clients/common/lapack/testing_getrf_large.hpp
+++ b/clients/common/lapack/testing_getrf_large.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -78,12 +78,12 @@ void getrf_large_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
         rocblas_init<T>(hB, false);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             // scale A to avoid singularities
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] += 400;
@@ -94,9 +94,9 @@ void getrf_large_initData(const rocblas_handle handle,
 
             // shuffle rows to test pivoting
             // always the same permuation for debugging purposes
-            for(rocblas_int i = 0; i < n / 2; i++)
+            for(int64_t i = 0; i < n / 2; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     tmp = hA[b][i + j * lda];
                     hA[b][i + j * lda] = hA[b][n - 1 - i + j * lda];
@@ -112,15 +112,15 @@ void getrf_large_initData(const rocblas_handle handle,
                 // matrices in the batch that are singular
                 rocblas_int j = n / 4 + b;
                 j -= (j / n) * n;
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                     hA[b][i + j * lda] = 0;
                 j = n / 2 + b;
                 j -= (j / n) * n;
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                     hA[b][i + j * lda] = 0;
                 j = n - 1 + b;
                 j -= (j / n) * n;
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                     hA[b][i + j * lda] = 0;
             }
         }
@@ -169,12 +169,12 @@ void getrf_large_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
         rocblas_init<T>(hB, false);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             // scale A to avoid singularities
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] += T(400, 400);
@@ -185,9 +185,9 @@ void getrf_large_initData(const rocblas_handle handle,
 
             // shuffle rows to test pivoting
             // always the same permuation for debugging purposes
-            for(rocblas_int i = 0; i < n / 2; i++)
+            for(int64_t i = 0; i < n / 2; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     tmp = hA[b][i + j * lda];
                     hA[b][i + j * lda] = hA[b][n - 1 - i + j * lda];
@@ -203,15 +203,15 @@ void getrf_large_initData(const rocblas_handle handle,
                 // matrices in the batch that are singular
                 rocblas_int j = n / 4 + b;
                 j -= (j / n) * n;
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                     hA[b][i + j * lda] = 0;
                 j = n / 2 + b;
                 j -= (j / n) * n;
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                     hA[b][i + j * lda] = 0;
                 j = n - 1 + b;
                 j -= (j / n) * n;
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                     hA[b][i + j * lda] = 0;
             }
         }
@@ -275,7 +275,7 @@ void getrf_large_getError(const rocblas_handle handle,
 
     double err;
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     { // Pass the matrices here
         err = norm_error('F', n, nrhs, ldb, hB[b], hBRes[b]);
         *max_err = err > *max_err ? err : *max_err;
@@ -318,8 +318,8 @@ void testing_getrf_large(Arguments& argus)
     rocblas_int nrhs = argus.get<rocblas_int>("nrhs", n);
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
     rocblas_int ldb = argus.get<rocblas_int>("ldb", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
-    rocblas_stride stB = argus.get<rocblas_stride>("strideB", ldb * nrhs);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
+    rocblas_stride stB = argus.get<rocblas_stride>("strideB", rocblas_stride(ldb) * nrhs);
     rocblas_stride stP = argus.get<rocblas_stride>("strideP", n);
 
     rocblas_int bc = argus.batch_count;

--- a/clients/common/lapack/testing_getri.hpp
+++ b/clients/common/lapack/testing_getri.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -139,12 +139,12 @@ void getri_initData(const rocblas_handle handle,
         T tmp;
         rocblas_init<T>(hA, true);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             // scale A to avoid singularities
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] = hA[b][i + j * lda] / 10.0 + 10; //+= 400;
@@ -155,9 +155,9 @@ void getri_initData(const rocblas_handle handle,
 
             // shuffle rows to test pivoting
             // always the same permuation for debugging purposes
-            for(rocblas_int i = 0; i < n / 2; i++)
+            for(int64_t i = 0; i < n / 2; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     tmp = hA[b][i + j * lda];
                     hA[b][i + j * lda] = hA[b][n - 1 - i + j * lda];
@@ -228,7 +228,7 @@ void getri_getError(const rocblas_handle handle,
     CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         cpu_getri(n, hA[b], lda, hIpiv[b], hW.data(), sizeW, hInfo[b]);
     }
@@ -236,7 +236,7 @@ void getri_getError(const rocblas_handle handle,
     // check info for singularities
     double err = 0;
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
@@ -248,7 +248,7 @@ void getri_getError(const rocblas_handle handle,
     // (THIS DOES NOT ACCOUNT FOR NUMERICAL REPRODUCIBILITY ISSUES.
     // IT MIGHT BE REVISITED IN THE FUTURE)
     // using frobenius norm
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(hInfoRes[b][0] == 0)
         {
@@ -288,7 +288,7 @@ void getri_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             cpu_getri(n, hA[b], lda, hIpiv[b], hW.data(), sizeW, hInfo[b]);
         }
@@ -298,7 +298,7 @@ void getri_getPerfData(const rocblas_handle handle,
     getri_initData<true, false, T>(handle, n, dA, lda, dIpiv, bc, hA, hIpiv, hInfo, singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         getri_initData<false, true, T>(handle, n, dA, lda, dIpiv, bc, hA, hIpiv, hInfo, singular);
 
@@ -321,7 +321,7 @@ void getri_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         getri_initData<false, true, T>(handle, n, dA, lda, dIpiv, bc, hA, hIpiv, hInfo, singular);
 
@@ -339,7 +339,7 @@ void testing_getri(Arguments& argus)
     rocblas_local_handle handle;
     rocblas_int n = argus.get<rocblas_int>("n");
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stP = argus.get<rocblas_stride>("strideP", n);
 
     rocblas_int bc = argus.batch_count;

--- a/clients/common/lapack/testing_getri.hpp
+++ b/clients/common/lapack/testing_getri.hpp
@@ -174,7 +174,7 @@ void getri_initData(const rocblas_handle handle,
                 // always the same elements for debugging purposes
                 // the algorithm must detect the first zero pivot in those
                 // matrices in the batch that are singular
-                rocblas_int i = n / 4 + b;
+                int64_t i = n / 4 + b;
                 i -= (i / n) * n;
                 hA[b][i + i * lda] = 0;
                 i = n / 2 + b;

--- a/clients/common/lapack/testing_getri_npvt.hpp
+++ b/clients/common/lapack/testing_getri_npvt.hpp
@@ -146,7 +146,7 @@ void getri_npvt_initData(const rocblas_handle handle,
                 // always the same elements for debugging purposes
                 // the algorithm must detect the first zero pivot in those
                 // matrices in the batch that are singular
-                rocblas_int i = n / 4 + b;
+                int64_t i = n / 4 + b;
                 i -= (i / n) * n;
                 hA[b][i + i * lda] = 0;
                 i = n / 2 + b;

--- a/clients/common/lapack/testing_getri_npvt.hpp
+++ b/clients/common/lapack/testing_getri_npvt.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -122,13 +122,13 @@ void getri_npvt_initData(const rocblas_handle handle,
         T tmp;
         rocblas_init<T>(hA, true);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             // scale A to avoid singularities
             // leaving matrix as diagonal dominant so that pivoting is not required
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] += 400;
@@ -197,7 +197,7 @@ void getri_npvt_getError(const rocblas_handle handle,
     CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         cpu_getri(n, hA[b], lda, hIpiv[b], hW.data(), sizeW, hInfo[b]);
     }
@@ -205,7 +205,7 @@ void getri_npvt_getError(const rocblas_handle handle,
     // check info for singularities
     double err = 0;
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
@@ -217,7 +217,7 @@ void getri_npvt_getError(const rocblas_handle handle,
     // (THIS DOES NOT ACCOUNT FOR NUMERICAL REPRODUCIBILITY ISSUES.
     // IT MIGHT BE REVISITED IN THE FUTURE)
     // using frobenius norm
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(hInfoRes[b][0] == 0)
         {
@@ -255,7 +255,7 @@ void getri_npvt_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             cpu_getri(n, hA[b], lda, hIpiv[b], hW.data(), sizeW, hInfo[b]);
         }
@@ -265,7 +265,7 @@ void getri_npvt_getPerfData(const rocblas_handle handle,
     getri_npvt_initData<true, false, T>(handle, n, dA, lda, bc, hA, hIpiv, hInfo, singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         getri_npvt_initData<false, true, T>(handle, n, dA, lda, bc, hA, hIpiv, hInfo, singular);
 
@@ -288,7 +288,7 @@ void getri_npvt_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         getri_npvt_initData<false, true, T>(handle, n, dA, lda, bc, hA, hIpiv, hInfo, singular);
 
@@ -306,7 +306,7 @@ void testing_getri_npvt(Arguments& argus)
     rocblas_local_handle handle;
     rocblas_int n = argus.get<rocblas_int>("n");
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stP = argus.get<rocblas_stride>("strideP", n);
 
     rocblas_int bc = argus.batch_count;

--- a/clients/common/lapack/testing_getri_npvt_outofplace.hpp
+++ b/clients/common/lapack/testing_getri_npvt_outofplace.hpp
@@ -166,7 +166,7 @@ void getri_npvt_outofplace_initData(const rocblas_handle handle,
                 // always the same elements for debugging purposes
                 // the algorithm must detect the first zero pivot in those
                 // matrices in the batch that are singular
-                rocblas_int i = n / 4 + b;
+                int64_t i = n / 4 + b;
                 i -= (i / n) * n;
                 hA[b][i + i * lda] = 0;
                 i = n / 2 + b;

--- a/clients/common/lapack/testing_getri_npvt_outofplace.hpp
+++ b/clients/common/lapack/testing_getri_npvt_outofplace.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -142,13 +142,13 @@ void getri_npvt_outofplace_initData(const rocblas_handle handle,
         T tmp;
         rocblas_init<T>(hA, true);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             // scale A to avoid singularities
             // leaving matrix as diagonal dominant so that pivoting is not required
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] += 400;
@@ -219,7 +219,7 @@ void getri_npvt_outofplace_getError(const rocblas_handle handle,
     CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         cpu_getri(n, hA[b], lda, hIpiv[b], hW.data(), sizeW, hInfo[b]);
     }
@@ -227,7 +227,7 @@ void getri_npvt_outofplace_getError(const rocblas_handle handle,
     // check info for singularities
     double err = 0;
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
@@ -239,7 +239,7 @@ void getri_npvt_outofplace_getError(const rocblas_handle handle,
     // (THIS DOES NOT ACCOUNT FOR NUMERICAL REPRODUCIBILITY ISSUES.
     // IT MIGHT BE REVISITED IN THE FUTURE)
     // using frobenius norm
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(hInfoRes[b][0] == 0)
         {
@@ -281,7 +281,7 @@ void getri_npvt_outofplace_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             cpu_getri(n, hA[b], lda, hIpiv[b], hW.data(), sizeW, hInfo[b]);
         }
@@ -292,7 +292,7 @@ void getri_npvt_outofplace_getPerfData(const rocblas_handle handle,
                                                    singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         getri_npvt_outofplace_initData<false, true, T>(handle, n, dA, lda, bc, hA, hIpiv, hInfo,
                                                        singular);
@@ -316,7 +316,7 @@ void getri_npvt_outofplace_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         getri_npvt_outofplace_initData<false, true, T>(handle, n, dA, lda, bc, hA, hIpiv, hInfo,
                                                        singular);
@@ -337,8 +337,8 @@ void testing_getri_npvt_outofplace(Arguments& argus)
     rocblas_int n = argus.get<rocblas_int>("n");
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
     rocblas_int ldc = argus.get<rocblas_int>("ldc", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
-    rocblas_stride stC = argus.get<rocblas_stride>("strideC", ldc * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
+    rocblas_stride stC = argus.get<rocblas_stride>("strideC", rocblas_stride(ldc) * n);
     rocblas_stride stP = argus.get<rocblas_stride>("strideP", n);
 
     rocblas_int bc = argus.batch_count;

--- a/clients/common/lapack/testing_getri_outofplace.hpp
+++ b/clients/common/lapack/testing_getri_outofplace.hpp
@@ -189,7 +189,7 @@ void getri_outofplace_initData(const rocblas_handle handle,
                 // always the same elements for debugging purposes
                 // the algorithm must detect the first zero pivot in those
                 // matrices in the batch that are singular
-                rocblas_int i = n / 4 + b;
+                int64_t i = n / 4 + b;
                 i -= (i / n) * n;
                 hA[b][i + i * lda] = 0;
                 i = n / 2 + b;

--- a/clients/common/lapack/testing_getri_outofplace.hpp
+++ b/clients/common/lapack/testing_getri_outofplace.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -154,12 +154,12 @@ void getri_outofplace_initData(const rocblas_handle handle,
         T tmp;
         rocblas_init<T>(hA, true);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             // scale A to avoid singularities
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] += 400;
@@ -170,9 +170,9 @@ void getri_outofplace_initData(const rocblas_handle handle,
 
             // shuffle rows to test pivoting
             // always the same permuation for debugging purposes
-            for(rocblas_int i = 0; i < n / 2; i++)
+            for(int64_t i = 0; i < n / 2; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     tmp = hA[b][i + j * lda];
                     hA[b][i + j * lda] = hA[b][n - 1 - i + j * lda];
@@ -247,7 +247,7 @@ void getri_outofplace_getError(const rocblas_handle handle,
     CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         cpu_getri(n, hA[b], lda, hIpiv[b], hW.data(), sizeW, hInfo[b]);
     }
@@ -255,7 +255,7 @@ void getri_outofplace_getError(const rocblas_handle handle,
     // check info for singularities
     double err = 0;
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
@@ -267,7 +267,7 @@ void getri_outofplace_getError(const rocblas_handle handle,
     // (THIS DOES NOT ACCOUNT FOR NUMERICAL REPRODUCIBILITY ISSUES.
     // IT MIGHT BE REVISITED IN THE FUTURE)
     // using frobenius norm
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(hInfoRes[b][0] == 0)
         {
@@ -311,7 +311,7 @@ void getri_outofplace_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             cpu_getri(n, hA[b], lda, hIpiv[b], hW.data(), sizeW, hInfo[b]);
         }
@@ -322,7 +322,7 @@ void getri_outofplace_getPerfData(const rocblas_handle handle,
                                               singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         getri_outofplace_initData<false, true, T>(handle, n, dA, lda, dIpiv, bc, hA, hIpiv, hInfo,
                                                   singular);
@@ -347,7 +347,7 @@ void getri_outofplace_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         getri_outofplace_initData<false, true, T>(handle, n, dA, lda, dIpiv, bc, hA, hIpiv, hInfo,
                                                   singular);
@@ -368,8 +368,8 @@ void testing_getri_outofplace(Arguments& argus)
     rocblas_int n = argus.get<rocblas_int>("n");
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
     rocblas_int ldc = argus.get<rocblas_int>("ldc", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
-    rocblas_stride stC = argus.get<rocblas_stride>("strideC", ldc * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
+    rocblas_stride stC = argus.get<rocblas_stride>("strideC", rocblas_stride(ldc) * n);
     rocblas_stride stP = argus.get<rocblas_stride>("strideP", n);
 
     rocblas_int bc = argus.batch_count;

--- a/clients/common/lapack/testing_getrs.hpp
+++ b/clients/common/lapack/testing_getrs.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -162,11 +162,11 @@ void getrs_initData(const rocblas_handle handle,
         rocblas_init<T>(hB, true);
 
         // scale A to avoid singularities
-        for(I b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(I i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(I j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] += 400;
@@ -177,12 +177,12 @@ void getrs_initData(const rocblas_handle handle,
         }
 
         // do the LU decomposition of matrix A w/ the reference LAPACK routine
-        for(I b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             int info;
             cpu_getrf(n, n, hA[b], lda, hIpiv_cpu[b], &info);
 
-            for(I i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
                 hIpiv[b][i] = hIpiv_cpu[b][i];
         }
     }
@@ -228,7 +228,7 @@ void getrs_getError(const rocblas_handle handle,
     CHECK_HIP_ERROR(hBRes.transfer_from(dB));
 
     // CPU lapack
-    for(I b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         cpu_getrs(trans, n, nrhs, hA[b], lda, hIpiv_cpu[b], hB[b], ldb);
     }
@@ -239,7 +239,7 @@ void getrs_getError(const rocblas_handle handle,
     // using vector-induced infinity norm
     double err;
     *max_err = 0;
-    for(I b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         err = norm_error('I', n, nrhs, ldb, hB[b], hBRes[b]);
         *max_err = err > *max_err ? err : *max_err;
@@ -278,7 +278,7 @@ void getrs_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(I b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             cpu_getrs(trans, n, nrhs, hA[b], lda, hIpiv_cpu[b], hB[b], ldb);
         }
@@ -289,7 +289,7 @@ void getrs_getPerfData(const rocblas_handle handle,
                                    bc, hA, hIpiv, hIpiv_cpu, hB);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         getrs_initData<false, true, T>(handle, trans, n, nrhs, dA, lda, stA, dIpiv, stP, dB, ldb,
                                        stB, bc, hA, hIpiv, hIpiv_cpu, hB);
@@ -313,7 +313,7 @@ void getrs_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         getrs_initData<false, true, T>(handle, trans, n, nrhs, dA, lda, stA, dIpiv, stP, dB, ldb,
                                        stB, bc, hA, hIpiv, hIpiv_cpu, hB);
@@ -336,9 +336,9 @@ void testing_getrs(Arguments& argus)
     I nrhs = argus.get<rocblas_int>("nrhs", n);
     I lda = argus.get<rocblas_int>("lda", n);
     I ldb = argus.get<rocblas_int>("ldb", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stP = argus.get<rocblas_stride>("strideP", n);
-    rocblas_stride stB = argus.get<rocblas_stride>("strideB", ldb * nrhs);
+    rocblas_stride stB = argus.get<rocblas_stride>("strideB", rocblas_stride(ldb) * nrhs);
 
     rocblas_operation trans = char2rocblas_operation(transC);
     I bc = argus.batch_count;

--- a/clients/common/lapack/testing_posv.hpp
+++ b/clients/common/lapack/testing_posv.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -156,10 +156,10 @@ void posv_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
         rocblas_init<T>(hB, true);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             // scale to ensure positive definiteness
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
                 hA[b][i + i * lda] = hA[b][i + i * lda] * sconj(hA[b][i + i * lda]) * 400;
 
             if(singular && (b == bc / 4 || b == bc / 2 || b == bc - 1))
@@ -222,7 +222,7 @@ void posv_getError(const rocblas_handle handle,
     CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         cpu_posv(uplo, n, nrhs, hA[b], lda, hB[b], ldb, hInfo[b]);
     }
@@ -233,7 +233,7 @@ void posv_getError(const rocblas_handle handle,
     // using vector-induced infinity norm
     double err;
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         err = norm_error('I', n, nrhs, ldb, hB[b], hBRes[b]);
         *max_err = err > *max_err ? err : *max_err;
@@ -241,7 +241,7 @@ void posv_getError(const rocblas_handle handle,
 
     // also check info for non positive definite cases
     err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
@@ -281,7 +281,7 @@ void posv_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             cpu_posv(uplo, n, nrhs, hA[b], lda, hB[b], ldb, hInfo[b]);
         }
@@ -292,7 +292,7 @@ void posv_getPerfData(const rocblas_handle handle,
                                   singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         posv_initData<false, true, T>(handle, uplo, n, nrhs, dA, lda, stA, dB, ldb, stB, bc, hA, hB,
                                       singular);
@@ -316,7 +316,7 @@ void posv_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         posv_initData<false, true, T>(handle, uplo, n, nrhs, dA, lda, stA, dB, ldb, stB, bc, hA, hB,
                                       singular);
@@ -339,8 +339,8 @@ void testing_posv(Arguments& argus)
     rocblas_int nrhs = argus.get<rocblas_int>("nrhs", n);
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
     rocblas_int ldb = argus.get<rocblas_int>("ldb", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
-    rocblas_stride stB = argus.get<rocblas_stride>("strideB", ldb * nrhs);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
+    rocblas_stride stB = argus.get<rocblas_stride>("strideB", rocblas_stride(ldb) * nrhs);
 
     rocblas_fill uplo = char2rocblas_fill(uploC);
     rocblas_int bc = argus.batch_count;

--- a/clients/common/lapack/testing_potf2_potrf.hpp
+++ b/clients/common/lapack/testing_potf2_potrf.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -139,10 +139,10 @@ void potf2_potrf_initData(const rocblas_handle handle,
     {
         rocblas_init<T>(hA, true);
 
-        for(I b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             // scale to ensure positive definiteness
-            for(I i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
                 hA[b][i + i * lda] = hA[b][i + i * lda] * sconj(hA[b][i + i * lda]) * 400;
 
             if(singular && (b == bc / 4 || b == bc / 2 || b == bc - 1))
@@ -207,7 +207,7 @@ void potf2_potrf_getError(const rocblas_handle handle,
     hashARes = deterministic_hash(hARes, bc);
 
     // CPU lapack
-    for(I b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         POTRF ? cpu_potrf(uplo, n, hA[b], lda, hInfo[b]) : cpu_potf2(uplo, n, hA[b], lda, hInfo[b]);
     }
@@ -219,7 +219,7 @@ void potf2_potrf_getError(const rocblas_handle handle,
     double err;
     I nn;
     *max_err = 0;
-    for(I b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         nn = hInfoRes[b][0] == 0 ? n : hInfoRes[b][0];
         // (TODO: For now, the algorithm is modifying the whole input matrix even when
@@ -232,7 +232,7 @@ void potf2_potrf_getError(const rocblas_handle handle,
 
     // also check info for non positive definite cases
     err = 0;
-    for(I b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
@@ -267,7 +267,7 @@ void potf2_potrf_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(I b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             POTRF ? cpu_potrf(uplo, n, hA[b], lda, hInfo[b])
                   : cpu_potf2(uplo, n, hA[b], lda, hInfo[b]);
@@ -279,7 +279,7 @@ void potf2_potrf_getPerfData(const rocblas_handle handle,
                                          singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         potf2_potrf_initData<false, true, T>(handle, uplo, n, dA, lda, stA, dInfo, bc, hA, hInfo,
                                              singular);
@@ -303,7 +303,7 @@ void potf2_potrf_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         potf2_potrf_initData<false, true, T>(handle, uplo, n, dA, lda, stA, dInfo, bc, hA, hInfo,
                                              singular);
@@ -323,7 +323,7 @@ void testing_potf2_potrf(Arguments& argus)
     char uploC = argus.get<char>("uplo");
     I n = argus.get<I>("n");
     I lda = argus.get<I>("lda", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
 
     rocblas_fill uplo = char2rocblas_fill(uploC);
     I bc = argus.batch_count;

--- a/clients/common/lapack/testing_potri.hpp
+++ b/clients/common/lapack/testing_potri.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -130,10 +130,10 @@ void potri_initData(const rocblas_handle handle,
     {
         rocblas_init<T>(hA, true);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             // scale to ensure positive definiteness
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
                 hA[b][i + i * lda] = hA[b][i + i * lda] * sconj(hA[b][i + i * lda]) * 400;
 
             // do the Cholesky factorization of matrix A w/ the reference LAPACK routine
@@ -192,7 +192,7 @@ void potri_getError(const rocblas_handle handle,
     CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         cpu_potri(uplo, n, hA[b], lda, hInfo[b]);
     }
@@ -200,7 +200,7 @@ void potri_getError(const rocblas_handle handle,
     // check info for singularities
     double err = 0;
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
@@ -212,7 +212,7 @@ void potri_getError(const rocblas_handle handle,
     // (THIS DOES NOT ACCOUNT FOR NUMERICAL REPRODUCIBILITY ISSUES.
     // IT MIGHT BE REVISITED IN THE FUTURE)
     // using frobenius norm
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(hInfoRes[b][0] == 0)
         {
@@ -247,7 +247,7 @@ void potri_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             cpu_potri(uplo, n, hA[b], lda, hInfo[b]);
         }
@@ -257,7 +257,7 @@ void potri_getPerfData(const rocblas_handle handle,
     potri_initData<true, false, T>(handle, uplo, n, dA, lda, stA, dInfo, bc, hA, hInfo, singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         potri_initData<false, true, T>(handle, uplo, n, dA, lda, stA, dInfo, bc, hA, hInfo, singular);
 
@@ -280,7 +280,7 @@ void potri_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         potri_initData<false, true, T>(handle, uplo, n, dA, lda, stA, dInfo, bc, hA, hInfo, singular);
 
@@ -299,7 +299,7 @@ void testing_potri(Arguments& argus)
     char uploC = argus.get<char>("uplo");
     rocblas_int n = argus.get<rocblas_int>("n");
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
 
     rocblas_fill uplo = char2rocblas_fill(uploC);
     rocblas_int bc = argus.batch_count;

--- a/clients/common/lapack/testing_potrs.hpp
+++ b/clients/common/lapack/testing_potrs.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -148,10 +148,10 @@ void potrs_initData(const rocblas_handle handle,
         rocblas_init<T>(hB, true);
         int info;
 
-        for(I b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             // scale to ensure positive definiteness
-            for(I i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
                 hA[b][i + i * lda] = hA[b][i + i * lda] * sconj(hA[b][i + i * lda]) * 400;
 
             // do the Cholesky factorization of matrix A w/ the reference LAPACK routine
@@ -194,7 +194,7 @@ void potrs_getError(const rocblas_handle handle,
     CHECK_HIP_ERROR(hBRes.transfer_from(dB));
 
     // CPU lapack
-    for(I b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         cpu_potrs(uplo, n, nrhs, hA[b], lda, hB[b], ldb);
     }
@@ -205,7 +205,7 @@ void potrs_getError(const rocblas_handle handle,
     // using vector-induced infinity norm
     double err;
     *max_err = 0;
-    for(I b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         err = norm_error('I', n, nrhs, ldb, hB[b], hBRes[b]);
         *max_err = err > *max_err ? err : *max_err;
@@ -239,7 +239,7 @@ void potrs_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(I b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             cpu_potrs(uplo, n, nrhs, hA[b], lda, hB[b], ldb);
         }
@@ -249,7 +249,7 @@ void potrs_getPerfData(const rocblas_handle handle,
     potrs_initData<true, false, T>(handle, uplo, n, nrhs, dA, lda, stA, dB, ldb, stB, bc, hA, hB);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         potrs_initData<false, true, T>(handle, uplo, n, nrhs, dA, lda, stA, dB, ldb, stB, bc, hA, hB);
 
@@ -272,7 +272,7 @@ void potrs_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         potrs_initData<false, true, T>(handle, uplo, n, nrhs, dA, lda, stA, dB, ldb, stB, bc, hA, hB);
 
@@ -293,8 +293,8 @@ void testing_potrs(Arguments& argus)
     I nrhs = argus.get<I>("nrhs", n);
     I lda = argus.get<I>("lda", n);
     I ldb = argus.get<I>("ldb", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
-    rocblas_stride stB = argus.get<rocblas_stride>("strideB", ldb * nrhs);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
+    rocblas_stride stB = argus.get<rocblas_stride>("strideB", rocblas_stride(ldb) * nrhs);
 
     rocblas_fill uplo = char2rocblas_fill(uploC);
     I bc = argus.batch_count;

--- a/clients/common/lapack/testing_syev_heev.hpp
+++ b/clients/common/lapack/testing_syev_heev.hpp
@@ -161,11 +161,11 @@ void syev_heev_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
 
         // scale A to avoid singularities
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] = std::real(hA[b][i + j * lda]) + 400;
@@ -177,9 +177,9 @@ void syev_heev_initData(const rocblas_handle handle,
             // make copy of original data to test vectors if required
             if(test && evect == rocblas_evect_original)
             {
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                         A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
                 }
             }
@@ -238,13 +238,13 @@ void syev_heev_getError(const rocblas_handle handle,
         CHECK_HIP_ERROR(hAres.transfer_from(dA));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
         cpu_syev_heev(evect, uplo, n, hA[b], lda, hD[b], work.data(), lwork, hE.data(), sizeE,
                       hinfo[b]);
 
     // Check info for non-convergence
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
@@ -257,7 +257,7 @@ void syev_heev_getError(const rocblas_handle handle,
 
     double err = 0;
 
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(evect != rocblas_evect_original)
         {
@@ -279,7 +279,7 @@ void syev_heev_getError(const rocblas_handle handle,
                 // eigenvalues
                 T alpha;
                 T beta = 0;
-                for(int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     alpha = T(1) / hDres[b][j];
                     cpu_symv_hemv(uplo, n, alpha, A.data() + b * lda * n, lda, hAres[b] + j * lda,
@@ -334,7 +334,7 @@ void syev_heev_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
             cpu_syev_heev(evect, uplo, n, hA[b], lda, hD[b], work.data(), lwork, hE.data(), sizeE,
                           hinfo[b]);
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
@@ -343,7 +343,7 @@ void syev_heev_getPerfData(const rocblas_handle handle,
     syev_heev_initData<true, false, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         syev_heev_initData<false, true, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
@@ -366,7 +366,7 @@ void syev_heev_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         syev_heev_initData<false, true, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
@@ -389,7 +389,7 @@ void testing_syev_heev(Arguments& argus)
     char uploC = argus.get<char>("uplo");
     rocblas_int n = argus.get<rocblas_int>("n");
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stD = argus.get<rocblas_stride>("strideD", n);
     rocblas_stride stE = argus.get<rocblas_stride>("strideE", n);
 

--- a/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/clients/common/lapack/testing_syevd_heevd.hpp
@@ -161,11 +161,11 @@ void syevd_heevd_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
 
         // scale A to avoid singularities
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] = std::real(hA[b][i + j * lda]) + 400;
@@ -177,9 +177,9 @@ void syevd_heevd_initData(const rocblas_handle handle,
             // make copy of original data to test vectors if required
             if(test && evect == rocblas_evect_original)
             {
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                         A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
                 }
             }
@@ -250,13 +250,13 @@ void syevd_heevd_getError(const rocblas_handle handle,
         CHECK_HIP_ERROR(hAres.transfer_from(dA));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
         cpu_syevd_heevd(evect, uplo, n, hA[b], lda, hD[b], work.data(), lwork, hE.data(), sizeE,
                         iwork.data(), liwork, hinfo[b]);
 
     // Check info for non-convergence
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
@@ -269,7 +269,7 @@ void syevd_heevd_getError(const rocblas_handle handle,
 
     double err = 0;
 
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(evect != rocblas_evect_original)
         {
@@ -291,7 +291,7 @@ void syevd_heevd_getError(const rocblas_handle handle,
                 // eigenvalues
                 T alpha;
                 T beta = 0;
-                for(int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     alpha = T(1) / hDres[b][j];
                     cpu_symv_hemv(uplo, n, alpha, A.data() + b * lda * n, lda, hAres[b] + j * lda,
@@ -358,7 +358,7 @@ void syevd_heevd_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
             cpu_syevd_heevd(evect, uplo, n, hA[b], lda, hD[b], work.data(), lwork, hE.data(), sizeE,
                             iwork.data(), liwork, hinfo[b]);
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
@@ -367,7 +367,7 @@ void syevd_heevd_getPerfData(const rocblas_handle handle,
     syevd_heevd_initData<true, false, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         syevd_heevd_initData<false, true, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
@@ -390,7 +390,7 @@ void syevd_heevd_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         syevd_heevd_initData<false, true, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
@@ -413,7 +413,7 @@ void testing_syevd_heevd(Arguments& argus)
     char uploC = argus.get<char>("uplo");
     rocblas_int n = argus.get<rocblas_int>("n");
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stD = argus.get<rocblas_stride>("strideD", n);
     rocblas_stride stE = argus.get<rocblas_stride>("strideE", n);
 

--- a/clients/common/lapack/testing_syevdj_heevdj.hpp
+++ b/clients/common/lapack/testing_syevdj_heevdj.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -151,11 +151,11 @@ void syevdj_heevdj_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
 
         // scale A to avoid singularities
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] = std::real(hA[b][i + j * lda]) + 400;
@@ -167,9 +167,9 @@ void syevdj_heevdj_initData(const rocblas_handle handle,
             // make copy of original data to test vectors if required
             if(test && evect == rocblas_evect_original)
             {
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                         A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
                 }
             }
@@ -226,13 +226,13 @@ void syevdj_heevdj_getError(const rocblas_handle handle,
         CHECK_HIP_ERROR(hAres.transfer_from(dA));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
         cpu_syev_heev(evect, uplo, n, hA[b], lda, hD[b], work.data(), lwork, rwork.data(), lrwork,
                       hinfo[b]);
 
     // Check info for non-convergence
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
@@ -245,7 +245,7 @@ void syevdj_heevdj_getError(const rocblas_handle handle,
 
     double err = 0;
 
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(evect != rocblas_evect_original)
         {
@@ -267,7 +267,7 @@ void syevdj_heevdj_getError(const rocblas_handle handle,
                 // eigenvalues
                 T alpha;
                 T beta = 0;
-                for(int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     alpha = T(1) / hDres[b][j];
                     cpu_symv_hemv(uplo, n, alpha, A.data() + b * lda * n, lda, hAres[b] + j * lda,
@@ -316,7 +316,7 @@ void syevdj_heevdj_getPerfData(const rocblas_handle handle,
     syevdj_heevdj_initData<true, false, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         syevdj_heevdj_initData<false, true, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
@@ -339,7 +339,7 @@ void syevdj_heevdj_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         syevdj_heevdj_initData<false, true, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
@@ -362,7 +362,7 @@ void testing_syevdj_heevdj(Arguments& argus)
     char uploC = argus.get<char>("uplo");
     rocblas_int n = argus.get<rocblas_int>("n");
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stD = argus.get<rocblas_stride>("strideD", n);
 
     rocblas_evect evect = char2rocblas_evect(evectC);

--- a/clients/common/lapack/testing_syevdx_heevdx.hpp
+++ b/clients/common/lapack/testing_syevdx_heevdx.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -199,11 +199,11 @@ void syevdx_heevdx_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
 
         // construct well conditioned matrix A such that all eigenvalues are in (-20, 20)
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(rocblas_int j = i; j < n; j++)
+                for(int64_t j = i; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] = std::real(hA[b][i + j * lda]) + 10;
@@ -225,9 +225,9 @@ void syevdx_heevdx_initData(const rocblas_handle handle,
             // make copy of original data to test vectors if required
             if(test && evect == rocblas_evect_original)
             {
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                         A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
                 }
             }
@@ -303,14 +303,14 @@ void syevdx_heevdx_getError(const rocblas_handle handle,
     // CPU lapack
     // abstol = 0 ensures max accuracy in rocsolver; for lapack we should use 2*safemin
     S atol = 2 * get_safemin<S>();
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
         cpu_syevx_heevx(evect, erange, uplo, n, hA[b], lda, vl, vu, il, iu, atol, hNev[b], hW[b],
                         hZ[b], ldz, work.data(), lwork, rwork.data(), iwork.data(), hIfail.data(),
                         hinfo[b]);
 
     // Check info for non-convergence
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
@@ -319,7 +319,7 @@ void syevdx_heevdx_getError(const rocblas_handle handle,
 
     // Check number of returned eigenvalues
     double err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hNev[b][0], hNevRes[b][0]) << "where b = " << b;
         if(hNev[b][0] != hNevRes[b][0])
@@ -331,7 +331,7 @@ void syevdx_heevdx_getError(const rocblas_handle handle,
     // implicitly the equivalent non-converged matrix is very complicated and it boils
     // down to essentially run the algorithm again and until convergence is achieved).
 
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(evect != rocblas_evect_original)
         {
@@ -353,7 +353,7 @@ void syevdx_heevdx_getError(const rocblas_handle handle,
                 // eigenvalues
                 T alpha;
                 T beta = 0;
-                for(int j = 0; j < hNev[b][0]; j++)
+                for(int64_t j = 0; j < hNev[b][0]; j++)
                 {
                     alpha = T(1) / hWRes[b][j];
                     cpu_symv_hemv(uplo, n, alpha, A.data() + b * lda * n, lda, hZRes[b] + j * ldz,
@@ -413,7 +413,7 @@ void syevdx_heevdx_getPerfData(const rocblas_handle handle,
     syevdx_heevdx_initData<true, false, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         syevdx_heevdx_initData<false, true, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
@@ -437,7 +437,7 @@ void syevdx_heevdx_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         syevdx_heevdx_initData<false, true, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
@@ -463,9 +463,9 @@ void testing_syevdx_heevdx(Arguments& argus)
     rocblas_int n = argus.get<rocblas_int>("n");
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
     rocblas_int ldz = argus.get<rocblas_int>("ldz", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stW = argus.get<rocblas_stride>("strideW", n);
-    rocblas_stride stZ = argus.get<rocblas_stride>("strideZ", ldz * n);
+    rocblas_stride stZ = argus.get<rocblas_stride>("strideZ", rocblas_stride(ldz) * n);
 
     S vl = S(argus.get<double>("vl", 0));
     S vu = S(argus.get<double>("vu", erangeC == 'V' ? 1 : 0));

--- a/clients/common/lapack/testing_syevdx_heevdx_inplace.hpp
+++ b/clients/common/lapack/testing_syevdx_heevdx_inplace.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -185,11 +185,11 @@ void syevdx_heevdx_inplace_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
 
         // construct well conditioned matrix A such that all eigenvalues are in (-20, 20)
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(rocblas_int j = i; j < n; j++)
+                for(int64_t j = i; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] = std::real(hA[b][i + j * lda]) + 10;
@@ -211,9 +211,9 @@ void syevdx_heevdx_inplace_initData(const rocblas_handle handle,
             // make copy of original data to test vectors if required
             if(test && evect == rocblas_evect_original)
             {
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                         A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
                 }
             }
@@ -286,14 +286,14 @@ void syevdx_heevdx_inplace_getError(const rocblas_handle handle,
     // CPU lapack
     // abstol = 0 ensures max accuracy in rocsolver; for lapack we should use 2*safemin
     S atol = (abstol == 0) ? 2 * get_safemin<S>() : abstol;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
         cpu_syevx_heevx(evect, erange, uplo, n, hA[b], lda, vl, vu, il, iu, atol, hNev[b], hW[b],
                         Z.data(), ldz, work.data(), lwork, rwork.data(), iwork.data(), ifail.data(),
                         hinfo[b]);
 
     // Check info for non-convergence
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
@@ -302,7 +302,7 @@ void syevdx_heevdx_inplace_getError(const rocblas_handle handle,
 
     // Check number of returned eigenvalues
     double err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hNev[b][0], hNevRes[b][0]) << "where b = " << b;
         if(hNev[b][0] != hNevRes[b][0])
@@ -314,7 +314,7 @@ void syevdx_heevdx_inplace_getError(const rocblas_handle handle,
     // implicitly the equivalent non-converged matrix is very complicated and it boils
     // down to essentially run the algorithm again and until convergence is achieved).
 
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(evect != rocblas_evect_original)
         {
@@ -336,7 +336,7 @@ void syevdx_heevdx_inplace_getError(const rocblas_handle handle,
                 // eigenvalues
                 T alpha;
                 T beta = 0;
-                for(int j = 0; j < hNev[b][0]; j++)
+                for(int64_t j = 0; j < hNev[b][0]; j++)
                 {
                     alpha = T(1) / hWRes[b][j];
                     cpu_symv_hemv(uplo, n, alpha, A.data() + b * lda * n, lda, hARes[b] + j * lda,
@@ -405,7 +405,7 @@ void syevdx_heevdx_inplace_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
             cpu_syevx_heevx(evect, erange, uplo, n, hA[b], lda, vl, vu, il, iu, atol, hNev[b],
                             hW[b], Z.data(), ldz, work.data(), lwork, rwork.data(), iwork.data(),
                             ifail.data(), hinfo[b]);
@@ -415,7 +415,7 @@ void syevdx_heevdx_inplace_getPerfData(const rocblas_handle handle,
     syevdx_heevdx_inplace_initData<true, false, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         syevdx_heevdx_inplace_initData<false, true, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
@@ -439,7 +439,7 @@ void syevdx_heevdx_inplace_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         syevdx_heevdx_inplace_initData<false, true, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
@@ -464,7 +464,7 @@ void testing_syevdx_heevdx_inplace(Arguments& argus)
     char uploC = argus.get<char>("uplo");
     rocblas_int n = argus.get<rocblas_int>("n");
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stW = argus.get<rocblas_stride>("strideW", n);
 
     S vl = S(argus.get<double>("vl", 0));

--- a/clients/common/lapack/testing_syevj_heevj.hpp
+++ b/clients/common/lapack/testing_syevj_heevj.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -191,11 +191,11 @@ void syevj_heevj_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
 
         // scale A to avoid singularities
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] = std::real(hA[b][i + j * lda]) + 400;
@@ -207,9 +207,9 @@ void syevj_heevj_initData(const rocblas_handle handle,
             // make copy of original data to test vectors if required
             if(test)
             {
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                         A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
                 }
             }
@@ -276,14 +276,14 @@ void syevj_heevj_getError(const rocblas_handle handle,
         CHECK_HIP_ERROR(hARes.transfer_from(dA));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
         cpu_syev_heev(evect, uplo, n, hA[b], lda, hW[b], work.data(), lwork, rwork.data(), lrwork,
                       hInfo[b]);
 
     // (We expect the used input matrices to always converge)
     // Check info for non-convergence
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hInfoRes[b][0], 0) << "where b = " << b;
         if(hInfoRes[b][0] != 0)
@@ -291,7 +291,7 @@ void syevj_heevj_getError(const rocblas_handle handle,
     }
 
     // Also check validity of residual
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_GE(hResidualRes[b][0], 0) << "where b = " << b;
         if(hResidualRes[b][0] < 0)
@@ -306,7 +306,7 @@ void syevj_heevj_getError(const rocblas_handle handle,
     }
 
     // Also check validity of sweeps
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_GE(hSweepsRes[b][0], 0) << "where b = " << b;
         EXPECT_LE(hSweepsRes[b][0], max_sweeps) << "where b = " << b;
@@ -316,7 +316,7 @@ void syevj_heevj_getError(const rocblas_handle handle,
 
     double err = 0;
 
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(evect != rocblas_evect_original)
         {
@@ -339,7 +339,7 @@ void syevj_heevj_getError(const rocblas_handle handle,
                 // eigenvalues
                 T alpha;
                 T beta = 0;
-                for(int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     alpha = T(1) / hWRes[b][j];
                     cpu_symv_hemv(uplo, n, alpha, A.data() + b * lda * n, lda, hARes[b] + j * lda,
@@ -396,7 +396,7 @@ void syevj_heevj_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
             cpu_syev_heev(evect, uplo, n, hA[b], lda, hW[b], work.data(), lwork, rwork.data(),
                           lrwork, hInfo[b]);
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
@@ -405,7 +405,7 @@ void syevj_heevj_getPerfData(const rocblas_handle handle,
     syevj_heevj_initData<true, false, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         syevj_heevj_initData<false, true, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
@@ -429,7 +429,7 @@ void syevj_heevj_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         syevj_heevj_initData<false, true, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
@@ -454,7 +454,7 @@ void testing_syevj_heevj(Arguments& argus)
     char uploC = argus.get<char>("uplo");
     rocblas_int n = argus.get<rocblas_int>("n");
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stW = argus.get<rocblas_stride>("strideD", n);
 
     S abstol = S(argus.get<double>("abstol", 0));

--- a/clients/common/lapack/testing_syevx_heevx.hpp
+++ b/clients/common/lapack/testing_syevx_heevx.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -216,11 +216,11 @@ void syevx_heevx_initData(const rocblas_handle handle,
         // construct well conditioned matrix A such that all eigenvalues are in (-20, 20)
 #ifdef ROCSOLVER_TESTS_USE_DEPRECATED_INITIALIZERS
         // Old matrix initialization
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(rocblas_int j = i; j < n; j++)
+                for(int64_t j = i; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] = std::real(hA[b][i + j * lda]) + 10;
@@ -243,7 +243,7 @@ void syevx_heevx_initData(const rocblas_handle handle,
         using HMat = HostMatrix<T, rocblas_int>;
         using BDesc = typename HMat::BlockDescriptor;
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             auto hAw = HMat::Wrap(hA[b], lda, n);
             if(hAw) // update matrix hA if n >= 1
@@ -262,9 +262,9 @@ void syevx_heevx_initData(const rocblas_handle handle,
             // make copy of original data to test vectors if required
             if(test && evect == rocblas_evect_original)
             {
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                         A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
                 }
             }
@@ -360,14 +360,14 @@ void syevx_heevx_getError(const rocblas_handle handle,
     // CPU lapack
     // abstol = 0 ensures max accuracy in rocsolver; for lapack we should use 2*safemin
     S atol = (abstol == 0) ? 2 * get_safemin<S>() : abstol;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
         cpu_syevx_heevx(evect, erange, uplo, n, hA[b], lda, vl, vu, il, iu, atol, hNev[b], hW[b],
                         hZ[b], ldz, work.data(), lwork, rwork.data(), iwork.data(), hIfail[b],
                         hinfo[b]);
 
     // Check info for non-convergence
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
@@ -376,7 +376,7 @@ void syevx_heevx_getError(const rocblas_handle handle,
 
     // Check number of returned eigenvalues
     double err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hNev[b][0], hNevRes[b][0]) << "where b = " << b;
         if(hNev[b][0] != hNevRes[b][0])
@@ -388,7 +388,7 @@ void syevx_heevx_getError(const rocblas_handle handle,
     // implicitly the equivalent non-converged matrix is very complicated and it boils
     // down to essentially run the algorithm again and until convergence is achieved).
 
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         // Number of eigenvalues
         auto num_eigs = hNev[b][0];
@@ -399,7 +399,7 @@ void syevx_heevx_getError(const rocblas_handle handle,
             {
                 // check ifail
                 err = 0;
-                for(int j = 0; j < hinfo[b][0]; j++)
+                for(int64_t j = 0; j < hinfo[b][0]; j++)
                 {
                     EXPECT_NE(hIfailRes[b][j], 0) << "where b = " << b << ", j = " << j;
                     if(hIfailRes[b][j] == 0)
@@ -431,7 +431,7 @@ void syevx_heevx_getError(const rocblas_handle handle,
             // eigenvectors due to non-uniqueness of eigenvectors under scaling
             // check ifail
             err = 0;
-            for(int j = 0; j < hNev[b][0]; j++)
+            for(int64_t j = 0; j < hNev[b][0]; j++)
             {
                 EXPECT_EQ(hIfailRes[b][j], 0) << "where b = " << b << ", j = " << j;
                 if(hIfailRes[b][j] != 0)
@@ -524,7 +524,7 @@ void syevx_heevx_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
             cpu_syevx_heevx(evect, erange, uplo, n, hA[b], lda, vl, vu, il, iu, atol, hNev[b],
                             hW[b], hZ[b], ldz, work.data(), lwork, rwork.data(), iwork.data(),
                             hIfail[b], hinfo[b]);
@@ -534,7 +534,7 @@ void syevx_heevx_getPerfData(const rocblas_handle handle,
     syevx_heevx_initData<true, false, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         syevx_heevx_initData<false, true, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
@@ -558,7 +558,7 @@ void syevx_heevx_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         syevx_heevx_initData<false, true, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
@@ -584,9 +584,9 @@ void testing_syevx_heevx(Arguments& argus)
     rocblas_int n = argus.get<rocblas_int>("n");
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
     rocblas_int ldz = argus.get<rocblas_int>("ldz", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stW = argus.get<rocblas_stride>("strideW", n);
-    rocblas_stride stZ = argus.get<rocblas_stride>("strideZ", ldz * n);
+    rocblas_stride stZ = argus.get<rocblas_stride>("strideZ", rocblas_stride(ldz) * n);
     rocblas_stride stF = argus.get<rocblas_stride>("strideF", n);
 
     S vl = S(argus.get<double>("vl", 0));

--- a/clients/common/lapack/testing_sygsx_hegsx.hpp
+++ b/clients/common/lapack/testing_sygsx_hegsx.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -155,14 +155,14 @@ void sygsx_hegsx_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
         rocblas_init<T>(U, true);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             // for testing purposes, we start with the reduced matrix M of the standard equivalent problem.
             // Then we construct the generalized pair (A, B) from there
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
                 // scale matrices and set hA = M (symmetric/hermitian), hB = U (upper triangular) or hB = U'
-                for(rocblas_int j = i; j < n; j++)
+                for(int64_t j = i; j < n; j++)
                 {
                     if(i == j)
                     {
@@ -193,8 +193,8 @@ void sygsx_hegsx_initData(const rocblas_handle handle,
             // store M = hA for implicit testing
             if(test)
             {
-                for(rocblas_int i = 0; i < n; i++)
-                    for(rocblas_int j = 0; j < n; j++)
+                for(int64_t i = 0; i < n; i++)
+                    for(int64_t j = 0; j < n; j++)
                         M[b][i + j * lda] = hA[b][i + j * lda];
             }
 
@@ -264,7 +264,7 @@ void sygsx_hegsx_getError(const rocblas_handle handle,
     else
     {
         // CPU lapack
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             memcpy(hARes[b], hA[b], lda * n * sizeof(T));
             SYGST ? cpu_sygst_hegst(itype, uplo, n, hARes[b], lda, hB[b], ldb)
@@ -276,7 +276,7 @@ void sygsx_hegsx_getError(const rocblas_handle handle,
     // using frobenius norm
     double err;
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(uplo == rocblas_fill_upper)
             err = norm_error_upperTr('F', n, n, lda, M[b], hARes[b]);
@@ -316,7 +316,7 @@ void sygsx_hegsx_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             SYGST ? cpu_sygst_hegst(itype, uplo, n, hA[b], lda, hB[b], ldb)
                   : cpu_sygs2_hegs2(itype, uplo, n, hA[b], lda, hB[b], ldb);
@@ -328,7 +328,7 @@ void sygsx_hegsx_getPerfData(const rocblas_handle handle,
                                          hB, M, false);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         sygsx_hegsx_initData<false, true, T>(handle, itype, uplo, n, dA, lda, stA, dB, ldb, stB, bc,
                                              hA, hB, M, false);
@@ -352,7 +352,7 @@ void sygsx_hegsx_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         sygsx_hegsx_initData<false, true, T>(handle, itype, uplo, n, dA, lda, stA, dB, ldb, stB, bc,
                                              hA, hB, M, false);
@@ -375,8 +375,8 @@ void testing_sygsx_hegsx(Arguments& argus)
     rocblas_int n = argus.get<rocblas_int>("n");
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
     rocblas_int ldb = argus.get<rocblas_int>("ldb", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
-    rocblas_stride stB = argus.get<rocblas_stride>("strideB", ldb * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
+    rocblas_stride stB = argus.get<rocblas_stride>("strideB", rocblas_stride(ldb) * n);
 
     rocblas_eform itype = char2rocblas_eform(itypeC);
     rocblas_fill uplo = char2rocblas_fill(uploC);

--- a/clients/common/lapack/testing_sygv_hegv.hpp
+++ b/clients/common/lapack/testing_sygv_hegv.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -193,11 +193,11 @@ void sygv_hegv_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
         rocblas_init<T>(hB, false);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                     {
@@ -231,9 +231,9 @@ void sygv_hegv_initData(const rocblas_handle handle,
             // store A and B for testing purposes
             if(test && evect != rocblas_evect_none)
             {
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                     {
                         if(itype != rocblas_eform_bax)
                         {
@@ -313,7 +313,7 @@ void sygv_hegv_getError(const rocblas_handle handle,
         CHECK_HIP_ERROR(hARes.transfer_from(dA));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         cpu_sygv_hegv(itype, evect, uplo, n, hA[b], lda, hB[b], ldb, hD[b], work.data(), lwork,
                       rwork.data(), hInfo[b]);
@@ -326,7 +326,7 @@ void sygv_hegv_getError(const rocblas_handle handle,
 
     // check info for non-convergence and/or positive-definiteness
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
@@ -335,7 +335,7 @@ void sygv_hegv_getError(const rocblas_handle handle,
 
     double err;
 
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(evect == rocblas_evect_none)
         {
@@ -368,7 +368,7 @@ void sygv_hegv_getError(const rocblas_handle handle,
                     // problem is A*x = (lambda)*B*x
 
                     // compute (1/lambda)*A*x and store in hA
-                    for(int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                     {
                         alpha = T(1) / hDRes[b][j];
                         cpu_symv_hemv(uplo, n, alpha, A[b], lda, hARes[b] + j * lda, 1, beta,
@@ -376,8 +376,8 @@ void sygv_hegv_getError(const rocblas_handle handle,
                     }
 
                     // move B*x into hARes
-                    for(rocblas_int i = 0; i < n; i++)
-                        for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t i = 0; i < n; i++)
+                        for(int64_t j = 0; j < n; j++)
                             hARes[b][i + j * lda] = hB[b][i + j * ldb];
                 }
                 else
@@ -385,7 +385,7 @@ void sygv_hegv_getError(const rocblas_handle handle,
                     // problem is A*B*x = (lambda)*x or B*A*x = (lambda)*x
 
                     // compute (1/lambda)*A*B*x or (1/lambda)*B*A*x and store in hA
-                    for(int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                     {
                         alpha = T(1) / hDRes[b][j];
                         cpu_symv_hemv(uplo, n, alpha, A[b], lda, hB[b] + j * ldb, 1, beta,
@@ -449,7 +449,7 @@ void sygv_hegv_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             cpu_sygv_hegv(itype, evect, uplo, n, hA[b], lda, hB[b], ldb, hD[b], work.data(), lwork,
                           rwork.data(), hInfo[b]);
@@ -461,7 +461,7 @@ void sygv_hegv_getPerfData(const rocblas_handle handle,
                                        hB, A, B, false, singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         sygv_hegv_initData<false, true, T>(handle, itype, evect, n, dA, lda, stA, dB, ldb, stB, bc,
                                            hA, hB, A, B, false, singular);
@@ -486,7 +486,7 @@ void sygv_hegv_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         sygv_hegv_initData<false, true, T>(handle, itype, evect, n, dA, lda, stA, dB, ldb, stB, bc,
                                            hA, hB, A, B, false, singular);
@@ -512,8 +512,8 @@ void testing_sygv_hegv(Arguments& argus)
     rocblas_int n = argus.get<rocblas_int>("n");
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
     rocblas_int ldb = argus.get<rocblas_int>("ldb", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
-    rocblas_stride stB = argus.get<rocblas_stride>("strideB", ldb * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
+    rocblas_stride stB = argus.get<rocblas_stride>("strideB", rocblas_stride(ldb) * n);
     rocblas_stride stD = argus.get<rocblas_stride>("strideD", n);
     rocblas_stride stE = argus.get<rocblas_stride>("strideE", n);
 

--- a/clients/common/lapack/testing_sygvd_hegvd.hpp
+++ b/clients/common/lapack/testing_sygvd_hegvd.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -197,11 +197,11 @@ void sygvd_hegvd_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
         rocblas_init<T>(hB, false);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                     {
@@ -235,9 +235,9 @@ void sygvd_hegvd_initData(const rocblas_handle handle,
             // store A and B for testing purposes
             if(test && evect != rocblas_evect_none)
             {
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                     {
                         if(itype != rocblas_eform_bax)
                         {
@@ -329,7 +329,7 @@ void sygvd_hegvd_getError(const rocblas_handle handle,
         CHECK_HIP_ERROR(hARes.transfer_from(dA));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         cpu_sygvd_hegvd(itype, evect, uplo, n, hA[b], lda, hB[b], ldb, hD[b], work.data(), lwork,
                         rwork.data(), lrwork, iwork.data(), liwork, hInfo[b]);
@@ -342,7 +342,7 @@ void sygvd_hegvd_getError(const rocblas_handle handle,
 
     // check info for non-convergence and/or positive-definiteness
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
@@ -351,7 +351,7 @@ void sygvd_hegvd_getError(const rocblas_handle handle,
 
     double err;
 
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(evect == rocblas_evect_none)
         {
@@ -384,7 +384,7 @@ void sygvd_hegvd_getError(const rocblas_handle handle,
                     // problem is A*x = (lambda)*B*x
 
                     // compute (1/lambda)*A*x and store in hA
-                    for(int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                     {
                         alpha = T(1) / hDRes[b][j];
                         cpu_symv_hemv(uplo, n, alpha, A[b], lda, hARes[b] + j * lda, 1, beta,
@@ -392,8 +392,8 @@ void sygvd_hegvd_getError(const rocblas_handle handle,
                     }
 
                     // move B*x into hARes
-                    for(rocblas_int i = 0; i < n; i++)
-                        for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t i = 0; i < n; i++)
+                        for(int64_t j = 0; j < n; j++)
                             hARes[b][i + j * lda] = hB[b][i + j * ldb];
                 }
                 else
@@ -401,7 +401,7 @@ void sygvd_hegvd_getError(const rocblas_handle handle,
                     // problem is A*B*x = (lambda)*x or B*A*x = (lambda)*x
 
                     // compute (1/lambda)*A*B*x or (1/lambda)*B*A*x and store in hA
-                    for(int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                     {
                         alpha = T(1) / hDRes[b][j];
                         cpu_symv_hemv(uplo, n, alpha, A[b], lda, hB[b] + j * ldb, 1, beta,
@@ -477,7 +477,7 @@ void sygvd_hegvd_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             cpu_sygvd_hegvd(itype, evect, uplo, n, hA[b], lda, hB[b], ldb, hD[b], work.data(),
                             lwork, rwork.data(), lrwork, iwork.data(), liwork, hInfo[b]);
@@ -489,7 +489,7 @@ void sygvd_hegvd_getPerfData(const rocblas_handle handle,
                                          hA, hB, A, B, false, singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         sygvd_hegvd_initData<false, true, T>(handle, itype, evect, n, dA, lda, stA, dB, ldb, stB,
                                              bc, hA, hB, A, B, false, singular);
@@ -514,7 +514,7 @@ void sygvd_hegvd_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         sygvd_hegvd_initData<false, true, T>(handle, itype, evect, n, dA, lda, stA, dB, ldb, stB,
                                              bc, hA, hB, A, B, false, singular);
@@ -540,8 +540,8 @@ void testing_sygvd_hegvd(Arguments& argus)
     rocblas_int n = argus.get<rocblas_int>("n");
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
     rocblas_int ldb = argus.get<rocblas_int>("ldb", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
-    rocblas_stride stB = argus.get<rocblas_stride>("strideB", ldb * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
+    rocblas_stride stB = argus.get<rocblas_stride>("strideB", rocblas_stride(ldb) * n);
     rocblas_stride stD = argus.get<rocblas_stride>("strideD", n);
     rocblas_stride stE = argus.get<rocblas_stride>("strideE", n);
 

--- a/clients/common/lapack/testing_sygvdj_hegvdj.hpp
+++ b/clients/common/lapack/testing_sygvdj_hegvdj.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -183,11 +183,11 @@ void sygvdj_hegvdj_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
         rocblas_init<T>(hB, false);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                     {
@@ -221,9 +221,9 @@ void sygvdj_hegvdj_initData(const rocblas_handle handle,
             // store A and B for testing purposes
             if(test && evect != rocblas_evect_none)
             {
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                     {
                         if(itype != rocblas_eform_bax)
                         {
@@ -301,7 +301,7 @@ void sygvdj_hegvdj_getError(const rocblas_handle handle,
         CHECK_HIP_ERROR(hARes.transfer_from(dA));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         cpu_sygv_hegv(itype, evect, uplo, n, hA[b], lda, hB[b], ldb, hD[b], work.data(), lwork,
                       rwork.data(), hInfo[b]);
@@ -314,7 +314,7 @@ void sygvdj_hegvdj_getError(const rocblas_handle handle,
 
     // check info for non-convergence and/or positive-definiteness
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
@@ -323,7 +323,7 @@ void sygvdj_hegvdj_getError(const rocblas_handle handle,
 
     double err;
 
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(evect == rocblas_evect_none)
         {
@@ -356,7 +356,7 @@ void sygvdj_hegvdj_getError(const rocblas_handle handle,
                     // problem is A*x = (lambda)*B*x
 
                     // compute (1/lambda)*A*x and store in hA
-                    for(int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                     {
                         alpha = T(1) / hDRes[b][j];
                         cpu_symv_hemv(uplo, n, alpha, A[b], lda, hARes[b] + j * lda, 1, beta,
@@ -364,8 +364,8 @@ void sygvdj_hegvdj_getError(const rocblas_handle handle,
                     }
 
                     // move B*x into hARes
-                    for(rocblas_int i = 0; i < n; i++)
-                        for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t i = 0; i < n; i++)
+                        for(int64_t j = 0; j < n; j++)
                             hARes[b][i + j * lda] = hB[b][i + j * ldb];
                 }
                 else
@@ -373,7 +373,7 @@ void sygvdj_hegvdj_getError(const rocblas_handle handle,
                     // problem is A*B*x = (lambda)*x or B*A*x = (lambda)*x
 
                     // compute (1/lambda)*A*B*x or (1/lambda)*B*A*x and store in hA
-                    for(int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                     {
                         alpha = T(1) / hDRes[b][j];
                         cpu_symv_hemv(uplo, n, alpha, A[b], lda, hB[b] + j * ldb, 1, beta,
@@ -431,7 +431,7 @@ void sygvdj_hegvdj_getPerfData(const rocblas_handle handle,
                                            hA, hB, A, B, false, singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         sygvdj_hegvdj_initData<false, true, T>(handle, itype, evect, n, dA, lda, stA, dB, ldb, stB,
                                                bc, hA, hB, A, B, false, singular);
@@ -456,7 +456,7 @@ void sygvdj_hegvdj_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         sygvdj_hegvdj_initData<false, true, T>(handle, itype, evect, n, dA, lda, stA, dB, ldb, stB,
                                                bc, hA, hB, A, B, false, singular);
@@ -482,8 +482,8 @@ void testing_sygvdj_hegvdj(Arguments& argus)
     rocblas_int n = argus.get<rocblas_int>("n");
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
     rocblas_int ldb = argus.get<rocblas_int>("ldb", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
-    rocblas_stride stB = argus.get<rocblas_stride>("strideB", ldb * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
+    rocblas_stride stB = argus.get<rocblas_stride>("strideB", rocblas_stride(ldb) * n);
     rocblas_stride stD = argus.get<rocblas_stride>("strideD", n);
 
     rocblas_eform itype = char2rocblas_eform(itypeC);

--- a/clients/common/lapack/testing_sygvdx_hegvdx.hpp
+++ b/clients/common/lapack/testing_sygvdx_hegvdx.hpp
@@ -300,17 +300,17 @@ void sygvdx_hegvdx_initData(const rocblas_handle handle,
 
         bool use_legacy_tests = sygvdx_hegvdx_use_legacy_tests();
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             // for testing purposes, we start with a reduced matrix M for the standard equivalent problem
             // with spectrum in a desired range (-20, 20). Then we construct the generalized pair
             // (A, B) from there.
             memset(hB[b], 0,
                    sizeof(T) * n * ldb); // since ldb >= n, make sure all entries of B are initialized
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
                 // scale matrices and set hA = M (symmetric/hermitian), hB = U (upper triangular)
-                for(rocblas_int j = i; j < n; j++)
+                for(int64_t j = i; j < n; j++)
                 {
                     if(i == j)
                     {
@@ -381,9 +381,9 @@ void sygvdx_hegvdx_initData(const rocblas_handle handle,
             // store A and B for testing purposes
             if(test && evect != rocblas_evect_none)
             {
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                     {
                         if(use_legacy_tests)
                         {
@@ -490,7 +490,7 @@ void sygvdx_hegvdx_getError(const rocblas_handle handle,
     // CPU lapack
     // abstol = 0 ensures max accuracy in rocsolver; for lapack we should use 2*safemin
     S atol = 2 * get_safemin<S>();
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         cpu_sygvx_hegvx(itype, evect, erange, uplo, n, hA[b], lda, hB[b], ldb, vl, vu, il, iu, atol,
                         hNev[b], hW[b], hZ[b], ldz, work.data(), lwork, rwork.data(), iwork.data(),
@@ -519,7 +519,7 @@ void sygvdx_hegvdx_getError(const rocblas_handle handle,
     std::vector<S> tols(bc, 0);
     std::vector<S> norms(bc, 0);
     S tol = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(hNev[b][0] > 0)
         {
@@ -561,7 +561,7 @@ void sygvdx_hegvdx_getError(const rocblas_handle handle,
 
     // check info for illegal values and/or positive-definiteness
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         // Capture failures where B is not positive definite (hInfo[b][0] > n),
         // or where the i-argument has an illegal value (hInfo[b][0] < 0).  All other LAPACK
@@ -587,7 +587,7 @@ void sygvdx_hegvdx_getError(const rocblas_handle handle,
     //
     double err;
 
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         auto [lapackEigs, rocsolverEigs] = clss[b].subseqs();
         auto [_, rocsolverEigsIds] = clss[b].subseqs_ids();
@@ -648,7 +648,7 @@ void sygvdx_hegvdx_getError(const rocblas_handle handle,
                     // problem is A*x = (lambda)*B*x
 
                     // compute (1/lambda)*A*x and store in hA
-                    for(int j = 0; j < numMatchingEigs; j++)
+                    for(int64_t j = 0; j < numMatchingEigs; j++)
                     {
                         int jj = hWResIds[j]; // Id of rocSOLVER eigen-pair associated to j-th LAPACK eigen-pair
                         alpha = T(1) / hWRes[b][jj];
@@ -657,9 +657,9 @@ void sygvdx_hegvdx_getError(const rocblas_handle handle,
                     }
 
                     // move B*x into hZRes
-                    for(rocblas_int i = 0; i < n; i++)
+                    for(int64_t i = 0; i < n; i++)
                     {
-                        for(rocblas_int j = 0; j < numMatchingEigs; j++)
+                        for(int64_t j = 0; j < numMatchingEigs; j++)
                         {
                             int jj = hWResIds[j]; // Id of rocSOLVER eigen-pair associated to j-th LAPACK eigen-pair
                             hZRes[b][i + j * ldz] = hB[b][i + jj * ldb];
@@ -671,7 +671,7 @@ void sygvdx_hegvdx_getError(const rocblas_handle handle,
                     // problem is A*B*x = (lambda)*x or B*A*x = (lambda)*x
 
                     // compute (1/lambda)*A*B*x or (1/lambda)*B*A*x and store in hA
-                    for(int j = 0; j < numMatchingEigs; j++)
+                    for(int64_t j = 0; j < numMatchingEigs; j++)
                     {
                         int jj = hWResIds[j]; // Id of rocSOLVER eigen-pair associated to j-th LAPACK eigen-pair
                         alpha = T(1) / hWRes[b][jj];
@@ -679,9 +679,9 @@ void sygvdx_hegvdx_getError(const rocblas_handle handle,
                                       hA[b] + j * lda, 1);
                     }
                     // move hZRes
-                    for(rocblas_int i = 0; i < n; i++)
+                    for(int64_t i = 0; i < n; i++)
                     {
-                        for(rocblas_int j = 0; j < numMatchingEigs; j++)
+                        for(int64_t j = 0; j < numMatchingEigs; j++)
                         {
                             int jj = hWResIds[j]; // Id of rocSOLVER eigen-pair associated to j-th LAPACK eigen-pair
                             if(j != jj)
@@ -729,7 +729,7 @@ void sygvdx_hegvdx_getError(const rocblas_handle handle,
                 if(numRocsolverEigs > numMatchingEigs)
                 {
                     rocblas_int ii;
-                    for(rocblas_int i = 0; i < numMatchingEigs; ++i)
+                    for(int64_t i = 0; i < numMatchingEigs; ++i)
                     {
                         ii = rocsolverEigsIds[i];
                         V_b.col(i, V_b.col(ii));
@@ -833,7 +833,7 @@ void sygvdx_hegvdx_getPerfData(const rocblas_handle handle,
                                            hA, hB, A, B, false, singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         sygvdx_hegvdx_initData<false, true, T>(handle, itype, evect, n, dA, lda, stA, dB, ldb, stB,
                                                bc, hA, hB, A, B, false, singular);
@@ -858,7 +858,7 @@ void sygvdx_hegvdx_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         sygvdx_hegvdx_initData<false, true, T>(handle, itype, evect, n, dA, lda, stA, dB, ldb, stB,
                                                bc, hA, hB, A, B, false, singular);
@@ -887,10 +887,10 @@ void testing_sygvdx_hegvdx(Arguments& argus)
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
     rocblas_int ldb = argus.get<rocblas_int>("ldb", n);
     rocblas_int ldz = argus.get<rocblas_int>("ldz", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
-    rocblas_stride stB = argus.get<rocblas_stride>("strideB", ldb * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
+    rocblas_stride stB = argus.get<rocblas_stride>("strideB", rocblas_stride(ldb) * n);
     rocblas_stride stW = argus.get<rocblas_stride>("strideW", n);
-    rocblas_stride stZ = argus.get<rocblas_stride>("strideZ", ldz * n);
+    rocblas_stride stZ = argus.get<rocblas_stride>("strideZ", rocblas_stride(ldz) * n);
 
     S vl = S(argus.get<double>("vl", 0));
     S vu = S(argus.get<double>("vu", erangeC == 'V' ? 1 : 0));

--- a/clients/common/lapack/testing_sygvdx_hegvdx_inplace.hpp
+++ b/clients/common/lapack/testing_sygvdx_hegvdx_inplace.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -220,15 +220,15 @@ void sygvdx_hegvdx_inplace_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
         rocblas_init<T>(U, true);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             // for testing purposes, we start with a reduced matrix M for the standard equivalent problem
             // with spectrum in a desired range (-20, 20). Then we construct the generalized pair
             // (A, B) from there.
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
                 // scale matrices and set hA = M (symmetric/hermitian), hB = U (upper triangular)
-                for(rocblas_int j = i; j < n; j++)
+                for(int64_t j = i; j < n; j++)
                 {
                     if(i == j)
                     {
@@ -299,9 +299,9 @@ void sygvdx_hegvdx_inplace_initData(const rocblas_handle handle,
             // store A and B for testing purposes
             if(test && evect != rocblas_evect_none)
             {
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                     {
                         if(itype != rocblas_eform_bax)
                         {
@@ -394,7 +394,7 @@ void sygvdx_hegvdx_inplace_getError(const rocblas_handle handle,
     // CPU lapack
     // abstol = 0 ensures max accuracy in rocsolver; for lapack we should use 2*safemin
     S atol = (abstol == 0) ? 2 * get_safemin<S>() : abstol;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         cpu_sygvx_hegvx(itype, evect, erange, uplo, n, hA[b], lda, hB[b], ldb, vl, vu, il, iu, atol,
                         hNev[b], hW[b], Z.data(), ldz, work.data(), lwork, rwork.data(),
@@ -408,7 +408,7 @@ void sygvdx_hegvdx_inplace_getError(const rocblas_handle handle,
 
     // check info for non-convergence and/or positive-definiteness
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
@@ -416,7 +416,7 @@ void sygvdx_hegvdx_inplace_getError(const rocblas_handle handle,
     }
 
     // Check number of returned eigenvalues
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hNev[b][0], hNevRes[b][0]) << "where b = " << b;
         if(hNev[b][0] != hNevRes[b][0])
@@ -425,7 +425,7 @@ void sygvdx_hegvdx_inplace_getError(const rocblas_handle handle,
 
     double err;
 
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(evect == rocblas_evect_none)
         {
@@ -458,7 +458,7 @@ void sygvdx_hegvdx_inplace_getError(const rocblas_handle handle,
                     // problem is A*x = (lambda)*B*x
 
                     // compute (1/lambda)*A*x and store in hA
-                    for(int j = 0; j < hNev[b][0]; j++)
+                    for(int64_t j = 0; j < hNev[b][0]; j++)
                     {
                         alpha = T(1) / hWRes[b][j];
                         cpu_symv_hemv(uplo, n, alpha, A[b], lda, hARes[b] + j * lda, 1, beta,
@@ -466,8 +466,8 @@ void sygvdx_hegvdx_inplace_getError(const rocblas_handle handle,
                     }
 
                     // move B*x into hARes
-                    for(rocblas_int i = 0; i < n; i++)
-                        for(rocblas_int j = 0; j < hNev[b][0]; j++)
+                    for(int64_t i = 0; i < n; i++)
+                        for(int64_t j = 0; j < hNev[b][0]; j++)
                             hARes[b][i + j * lda] = hB[b][i + j * ldb];
                 }
                 else
@@ -475,7 +475,7 @@ void sygvdx_hegvdx_inplace_getError(const rocblas_handle handle,
                     // problem is A*B*x = (lambda)*x or B*A*x = (lambda)*x
 
                     // compute (1/lambda)*A*B*x or (1/lambda)*B*A*x and store in hA
-                    for(int j = 0; j < hNev[b][0]; j++)
+                    for(int64_t j = 0; j < hNev[b][0]; j++)
                     {
                         alpha = T(1) / hWRes[b][j];
                         cpu_symv_hemv(uplo, n, alpha, A[b], lda, hB[b] + j * ldb, 1, beta,
@@ -553,7 +553,7 @@ void sygvdx_hegvdx_inplace_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             cpu_sygvx_hegvx(itype, evect, erange, uplo, n, hA[b], lda, hB[b], ldb, vl, vu, il, iu,
                             atol, hNev[b], hW[b], Z.data(), ldz, work.data(), lwork, rwork.data(),
@@ -566,7 +566,7 @@ void sygvdx_hegvdx_inplace_getPerfData(const rocblas_handle handle,
                                                    stB, bc, hA, hB, A, B, false, singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         sygvdx_hegvdx_inplace_initData<false, true, T>(handle, itype, evect, n, dA, lda, stA, dB,
                                                        ldb, stB, bc, hA, hB, A, B, false, singular);
@@ -591,7 +591,7 @@ void sygvdx_hegvdx_inplace_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         sygvdx_hegvdx_inplace_initData<false, true, T>(handle, itype, evect, n, dA, lda, stA, dB,
                                                        ldb, stB, bc, hA, hB, A, B, false, singular);
@@ -619,8 +619,8 @@ void testing_sygvdx_hegvdx_inplace(Arguments& argus)
     rocblas_int n = argus.get<rocblas_int>("n");
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
     rocblas_int ldb = argus.get<rocblas_int>("ldb", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
-    rocblas_stride stB = argus.get<rocblas_stride>("strideB", ldb * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
+    rocblas_stride stB = argus.get<rocblas_stride>("strideB", rocblas_stride(ldb) * n);
     rocblas_stride stW = argus.get<rocblas_stride>("strideW", n);
 
     S vl = S(argus.get<double>("vl", 0));

--- a/clients/common/lapack/testing_sygvj_hegvj.hpp
+++ b/clients/common/lapack/testing_sygvj_hegvj.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -218,11 +218,11 @@ void sygvj_hegvj_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
         rocblas_init<T>(hB, false);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                     {
@@ -256,9 +256,9 @@ void sygvj_hegvj_initData(const rocblas_handle handle,
             // store A and B for testing purposes
             if(test && evect != rocblas_evect_none)
             {
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                     {
                         if(itype != rocblas_eform_bax)
                         {
@@ -323,8 +323,8 @@ void sygvj_hegvj_getError(const rocblas_handle handle,
     rocblas_int lrwork = (COMPLEX ? 3 * n - 2 : 0);
     std::vector<T> work(lwork);
     std::vector<S> rwork(lrwork);
-    host_strided_batch_vector<T> A(lda * n, 1, lda * n, bc);
-    host_strided_batch_vector<T> B(ldb * n, 1, ldb * n, bc);
+    host_strided_batch_vector<T> A(lda * n, 1, size_t(lda) * n, bc);
+    host_strided_batch_vector<T> B(ldb * n, 1, size_t(ldb) * n, bc);
 
     // input data initialization
     sygvj_hegvj_initData<true, true, T>(handle, itype, evect, n, dA, lda, stA, dB, ldb, stB, bc, hA,
@@ -344,7 +344,7 @@ void sygvj_hegvj_getError(const rocblas_handle handle,
         CHECK_HIP_ERROR(hARes.transfer_from(dA));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         cpu_sygv_hegv(itype, evect, uplo, n, hA[b], lda, hB[b], ldb, hW[b], work.data(), lwork,
                       rwork.data(), hInfo[b]);
@@ -353,7 +353,7 @@ void sygvj_hegvj_getError(const rocblas_handle handle,
     // (We expect the used input matrices to always converge)
     // check info for non-convergence and/or positive-definiteness
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
@@ -361,7 +361,7 @@ void sygvj_hegvj_getError(const rocblas_handle handle,
     }
 
     // Also check validity of residual
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
         if(hInfoRes[b][0] == 0)
         {
             EXPECT_GE(hResidualRes[b][0], 0) << "where b = " << b;
@@ -370,7 +370,7 @@ void sygvj_hegvj_getError(const rocblas_handle handle,
         }
 
     // Also check validity of sweeps
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
         if(hInfoRes[b][0] == 0)
         {
             EXPECT_GE(hSweepsRes[b][0], 0) << "where b = " << b;
@@ -381,7 +381,7 @@ void sygvj_hegvj_getError(const rocblas_handle handle,
 
     double err;
 
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(evect == rocblas_evect_none)
         {
@@ -414,7 +414,7 @@ void sygvj_hegvj_getError(const rocblas_handle handle,
                     // problem is A*x = (lambda)*B*x
 
                     // compute (1/lambda)*A*x and store in hA
-                    for(int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                     {
                         alpha = T(1) / hWRes[b][j];
                         cpu_symv_hemv(uplo, n, alpha, A[b], lda, hARes[b] + j * lda, 1, beta,
@@ -422,8 +422,8 @@ void sygvj_hegvj_getError(const rocblas_handle handle,
                     }
 
                     // move B*x into hARes
-                    for(rocblas_int i = 0; i < n; i++)
-                        for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t i = 0; i < n; i++)
+                        for(int64_t j = 0; j < n; j++)
                             hARes[b][i + j * lda] = hB[b][i + j * ldb];
                 }
                 else
@@ -431,7 +431,7 @@ void sygvj_hegvj_getError(const rocblas_handle handle,
                     // problem is A*B*x = (lambda)*x or B*A*x = (lambda)*x
 
                     // compute (1/lambda)*A*B*x or (1/lambda)*B*A*x and store in hA
-                    for(int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                     {
                         alpha = T(1) / hWRes[b][j];
                         cpu_symv_hemv(uplo, n, alpha, A[b], lda, hB[b] + j * ldb, 1, beta,
@@ -496,7 +496,7 @@ void sygvj_hegvj_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             cpu_sygv_hegv(itype, evect, uplo, n, hA[b], lda, hB[b], ldb, hW[b], work.data(), lwork,
                           rwork.data(), hInfo[b]);
@@ -508,7 +508,7 @@ void sygvj_hegvj_getPerfData(const rocblas_handle handle,
                                          hA, hB, A, B, false, singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         sygvj_hegvj_initData<false, true, T>(handle, itype, evect, n, dA, lda, stA, dB, ldb, stB,
                                              bc, hA, hB, A, B, false, singular);
@@ -533,7 +533,7 @@ void sygvj_hegvj_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         sygvj_hegvj_initData<false, true, T>(handle, itype, evect, n, dA, lda, stA, dB, ldb, stB,
                                              bc, hA, hB, A, B, false, singular);
@@ -560,8 +560,8 @@ void testing_sygvj_hegvj(Arguments& argus)
     rocblas_int n = argus.get<rocblas_int>("n");
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
     rocblas_int ldb = argus.get<rocblas_int>("ldb", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
-    rocblas_stride stB = argus.get<rocblas_stride>("strideB", ldb * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
+    rocblas_stride stB = argus.get<rocblas_stride>("strideB", rocblas_stride(ldb) * n);
     rocblas_stride stW = argus.get<rocblas_stride>("strideD", n);
 
     S abstol = S(argus.get<double>("abstol", 0));

--- a/clients/common/lapack/testing_sygvx_hegvx.hpp
+++ b/clients/common/lapack/testing_sygvx_hegvx.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -258,15 +258,15 @@ void sygvx_hegvx_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
         rocblas_init<T>(U, true);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             // for testing purposes, we start with a reduced matrix M for the standard equivalent problem
             // with spectrum in a desired range (-20, 20). Then we construct the generalized pair
             // (A, B) from there.
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
                 // scale matrices and set hA = M (symmetric/hermitian), hB = U (upper triangular)
-                for(rocblas_int j = i; j < n; j++)
+                for(int64_t j = i; j < n; j++)
                 {
                     if(i == j)
                     {
@@ -337,9 +337,9 @@ void sygvx_hegvx_initData(const rocblas_handle handle,
             // store A and B for testing purposes
             if(test && evect != rocblas_evect_none)
             {
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(int64_t j = 0; j < n; j++)
                     {
                         if(itype != rocblas_eform_bax)
                         {
@@ -456,7 +456,7 @@ void sygvx_hegvx_getError(const rocblas_handle handle,
     // CPU lapack
     // abstol = 0 ensures max accuracy in rocsolver; for lapack we should use 2*safemin
     S atol = (abstol == 0) ? 2 * get_safemin<S>() : abstol;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         cpu_sygvx_hegvx(itype, evect, erange, uplo, n, hA[b], lda, hB[b], ldb, vl, vu, il, iu, atol,
                         hNev[b], hW[b], hZ[b], ldz, work.data(), lwork, rwork.data(), iwork.data(),
@@ -470,7 +470,7 @@ void sygvx_hegvx_getError(const rocblas_handle handle,
 
     // check info for non-convergence and/or positive-definiteness
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
@@ -478,7 +478,7 @@ void sygvx_hegvx_getError(const rocblas_handle handle,
     }
 
     // Check number of returned eigenvalues
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hNev[b][0], hNevRes[b][0]) << "where b = " << b;
         if(hNev[b][0] != hNevRes[b][0])
@@ -487,7 +487,7 @@ void sygvx_hegvx_getError(const rocblas_handle handle,
 
     double err;
 
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(evect == rocblas_evect_none)
         {
@@ -509,7 +509,7 @@ void sygvx_hegvx_getError(const rocblas_handle handle,
             {
                 // check ifail
                 err = 0;
-                for(int j = 0; j < hNev[b][0]; j++)
+                for(int64_t j = 0; j < hNev[b][0]; j++)
                 {
                     EXPECT_EQ(hIfailRes[b][j], 0) << "where b = " << b << ", j = " << j;
                     if(hIfailRes[b][j] != 0)
@@ -530,7 +530,7 @@ void sygvx_hegvx_getError(const rocblas_handle handle,
                     // problem is A*x = (lambda)*B*x
 
                     // compute (1/lambda)*A*x and store in hA
-                    for(int j = 0; j < hNev[b][0]; j++)
+                    for(int64_t j = 0; j < hNev[b][0]; j++)
                     {
                         alpha = T(1) / hWRes[b][j];
                         cpu_symv_hemv(uplo, n, alpha, A[b], lda, hZRes[b] + j * ldz, 1, beta,
@@ -538,8 +538,8 @@ void sygvx_hegvx_getError(const rocblas_handle handle,
                     }
 
                     // move B*x into hZRes
-                    for(rocblas_int i = 0; i < n; i++)
-                        for(rocblas_int j = 0; j < hNev[b][0]; j++)
+                    for(int64_t i = 0; i < n; i++)
+                        for(int64_t j = 0; j < hNev[b][0]; j++)
                             hZRes[b][i + j * ldz] = hB[b][i + j * ldb];
                 }
                 else
@@ -547,7 +547,7 @@ void sygvx_hegvx_getError(const rocblas_handle handle,
                     // problem is A*B*x = (lambda)*x or B*A*x = (lambda)*x
 
                     // compute (1/lambda)*A*B*x or (1/lambda)*B*A*x and store in hA
-                    for(int j = 0; j < hNev[b][0]; j++)
+                    for(int64_t j = 0; j < hNev[b][0]; j++)
                     {
                         alpha = T(1) / hWRes[b][j];
                         cpu_symv_hemv(uplo, n, alpha, A[b], lda, hB[b] + j * ldb, 1, beta,
@@ -564,7 +564,7 @@ void sygvx_hegvx_getError(const rocblas_handle handle,
             {
                 // check ifail
                 err = 0;
-                for(int j = 0; j < hInfo[b][0]; j++)
+                for(int64_t j = 0; j < hInfo[b][0]; j++)
                 {
                     EXPECT_NE(hIfailRes[b][j], 0) << "where b = " << b << ", j = " << j;
                     if(hIfailRes[b][j] == 0)
@@ -641,7 +641,7 @@ void sygvx_hegvx_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             cpu_sygvx_hegvx(itype, evect, erange, uplo, n, hA[b], lda, hB[b], ldb, vl, vu, il, iu,
                             atol, hNev[b], hW[b], hZ[b], ldz, work.data(), lwork, rwork.data(),
@@ -654,7 +654,7 @@ void sygvx_hegvx_getPerfData(const rocblas_handle handle,
                                          hA, hB, A, B, false, singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         sygvx_hegvx_initData<false, true, T>(handle, itype, evect, n, dA, lda, stA, dB, ldb, stB,
                                              bc, hA, hB, A, B, false, singular);
@@ -680,7 +680,7 @@ void sygvx_hegvx_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         sygvx_hegvx_initData<false, true, T>(handle, itype, evect, n, dA, lda, stA, dB, ldb, stB,
                                              bc, hA, hB, A, B, false, singular);
@@ -709,11 +709,11 @@ void testing_sygvx_hegvx(Arguments& argus)
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
     rocblas_int ldb = argus.get<rocblas_int>("ldb", n);
     rocblas_int ldz = argus.get<rocblas_int>("ldz", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
-    rocblas_stride stB = argus.get<rocblas_stride>("strideB", ldb * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
+    rocblas_stride stB = argus.get<rocblas_stride>("strideB", rocblas_stride(ldb) * n);
     rocblas_stride stW = argus.get<rocblas_stride>("strideW", n);
     rocblas_stride stF = argus.get<rocblas_stride>("strideF", n);
-    rocblas_stride stZ = argus.get<rocblas_stride>("strideZ", ldz * n);
+    rocblas_stride stZ = argus.get<rocblas_stride>("strideZ", rocblas_stride(ldz) * n);
 
     S vl = S(argus.get<double>("vl", 0));
     S vu = S(argus.get<double>("vu", erangeC == 'V' ? 1 : 0));

--- a/clients/common/lapack/testing_sytf2_sytrf.hpp
+++ b/clients/common/lapack/testing_sytf2_sytrf.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -153,12 +153,12 @@ void sytf2_sytrf_initData(const rocblas_handle handle,
         T tmp;
         rocblas_init<T>(hA, true);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             // scale A to avoid singularities
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] += 400;
@@ -169,9 +169,9 @@ void sytf2_sytrf_initData(const rocblas_handle handle,
 
             // shuffle rows to test pivoting
             // always the same permuation for debugging purposes
-            for(rocblas_int i = 0; i < n / 2; i++)
+            for(int64_t i = 0; i < n / 2; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     tmp = hA[b][i + j * lda];
                     hA[b][i + j * lda] = hA[b][n - 1 - i + j * lda];
@@ -187,21 +187,21 @@ void sytf2_sytrf_initData(const rocblas_handle handle,
                 // matrices in the batch that are singular
                 rocblas_int j = n / 4 + b;
                 j -= (j / n) * n;
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                 {
                     hA[b][i + j * lda] = 0;
                     hA[b][j + i * lda] = 0;
                 }
                 j = n / 2 + b;
                 j -= (j / n) * n;
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                 {
                     hA[b][i + j * lda] = 0;
                     hA[b][j + i * lda] = 0;
                 }
                 j = n - 1 + b;
                 j -= (j / n) * n;
-                for(rocblas_int i = 0; i < n; i++)
+                for(int64_t i = 0; i < n; i++)
                 {
                     hA[b][i + j * lda] = 0;
                     hA[b][j + i * lda] = 0;
@@ -253,7 +253,7 @@ void sytf2_sytrf_getError(const rocblas_handle handle,
     CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         SYTRF ? cpu_sytrf(uplo, n, hA[b], lda, hIpiv[b], work.data(), lwork, hInfo[b])
               : cpu_sytf2(uplo, n, hA[b], lda, hIpiv[b], hInfo[b]);
@@ -265,14 +265,14 @@ void sytf2_sytrf_getError(const rocblas_handle handle,
     // using frobenius norm
     double err;
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         err = norm_error('F', n, n, lda, hA[b], hARes[b]);
         *max_err = err > *max_err ? err : *max_err;
 
         // also check pivoting (count the number of incorrect pivots)
         err = 0;
-        for(rocblas_int i = 0; i < n; ++i)
+        for(int64_t i = 0; i < n; ++i)
         {
             EXPECT_EQ(hIpiv[b][i], hIpivRes[b][i]) << "where b = " << b << ", i = " << i;
             if(hIpiv[b][i] != hIpivRes[b][i])
@@ -283,7 +283,7 @@ void sytf2_sytrf_getError(const rocblas_handle handle,
 
     // also check info
     err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
@@ -324,7 +324,7 @@ void sytf2_sytrf_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             SYTRF ? cpu_sytrf(uplo, n, hA[b], lda, hIpiv[b], work.data(), lwork, hInfo[b])
                   : cpu_sytf2(uplo, n, hA[b], lda, hIpiv[b], hInfo[b]);
@@ -336,7 +336,7 @@ void sytf2_sytrf_getPerfData(const rocblas_handle handle,
                                          hIpiv, hInfo, singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         sytf2_sytrf_initData<false, true, T>(handle, uplo, n, dA, lda, stA, dIpiv, stP, dInfo, bc,
                                              hA, hIpiv, hInfo, singular);
@@ -360,7 +360,7 @@ void sytf2_sytrf_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         sytf2_sytrf_initData<false, true, T>(handle, uplo, n, dA, lda, stA, dIpiv, stP, dInfo, bc,
                                              hA, hIpiv, hInfo, singular);
@@ -381,7 +381,7 @@ void testing_sytf2_sytrf(Arguments& argus)
     char uploC = argus.get<char>("uplo");
     rocblas_int n = argus.get<rocblas_int>("n");
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stP = argus.get<rocblas_stride>("strideP", n);
 
     rocblas_fill uplo = char2rocblas_fill(uploC);

--- a/clients/common/lapack/testing_sytxx_hetxx.hpp
+++ b/clients/common/lapack/testing_sytxx_hetxx.hpp
@@ -1,4 +1,4 @@
-/* ************************************************************************** 
+/* **************************************************************************
  * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -156,11 +156,11 @@ void sytxx_hetxx_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
 
         // scale A to avoid singularities
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j || i == j + 1 || i == j - 1)
                         hA[b][i + j * lda] += 400;
@@ -191,11 +191,11 @@ void sytxx_hetxx_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
 
         // scale A to avoid singularities
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] = hA[b][i + j * lda].real() + 400;
@@ -254,26 +254,26 @@ void sytxx_hetxx_getError(const rocblas_handle handle,
     // A = H(n-1)...H(2)H(1)*T*H(1)'H(2)'...H(n-1)' if upper
     // A = H(1)H(2)...H(n-1)*T*H(n-1)'...H(2)'H(1)' if lower
     std::vector<T> v(n);
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         T* a = hARes[b];
         T* t = hTau[b];
 
         if(uplo == rocblas_fill_lower)
         {
-            for(rocblas_int i = 0; i < n - 2; ++i)
+            for(int64_t i = 0; i < n - 2; ++i)
                 a[i + (n - 1) * lda] = 0;
             a[(n - 2) + (n - 1) * lda] = a[(n - 1) + (n - 2) * lda];
 
             // for each column
-            for(rocblas_int j = n - 2; j >= 0; --j)
+            for(int64_t j = n - 2; j >= 0; --j)
             {
                 // prepare T and v
-                for(rocblas_int i = 0; i < j - 1; ++i)
+                for(int64_t i = 0; i < j - 1; ++i)
                     a[i + j * lda] = 0;
                 if(j > 0)
                     a[(j - 1) + j * lda] = a[j + (j - 1) * lda];
-                for(rocblas_int i = j + 2; i < n; ++i)
+                for(int64_t i = j + 2; i < n; ++i)
                 {
                     v[i - j - 1] = a[i + j * lda];
                     a[i + j * lda] = 0;
@@ -293,14 +293,14 @@ void sytxx_hetxx_getError(const rocblas_handle handle,
         else
         {
             a[1] = a[lda];
-            for(rocblas_int i = 2; i < n; ++i)
+            for(int64_t i = 2; i < n; ++i)
                 a[i] = 0;
 
             // for each column
-            for(rocblas_int j = 1; j <= n - 1; ++j)
+            for(int64_t j = 1; j <= n - 1; ++j)
             {
                 // prepare T and v
-                for(rocblas_int i = 0; i < j - 1; ++i)
+                for(int64_t i = 0; i < j - 1; ++i)
                 {
                     v[i] = a[i + j * lda];
                     a[i + j * lda] = 0;
@@ -308,7 +308,7 @@ void sytxx_hetxx_getError(const rocblas_handle handle,
                 v[j - 1] = 1;
                 if(j < n - 1)
                     a[(j + 1) + j * lda] = a[j + (j + 1) * lda];
-                for(rocblas_int i = j + 2; i < n; ++i)
+                for(int64_t i = j + 2; i < n; ++i)
                     a[i + j * lda] = 0;
 
                 // apply householder reflector
@@ -324,7 +324,7 @@ void sytxx_hetxx_getError(const rocblas_handle handle,
     // using frobenius norm
     double err;
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         *max_err = (uplo == rocblas_fill_lower)
             ? norm_error_lowerTr('F', n, n, lda, hA[b], hARes[b])
@@ -365,7 +365,7 @@ void sytxx_hetxx_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             SYTRD
             ? cpu_sytrd_hetrd(uplo, n, hA[b], lda, hD[b], hE[b], hTau[b], hW.data(), 32 * n)
@@ -377,7 +377,7 @@ void sytxx_hetxx_getPerfData(const rocblas_handle handle,
     sytxx_hetxx_initData<true, false, T>(handle, n, dA, lda, bc, hA);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         sytxx_hetxx_initData<false, true, T>(handle, n, dA, lda, bc, hA);
 
@@ -401,7 +401,7 @@ void sytxx_hetxx_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         sytxx_hetxx_initData<false, true, T>(handle, n, dA, lda, bc, hA);
 
@@ -423,7 +423,7 @@ void testing_sytxx_hetxx(Arguments& argus)
     char uploC = argus.get<char>("uplo");
     rocblas_int n = argus.get<rocblas_int>("n");
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     rocblas_stride stD = argus.get<rocblas_stride>("strideD", n);
     rocblas_stride stE = argus.get<rocblas_stride>("strideE", n - 1);
     rocblas_stride stP = argus.get<rocblas_stride>("strideP", n - 1);

--- a/clients/common/lapack/testing_trtri.hpp
+++ b/clients/common/lapack/testing_trtri.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -133,12 +133,12 @@ void trtri_initData(const rocblas_handle handle,
         T tmp;
         rocblas_init<T>(hA, true);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             // scale A to avoid singularities
-            for(rocblas_int i = 0; i < n; i++)
+            for(int64_t i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(int64_t j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] = hA[b][i + j * lda] / 10.0 + 1;
@@ -202,7 +202,7 @@ void trtri_getError(const rocblas_handle handle,
     CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         cpu_trtri(uplo, diag, n, hA[b], lda, hInfo[b]);
     }
@@ -210,7 +210,7 @@ void trtri_getError(const rocblas_handle handle,
     // check info for singularities
     double err = 0;
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
@@ -222,7 +222,7 @@ void trtri_getError(const rocblas_handle handle,
     // (THIS DOES NOT ACCOUNT FOR NUMERICAL REPRODUCIBILITY ISSUES.
     // IT MIGHT BE REVISITED IN THE FUTURE)
     // using frobenius norm
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(int64_t b = 0; b < bc; ++b)
     {
         if(hInfoRes[b][0] == 0)
         {
@@ -258,7 +258,7 @@ void trtri_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(int64_t b = 0; b < bc; ++b)
         {
             cpu_trtri(uplo, diag, n, hA[b], lda, hInfo[b]);
         }
@@ -268,7 +268,7 @@ void trtri_getPerfData(const rocblas_handle handle,
     trtri_initData<true, false, T>(handle, n, dA, lda, bc, hA, singular);
 
     // cold calls
-    for(int iter = 0; iter < 2; iter++)
+    for(int64_t iter = 0; iter < 2; iter++)
     {
         trtri_initData<false, true, T>(handle, n, dA, lda, bc, hA, singular);
 
@@ -291,7 +291,7 @@ void trtri_getPerfData(const rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         trtri_initData<false, true, T>(handle, n, dA, lda, bc, hA, singular);
 
@@ -309,7 +309,7 @@ void testing_trtri(Arguments& argus)
     rocblas_local_handle handle;
     rocblas_int n = argus.get<rocblas_int>("n");
     rocblas_int lda = argus.get<rocblas_int>("lda", n);
-    rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
+    rocblas_stride stA = argus.get<rocblas_stride>("strideA", rocblas_stride(lda) * n);
     char uploC = argus.get<char>("uplo");
     rocblas_fill uplo = char2rocblas_fill(uploC);
     char diagC = argus.get<char>("diag");

--- a/clients/common/matrix_utils/host_matrix.hpp
+++ b/clients/common/matrix_utils/host_matrix.hpp
@@ -105,7 +105,7 @@ public:
             ptr = nullptr;
         }
 
-        for(I i = 0; i < ptr->size(); ++i)
+        for(int64_t i = 0; i < ptr->size(); ++i)
         {
             ptr->operator[](i) = T(in_data[i]);
         }
@@ -118,7 +118,7 @@ public:
     {
         HostMatrix<T_, I_> Out(In.nrows(), In.ncols());
 
-        for(I i = 0; i < Out.size(); ++i)
+        for(int64_t i = 0; i < Out.size(); ++i)
         {
             Out[i] = T_(In[i]);
         }
@@ -150,7 +150,7 @@ public:
         if(!Id.empty())
         {
             I dim = std::min(Id.nrows(), Id.ncols());
-            for(I i = 0; i < dim; ++i)
+            for(int64_t i = 0; i < dim; ++i)
             {
                 Id(i, i) = T_(1.);
             }
@@ -170,7 +170,7 @@ public:
 
         if(!ones.empty())
         {
-            for(I i = 0; i < ones.size(); ++i)
+            for(int64_t i = 0; i < ones.size(); ++i)
             {
                 ones[i] = T_(1.);
             }
@@ -193,7 +193,7 @@ public:
 
         I dim = std::max(d.nrows(), d.ncols());
         HostMatrix<T_, I_> Z(dim, dim);
-        for(I i = 0; i < dim; ++i)
+        for(int64_t i = 0; i < dim; ++i)
         {
             Z(i, i) = d[i];
         }
@@ -233,7 +233,7 @@ public:
         T t = (end_val - start_val) / static_cast<T>(nvals - 1);
 
         HostMatrix<T_, I_> Z(1, nvals);
-        for(I i = 0; i < Z.size(); ++i)
+        for(int64_t i = 0; i < Z.size(); ++i)
         {
             Z[i] = start_val + t * static_cast<T>(i);
         }
@@ -370,9 +370,9 @@ public:
 
         /* [[maybe_unused]] auto volatile mptr */
         /* = memmove(this->data(), src.data(), src.num_bytes()); */
-        for(I j = 0; j < src.ncols(); ++j)
+        for(int64_t j = 0; j < src.ncols(); ++j)
         {
-            for(I i = 0; i < src.nrows(); ++i)
+            for(int64_t i = 0; i < src.nrows(); ++i)
             {
                 this->operator()(i, j) = src(i, j);
             }
@@ -468,7 +468,7 @@ public:
     virtual S max_coeff_norm() const override
     {
         S norm = S(0.);
-        for(I i = 0; i < size(); ++i)
+        for(int64_t i = 0; i < size(); ++i)
         {
             S el = detail::abs(this->operator[](i));
             norm = (norm > el) ? norm : el;
@@ -482,9 +482,9 @@ public:
         S norm = S(0.);
         auto col_norm = HostMatrix<S, I_>::Zeros(1, ncols());
 
-        for(I j = 0; j < ncols(); ++j)
+        for(int64_t j = 0; j < ncols(); ++j)
         {
-            for(I i = 0; i < nrows(); ++i)
+            for(int64_t i = 0; i < nrows(); ++i)
             {
                 col_norm(0, j) += detail::norm(this->operator()(i, j));
             }
@@ -499,15 +499,15 @@ public:
         S norm = S(0.);
         auto col_norm = HostMatrix<S, I_>::Zeros(1, ncols());
 
-        for(I j = 0; j < ncols(); ++j)
+        for(int64_t j = 0; j < ncols(); ++j)
         {
-            for(I i = 0; i < nrows(); ++i)
+            for(int64_t i = 0; i < nrows(); ++i)
             {
                 col_norm(0, j) += detail::norm(this->operator()(i, j));
             }
         }
 
-        for(I i = 0; i < col_norm.size(); ++i)
+        for(int64_t i = 0; i < col_norm.size(); ++i)
         {
             norm += col_norm[i];
         }
@@ -523,7 +523,7 @@ public:
 
         HostMatrix<T_, I_> out(1, ncols());
 
-        for(I i = 0; i < ncols(); ++i)
+        for(int64_t i = 0; i < ncols(); ++i)
         {
             out[i] = this->operator()(k, i);
         }
@@ -540,7 +540,7 @@ public:
 
         HostMatrix<T_, I_> out(nrows(), 1);
 
-        for(I i = 0; i < nrows(); ++i)
+        for(int64_t i = 0; i < nrows(); ++i)
         {
             out[i] = this->operator()(i, k);
         }
@@ -555,7 +555,7 @@ public:
 
         if(!out.empty())
         {
-            for(I i = 0; i < dim; ++i)
+            for(int64_t i = 0; i < dim; ++i)
             {
                 out[i] = this->operator()(i, i);
             }
@@ -571,7 +571,7 @@ public:
 
         if(!out.empty())
         {
-            for(I i = 0; i < dim; ++i)
+            for(int64_t i = 0; i < dim; ++i)
             {
                 out[i] = this->operator()(i + 1, i);
             }
@@ -587,7 +587,7 @@ public:
 
         if(!out.empty())
         {
-            for(I i = 0; i < dim; ++i)
+            for(int64_t i = 0; i < dim; ++i)
             {
                 out[i] = this->operator()(i, i + 1);
             }
@@ -675,9 +675,9 @@ public:
 
         HostMatrix<T_, I_> out(bd.nrows_, bd.ncols_);
 
-        for(I j = 0; j < out.ncols(); ++j)
+        for(int64_t j = 0; j < out.ncols(); ++j)
         {
-            for(I i = 0; i < out.nrows(); ++i)
+            for(int64_t i = 0; i < out.nrows(); ++i)
             {
                 out(i, j) = this->operator()(i + bd.from_row_, j + bd.from_col_);
             }
@@ -691,7 +691,7 @@ public:
         auto b = BlockDescriptor().from_col(0).ncols(ncols()).from_row(k).nrows(1);
         if(!empty() || b.range_check(nrows(), ncols()))
         {
-            for(I i = 0; i < ncols(); ++i)
+            for(int64_t i = 0; i < ncols(); ++i)
             {
                 this->operator()(k, i) = r[i];
             }
@@ -705,7 +705,7 @@ public:
         auto b = BlockDescriptor().from_row(0).nrows(nrows()).from_col(k).ncols(1);
         if(!empty() || b.range_check(nrows(), ncols()))
         {
-            for(I i = 0; i < nrows(); ++i)
+            for(int64_t i = 0; i < nrows(); ++i)
             {
                 this->operator()(i, k) = c[i];
             }
@@ -719,7 +719,7 @@ public:
         I dim = std::min(nrows(), ncols());
         if(!empty() && (dim == d.size()))
         {
-            for(I i = 0; i < dim; ++i)
+            for(int64_t i = 0; i < dim; ++i)
             {
                 this->operator()(i, i) = d[i];
             }
@@ -734,7 +734,7 @@ public:
 
         if(!empty() && (dim == f.size()))
         {
-            for(I i = 0; i < dim; ++i)
+            for(int64_t i = 0; i < dim; ++i)
             {
                 this->operator()(i + 1, i) = f[i];
             }
@@ -749,7 +749,7 @@ public:
 
         if(!empty() && (dim == e.size()))
         {
-            for(I i = 0; i < dim; ++i)
+            for(int64_t i = 0; i < dim; ++i)
             {
                 this->operator()(i, i + 1) = e[i];
             }
@@ -762,9 +762,9 @@ public:
     {
         if(!empty() && bd.range_check(nrows(), ncols()))
         {
-            for(I j = 0; j < bd.ncols_; ++j)
+            for(int64_t j = 0; j < bd.ncols_; ++j)
             {
-                for(I i = 0; i < bd.nrows_; ++i)
+                for(int64_t i = 0; i < bd.nrows_; ++i)
                 {
                     this->operator()(i + bd.from_row_, j + bd.from_col_) = b(i, j);
                 }
@@ -784,9 +784,9 @@ public:
         /*         else */
         /*             std::cout << "\n" << std::flush; */
         /* } */
-        for(I i = 0; i < nrows_; ++i)
+        for(int64_t i = 0; i < nrows_; ++i)
         {
-            for(I j = 0; j < ncols_; ++j)
+            for(int64_t j = 0; j < ncols_; ++j)
             {
                 std::cout << this->operator()(i, j);
                 if(j != ncols_ - 1)
@@ -968,7 +968,7 @@ auto operator+(const HostMatrix_<T, I>& A, const HostMatrix_<T, I>& B)
     I size = A.size();
     HostMatrix_<T, I> Z(nrows, ncols);
 
-    for(I i = 0; i < size; ++i)
+    for(int64_t i = 0; i < size; ++i)
     {
         Z[i] = A[i] + B[i];
     }
@@ -994,7 +994,7 @@ auto operator-(const HostMatrix_<T, I>& A, const HostMatrix_<T, I>& B)
     I size = A.size();
     HostMatrix_<T, I> Z(nrows, ncols);
 
-    for(I i = 0; i < size; ++i)
+    for(int64_t i = 0; i < size; ++i)
     {
         Z[i] = A[i] - B[i];
     }
@@ -1016,7 +1016,7 @@ auto operator-(const HostMatrix_<T, I>& A)
     I size = A.size();
     HostMatrix_<T, I> Z(nrows, ncols);
 
-    for(I i = 0; i < size; ++i)
+    for(int64_t i = 0; i < size; ++i)
     {
         Z[i] = -A[i];
     }
@@ -1031,9 +1031,9 @@ auto operator*(const HostMatrix_<T, I>& A, S alpha)
     I ncols = A.ncols();
     HostMatrix_<T, I> Z(nrows, ncols);
 
-    for(I j = 0; j < ncols; ++j)
+    for(int64_t j = 0; j < ncols; ++j)
     {
-        for(I i = 0; i < nrows; ++i)
+        for(int64_t i = 0; i < nrows; ++i)
         {
             Z(i, j) = A(i, j) * static_cast<T>(alpha);
         }
@@ -1049,9 +1049,9 @@ auto operator*(S alpha, const HostMatrix_<T, I>& A)
     I ncols = A.ncols();
     HostMatrix_<T, I> Z(nrows, ncols);
 
-    for(I j = 0; j < ncols; ++j)
+    for(int64_t j = 0; j < ncols; ++j)
     {
-        for(I i = 0; i < nrows; ++i)
+        for(int64_t i = 0; i < nrows; ++i)
         {
             Z(i, j) = static_cast<T>(alpha) * A(i, j);
         }
@@ -1095,9 +1095,9 @@ auto operator*(const HostMatrix_<T, I>& A, const HostMatrix_<T, I>& B)
         else
         {
             I dim = A.ncols();
-            for(I j = 0; j < ncols; ++j)
-                for(I i = 0; i < nrows; ++i)
-                    for(I k = 0; k < dim; ++k)
+            for(int64_t j = 0; j < ncols; ++j)
+                for(int64_t i = 0; i < nrows; ++i)
+                    for(int64_t k = 0; k < dim; ++k)
                         Z(i, j) += A(i, k) * B(k, j);
         }
     }
@@ -1112,9 +1112,9 @@ auto operator/(const HostMatrix_<T, I>& A, S alpha)
     I ncols = A.ncols();
     HostMatrix_<T, I> Z(nrows, ncols);
 
-    for(I j = 0; j < ncols; ++j)
+    for(int64_t j = 0; j < ncols; ++j)
     {
-        for(I i = 0; i < nrows; ++i)
+        for(int64_t i = 0; i < nrows; ++i)
         {
             Z(i, j) = A(i, j) / static_cast<T>(alpha);
         }
@@ -1153,13 +1153,13 @@ auto cat(const HostMatrix_<T, I>& A, const HostMatrix_<T, I>& B)
     }
     HostMatrix_<T, I> Z(nrows, ncols);
 
-    for(I i = 0; i < A.size(); ++i)
+    for(int64_t i = 0; i < A.size(); ++i)
     {
         Z[i] = A[i];
     }
 
     I a_size = A.size();
-    for(I i = 0; i < B.size(); ++i)
+    for(int64_t i = 0; i < B.size(); ++i)
     {
         Z[i + a_size] = B[i];
     }
@@ -1172,9 +1172,9 @@ HostMatrix_<T, I> transpose(const HostMatrix_<T, I>& A)
 {
     HostMatrix_<T, I> Z(A.ncols(), A.nrows());
 
-    for(I j = 0; j < Z.ncols(); ++j)
+    for(int64_t j = 0; j < Z.ncols(); ++j)
     {
-        for(I i = 0; i < Z.nrows(); ++i)
+        for(int64_t i = 0; i < Z.nrows(); ++i)
         {
             Z(i, j) = A(j, i);
         }
@@ -1188,7 +1188,7 @@ HostMatrix_<T, I> conjugate(const HostMatrix_<T, I>& A)
     HostMatrix_<T, I> Z(A.nrows(), A.ncols());
 
     // TODO: avoid for loop when `T` is real
-    for(I i = 0; i < A.size(); ++i)
+    for(int64_t i = 0; i < A.size(); ++i)
     {
         Z[i] = detail::conj(A[i]);
     }
@@ -1374,7 +1374,7 @@ auto inv(const HostMatrix_<T, I>& A) -> HostMatrix_<T, I> /* Pseudo-Inverse of A
     I ncols = A.ncols();
     I dim = std::min(nrows, ncols);
 
-    for(I i = 0; i < dim; ++i)
+    for(int64_t i = 0; i < dim; ++i)
     {
         if(std::abs(Sigma(i, i)) > std::max(std::numeric_limits<S>::min(), S(0)))
         {

--- a/clients/common/matrix_utils/matrix_utils_detail.hpp
+++ b/clients/common/matrix_utils/matrix_utils_detail.hpp
@@ -130,10 +130,10 @@ namespace detail
         {
             auto volatile mptr = memset(R, 0, sizeof(T) * nrowsR * ncolsR);
         }
-        for(int i = 0; i < rank; ++i)
+        for(int64_t i = 0; i < rank; ++i)
         {
             R[i + i * static_cast<std::int64_t>(ldR)] = Q[i + i * static_cast<std::int64_t>(ldQ)];
-            for(int j = i + 1; j < ncolsR; ++j)
+            for(int64_t j = i + 1; j < ncolsR; ++j)
             {
                 R[i + j * static_cast<std::int64_t>(ldR)] = Q[i + j * static_cast<std::int64_t>(ldQ)];
             }

--- a/clients/common/misc/clients_utility.cpp
+++ b/clients/common/misc/clients_utility.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -119,7 +119,7 @@ rocblas_int query_device_property()
     }
     fmt::print("Query device success: there are {} devices\n", device_count);
 
-    for(int i = 0;; i++)
+    for(int64_t i = 0;; i++)
     {
         fmt::print("{:-<79}\n", ""); // horizontal rule
         if(i >= device_count)

--- a/clients/common/misc/clients_utility.hpp
+++ b/clients/common/misc/clients_utility.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -111,11 +111,11 @@ void print_strided_batched(const char* name,
     std::string s = fmt::format("----------{}----------\n", name);
     int max_size = 8;
 
-    for(int i3 = 0; i3 < n3 && i3 < max_size; i3++)
+    for(int64_t i3 = 0; i3 < n3 && i3 < max_size; i3++)
     {
-        for(int i1 = 0; i1 < n1 && i1 < max_size; i1++)
+        for(int64_t i1 = 0; i1 < n1 && i1 < max_size; i1++)
         {
-            for(int i2 = 0; i2 < n2 && i2 < max_size; i2++)
+            for(int64_t i2 = 0; i2 < n2 && i2 < max_size; i2++)
             {
                 s += fmt::format("{}|", A[(i1 * s1) + (i2 * s2) + (i3 * s3)]);
             }

--- a/clients/common/misc/clss.hpp
+++ b/clients/common/misc/clss.hpp
@@ -397,7 +397,7 @@ public:
             os << ">>> Input: \n";
 
             os << ":: :: a = {";
-            for(I i = 0; i < a_size; ++i)
+            for(int64_t i = 0; i < a_size; ++i)
             {
                 os << a[i];
                 if(i != a_size - 1)
@@ -408,7 +408,7 @@ public:
             os << "}\n\n";
 
             os << ":: :: b = {";
-            for(I i = 0; i < b_size; ++i)
+            for(int64_t i = 0; i < b_size; ++i)
             {
                 os << b[i];
                 if(i != b_size - 1)

--- a/clients/common/misc/csr_norm.hpp
+++ b/clients/common/misc/csr_norm.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -82,7 +82,7 @@ double csr_norm_error(char const norm_type,
 
     double norm_err = static_cast<double>(0);
 
-    for(Iint irow = 0; irow < nrow; irow++)
+    for(int64_t irow = 0; irow < nrow; irow++)
     {
         // ------------------------------------
         // copy data into temporary full vector
@@ -92,7 +92,7 @@ double csr_norm_error(char const norm_type,
         Ilong const kstartB = Bp[irow];
         Ilong const kendB = Bp[irow + 1];
 
-        for(Ilong k = kstartA; k < kendA; k++)
+        for(int64_t k = kstartA; k < kendA; k++)
         {
             auto const colA = Ai[k];
             assert((0 <= colA) && (colA < ncol));
@@ -106,7 +106,7 @@ double csr_norm_error(char const norm_type,
             };
         };
 
-        for(Ilong k = kstartB; k < kendB; k++)
+        for(int64_t k = kstartB; k < kendB; k++)
         {
             Iint const colB = Bi[k];
             assert((0 <= colB) && (colB < ncol));
@@ -123,7 +123,7 @@ double csr_norm_error(char const norm_type,
         // ----------------------
         // evaluate norm of difference
         // ----------------------
-        for(Ilong k = kstartA; k < kendA; k++)
+        for(int64_t k = kstartA; k < kendA; k++)
         {
             Iint const colA = Ai[k];
 
@@ -146,7 +146,7 @@ double csr_norm_error(char const norm_type,
             };
         };
 
-        for(Ilong k = kstartB; k < kendB; k++)
+        for(int64_t k = kstartB; k < kendB; k++)
         {
             Iint const colB = Bi[k];
             bool const is_lower = (irow >= colB);

--- a/clients/common/misc/data_initializer.hpp
+++ b/clients/common/misc/data_initializer.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -366,13 +366,13 @@ void random_sparse_matrix(rocblas_int n,
 
     // initialize ptrA
     nnz = (!randomdiag) ? n : 0;
-    for(rocblas_int j = 0; j <= n; ++j)
+    for(int64_t j = 0; j <= n; ++j)
         ptrA[j] = (!randomdiag) ? j : 0;
 
     while(nnz < nnzA)
     {
         // for each row in matrix
-        for(rocblas_int i = 0; i < n; ++i)
+        for(int64_t i = 0; i < n; ++i)
         {
             // set the number of non-zeros
             // op is the max number of non-zeros in a row
@@ -388,7 +388,7 @@ void random_sparse_matrix(rocblas_int n,
                 nn = 0;
 
             // update ptrA
-            for(rocblas_int j = i + 1; j <= n; ++j)
+            for(int64_t j = i + 1; j <= n; ++j)
                 ptrA[j] += nn;
         }
     }
@@ -398,11 +398,11 @@ void random_sparse_matrix(rocblas_int n,
     /////////////////////////////
 
     // random non-zero values
-    for(rocblas_int i = 0; i < nnzA; ++i)
+    for(int64_t i = 0; i < nnzA; ++i)
         valA[i] = random_generator<T>(1, 10);
 
     // for each row in matrix
-    for(rocblas_int i = 0; i < n; ++i)
+    for(int64_t i = 0; i < n; ++i)
     {
         nn = ptrA[i + 1] - ptrA[i];
 
@@ -413,19 +413,19 @@ void random_sparse_matrix(rocblas_int n,
             if(fullmatrix)
             {
                 // full matrix
-                for(rocblas_int j = 0; j < n; ++j)
+                for(int64_t j = 0; j < n; ++j)
                     ops[j] = j;
             }
             else if(lowertriang)
             {
                 // lower triangular
-                for(rocblas_int j = 0; j <= i; ++j)
+                for(int64_t j = 0; j <= i; ++j)
                     ops[j] = j;
             }
             else
             {
                 // upper triangular
-                for(rocblas_int j = i; j < n; ++j)
+                for(int64_t j = i; j < n; ++j)
                     ops[j - i] = j;
             }
 
@@ -442,7 +442,7 @@ void random_sparse_matrix(rocblas_int n,
             // choose the other non-zero positions
             // op is the max number of non-zeros in a row
             op = (fullmatrix) ? n : (lowertriang) ? i + 1 : n - i;
-            for(rocblas_int j = in; j < nn; ++j)
+            for(int64_t j = in; j < nn; ++j)
             {
                 pp = random_generator<rocblas_int>(0, op - 1);
                 p = pp;
@@ -458,11 +458,11 @@ void random_sparse_matrix(rocblas_int n,
             }
 
             // order non-zero positions in increasing order
-            for(rocblas_int j = 0; j < nn - 1; ++j)
+            for(int64_t j = 0; j < nn - 1; ++j)
             {
                 m = j;
                 p = z[j];
-                for(rocblas_int k = j + 1; k < nn; ++k)
+                for(int64_t k = j + 1; k < nn; ++k)
                 {
                     if(z[k] < p)
                     {
@@ -478,7 +478,7 @@ void random_sparse_matrix(rocblas_int n,
             }
 
             // update indA and valA if necessary
-            for(rocblas_int j = 0; j < nn; ++j)
+            for(int64_t j = 0; j < nn; ++j)
             {
                 indA[ptrA[i] + j] = z[j];
                 if(unitdiag && z[j] == i)
@@ -503,13 +503,13 @@ void cpu_sumlu(const rocblas_int n,
                T* valT)
 {
     // generate ptrT
-    for(rocblas_int i = 0; i <= n; ++i)
+    for(int64_t i = 0; i <= n; ++i)
         ptrT[i] = ptrL[i] + ptrU[i] - i;
 
     // generate indT and valT
     rocblas_int p = 0;
     rocblas_int nzL, nzU, iL, iU;
-    for(rocblas_int i = 0; i < n; ++i)
+    for(int64_t i = 0; i < n; ++i)
     {
         iL = ptrL[i];
         iU = ptrU[i];
@@ -517,7 +517,7 @@ void cpu_sumlu(const rocblas_int n,
         nzU = ptrU[i + 1] - iU;
 
         // insert lower part - I
-        for(rocblas_int j = 0; j < nzL; ++j)
+        for(int64_t j = 0; j < nzL; ++j)
         {
             indT[p] = indL[iL + j];
             valT[p] = valL[iL + j];
@@ -525,7 +525,7 @@ void cpu_sumlu(const rocblas_int n,
         }
 
         // insert upper part
-        for(rocblas_int j = 0; j < nzU; ++j)
+        for(int64_t j = 0; j < nzU; ++j)
         {
             indT[p] = indU[iU + j];
             valT[p] = valU[iU + j];

--- a/clients/common/misc/norm.hpp
+++ b/clients/common/misc/norm.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -57,12 +57,12 @@ double norm_error(char norm_type,
     if(lda_comp <= 0)
         lda_comp = lda_gold;
 
-    std::vector<DoublePrecisionType> gold_double(N * lda);
-    std::vector<DoublePrecisionType> comp_double(N * lda);
+    std::vector<DoublePrecisionType> gold_double(N * size_t(lda));
+    std::vector<DoublePrecisionType> comp_double(N * size_t(lda));
 
-    for(rocblas_int j = 0; j < N; j++)
+    for(int64_t j = 0; j < N; j++)
     {
-        for(rocblas_int i = 0; i < M; i++)
+        for(int64_t i = 0; i < M; i++)
         {
             gold_double[i + j * lda] = DoublePrecisionType(gold[i + j * lda_gold]);
             comp_double[i + j * lda] = DoublePrecisionType(comp[i + j * lda_comp]);
@@ -72,10 +72,31 @@ double norm_error(char norm_type,
     std::vector<double> work(M);
     rocblas_int incx = 1;
     DoublePrecisionType alpha = -1.0;
-    rocblas_int size = lda * N;
+    auto size = size_t(lda) * N;
+
+    auto axpy = [](auto n, auto alpha, auto x, auto incx, auto y, auto incy) {
+        if((incx == 1) && (incy == 1))
+        {
+            for(int64_t i = 0; i < n; i++)
+            {
+                y[i] += alpha * x[i];
+            }
+        }
+        else
+        {
+            for(int64_t i = 0; i < n; i++)
+            {
+                auto const ix = 0 + i * incx;
+                auto const iy = 0 + i * incy;
+                y[iy] += alpha * x[ix];
+            }
+        }
+    };
 
     double gold_norm = cpu_lange(norm_type, M, N, gold_double.data(), lda, work.data());
-    cpu_axpy(size, alpha, gold_double.data(), incx, comp_double.data(), incx);
+    // cpu_axpy(size, alpha, gold_double.data(), incx, comp_double.data(), incx);
+    axpy(size, alpha, gold_double.data(), incx, comp_double.data(), incx);
+
     double error = cpu_lange(norm_type, M, N, comp_double.data(), lda, work.data());
     if(gold_norm > 0)
         error /= gold_norm;
@@ -86,9 +107,9 @@ double norm_error(char norm_type,
 template <typename T>
 double norm_error_upperTr(char norm_type, rocblas_int M, rocblas_int N, rocblas_int lda, T* gold, T* comp)
 {
-    for(rocblas_int i = 0; i < M; ++i)
+    for(int64_t i = 0; i < M; ++i)
     {
-        for(rocblas_int j = 0; j < N; ++j)
+        for(int64_t j = 0; j < N; ++j)
         {
             if(i > j)
             {
@@ -103,9 +124,9 @@ double norm_error_upperTr(char norm_type, rocblas_int M, rocblas_int N, rocblas_
 template <typename T>
 double norm_error_lowerTr(char norm_type, rocblas_int M, rocblas_int N, rocblas_int lda, T* gold, T* comp)
 {
-    for(rocblas_int i = 0; i < M; ++i)
+    for(int64_t i = 0; i < M; ++i)
     {
-        for(rocblas_int j = 0; j < N; ++j)
+        for(int64_t j = 0; j < N; ++j)
         {
             if(i < j)
             {

--- a/clients/common/refact/testing_csrrf_splitlu.hpp
+++ b/clients/common/refact/testing_csrrf_splitlu.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -242,19 +242,19 @@ void csrrf_splitlu_getError(rocblas_handle handle,
     // if not matrix zero, compare computed results with golden result
     if(!mat_zero)
     {
-        for(rocblas_int i = 0; i <= n; ++i)
+        for(int64_t i = 0; i <= n; ++i)
         {
             err += (hptrL[0][i] - hptrLres[0][i]);
             err += (hptrU[0][i] - hptrUres[0][i]);
         }
 
-        for(rocblas_int i = 0; i < nnzL; ++i)
+        for(int64_t i = 0; i < nnzL; ++i)
         {
             err += (hindL[0][i] - hindLres[0][i]);
             err += (hvalL[0][i] - hvalLres[0][i]);
         }
 
-        for(rocblas_int i = 0; i < nnzU; ++i)
+        for(int64_t i = 0; i < nnzU; ++i)
         {
             err += (hindU[0][i] - hindUres[0][i]);
             err += (hvalU[0][i] - hvalUres[0][i]);
@@ -263,7 +263,7 @@ void csrrf_splitlu_getError(rocblas_handle handle,
     // otherwise simply check that L = identity and ptrU = 0
     else
     {
-        for(rocblas_int i = 0; i < n; ++i)
+        for(int64_t i = 0; i < n; ++i)
         {
             err += i - hptrLres[0][i];
             err += i - hindLres[0][i];
@@ -340,7 +340,7 @@ void csrrf_splitlu_getPerfData(rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         csrrf_splitlu_initData<false, true, T>(handle, n, nnzT, nnzL, nnzU, dptrT, dindT, dvalT,
                                                hptrT, hindT, hvalT, hptrL, hindL, hvalL, hptrU,

--- a/clients/common/refact/testing_csrrf_sumlu.hpp
+++ b/clients/common/refact/testing_csrrf_sumlu.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -241,10 +241,10 @@ void csrrf_sumlu_getError(rocblas_handle handle,
     // if not matrix zero, compare computed results with golden result
     if(!mat_zero)
     {
-        for(rocblas_int i = 0; i <= n; ++i)
+        for(int64_t i = 0; i <= n; ++i)
             err += (hptrT[0][i] - hptrTres[0][i]);
 
-        for(rocblas_int i = 0; i < nnzT; ++i)
+        for(int64_t i = 0; i < nnzT; ++i)
         {
             err += (hindT[0][i] - hindTres[0][i]);
             err += (hvalT[0][i] - hvalTres[0][i]);
@@ -253,7 +253,7 @@ void csrrf_sumlu_getError(rocblas_handle handle,
     // otherwise simply check that ptrT = 0
     else
     {
-        for(rocblas_int i = 0; i <= n; ++i)
+        for(int64_t i = 0; i <= n; ++i)
             err += hptrTres[0][i];
     }
 
@@ -324,7 +324,7 @@ void csrrf_sumlu_getPerfData(rocblas_handle handle,
         rocsolver_log_set_max_levels(profile);
     }
 
-    for(rocblas_int iter = 0; iter < hot_calls; iter++)
+    for(int64_t iter = 0; iter < hot_calls; iter++)
     {
         csrrf_sumlu_initData<false, true, T>(handle, n, nnzT, nnzL, nnzU, dptrL, dindL, dvalL,
                                              dptrU, dindU, dvalU, hptrL, hindL, hvalL, hptrU, hindU,

--- a/clients/gtest/auxiliary/ormbr_unmbr_gtest.cpp
+++ b/clients/gtest/auxiliary/ormbr_unmbr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -119,7 +119,7 @@ Arguments ormbr_setup_arguments(ormbr_tuple tup)
     if(store[4] == 0)
         arg.set<rocblas_int>("lda", nq + store[0] * 10);
     else
-        arg.set<rocblas_int>("lda", min(nq, k) + store[0] * 10);
+        arg.set<rocblas_int>("lda", std::min(nq, k) + store[0] * 10);
     arg.set<rocblas_int>("ldc", m + store[1] * 10);
     arg.set<char>("side", store[2] == 0 ? 'L' : 'R');
     arg.set<char>("trans", (store[3] == 0 ? 'N' : (store[3] == 1 ? 'T' : 'C')));

--- a/clients/gtest/lapack/gesdd_gtest.cpp
+++ b/clients/gtest/lapack/gesdd_gtest.cpp
@@ -109,7 +109,7 @@ Arguments gesdd_setup_arguments(gesdd_tuple tup, bool notransv)
     if(notransv)
         arg.set<rocblas_int>("ldv", n + opt[2] * 10);
     else
-        arg.set<rocblas_int>("ldv", min(m, n) + opt[2] * 10);
+        arg.set<rocblas_int>("ldv", std::min(m, n) + opt[2] * 10);
 
     // vector options
     if(opt[3] == 0)

--- a/clients/gtest/lapack/gesvd_gtest.cpp
+++ b/clients/gtest/lapack/gesvd_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -129,7 +129,7 @@ Arguments gesvd_setup_arguments(gesvd_tuple tup)
     if(opt[4] == 2)
         arg.set<rocblas_int>("ldv", n + opt[2] * 10);
     else
-        arg.set<rocblas_int>("ldv", min(m, n) + opt[2] * 10);
+        arg.set<rocblas_int>("ldv", std::min(m, n) + opt[2] * 10);
 
     // vector options
     if(opt[3] == 0)

--- a/clients/gtest/lapack/gesvdj_gtest.cpp
+++ b/clients/gtest/lapack/gesvdj_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -109,7 +109,7 @@ Arguments gesvdj_setup_arguments(gesvdj_tuple tup, bool notransv)
     if(notransv)
         arg.set<rocblas_int>("ldv", n + opt[2] * 10);
     else
-        arg.set<rocblas_int>("ldv", min(m, n) + opt[2] * 10);
+        arg.set<rocblas_int>("ldv", std::min(m, n) + opt[2] * 10);
 
     // vector options
     if(opt[3] == 0)

--- a/clients/gtest/lapack/gesvdx_gtest.cpp
+++ b/clients/gtest/lapack/gesvdx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -122,7 +122,7 @@ Arguments gesvdx_setup_arguments(gesvdx_tuple tup, bool notransv)
     if(notransv)
         arg.set<rocblas_int>("ldv", n + size[4] * 10);
     else
-        arg.set<rocblas_int>("ldv", min(m, n) + size[4] * 10);
+        arg.set<rocblas_int>("ldv", std::min(m, n) + size[4] * 10);
 
     // vector options
     if(opt[0] == 0)

--- a/library/src/lapack/roclapack_getf2.hpp
+++ b/library/src/lapack/roclapack_getf2.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -66,8 +66,8 @@ ROCSOLVER_KERNEL void getf2_check_singularity(const I n,
                                               const I j,
                                               U AA,
                                               const rocblas_stride shiftA,
-                                              const I inca,
-                                              const I lda,
+                                              const I inca_arg,
+                                              const I lda_arg,
                                               const rocblas_stride strideA,
                                               I* ipivA,
                                               const rocblas_stride shiftP,
@@ -80,6 +80,8 @@ ROCSOLVER_KERNEL void getf2_check_singularity(const I n,
                                               const rocblas_stride stridePI)
 {
     using S = decltype(std::real(T{}));
+    rocblas_stride const lda = lda_arg;
+    rocblas_stride const inca = inca_arg;
 
     const I id = hipBlockIdx_y;
     I tid = hipBlockIdx_x * static_cast<I>(hipBlockDim_x) + hipThreadIdx_x;
@@ -127,14 +129,16 @@ template <typename T, typename I, typename INFO, typename U>
 ROCSOLVER_KERNEL void getf2_npvt_check_singularity(const I j,
                                                    U AA,
                                                    const rocblas_stride shiftA,
-                                                   const I inca,
-                                                   const I lda,
+                                                   const I inca_arg,
+                                                   const I lda_arg,
                                                    const rocblas_stride strideA,
                                                    T* pivot_val,
                                                    INFO* info,
                                                    const I offset)
 {
     using S = decltype(std::real(T{}));
+    rocblas_stride const lda = lda_arg;
+    rocblas_stride const inca = inca_arg;
 
     const I id = hipBlockIdx_y;
 

--- a/library/src/lapack/roclapack_getf2.hpp
+++ b/library/src/lapack/roclapack_getf2.hpp
@@ -80,8 +80,8 @@ ROCSOLVER_KERNEL void getf2_check_singularity(const I n,
                                               const rocblas_stride stridePI)
 {
     using S = decltype(std::real(T{}));
-    rocblas_stride const lda = lda_arg;
-    rocblas_stride const inca = inca_arg;
+#define lda (static_cast<int64_t>(lda_arg))
+#define inca (static_cast<int64_t>(inca_arg))
 
     const I id = hipBlockIdx_y;
     I tid = hipBlockIdx_x * static_cast<I>(hipBlockDim_x) + hipThreadIdx_x;
@@ -122,6 +122,8 @@ ROCSOLVER_KERNEL void getf2_check_singularity(const I n,
                 pivot_val[id] = S(1) / A[j * inca + j * lda];
         }
     }
+#undef lda
+#undef inca
 }
 
 /** Non-pivoting version **/
@@ -137,8 +139,8 @@ ROCSOLVER_KERNEL void getf2_npvt_check_singularity(const I j,
                                                    const I offset)
 {
     using S = decltype(std::real(T{}));
-    rocblas_stride const lda = lda_arg;
-    rocblas_stride const inca = inca_arg;
+#define lda (static_cast<int64_t>(lda_arg))
+#define inca (static_cast<int64_t>(inca_arg))
 
     const I id = hipBlockIdx_y;
 
@@ -154,6 +156,9 @@ ROCSOLVER_KERNEL void getf2_npvt_check_singularity(const I j,
     }
     else
         pivot_val[id] = S(1) / A[j * inca + j * lda];
+
+#undef lda
+#undef inca
 }
 
 /** This kernel executes an optimized reduction to find the index of the

--- a/library/src/lapack/roclapack_getrf.hpp
+++ b/library/src/lapack/roclapack_getrf.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -199,12 +199,15 @@ ROCSOLVER_KERNEL void getrf_row_permutate(const I n,
                                           const I blk,
                                           U AA,
                                           const rocblas_stride shiftA,
-                                          const I inca,
-                                          const I lda,
+                                          const I inca_arg,
+                                          const I lda_arg,
                                           const rocblas_stride strideA,
                                           I* pividx,
                                           const rocblas_stride stridePI)
 {
+    rocblas_stride const lda = lda_arg;
+    rocblas_stride const inca = inca_arg;
+
     I id = hipBlockIdx_z;
     I tx = hipThreadIdx_x;
     I ty = hipThreadIdx_y;

--- a/library/src/lapack/roclapack_getrf.hpp
+++ b/library/src/lapack/roclapack_getrf.hpp
@@ -205,8 +205,8 @@ ROCSOLVER_KERNEL void getrf_row_permutate(const I n,
                                           I* pividx,
                                           const rocblas_stride stridePI)
 {
-    rocblas_stride const lda = lda_arg;
-    rocblas_stride const inca = inca_arg;
+#define lda (static_cast<int64_t>(lda_arg))
+#define inca (static_cast<int64_t>(inca_arg))
 
     I id = hipBlockIdx_z;
     I tx = hipThreadIdx_x;
@@ -236,6 +236,8 @@ ROCSOLVER_KERNEL void getrf_row_permutate(const I n,
         // copy temp results back to A
         A[tx * inca + j * lda] = temp[tx + ty * bdx];
     }
+#undef lda
+#undef inca
 }
 
 /** This function returns the outer block size based on defined variables


### PR DESCRIPTION
Minor change to getrf and getf2 to use 64bit arithmetic for index address calculations.  

This can allow large problems (say n=60,000) to be solved using 32bit rocblas_int version of rocsolver library. 

Similar changes may be applicable to Cholesky and QR factorization to solve large problems.