### PR TITLE
Cherry-pick to release-staging/rocm-rel-7.0: Refactor warpSize as it is removed as compile time constant (#967)

### DIFF
--- a/clients/common/misc/rocblas_random.hpp
+++ b/clients/common/misc/rocblas_random.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@
 #include "rocblas_math.hpp"
 #include <cinttypes>
 #include <random>
+#include <thread>
 #include <type_traits>
 
 /* ============================================================================================

--- a/common/include/common_host_helpers.hpp
+++ b/common/include/common_host_helpers.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -100,6 +100,12 @@ double get_time_us_sync(hipStream_t stream);
 /*! \brief  CPU Timer(in microsecond): no GPU synchronization and return wall
  * time */
 double get_time_us_no_sync();
+
+/* =============================================================================================== */
+/* Device query functions.                                                                         */
+
+/*! \brief Get warp size of the current device */
+int get_device_warp_size();
 
 /* =============================================================================================== */
 /* Print functions.                                                                                */

--- a/common/src/common_host_helpers.cpp
+++ b/common/src/common_host_helpers.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -74,6 +74,30 @@ double get_time_us_sync(hipStream_t stream)
     THROW_IF_HIP_ERROR(status);
 #endif
     return get_time_us_no_sync();
+}
+
+/*! \brief Get warp size of the current device */
+int get_device_warp_size()
+{
+    int warp_size;
+    int device_id;
+    hipError_t err;
+
+    err = hipGetDevice(&device_id);
+
+    if(err != hipSuccess)
+    {
+        return 0;
+    }
+
+    err = hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, device_id);
+
+    if(err != hipSuccess)
+    {
+        return 0;
+    }
+
+    return warp_size;
 }
 
 #ifdef ROCSOLVER_LIBRARY

--- a/library/src/auxiliary/rocauxiliary_bdsqr_hybrid.hpp
+++ b/library/src/auxiliary/rocauxiliary_bdsqr_hybrid.hpp
@@ -33,6 +33,7 @@
 
 #pragma once
 
+#include "common_host_helpers.hpp"
 #include "lapack_host_functions.hpp"
 #include "rocauxiliary_lasr.hpp"
 #include "rocsolver_hybrid_storage.hpp"
@@ -52,7 +53,7 @@ static void swap_template(rocblas_handle handle,
                           I const incy,
                           hipStream_t stream)
 {
-    auto nthreads = warpSize * 2;
+    auto nthreads = get_device_warp_size() * 2;
     auto nblocks = (n - 1) / nthreads + 1;
 
     ROCSOLVER_LAUNCH_KERNEL((swap_kernel<T, I>), dim3(nblocks, 1, 1), dim3(nthreads, 1, 1), 0,
@@ -70,7 +71,7 @@ static void rot_template(rocblas_handle handle,
                          S const s,
                          hipStream_t stream)
 {
-    auto nthreads = warpSize * 2;
+    auto nthreads = get_device_warp_size() * 2;
     auto nblocks = (n - 1) / nthreads + 1;
 
     ROCSOLVER_LAUNCH_KERNEL((rot_kernel<S, T, I>), dim3(nblocks, 1, 1), dim3(nthreads, 1, 1), 0,
@@ -85,7 +86,7 @@ static void scal_template(rocblas_handle handle,
                           I const incx,
                           hipStream_t stream)
 {
-    auto nthreads = warpSize * 2;
+    auto nthreads = get_device_warp_size() * 2;
     auto nblocks = (n - 1) / nthreads + 1;
 
     ROCSOLVER_LAUNCH_KERNEL((scal_kernel<S, T, I>), dim3(nblocks, 1, 1), dim3(nthreads, 1, 1), 0,

--- a/library/src/auxiliary/rocauxiliary_larfg.hpp
+++ b/library/src/auxiliary/rocauxiliary_larfg.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     November 2017
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,6 +35,12 @@
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
 #include "rocsolver_run_specialized_kernels.hpp"
+
+#if defined(__GFX9__)
+__device__ static constexpr int WarpSize = 64;
+#else
+__device__ static constexpr int WarpSize = 32;
+#endif
 
 ROCSOLVER_BEGIN_NAMESPACE
 

--- a/library/src/lapack/roclapack_sygs2_hegs2.hpp
+++ b/library/src/lapack/roclapack_sygs2_hegs2.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,6 +33,7 @@
 #pragma once
 
 #include "auxiliary/rocauxiliary_lacgv.hpp"
+#include "common_host_helpers.hpp"
 #include "lapack_device_functions.hpp"
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
@@ -237,9 +238,9 @@ rocblas_status rocsolver_sygs2_hegs2_template(rocblas_handle handle,
     rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
 
     rocblas_int blocks_batch = (batch_count - 1) / BS1 + 1;
-    rocblas_int waves_batch = (batch_count - 1) / warpSize + 1;
+    rocblas_int waves_batch = (batch_count - 1) / get_device_warp_size() + 1;
     dim3 blocks(blocks_batch, 1, 1);
-    dim3 threads(std::min(BS1, warpSize * waves_batch), 1, 1);
+    dim3 threads(std::min(BS1, get_device_warp_size() * waves_batch), 1, 1);
 
     if(itype == rocblas_eform_ax)
     {

--- a/library/src/refact/rocrefact_csrrf_splitlu.hpp
+++ b/library/src/refact/rocrefact_csrrf_splitlu.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@
 #include <iostream>
 #include <rocprim/rocprim.hpp>
 
+#include "common_host_helpers.hpp"
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
 
@@ -70,12 +71,18 @@ __host__ __device__ static I cal_wave_size(I avg_nnzM)
 
     const auto ifactor = 2;
 
-    const auto wave_size = ((avg_nnzM >= ifactor * warpSize)              ? warpSize
-                                : (avg_nnzM >= ifactor * (warpSize / 2))  ? (warpSize / 2)
-                                : (avg_nnzM >= ifactor * (warpSize / 4))  ? (warpSize / 4)
-                                : (avg_nnzM >= ifactor * (warpSize / 8))  ? (warpSize / 8)
-                                : (avg_nnzM >= ifactor * (warpSize / 16)) ? (warpSize / 16)
-                                                                          : 1);
+#if defined(__HIP_DEVICE_COMPILE__)
+    const int warp_size = warpSize;
+#else
+    const int warp_size = get_device_warp_size();
+#endif
+
+    const auto wave_size = ((avg_nnzM >= ifactor * warp_size)              ? warp_size
+                                : (avg_nnzM >= ifactor * (warp_size / 2))  ? (warp_size / 2)
+                                : (avg_nnzM >= ifactor * (warp_size / 4))  ? (warp_size / 4)
+                                : (avg_nnzM >= ifactor * (warp_size / 8))  ? (warp_size / 8)
+                                : (avg_nnzM >= ifactor * (warp_size / 16)) ? (warp_size / 16)
+                                                                           : 1);
     return wave_size;
 }
 


### PR DESCRIPTION
This cherry-picks the patch for the removal of _AMDGCN_WAVEFRONT_SIZE & warpSize into the 7.0 staging branch.