### PR TITLE
Remove deprecated rocBLAS memory management

### DIFF
--- a/clients/common/auxiliary/testing_bdsqr.hpp
+++ b/clients/common/auxiliary/testing_bdsqr.hpp
@@ -562,7 +562,7 @@ void testing_bdsqr(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_bdsqr(handle, uplo, n, nv, nu, nc, (S*)nullptr, (S*)nullptr,
@@ -571,13 +571,9 @@ void testing_bdsqr(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_bdsvdx.hpp
+++ b/clients/common/auxiliary/testing_bdsvdx.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -489,7 +489,7 @@ void testing_bdsvdx(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_bdsvdx(handle, uplo, svect, srange, n, (T*)nullptr, (T*)nullptr,
@@ -499,13 +499,9 @@ void testing_bdsvdx(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_labrd.hpp
+++ b/clients/common/auxiliary/testing_labrd.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -366,7 +366,7 @@ void testing_labrd(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_labrd(handle, m, n, nb, (T*)nullptr, lda, (S*)nullptr,
@@ -375,13 +375,9 @@ void testing_labrd(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_lacgv.hpp
+++ b/clients/common/auxiliary/testing_lacgv.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -205,20 +205,16 @@ void testing_lacgv(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_lacgv(handle, n, (T*)nullptr, inc));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_larf.hpp
+++ b/clients/common/auxiliary/testing_larf.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -297,7 +297,7 @@ void testing_larf(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(
@@ -305,13 +305,9 @@ void testing_larf(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_larfb.hpp
+++ b/clients/common/auxiliary/testing_larfb.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -441,7 +441,7 @@ void testing_larfb(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_larfb(handle, side, trans, direct, storev, m, n, k, (T*)nullptr,
@@ -449,13 +449,9 @@ void testing_larfb(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_larfg.hpp
+++ b/clients/common/auxiliary/testing_larfg.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -235,20 +235,16 @@ void testing_larfg(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_larfg(handle, n, (T*)nullptr, (T*)nullptr, inc, (T*)nullptr));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_larft.hpp
+++ b/clients/common/auxiliary/testing_larft.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -325,7 +325,7 @@ void testing_larft(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_larft(handle, direct, storev, n, k, (T*)nullptr, ldv,
@@ -333,13 +333,9 @@ void testing_larft(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_lasr.hpp
+++ b/clients/common/auxiliary/testing_lasr.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -321,7 +321,7 @@ void testing_lasr(Arguments& argus)
     size_t size_Ar = (argus.unit_check || argus.norm_check) ? size_A : 0;
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_lasr(handle, side, pivot, direct, m, n, (S*)nullptr,
@@ -329,13 +329,9 @@ void testing_lasr(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_laswp.hpp
+++ b/clients/common/auxiliary/testing_laswp.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -256,7 +256,7 @@ void testing_laswp(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(
@@ -264,13 +264,9 @@ void testing_laswp(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_lasyf.hpp
+++ b/clients/common/auxiliary/testing_lasyf.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -378,7 +378,7 @@ void testing_lasyf(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_lasyf(handle, uplo, n, nb, (rocblas_int*)nullptr, (T*)nullptr,
@@ -386,13 +386,9 @@ void testing_lasyf(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_latrd.hpp
+++ b/clients/common/auxiliary/testing_latrd.hpp
@@ -332,7 +332,7 @@ void testing_latrd(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_latrd(handle, uplo, n, k, (T*)nullptr, lda, (S*)nullptr,
@@ -340,13 +340,9 @@ void testing_latrd(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_lauum.hpp
+++ b/clients/common/auxiliary/testing_lauum.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -229,20 +229,16 @@ void testing_lauum(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_lauum(handle, uplo, n, (T*)nullptr, lda));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_orgbr_ungbr.hpp
+++ b/clients/common/auxiliary/testing_orgbr_ungbr.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -318,7 +318,7 @@ void testing_orgbr_ungbr(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(
@@ -326,13 +326,9 @@ void testing_orgbr_ungbr(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_orglx_unglx.hpp
+++ b/clients/common/auxiliary/testing_orglx_unglx.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -265,20 +265,16 @@ void testing_orglx_unglx(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_orglx_unglx(GLQ, handle, m, n, k, (T*)nullptr, lda, (T*)nullptr));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_orgtr_ungtr.hpp
+++ b/clients/common/auxiliary/testing_orgtr_ungtr.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -265,20 +265,16 @@ void testing_orgtr_ungtr(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_orgtr_ungtr(handle, uplo, n, (T*)nullptr, lda, (T*)nullptr));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_orgxl_ungxl.hpp
+++ b/clients/common/auxiliary/testing_orgxl_ungxl.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -265,20 +265,16 @@ void testing_orgxl_ungxl(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_orgxl_ungxl(GQL, handle, m, n, k, (T*)nullptr, lda, (T*)nullptr));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_orgxr_ungxr.hpp
+++ b/clients/common/auxiliary/testing_orgxr_ungxr.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -265,20 +265,16 @@ void testing_orgxr_ungxr(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_orgxr_ungxr(GQR, handle, m, n, k, (T*)nullptr, lda, (T*)nullptr));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_ormbr_unmbr.hpp
+++ b/clients/common/auxiliary/testing_ormbr_unmbr.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -391,7 +391,7 @@ void testing_ormbr_unmbr(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_ormbr_unmbr(handle, storev, side, trans, m, n, k, (T*)nullptr,
@@ -399,13 +399,9 @@ void testing_ormbr_unmbr(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_ormlx_unmlx.hpp
+++ b/clients/common/auxiliary/testing_ormlx_unmlx.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -359,7 +359,7 @@ void testing_ormlx_unmlx(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_ormlx_unmlx(MLQ, handle, side, trans, m, n, k, (T*)nullptr, lda,
@@ -367,13 +367,9 @@ void testing_ormlx_unmlx(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_ormtr_unmtr.hpp
+++ b/clients/common/auxiliary/testing_ormtr_unmtr.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -360,7 +360,7 @@ void testing_ormtr_unmtr(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_ormtr_unmtr(handle, side, uplo, trans, m, n, (T*)nullptr, lda,
@@ -368,13 +368,9 @@ void testing_ormtr_unmtr(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_ormxl_unmxl.hpp
+++ b/clients/common/auxiliary/testing_ormxl_unmxl.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -359,7 +359,7 @@ void testing_ormxl_unmxl(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_ormxl_unmxl(MQL, handle, side, trans, m, n, k, (T*)nullptr, lda,
@@ -367,13 +367,9 @@ void testing_ormxl_unmxl(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_ormxr_unmxr.hpp
+++ b/clients/common/auxiliary/testing_ormxr_unmxr.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -359,7 +359,7 @@ void testing_ormxr_unmxr(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_ormxr_unmxr(MQR, handle, side, trans, m, n, k, (T*)nullptr, lda,
@@ -367,13 +367,9 @@ void testing_ormxr_unmxr(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_stebz.hpp
+++ b/clients/common/auxiliary/testing_stebz.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -416,7 +416,7 @@ void testing_stebz(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_stebz(handle, erange, eorder, n, vl, vu, il, iu, abstol,
@@ -426,13 +426,9 @@ void testing_stebz(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_stedc.hpp
+++ b/clients/common/auxiliary/testing_stedc.hpp
@@ -470,7 +470,7 @@ void testing_stedc(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_stedc(handle, evect, n, (S*)nullptr, (S*)nullptr, (T*)nullptr,
@@ -478,13 +478,9 @@ void testing_stedc(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_stedcj.hpp
+++ b/clients/common/auxiliary/testing_stedcj.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -465,7 +465,7 @@ void testing_stedcj(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_stedcj(handle, evect, n, (S*)nullptr, (S*)nullptr, (T*)nullptr,
@@ -473,13 +473,9 @@ void testing_stedcj(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_stedcx.hpp
+++ b/clients/common/auxiliary/testing_stedcx.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -426,7 +426,7 @@ void testing_stedcx(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_stedcx(handle, evect, erange, n, vl, vu, il, iu, (S*)nullptr,
@@ -435,13 +435,9 @@ void testing_stedcx(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_stein.hpp
+++ b/clients/common/auxiliary/testing_stein.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -460,7 +460,7 @@ void testing_stein(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_stein(handle, n, (S*)nullptr, (S*)nullptr,
@@ -470,13 +470,9 @@ void testing_stein(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_steqr.hpp
+++ b/clients/common/auxiliary/testing_steqr.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -369,7 +369,7 @@ void testing_steqr(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_steqr(handle, evect, n, (S*)nullptr, (S*)nullptr, (T*)nullptr,
@@ -377,13 +377,9 @@ void testing_steqr(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/auxiliary/testing_sterf.hpp
+++ b/clients/common/auxiliary/testing_sterf.hpp
@@ -252,20 +252,16 @@ void testing_sterf(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_sterf(handle, n, (T*)nullptr, (T*)nullptr, (rocblas_int*)nullptr));
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/lapack/testing_gebd2_gebrd.hpp
+++ b/clients/common/lapack/testing_gebd2_gebrd.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -494,7 +494,7 @@ void testing_gebd2_gebrd(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -508,13 +508,9 @@ void testing_gebd2_gebrd(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_geblttrf_npvt.hpp
+++ b/clients/common/lapack/testing_geblttrf_npvt.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -523,7 +523,7 @@ void testing_geblttrf_npvt(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -537,13 +537,9 @@ void testing_geblttrf_npvt(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_geblttrf_npvt_interleaved.hpp
+++ b/clients/common/lapack/testing_geblttrf_npvt_interleaved.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -543,7 +543,7 @@ void testing_geblttrf_npvt_interleaved(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_geblttrf_npvt_interleaved(
@@ -552,13 +552,9 @@ void testing_geblttrf_npvt_interleaved(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/lapack/testing_geblttrs_npvt.hpp
+++ b/clients/common/lapack/testing_geblttrs_npvt.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -467,7 +467,7 @@ void testing_geblttrs_npvt(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -481,13 +481,9 @@ void testing_geblttrs_npvt(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_geblttrs_npvt_interleaved.hpp
+++ b/clients/common/lapack/testing_geblttrs_npvt_interleaved.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -513,7 +513,7 @@ void testing_geblttrs_npvt_interleaved(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_geblttrs_npvt_interleaved(
@@ -522,13 +522,9 @@ void testing_geblttrs_npvt_interleaved(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/clients/common/lapack/testing_gelq2_gelqf.hpp
+++ b/clients/common/lapack/testing_gelq2_gelqf.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -327,7 +327,7 @@ void testing_gelq2_gelqf(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -339,13 +339,9 @@ void testing_gelq2_gelqf(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_gels.hpp
+++ b/clients/common/lapack/testing_gels.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -446,7 +446,7 @@ void testing_gels(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -459,13 +459,9 @@ void testing_gels(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_gels_outofplace.hpp
+++ b/clients/common/lapack/testing_gels_outofplace.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -508,7 +508,7 @@ void testing_gels_outofplace(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -522,13 +522,9 @@ void testing_gels_outofplace(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_geql2_geqlf.hpp
+++ b/clients/common/lapack/testing_geql2_geqlf.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -327,7 +327,7 @@ void testing_geql2_geqlf(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -339,13 +339,9 @@ void testing_geql2_geqlf(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_geqr2_geqrf.hpp
+++ b/clients/common/lapack/testing_geqr2_geqrf.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -327,7 +327,7 @@ void testing_geqr2_geqrf(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -339,13 +339,9 @@ void testing_geqr2_geqrf(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED && STRIDED)

--- a/clients/common/lapack/testing_gerq2_gerqf.hpp
+++ b/clients/common/lapack/testing_gerq2_gerqf.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -327,7 +327,7 @@ void testing_gerq2_gerqf(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -339,13 +339,9 @@ void testing_gerq2_gerqf(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_gesdd.hpp
+++ b/clients/common/lapack/testing_gesdd.hpp
@@ -668,7 +668,7 @@ void testing_gesdd(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -692,13 +692,9 @@ void testing_gesdd(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations (all cases)

--- a/clients/common/lapack/testing_gesv.hpp
+++ b/clients/common/lapack/testing_gesv.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -404,7 +404,7 @@ void testing_gesv(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -418,13 +418,9 @@ void testing_gesv(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_gesv_outofplace.hpp
+++ b/clients/common/lapack/testing_gesv_outofplace.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -436,7 +436,7 @@ void testing_gesv_outofplace(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -451,13 +451,9 @@ void testing_gesv_outofplace(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_gesvd.hpp
+++ b/clients/common/lapack/testing_gesvd.hpp
@@ -706,7 +706,7 @@ void testing_gesvd(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -734,13 +734,9 @@ void testing_gesvd(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations (all cases)

--- a/clients/common/lapack/testing_gesvdj.hpp
+++ b/clients/common/lapack/testing_gesvdj.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -685,7 +685,7 @@ void testing_gesvdj(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -713,13 +713,9 @@ void testing_gesvdj(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations (all cases)

--- a/clients/common/lapack/testing_gesvdj_notransv.hpp
+++ b/clients/common/lapack/testing_gesvdj_notransv.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -705,7 +705,7 @@ void testing_gesvdj_notransv(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -733,13 +733,9 @@ void testing_gesvdj_notransv(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations (all cases)

--- a/clients/common/lapack/testing_gesvdx.hpp
+++ b/clients/common/lapack/testing_gesvdx.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -834,7 +834,7 @@ void testing_gesvdx(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -862,13 +862,9 @@ void testing_gesvdx(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations (all cases)

--- a/clients/common/lapack/testing_gesvdx_notransv.hpp
+++ b/clients/common/lapack/testing_gesvdx_notransv.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -854,7 +854,7 @@ void testing_gesvdx_notransv(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -882,13 +882,9 @@ void testing_gesvdx_notransv(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations (all cases)

--- a/clients/common/lapack/testing_getf2_getrf.hpp
+++ b/clients/common/lapack/testing_getf2_getrf.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -419,7 +419,7 @@ void testing_getf2_getrf(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -431,13 +431,9 @@ void testing_getf2_getrf(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_getf2_getrf_npvt.hpp
+++ b/clients/common/lapack/testing_getf2_getrf_npvt.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -358,7 +358,7 @@ void testing_getf2_getrf_npvt(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -370,13 +370,9 @@ void testing_getf2_getrf_npvt(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_getrf_large.hpp
+++ b/clients/common/lapack/testing_getrf_large.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -361,7 +361,7 @@ void testing_getrf_large(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -375,13 +375,9 @@ void testing_getrf_large(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_getri.hpp
+++ b/clients/common/lapack/testing_getri.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -379,7 +379,7 @@ void testing_getri(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -391,13 +391,9 @@ void testing_getri(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_getri_npvt.hpp
+++ b/clients/common/lapack/testing_getri_npvt.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -344,7 +344,7 @@ void testing_getri_npvt(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -356,13 +356,9 @@ void testing_getri_npvt(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_getri_npvt_outofplace.hpp
+++ b/clients/common/lapack/testing_getri_npvt_outofplace.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -379,7 +379,7 @@ void testing_getri_npvt_outofplace(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -393,13 +393,9 @@ void testing_getri_npvt_outofplace(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_getri_outofplace.hpp
+++ b/clients/common/lapack/testing_getri_outofplace.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -411,7 +411,7 @@ void testing_getri_outofplace(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -425,13 +425,9 @@ void testing_getri_outofplace(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_getrs.hpp
+++ b/clients/common/lapack/testing_getrs.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -378,7 +378,7 @@ void testing_getrs(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -391,13 +391,9 @@ void testing_getrs(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_posv.hpp
+++ b/clients/common/lapack/testing_posv.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -395,7 +395,7 @@ void testing_posv(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -408,13 +408,9 @@ void testing_posv(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_potf2_potrf.hpp
+++ b/clients/common/lapack/testing_potf2_potrf.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -376,7 +376,7 @@ void testing_potf2_potrf(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -388,13 +388,9 @@ void testing_potf2_potrf(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_potri.hpp
+++ b/clients/common/lapack/testing_potri.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -351,7 +351,7 @@ void testing_potri(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -363,13 +363,9 @@ void testing_potri(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_potrs.hpp
+++ b/clients/common/lapack/testing_potrs.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -347,7 +347,7 @@ void testing_potrs(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -359,13 +359,9 @@ void testing_potrs(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_syev_heev.hpp
+++ b/clients/common/lapack/testing_syev_heev.hpp
@@ -462,7 +462,7 @@ void testing_syev_heev(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -476,13 +476,9 @@ void testing_syev_heev(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations (all cases)

--- a/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/clients/common/lapack/testing_syevd_heevd.hpp
@@ -486,7 +486,7 @@ void testing_syevd_heevd(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -500,13 +500,9 @@ void testing_syevd_heevd(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations (all cases)

--- a/clients/common/lapack/testing_syevdj_heevdj.hpp
+++ b/clients/common/lapack/testing_syevdj_heevdj.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -420,7 +420,7 @@ void testing_syevdj_heevdj(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -434,13 +434,9 @@ void testing_syevdj_heevdj(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations (all cases)

--- a/clients/common/lapack/testing_syevdx_heevdx.hpp
+++ b/clients/common/lapack/testing_syevdx_heevdx.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -536,7 +536,7 @@ void testing_syevdx_heevdx(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -552,13 +552,9 @@ void testing_syevdx_heevdx(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations (all cases)

--- a/clients/common/lapack/testing_syevdx_heevdx_inplace.hpp
+++ b/clients/common/lapack/testing_syevdx_heevdx_inplace.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -535,7 +535,7 @@ void testing_syevdx_heevdx_inplace(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -549,13 +549,9 @@ void testing_syevdx_heevdx_inplace(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations (all cases)

--- a/clients/common/lapack/testing_syevj_heevj.hpp
+++ b/clients/common/lapack/testing_syevj_heevj.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -520,7 +520,7 @@ void testing_syevj_heevj(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -535,13 +535,9 @@ void testing_syevj_heevj(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations (all cases)

--- a/clients/common/lapack/testing_syevx_heevx.hpp
+++ b/clients/common/lapack/testing_syevx_heevx.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -667,7 +667,7 @@ void testing_syevx_heevx(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -683,13 +683,9 @@ void testing_syevx_heevx(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations (all cases)

--- a/clients/common/lapack/testing_sygsx_hegsx.hpp
+++ b/clients/common/lapack/testing_sygsx_hegsx.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -435,7 +435,7 @@ void testing_sygsx_hegsx(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -448,13 +448,9 @@ void testing_sygsx_hegsx(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_sygv_hegv.hpp
+++ b/clients/common/lapack/testing_sygv_hegv.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -582,7 +582,7 @@ void testing_sygv_hegv(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -597,13 +597,9 @@ void testing_sygv_hegv(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations (all cases)

--- a/clients/common/lapack/testing_sygvd_hegvd.hpp
+++ b/clients/common/lapack/testing_sygvd_hegvd.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -610,7 +610,7 @@ void testing_sygvd_hegvd(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -625,13 +625,9 @@ void testing_sygvd_hegvd(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations (all cases)

--- a/clients/common/lapack/testing_sygvdj_hegvdj.hpp
+++ b/clients/common/lapack/testing_sygvdj_hegvdj.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -550,7 +550,7 @@ void testing_sygvdj_hegvdj(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -564,13 +564,9 @@ void testing_sygvdj_hegvdj(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations (all cases)

--- a/clients/common/lapack/testing_sygvdx_hegvdx.hpp
+++ b/clients/common/lapack/testing_sygvdx_hegvdx.hpp
@@ -971,7 +971,7 @@ void testing_sygvdx_hegvdx(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -987,13 +987,9 @@ void testing_sygvdx_hegvdx(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations (all cases)

--- a/clients/common/lapack/testing_sygvdx_hegvdx_inplace.hpp
+++ b/clients/common/lapack/testing_sygvdx_hegvdx_inplace.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -701,7 +701,7 @@ void testing_sygvdx_hegvdx_inplace(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -717,13 +717,9 @@ void testing_sygvdx_hegvdx_inplace(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations (all cases)

--- a/clients/common/lapack/testing_sygvj_hegvj.hpp
+++ b/clients/common/lapack/testing_sygvj_hegvj.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -635,7 +635,7 @@ void testing_sygvj_hegvj(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -651,13 +651,9 @@ void testing_sygvj_hegvj(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations (all cases)

--- a/clients/common/lapack/testing_sygvx_hegvx.hpp
+++ b/clients/common/lapack/testing_sygvx_hegvx.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -801,7 +801,7 @@ void testing_sygvx_hegvx(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -818,13 +818,9 @@ void testing_sygvx_hegvx(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations (all cases)

--- a/clients/common/lapack/testing_sytf2_sytrf.hpp
+++ b/clients/common/lapack/testing_sytf2_sytrf.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -441,7 +441,7 @@ void testing_sytf2_sytrf(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -455,13 +455,9 @@ void testing_sytf2_sytrf(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/lapack/testing_sytxx_hetxx.hpp
+++ b/clients/common/lapack/testing_sytxx_hetxx.hpp
@@ -1,4 +1,4 @@
-/* ************************************************************************** 
+/* **************************************************************************
  * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -485,7 +485,7 @@ void testing_sytxx_hetxx(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -499,13 +499,9 @@ void testing_sytxx_hetxx(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations (all cases)

--- a/clients/common/lapack/testing_trtri.hpp
+++ b/clients/common/lapack/testing_trtri.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -363,7 +363,7 @@ void testing_trtri(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         if(BATCHED)
@@ -375,13 +375,9 @@ void testing_trtri(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     if(BATCHED)

--- a/clients/common/misc/rocsolver_test.hpp
+++ b/clients/common/misc/rocsolver_test.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,10 +45,6 @@ namespace fs = std::experimental::filesystem;
 #include <fmt/ostream.h>
 #include <fmt/ranges.h>
 #include <rocblas/rocblas.h>
-
-// If USE_ROCBLAS_REALLOC_ON_DEMAND is false, automatic reallocation is disable and we will manually
-// reallocate workspace
-#define USE_ROCBLAS_REALLOC_ON_DEMAND true
 
 #ifdef ROCSOLVER_CLIENTS_TEST
 #define ROCSOLVER_TEST_CHECK(T, max_error, tol) ASSERT_LE((max_error), (tol)*get_epsilon<T>())

--- a/clients/common/refact/testing_csrrf_analysis.hpp
+++ b/clients/common/refact/testing_csrrf_analysis.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -468,7 +468,7 @@ void testing_csrrf_analysis(Arguments& argus)
     }
 
     // memory size query if necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_csrrf_analysis(
@@ -478,13 +478,9 @@ void testing_csrrf_analysis(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // determine sizes

--- a/clients/common/refact/testing_csrrf_refactchol.hpp
+++ b/clients/common/refact/testing_csrrf_refactchol.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -400,7 +400,7 @@ void testing_csrrf_refactchol(Arguments& argus)
     }
 
     // memory size query if necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_csrrf_refactchol(handle, n, nnzA, (rocblas_int*)nullptr,
@@ -410,13 +410,9 @@ void testing_csrrf_refactchol(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // determine sizes

--- a/clients/common/refact/testing_csrrf_refactlu.hpp
+++ b/clients/common/refact/testing_csrrf_refactlu.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -411,7 +411,7 @@ void testing_csrrf_refactlu(Arguments& argus)
     }
 
     // memory size query if necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_csrrf_refactlu(
@@ -421,13 +421,9 @@ void testing_csrrf_refactlu(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // determine sizes

--- a/clients/common/refact/testing_csrrf_solve.hpp
+++ b/clients/common/refact/testing_csrrf_solve.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -425,7 +425,7 @@ void testing_csrrf_solve(Arguments& argus)
     }
 
     // memory size query if necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_csrrf_solve(
@@ -434,13 +434,9 @@ void testing_csrrf_solve(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // determine sizes

--- a/clients/common/refact/testing_csrrf_splitlu.hpp
+++ b/clients/common/refact/testing_csrrf_splitlu.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -385,7 +385,7 @@ void testing_csrrf_splitlu(Arguments& argus)
     }
 
     // memory size query if necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_csrrf_splitlu(
@@ -395,13 +395,9 @@ void testing_csrrf_splitlu(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // determine/validate number of non-zeros

--- a/clients/common/refact/testing_csrrf_sumlu.hpp
+++ b/clients/common/refact/testing_csrrf_sumlu.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -370,7 +370,7 @@ void testing_csrrf_sumlu(Arguments& argus)
     }
 
     // memory size query if necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_csrrf_sumlu(
@@ -380,13 +380,9 @@ void testing_csrrf_sumlu(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // determine/validate number of non-zeros

--- a/clients/common/refact/testing_csrrf_workflow.hpp
+++ b/clients/common/refact/testing_csrrf_workflow.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -352,7 +352,7 @@ void testing_csrrf_workflow(Arguments& argus)
     }
 
     // memory size query if necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_csrrf_analysis(
@@ -362,13 +362,9 @@ void testing_csrrf_workflow(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // determine sizes

--- a/clients/gtest/testing_managed_malloc.hpp
+++ b/clients/gtest/testing_managed_malloc.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -257,7 +257,7 @@ void testing_managed_malloc(Arguments& argus)
     }
 
     // memory size query is necessary
-    if(argus.mem_query || !USE_ROCBLAS_REALLOC_ON_DEMAND)
+    if(argus.mem_query)
     {
         CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
         CHECK_ALLOC_QUERY(rocsolver_labrd(handle, m, n, nb, (T*)nullptr, lda, (S*)nullptr,
@@ -266,13 +266,9 @@ void testing_managed_malloc(Arguments& argus)
 
         size_t size;
         CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
-        if(argus.mem_query)
-        {
-            rocsolver_bench_inform(inform_mem_query, size);
-            return;
-        }
 
-        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+        rocsolver_bench_inform(inform_mem_query, size);
+        return;
     }
 
     // memory allocations

--- a/docs/howto/memory.rst
+++ b/docs/howto/memory.rst
@@ -8,17 +8,19 @@
 rocSOLVER Memory Model
 *******************************
 
-Almost all LAPACK and rocSOLVER routines require workspace memory in order to compute their results. In contrast to LAPACK, however, pointers to the workspace are not explicitly passed to rocSOLVER functions as arguments; instead, they are managed behind-the-scenes using a configurable device memory model.
+Almost all LAPACK and rocSOLVER routines require workspace memory in order to compute their results. In contrast to LAPACK,
+however, pointers to the workspace are not explicitly passed to rocSOLVER functions as arguments; instead, they are
+managed behind-the-scenes using a configurable device memory model.
 
-rocSOLVER makes use of and is integrated with :doc:`the rocBLAS memory model <rocblas:reference/memory-alloc>`. Workspace memory, and the scheme used to manage it, is tracked on a per- ``rocblas_handle`` basis. The same functionality that is used to manipulate rocBLAS's workspace memory will also affect rocSOLVER's workspace memory.
+rocSOLVER makes use of and is integrated with :doc:`the rocBLAS memory model <rocblas:reference/memory-alloc>`. Workspace memory,
+and the scheme used to manage it, is tracked on a per- ``rocblas_handle`` basis. The same functionality that is used to
+manipulate rocBLAS's workspace memory will also affect rocSOLVER's workspace memory.
 You can also refer to the rocBLAS :ref:`rocblas:Device Memory allocation in detail` documentation.
 
-There are four schemes for device memory management:
+There are two schemes for device memory management:
 
 * Automatic (managed by rocSOLVER/rocBLAS): The default scheme. Device memory persists between function
   calls and will be automatically reallocated if more memory is required by a function.
-* User-managed (preallocated): The desired workspace size is specified by the user as an environment variable before handle creation, and cannot be altered after the handle is created.
-* User-managed (manual): The desired workspace size can be manipulated using rocBLAS helper functions.
 * User-owned: The user manually allocates device memory and calls a rocBLAS helper function to use it
   as the workspace.
 

--- a/docs/howto/memory.rst
+++ b/docs/howto/memory.rst
@@ -36,7 +36,7 @@ This scheme has the disadvantage that automatic reallocation is synchronizing, a
 User-owned workspace
 ================================================
 
-Alternatively, the user may opt to manage the workspace memory manually using HIP. This involves querying rocSOLVER to determine the minimum amount of memory required,
+Alternatively, the user can opt to manage the workspace memory manually using HIP. This involves querying rocSOLVER to determine the minimum amount of memory required,
 allocating the memory with ``hipMalloc``, and then passing the resulting pointer to rocBLAS.
 
 Minimum required size
@@ -61,7 +61,7 @@ For more details on the rocBLAS APIs, see :doc:`Device Memory Allocation Functio
 Setting the workspace
 ------------------------------
 
-By calling the function ``rocblas_set_workspace``, the user may pass a pointer to device memory to rocBLAS that will be used as the workspace for rocSOLVER. For example:
+By calling the function ``rocblas_set_workspace``, the user can pass a pointer to device memory to rocBLAS that will be used as the workspace for rocSOLVER. For example:
 
 .. code-block:: cpp
 

--- a/docs/howto/memory.rst
+++ b/docs/howto/memory.rst
@@ -10,7 +10,7 @@ rocSOLVER Memory Model
 
 Almost all LAPACK and rocSOLVER routines require workspace memory in order to compute their results. In contrast to LAPACK, however, pointers to the workspace are not explicitly passed to rocSOLVER functions as arguments; instead, they are managed behind-the-scenes using a configurable device memory model.
 
-rocSOLVER makes use of and is integrated with :doc:`the rocBLAS memory model <rocblas:reference/memory-alloc>`. Workspace memory, and the scheme used to manage it, is tracked on a per- ``rocblas_handle`` basis. The same functionality that is used to manipulate rocBLAS's workspace memory will also affect rocSOLVER's workspace memory. 
+rocSOLVER makes use of and is integrated with :doc:`the rocBLAS memory model <rocblas:reference/memory-alloc>`. Workspace memory, and the scheme used to manage it, is tracked on a per- ``rocblas_handle`` basis. The same functionality that is used to manipulate rocBLAS's workspace memory will also affect rocSOLVER's workspace memory.
 You can also refer to the rocBLAS :ref:`rocblas:Device Memory allocation in detail` documentation.
 
 There are four schemes for device memory management:
@@ -26,20 +26,25 @@ Automatic workspace
 ================================================
 
 By default, rocSOLVER will automatically allocate device memory to be used as internal workspace
-using the rocBLAS memory model, and will increase the amount of allocated memory as needed by rocSOLVER functions. If this scheme is in use, the function ``rocblas_is_managing_device_memory`` will return
-``true``. In order to re-enable this scheme if it is not in use, a ``nullptr`` or zero size can be passed to the helper functions ``rocblas_set_device_memory_size`` or ``rocblas_set_workspace``. For more details on these rocBLAS APIs, see :doc:`Device Memory Allocation Functions in rocBLAS <rocblas:reference/memory-alloc>`.
+using the rocBLAS memory model, and will increase the amount of allocated memory as needed by rocSOLVER functions.
+If this scheme is in use, the function ``rocblas_is_managing_device_memory`` will return
+``true``. In order to re-enable this scheme if it is not in use, a ``nullptr`` or zero size can be passed to the
+helper function ``rocblas_set_workspace``. For more details on these rocBLAS APIs, see :doc:`Device Memory Allocation Functions in rocBLAS <rocblas:reference/memory-alloc>`.
 
 This scheme has the disadvantage that automatic reallocation is synchronizing, and the user cannot control when this synchronization happens.
 
-User-managed workspace
+User-owned workspace
 ================================================
 
-Alternatively, the user can manually specify an amount of memory to be allocated by rocSOLVER/rocBLAS. This allows the user to control when and if memory is reallocated and synchronization occurs. However, function calls will fail if there is not enough allocated memory.
+Alternatively, the user may opt to manage the workspace memory manually using HIP. This involves querying rocSOLVER to determine the minimum amount of memory required,
+allocating the memory with ``hipMalloc``, and then passing the resulting pointer to rocBLAS.
 
 Minimum required size
 ------------------------------
 
-In order to choose an appropriate amount of memory to allocate, rocSOLVER can be queried to determine the minimum amount of memory required for functions to complete. The query can be started by calling ``rocblas_start_device_memory_size_query``, followed by calls to the desired functions with appropriate problem sizes (a null pointer can be passed to the device pointer arguments). A final call to ``rocblas_stop_device_memory_size_query`` will return the minimum required size.
+In order to choose an appropriate amount of memory to allocate, rocSOLVER can be queried to determine the minimum amount of memory required for functions to complete.
+The query can be started by calling ``rocblas_start_device_memory_size_query``, followed by calls to the desired functions with appropriate problem sizes (a null pointer
+can be passed to the device pointer arguments). A final call to ``rocblas_stop_device_memory_size_query`` will return the minimum required size.
 
 For example, the following code snippet will return the memory size required to solve a 1024*1024 linear system with 1 right-hand side (involving calls to ``getrf`` and ``getrs``):
 
@@ -53,32 +58,10 @@ For example, the following code snippet will return the memory size required to 
 
 For more details on the rocBLAS APIs, see :doc:`Device Memory Allocation Functions in rocBLAS <rocblas:reference/memory-alloc>`.
 
-Using an environment variable
+Setting the workspace
 ------------------------------
 
-The desired workspace size can be provided before creation of the ``rocblas_handle`` by setting the value of environment variable ``ROCBLAS_DEVICE_MEMORY_SIZE``. If this variable is unset or the value is == 0, then it will be ignored. Note that a workspace size set in this way cannot be changed once the handle has been created.
-
-Using helper functions
-------------------------------
-
-Another way to set the desired workspace size is by using the helper function ``rocblas_set_device_memory_size``.
-This function is called after handle creation and can be called multiple times; however, it is
-recommended to first synchronize the handle stream if a rocSOLVER or rocBLAS routine has already been called. For example:
-
-.. code-block:: cpp
-
-    hipStream_t stream;
-    rocblas_get_stream(handle, &stream);
-    hipStreamSynchronize(stream);
-
-    rocblas_set_device_memory_size(handle, memory_size);
-
-For more details on the rocBLAS APIs, see :doc:`Device Memory Allocation Functions in rocBLAS <rocblas:reference/memory-alloc>`.
-
-User-owned workspace
-================================================
-
-Finally, the user may opt to manage the workspace memory manually using HIP. By calling the function ``rocblas_set_workspace``, the user may pass a pointer to device memory to rocBLAS that will be used as the workspace for rocSOLVER. For example:
+By calling the function ``rocblas_set_workspace``, the user may pass a pointer to device memory to rocBLAS that will be used as the workspace for rocSOLVER. For example:
 
 .. code-block:: cpp
 


### PR DESCRIPTION
Updates rocSOLVER in accordance with functionality being removed by https://github.com/ROCm/rocBLAS-internal/pull/2859