### PR TITLE
Docs: Add environment variable reference page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ The rocSOLVER public repository is located at `<https://github.com/ROCm/rocSOLVE
     * :doc:`rocSOLVER API introduction <./reference/intro>`
     * :doc:`rocSOLVER types <./reference/types>`
     * :doc:`rocSOLVER precision support <./reference/precision>`
+    * :doc:`rocSOLVER environment variables <./reference/env_variables>`
     * :doc:`LAPACK auxiliary functions <./reference/auxiliary>`
     * :doc:`LAPACK functions <./reference/lapack>`
     * :doc:`LAPACK-like functions <./reference/lapacklike>`

--- a/docs/reference/env_variables.rst
+++ b/docs/reference/env_variables.rst
@@ -19,15 +19,13 @@ For more information, see :doc:`Use multi-level logging <../howto/logging>`.
 
 .. list-table::
     :header-rows: 1
-    :widths: 35,14,51
+    :widths: 70,30
 
     * - **Environment variable**
-      - **Default value**
       - **Value**
 
     * - | ``ROCSOLVER_LAYER``
         | Specifies which logging types, if any, are activated.
-      - Unset by default.
       - | Bitwise OR of zero or more bit masks:
         | 0: No logging (if not set)
         | 1: Trace logging
@@ -39,29 +37,24 @@ For more information, see :doc:`Use multi-level logging <../howto/logging>`.
 
     * - | ``ROCSOLVER_LEVELS``
         | Specifies the default maximum depth of nested function calls for trace and profile logging.
-      - ``1``
       - | Integer value representing maximum nesting depth.
 
     * - | ``ROCSOLVER_LOG_PATH``
         | Sets the full path for logging output when specific log path variables are not set.
-      - stderr output
       - | Full path name for log files.
         | If not set, output streams to standard error.
 
     * - | ``ROCSOLVER_LOG_TRACE_PATH``
         | Sets the full path name for trace logging output.
-      - ``ROCSOLVER_LOG_PATH``
       - | Full path name for trace log files.
         | Falls back to ``ROCSOLVER_LOG_PATH`` if not set.
 
     * - | ``ROCSOLVER_LOG_BENCH_PATH``
         | Sets the full path name for bench logging output.
-      - ``ROCSOLVER_LOG_PATH``
       - | Full path name for bench log files.
         | Falls back to ``ROCSOLVER_LOG_PATH`` if not set.
 
     * - | ``ROCSOLVER_LOG_PROFILE_PATH``
         | Sets the full path name for profile logging output.
-      - ``ROCSOLVER_LOG_PATH``
       - | Full path name for profile log files.
         | Falls back to ``ROCSOLVER_LOG_PATH`` if not set.

--- a/docs/reference/env_variables.rst
+++ b/docs/reference/env_variables.rst
@@ -1,0 +1,67 @@
+.. meta::
+  :description: rocSOLVER environment variables reference
+  :keywords: rocSOLVER, ROCm, API, environment variables, environment, reference
+
+.. _rocsolver-environment-variables:
+
+********************************************************************
+rocSOLVER environment variables
+********************************************************************
+
+This section describes the important rocSOLVER environment variables,
+which are grouped by functionality.
+
+Logging variables
+================================================================================
+
+The logging environment variables for rocSOLVER are collected in the following table.
+For more information, see :doc:`Use multi-level logging <../howto/logging>`.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 35,14,51
+
+    * - **Environment variable**
+      - **Default value**
+      - **Value**
+
+    * - | ``ROCSOLVER_LAYER``
+        | Specifies which logging types, if any, are activated.
+      - Unset by default.
+      - | Bitwise OR of zero or more bit masks:
+        | 0: No logging (if not set)
+        | 1: Trace logging
+        | 2: Bench logging
+        | 4: Profile logging
+        | 16: Kernel logging
+        | 17: Trace logging with kernel calls
+        | 20: Profile logging with kernel calls
+
+    * - | ``ROCSOLVER_LEVELS``
+        | Specifies the default maximum depth of nested function calls for trace and profile logging.
+      - ``1``
+      - | Integer value representing maximum nesting depth.
+
+    * - | ``ROCSOLVER_LOG_PATH``
+        | Sets the full path for logging output when specific log path variables are not set.
+      - stderr output
+      - | Full path name for log files.
+        | If not set, output streams to standard error.
+
+    * - | ``ROCSOLVER_LOG_TRACE_PATH``
+        | Sets the full path name for trace logging output.
+      - ``ROCSOLVER_LOG_PATH``
+      - | Full path name for trace log files.
+        | Falls back to ``ROCSOLVER_LOG_PATH`` if not set.
+
+    * - | ``ROCSOLVER_LOG_BENCH_PATH``
+        | Sets the full path name for bench logging output.
+      - ``ROCSOLVER_LOG_PATH``
+      - | Full path name for bench log files.
+        | Falls back to ``ROCSOLVER_LOG_PATH`` if not set.
+
+    * - | ``ROCSOLVER_LOG_PROFILE_PATH``
+        | Sets the full path name for profile logging output.
+      - ``ROCSOLVER_LOG_PATH``
+      - | Full path name for profile log files.
+        | Falls back to ``ROCSOLVER_LOG_PATH`` if not set.

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -37,6 +37,8 @@ subtrees:
         title: rocSOLVER types
       - file: reference/precision.rst
         title: rocSOLVER precision support
+      - file: reference/env_variables.rst
+        title: rocSOLVER environment variables
       - file: reference/auxiliary.rst
         title: LAPACK auxiliary functions
       - file: reference/lapack.rst


### PR DESCRIPTION
This is part of the environment variable initiative, where we aim to create a ROCm environment variable index page that contains the links to every component's environment variable page. Do let me know if there are any other environment variables besides the one that is listed, and whether the description/default values are correct.