### PR TITLE
Add cmake option BUILD_PARALLEL_HIP_JOBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,9 @@ option(WERROR "Treat warnings as errors" OFF)
 option(BUILD_COMPRESSED_DBG "Enable compressed debug symbols" ON)
 check_cxx_compiler_flag("--offload-compress" CXX_COMPILER_SUPPORTS_OFFLOAD_COMPRESS)
 cmake_dependent_option(BUILD_OFFLOAD_COMPRESS "Build with offload compression" ON CXX_COMPILER_SUPPORTS_OFFLOAD_COMPRESS OFF)
+check_cxx_compiler_flag("-parallel-jobs=4" CXX_COMPILER_SUPPORTS_PARALLEL_HIP_JOBS)
+cmake_dependent_option(BUILD_PARALLEL_HIP_JOBS "Build with parallel hip jobs" ON CXX_COMPILER_SUPPORTS_PARALLEL_HIP_JOBS OFF)
+
 
 cmake_dependent_option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY
   "Build with file/folder reorg backward compatibility enabled" OFF "NOT WIN32" OFF)

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -448,6 +448,10 @@ if(BUILD_OFFLOAD_COMPRESS)
   target_compile_options(rocsolver PRIVATE "--offload-compress")
 endif()
 
+if(BUILD_PARALLEL_HIP_JOBS)
+  target_compile_options(rocsolver PRIVATE "-parallel-jobs=4")
+endif()
+
 target_include_directories(rocsolver
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/library/include>


### PR DESCRIPTION
Build speed is dependent on AMDGPU_TARGETS.
Use the  BUILD_PARALLEL_HIP_JOBS=ON option to use the -parallel-jobs compiler option if it is available and reduce the build time.