### PR TITLE
Inverse triangular factor for GEQRF

### DIFF
--- a/library/src/auxiliary/rocauxiliary_larfb.hpp
+++ b/library/src/auxiliary/rocauxiliary_larfb.hpp
@@ -339,30 +339,8 @@ rocblas_status rocsolver_larfb_template(rocblas_handle handle,
 
     // compute: trans(T) * (V1' * A1 + V2' * A2)
     //    or    (A1 * V1 + A2 * V2) * trans(T)
-    if(colwise && forward && leftside)
-    {
-        size_t size_work1, size_work2, size_work3, size_work4;
-        bool optim_mem;
-        rocsolver_trsm_mem<false, false, T>(side, transt, ldw, order, batch_count, &size_work1,
-                                            &size_work2, &size_work3, &size_work4, &optim_mem);
-        void *work1, *work2, *work3, *work4;
-        HIP_CHECK(hipMalloc(&work1, sizeof(size_work1)));
-        HIP_CHECK(hipMalloc(&work2, sizeof(size_work2)));
-        HIP_CHECK(hipMalloc(&work3, sizeof(size_work3)));
-        HIP_CHECK(hipMalloc(&work4, sizeof(size_work4)));
-        rocsolver_trsm_upper<false, false, T>(handle, side, transt, rocblas_diagonal_non_unit, ldw,
-                                              order, F, shiftF, ldf, strideF, tmptr, 0, ldw, strideW,
-                                              batch_count, optim_mem, work1, work2, work3, work4);
-        HIP_CHECK(hipFree(work1));
-        HIP_CHECK(hipFree(work2));
-        HIP_CHECK(hipFree(work3));
-        HIP_CHECK(hipFree(work4));
-    }
-    else
-    {
-        rocblasCall_trmm(handle, side, uploT, transt, rocblas_diagonal_non_unit, ldw, order, &one,
-                         0, F, shiftF, ldf, strideF, tmptr, 0, ldw, strideW, batch_count, workArr);
-    }
+    rocblasCall_trmm(handle, side, uploT, transt, rocblas_diagonal_non_unit, ldw, order, &one, 0, F,
+                     shiftF, ldf, strideF, tmptr, 0, ldw, strideW, batch_count, workArr);
 
     // compute: A2 - V2 * trans(T) * (V1' * A1 + V2' * A2)
     //    or    A2 - (A1 * V1 + A2 * V2) * trans(T) * V2'
@@ -490,9 +468,10 @@ rocblas_status rocsolver_larfb_inverse_template(rocblas_handle handle,
                                                 T** workArr,
                                                 bool optim_mem)
 {
-    ROCSOLVER_ENTER("larfb", "side:", side, "trans:", trans, "direct:", direct, "storev:", storev,
-                    "m:", m, "n:", n, "k:", k, "shiftV:", shiftV, "ldv:", ldv, "shiftF:", shiftF,
-                    "ldf:", ldf, "shiftA:", shiftA, "lda:", lda, "bc:", batch_count);
+    ROCSOLVER_ENTER("larfb_inverse", "side:", side, "trans:", trans, "direct:", direct,
+                    "storev:", storev, "m:", m, "n:", n, "k:", k, "shiftV:", shiftV, "ldv:", ldv,
+                    "shiftF:", shiftF, "ldf:", ldf, "shiftA:", shiftA, "lda:", lda,
+                    "bc:", batch_count);
 
     // quick return
     if(m == 0 || n == 0 || batch_count == 0)

--- a/library/src/auxiliary/rocauxiliary_larfb.hpp
+++ b/library/src/auxiliary/rocauxiliary_larfb.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     June 2013
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -339,8 +339,30 @@ rocblas_status rocsolver_larfb_template(rocblas_handle handle,
 
     // compute: trans(T) * (V1' * A1 + V2' * A2)
     //    or    (A1 * V1 + A2 * V2) * trans(T)
-    rocblasCall_trmm(handle, side, uploT, transt, rocblas_diagonal_non_unit, ldw, order, &one, 0, F,
-                     shiftF, ldf, strideF, tmptr, 0, ldw, strideW, batch_count, workArr);
+    if(colwise && forward && leftside)
+    {
+        size_t size_work1, size_work2, size_work3, size_work4;
+        bool optim_mem;
+        rocsolver_trsm_mem<false, false, T>(side, transt, ldw, order, batch_count, &size_work1,
+                                            &size_work2, &size_work3, &size_work4, &optim_mem);
+        void *work1, *work2, *work3, *work4;
+        HIP_CHECK(hipMalloc(&work1, sizeof(size_work1)));
+        HIP_CHECK(hipMalloc(&work2, sizeof(size_work2)));
+        HIP_CHECK(hipMalloc(&work3, sizeof(size_work3)));
+        HIP_CHECK(hipMalloc(&work4, sizeof(size_work4)));
+        rocsolver_trsm_upper<false, false, T>(handle, side, transt, rocblas_diagonal_non_unit, ldw,
+                                              order, F, shiftF, ldf, strideF, tmptr, 0, ldw, strideW,
+                                              batch_count, optim_mem, work1, work2, work3, work4);
+        HIP_CHECK(hipFree(work1));
+        HIP_CHECK(hipFree(work2));
+        HIP_CHECK(hipFree(work3));
+        HIP_CHECK(hipFree(work4));
+    }
+    else
+    {
+        rocblasCall_trmm(handle, side, uploT, transt, rocblas_diagonal_non_unit, ldw, order, &one,
+                         0, F, shiftF, ldf, strideF, tmptr, 0, ldw, strideW, batch_count, workArr);
+    }
 
     // compute: A2 - V2 * trans(T) * (V1' * A1 + V2' * A2)
     //    or    A2 - (A1 * V1 + A2 * V2) * trans(T) * V2'

--- a/library/src/auxiliary/rocauxiliary_larfb.hpp
+++ b/library/src/auxiliary/rocauxiliary_larfb.hpp
@@ -397,4 +397,276 @@ rocblas_status rocsolver_larfb_template(rocblas_handle handle,
     return rocblas_status_success;
 }
 
+template <bool BATCHED, bool STRIDED, typename T>
+void rocsolver_larfb_inverse_getMemorySize(const rocblas_side side,
+                                           const rocblas_operation trans,
+                                           const rocblas_int m,
+                                           const rocblas_int n,
+                                           const rocblas_int k,
+                                           const rocblas_int batch_count,
+                                           size_t* size_tmptr,
+                                           size_t* size_work1,
+                                           size_t* size_work2,
+                                           size_t* size_work3,
+                                           size_t* size_work4,
+                                           size_t* size_workArr,
+                                           bool* optim_mem)
+{
+    // if quick return, no workspace needed
+    if(m == 0 || n == 0 || batch_count == 0)
+    {
+        *size_tmptr = 0;
+        *size_workArr = 0;
+        *size_work1 = 0;
+        *size_work2 = 0;
+        *size_work3 = 0;
+        *size_work4 = 0;
+        *optim_mem = true;
+        return;
+    }
+
+    bool leftside = (side == rocblas_side_left);
+    rocblas_operation transt
+        = (leftside && trans == rocblas_operation_transpose ? rocblas_operation_conjugate_transpose
+                                                            : trans);
+
+    rocblas_int order, ldw;
+    if(leftside)
+    {
+        order = n;
+        ldw = k;
+    }
+    else
+    {
+        order = k;
+        ldw = m;
+    }
+
+    rocsolver_trsm_mem<BATCHED, STRIDED, T>(side, transt, ldw, order, batch_count, size_work1,
+                                            size_work2, size_work3, size_work4, optim_mem, true);
+
+    // size of temporary array for computations with
+    // triangular part of V
+    if(side == rocblas_side_left)
+        *size_tmptr = n;
+    else
+        *size_tmptr = m;
+    *size_tmptr *= sizeof(T) * k * batch_count;
+
+    // size of array of pointers to workspace
+    if(BATCHED)
+        *size_workArr = sizeof(T*) * batch_count;
+    else
+        *size_workArr = 0;
+}
+
+template <bool BATCHED, bool STRIDED, typename T, typename U>
+rocblas_status rocsolver_larfb_inverse_template(rocblas_handle handle,
+                                                const rocblas_side side,
+                                                const rocblas_operation trans,
+                                                const rocblas_direct direct,
+                                                const rocblas_storev storev,
+                                                const rocblas_int m,
+                                                const rocblas_int n,
+                                                const rocblas_int k,
+                                                U V,
+                                                const rocblas_int shiftV,
+                                                const rocblas_int ldv,
+                                                const rocblas_stride strideV,
+                                                T* F,
+                                                const rocblas_int shiftF,
+                                                const rocblas_int ldf,
+                                                const rocblas_stride strideF,
+                                                U A,
+                                                const rocblas_int shiftA,
+                                                const rocblas_int lda,
+                                                const rocblas_stride strideA,
+                                                const rocblas_int batch_count,
+                                                T* tmptr,
+                                                void* work1,
+                                                void* work2,
+                                                void* work3,
+                                                void* work4,
+                                                T** workArr,
+                                                bool optim_mem)
+{
+    ROCSOLVER_ENTER("larfb", "side:", side, "trans:", trans, "direct:", direct, "storev:", storev,
+                    "m:", m, "n:", n, "k:", k, "shiftV:", shiftV, "ldv:", ldv, "shiftF:", shiftF,
+                    "ldf:", ldf, "shiftA:", shiftA, "lda:", lda, "bc:", batch_count);
+
+    // quick return
+    if(m == 0 || n == 0 || batch_count == 0)
+        return rocblas_status_success;
+
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+    T *Vp, *Fp;
+
+    // everything must be executed with scalars on the host
+    rocblas_pointer_mode old_mode;
+    rocblas_get_pointer_mode(handle, &old_mode);
+    rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
+
+    // constants to use when calling rocablas functions
+    T minone = -1;
+    T one = 1;
+
+    // determine the side, size of workspace
+    // and whether V is trapezoidal
+    bool trap;
+    bool colwise = (storev == rocblas_column_wise);
+    bool forward = (direct == rocblas_forward_direction);
+    bool leftside = (side == rocblas_side_left);
+    rocblas_operation transt
+        = (leftside && trans == rocblas_operation_transpose ? rocblas_operation_conjugate_transpose
+                                                            : trans);
+    rocblas_operation transp;
+    rocblas_fill uploV, uploT;
+    rocblas_int order, ldw;
+    rocblas_int shift1, shift2;
+    size_t offsetA1, offsetA2;
+    size_t offsetV1, offsetV2;
+
+    if(leftside)
+    {
+        order = n;
+        ldw = k;
+        trap = (m > k);
+
+        if(forward)
+        {
+            offsetA1 = shiftA;
+            offsetA2 = shiftA + idx2D(k, 0, lda);
+        }
+        else
+        {
+            offsetA1 = shiftA + idx2D(m - k, 0, lda);
+            offsetA2 = shiftA;
+        }
+    }
+    else
+    {
+        order = k;
+        ldw = m;
+        trap = (n > k);
+
+        if(forward)
+        {
+            offsetA1 = shiftA;
+            offsetA2 = shiftA + idx2D(0, k, lda);
+        }
+        else
+        {
+            offsetA1 = shiftA + idx2D(0, n - k, lda);
+            offsetA2 = shiftA;
+        }
+    }
+
+    if(colwise)
+    {
+        if(leftside)
+            transp = rocblas_operation_conjugate_transpose;
+        else
+            transp = rocblas_operation_none;
+
+        if(forward)
+        {
+            uploV = rocblas_fill_lower;
+            offsetV1 = shiftV;
+            offsetV2 = shiftV + idx2D(k, 0, ldv);
+        }
+        else
+        {
+            uploV = rocblas_fill_upper;
+            offsetV1 = shiftV + idx2D((leftside ? m - k : n - k), 0, ldv);
+            offsetV2 = shiftV;
+        }
+    }
+    else
+    {
+        if(leftside)
+            transp = rocblas_operation_none;
+        else
+            transp = rocblas_operation_conjugate_transpose;
+
+        if(forward)
+        {
+            uploV = rocblas_fill_upper;
+            offsetV1 = shiftV;
+            offsetV2 = shiftV + idx2D(0, k, ldv);
+        }
+        else
+        {
+            uploV = rocblas_fill_lower;
+            offsetV1 = shiftV + idx2D(0, (leftside ? m - k : n - k), ldv);
+            offsetV2 = shiftV;
+        }
+    }
+    rocblas_stride strideW = rocblas_stride(ldw) * order;
+    uploT = (forward ? rocblas_fill_upper : rocblas_fill_lower);
+
+    // copy A1 to tmptr
+    rocblas_int blocksx = (order - 1) / 32 + 1;
+    rocblas_int blocksy = (ldw - 1) / 32 + 1;
+    ROCSOLVER_LAUNCH_KERNEL(copymatA1, dim3(blocksx, blocksy, batch_count), dim3(32, 32), 0, stream,
+                            ldw, order, A, offsetA1, lda, strideA, tmptr);
+
+    // compute: V1' * A1
+    //   or    A1 * V1
+    rocblasCall_trmm(handle, side, uploV, transp, rocblas_diagonal_unit, ldw, order, &one, 0, V,
+                     offsetV1, ldv, strideV, tmptr, 0, ldw, strideW, batch_count, workArr);
+
+    // compute: V1' * A1 + V2' * A2
+    //    or    A1 * V1 + A2 * V2
+    if(trap)
+    {
+        if(leftside)
+            rocsolver_gemm(handle, transp, rocblas_operation_none, ldw, order, m - k, &one, V,
+                           offsetV2, ldv, strideV, A, offsetA2, lda, strideA, &one, tmptr, 0, ldw,
+                           strideW, batch_count, workArr);
+        else
+            rocsolver_gemm(handle, rocblas_operation_none, transp, ldw, order, n - k, &one, A,
+                           offsetA2, lda, strideA, V, offsetV2, ldv, strideV, &one, tmptr, 0, ldw,
+                           strideW, batch_count, workArr);
+    }
+
+    // compute: inv(trans(T)) * (V1' * A1 + V2' * A2)
+    //    or    (A1 * V1 + A2 * V2) * inv(trans(T))
+    rocsolver_trsm_upper<BATCHED, STRIDED, T>(handle, side, transt, rocblas_diagonal_non_unit, ldw,
+                                              order, F, shiftF, ldf, strideF, tmptr, 0, ldw, strideW,
+                                              batch_count, optim_mem, work1, work2, work3, work4);
+
+    // compute: A2 - V2 * trans(T) * (V1' * A1 + V2' * A2)
+    //    or    A2 - (A1 * V1 + A2 * V2) * trans(T) * V2'
+    if(transp == rocblas_operation_none)
+        transp = rocblas_operation_conjugate_transpose;
+    else
+        transp = rocblas_operation_none;
+
+    if(trap)
+    {
+        if(leftside)
+            rocsolver_gemm(handle, transp, rocblas_operation_none, m - k, order, ldw, &minone, V,
+                           offsetV2, ldv, strideV, tmptr, 0, ldw, strideW, &one, A, offsetA2, lda,
+                           strideA, batch_count, workArr);
+        else
+            rocsolver_gemm(handle, rocblas_operation_none, transp, ldw, n - k, order, &minone,
+                           tmptr, 0, ldw, strideW, V, offsetV2, ldv, strideV, &one, A, offsetA2,
+                           lda, strideA, batch_count, workArr);
+    }
+
+    // compute: V1 * trans(T) * (V1' * A1 + V2' * A2)
+    //    or    (A1 * V1 + A2 * V2) * trans(T) * V1'
+    rocblasCall_trmm(handle, side, uploV, transp, rocblas_diagonal_unit, ldw, order, &one, 0, V,
+                     offsetV1, ldv, strideV, tmptr, 0, ldw, strideW, batch_count, workArr);
+
+    // compute: A1 - V1 * trans(T) * (V1' * A1 + V2' * A2)
+    //    or    A1 - (A1 * V1 + A2 * V2) * trans(T) * V1'
+    ROCSOLVER_LAUNCH_KERNEL(addmatA1, dim3(blocksx, blocksy, batch_count), dim3(32, 32), 0, stream,
+                            ldw, order, A, offsetA1, lda, strideA, tmptr);
+
+    rocblas_set_pointer_mode(handle, old_mode);
+    return rocblas_status_success;
+}
+
 ROCSOLVER_END_NAMESPACE

--- a/library/src/auxiliary/rocauxiliary_larfb.hpp
+++ b/library/src/auxiliary/rocauxiliary_larfb.hpp
@@ -611,9 +611,14 @@ rocblas_status rocsolver_larfb_inverse_template(rocblas_handle handle,
 
     // compute: inv(trans(T)) * (V1' * A1 + V2' * A2)
     //    or    (A1 * V1 + A2 * V2) * inv(trans(T))
-    rocsolver_trsm_upper<BATCHED, STRIDED, T>(handle, side, transt, rocblas_diagonal_non_unit, ldw,
-                                              order, F, shiftF, ldf, strideF, tmptr, 0, ldw, strideW,
-                                              batch_count, optim_mem, work1, work2, work3, work4);
+    if(forward)
+        rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+            handle, side, transt, rocblas_diagonal_non_unit, ldw, order, F, shiftF, ldf, strideF,
+            tmptr, 0, ldw, strideW, batch_count, optim_mem, work1, work2, work3, work4);
+    else
+        rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+            handle, side, transt, rocblas_diagonal_non_unit, ldw, order, F, shiftF, ldf, strideF,
+            tmptr, 0, ldw, strideW, batch_count, optim_mem, work1, work2, work3, work4);
 
     // compute: A2 - V2 * trans(T) * (V1' * A1 + V2' * A2)
     //    or    A2 - (A1 * V1 + A2 * V2) * trans(T) * V2'

--- a/library/src/auxiliary/rocauxiliary_larfb.hpp
+++ b/library/src/auxiliary/rocauxiliary_larfb.hpp
@@ -420,8 +420,9 @@ void rocsolver_larfb_inverse_getMemorySize(const rocblas_side side,
         ldw = m;
     }
 
-    rocsolver_trsm_mem<BATCHED, STRIDED, T>(side, transt, ldw, order, batch_count, size_work1,
-                                            size_work2, size_work3, size_work4, optim_mem, true);
+    rocsolver_trsm_mem<false, BATCHED || STRIDED, T>(side, transt, ldw, order, batch_count,
+                                                     size_work1, size_work2, size_work3, size_work4,
+                                                     optim_mem, true);
 
     // size of temporary array for computations with
     // triangular part of V
@@ -612,11 +613,11 @@ rocblas_status rocsolver_larfb_inverse_template(rocblas_handle handle,
     // compute: inv(trans(T)) * (V1' * A1 + V2' * A2)
     //    or    (A1 * V1 + A2 * V2) * inv(trans(T))
     if(forward)
-        rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+        rocsolver_trsm_upper<false, BATCHED || STRIDED, T>(
             handle, side, transt, rocblas_diagonal_non_unit, ldw, order, F, shiftF, ldf, strideF,
             tmptr, 0, ldw, strideW, batch_count, optim_mem, work1, work2, work3, work4);
     else
-        rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+        rocsolver_trsm_lower<false, BATCHED || STRIDED, T>(
             handle, side, transt, rocblas_diagonal_non_unit, ldw, order, F, shiftF, ldf, strideF,
             tmptr, 0, ldw, strideW, batch_count, optim_mem, work1, work2, work3, work4);
 

--- a/library/src/auxiliary/rocauxiliary_larft.hpp
+++ b/library/src/auxiliary/rocauxiliary_larft.hpp
@@ -36,6 +36,7 @@
 
 #pragma once
 
+#include "lapack/roclapack_trtri.hpp"
 #include "rocauxiliary_lacgv.hpp"
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
@@ -74,7 +75,7 @@ ROCSOLVER_KERNEL void set_triangular(const rocblas_int n,
         Fp = F + b * strideF;
 
         if(j == i)
-            Fp[idx2D(j, i, ldf)] = tp[i];
+            Fp[j + i * ldf] = 1 / tp[i];
         else if(direct == rocblas_forward_direction)
         {
             if(j < i)
@@ -83,13 +84,14 @@ ROCSOLVER_KERNEL void set_triangular(const rocblas_int n,
                 {
                     if(!add_fp)
                     {
-                        Fp[idx2D(j, i, ldf)] = -tp[i] * Vp[idx2D(i, j, ldv)];
+                        Fp[idx2D(j, i, ldf)] = Vp[idx2D(i, j, ldv)];
                     }
                     else
                     {
-                        Fp[idx2D(j, i, ldf)] = -tp[i] * (Fp[idx2D(j, i, ldf)] + Vp[idx2D(i, j, ldv)]);
+                        Fp[idx2D(j, i, ldf)] = (Fp[idx2D(j, i, ldf)] + Vp[idx2D(i, j, ldv)]);
                     }
                 }
+                // Fp[j + i * ldf] = Vp[i + j * ldv];
                 else
                 {
                     if(!add_fp)
@@ -168,7 +170,7 @@ ROCSOLVER_KERNEL void set_triangular(const rocblas_int n,
         Fp = F + b * strideF;
 
         if(j == i)
-            Fp[idx2D(j, i, ldf)] = tp[i];
+            Fp[j + i * ldf] = 1 / tp[i];
         else if(direct == rocblas_forward_direction)
         {
             if(j < i)
@@ -177,14 +179,14 @@ ROCSOLVER_KERNEL void set_triangular(const rocblas_int n,
                 {
                     if(!add_fp)
                     {
-                        Fp[idx2D(j, i, ldf)] = -tp[i] * conj(Vp[idx2D(i, j, ldv)]);
+                        Fp[idx2D(j, i, ldf)] = conj(Vp[idx2D(i, j, ldv)]);
                     }
                     else
                     {
-                        Fp[idx2D(j, i, ldf)]
-                            = -tp[i] * (Fp[idx2D(j, i, ldf)] + conj(Vp[idx2D(i, j, ldv)]));
+                        Fp[idx2D(j, i, ldf)] = (Fp[idx2D(j, i, ldf)] + conj(Vp[idx2D(i, j, ldv)]));
                     }
                 }
+                // Fp[j + i * ldf] = conj(Vp[i + j * ldv]);
                 else
                 {
                     if(!add_fp)
@@ -508,6 +510,15 @@ rocblas_status rocsolver_larft_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
+template <typename T, typename U>
+rocblas_status rocsolver_trtri_impl(rocblas_handle handle,
+                                    const rocblas_fill uplo,
+                                    const rocblas_diagonal diag,
+                                    const rocblas_int n,
+                                    U A,
+                                    const rocblas_int lda,
+                                    rocblas_int* info);
+
 template <typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_larft_template(rocblas_handle handle,
                                         const rocblas_direct direct,
@@ -612,21 +623,26 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
         //      IT WILL WORK ON THE ENTIRE MATRIX/VECTOR REGARDLESS OF
         //      ZERO ENTRIES ****
 
-        if(k <= LARFT_SWITCHSIZE && lmemsize <= props.sharedMemPerBlock)
-        {
-            ROCSOLVER_LAUNCH_KERNEL(larft_kernel_forward, dim3(1, batch_count), dim3(BS1, 1),
-                                    lmemsize, stream, storev, u1_n, k, V, shiftV, ldv, strideV, tau,
-                                    strideT, F, ldf, strideF);
-        }
-        else
+        // if(k <= LARFT_SWITCHSIZE && lmemsize <= props.sharedMemPerBlock)
+        // {
+        //     ROCSOLVER_LAUNCH_KERNEL(larft_kernel_forward, dim3(1, batch_count), dim3(BS1, 1),
+        //                             lmemsize, stream, storev, u1_n, k, V, shiftV, ldv, strideV, tau,
+        //                             strideT, F, ldf, strideF);
+        // }
+        // else
         {
             for(rocblas_int i = 1; i < k; ++i)
             {
                 // compute the matrix vector product, using the householder vectors
                 if(storev == rocblas_column_wise)
                 {
+                    // trans = rocblas_operation_conjugate_transpose;
+                    // rocblasCall_gemv<T>(handle, trans, n - 1 - i, i, scalars + 2, strideT, V,
+                    //                     shiftV + idx2D(i + 1, 0, ldv), ldv, strideV, V,
+                    //                     shiftV + idx2D(i + 1, i, ldv), 1, strideV, scalars + 2, 0, F,
+                    //                     idx2D(0, i, ldf), 1, strideF, batch_count, workArr);
                     trans = rocblas_operation_conjugate_transpose;
-                    rocblasCall_gemv<T>(handle, trans, u1_n - 1 - i, i, tau + i, strideT, V,
+                    rocblasCall_gemv<T>(handle, trans, u1_n - 1 - i, i, scalars + 2, strideT, V,
                                         shiftV + idx2D(i + 1, 0, ldv), ldv, strideV, V,
                                         shiftV + idx2D(i + 1, i, ldv), 1, strideV, scalars + 2, 0,
                                         F, idx2D(0, i, ldf), 1, strideF, batch_count, workArr);
@@ -651,9 +667,12 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
                 }
 
                 // multiply by the previous triangular factor
-                trans = rocblas_operation_none;
-                rocblasCall_trmv<T>(handle, uplo, trans, diag, i, F, 0, ldf, strideF, F,
-                                    idx2D(0, i, ldf), 1, strideF, work, stridew, batch_count);
+                if(storev != rocblas_column_wise)
+                {
+                    trans = rocblas_operation_none;
+                    rocblasCall_trmv<T>(handle, uplo, trans, diag, i, F, 0, ldf, strideF, F,
+                                        idx2D(0, i, ldf), 1, strideF, work, stridew, batch_count);
+                }
             }
         }
     }
@@ -716,6 +735,56 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
     // restore tau
     ROCSOLVER_LAUNCH_KERNEL(set_tau, dim3(blocks, batch_count), dim3(32, 1), 0, stream, k, tau,
                             strideT);
+
+    if(direct == rocblas_forward_direction && storev == rocblas_column_wise)
+    {
+        size_t size_w1, size_w2, size_w3, size_w4, size_tmp, size_work;
+        bool optim_mem;
+        // rocsolver_trtri_getMemorySize(rocblas_diagonal_non_unit, k,
+        //                            batch_count,
+        //                            &size_w1,
+        //                            &size_w2,
+        //                            &size_w3,
+        //                            &size_w4,
+        //                            &size_tmp,
+        //                            &size_work,
+        //                            &optim_mem);
+        void *w1, *w2, *w3, *w4, *tmp, *work1;
+        rocblas_int* info;
+        // HIP_CHECK(hipMalloc(&info, sizeof(rocblas_int)));
+        // HIP_CHECK(hipMalloc(&w1, sizeof(size_w1)));
+        // HIP_CHECK(hipMalloc(&w2, sizeof(size_w2)));
+        // HIP_CHECK(hipMalloc(&w3, sizeof(size_w3)));
+        // HIP_CHECK(hipMalloc(&w4, sizeof(size_w4)));
+        // HIP_CHECK(hipMalloc(&tmp, sizeof(size_tmp)));
+        // HIP_CHECK(hipMalloc(&work1, sizeof(size_work)));
+        // rocsolver_trtri_impl<T>(handle, rocblas_fill_upper, rocblas_diagonal_non_unit, k,
+        //     F,
+        //     ldf,
+        //     info);
+        // rocsolver_trtri_template(handle,
+        //                                 rocblas_fill_upper, rocblas_diagonal_non_unit, k,
+        //                                 F,
+        //                                 0,
+        //                                 ldf,
+        //                                 strideF,
+        //                                 info,
+        //                                 batch_count,
+        //                                 w1,
+        //                                 w2,
+        //                                 w3,
+        //                                 w4,
+        //                                 (T*)tmp,
+        //                                 (T**)work1,
+        //                                 optim_mem);
+        // HIP_CHECK(hipFree(info));
+        // HIP_CHECK(hipFree(w1));
+        // HIP_CHECK(hipFree(w2));
+        // HIP_CHECK(hipFree(w3));
+        // HIP_CHECK(hipFree(w4));
+        // HIP_CHECK(hipFree(tmp));
+        // HIP_CHECK(hipFree(work1));
+    }
 
     rocblas_set_pointer_mode(handle, old_mode);
     return rocblas_status_success;

--- a/library/src/auxiliary/rocauxiliary_larft.hpp
+++ b/library/src/auxiliary/rocauxiliary_larft.hpp
@@ -36,7 +36,6 @@
 
 #pragma once
 
-#include "lapack/roclapack_trtri.hpp"
 #include "rocauxiliary_lacgv.hpp"
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
@@ -75,7 +74,7 @@ ROCSOLVER_KERNEL void set_triangular(const rocblas_int n,
         Fp = F + b * strideF;
 
         if(j == i)
-            Fp[j + i * ldf] = 1 / tp[i];
+            Fp[idx2D(j, i, ldf)] = tp[i];
         else if(direct == rocblas_forward_direction)
         {
             if(j < i)
@@ -84,14 +83,13 @@ ROCSOLVER_KERNEL void set_triangular(const rocblas_int n,
                 {
                     if(!add_fp)
                     {
-                        Fp[idx2D(j, i, ldf)] = Vp[idx2D(i, j, ldv)];
+                        Fp[idx2D(j, i, ldf)] = -tp[i] * Vp[idx2D(i, j, ldv)];
                     }
                     else
                     {
-                        Fp[idx2D(j, i, ldf)] = (Fp[idx2D(j, i, ldf)] + Vp[idx2D(i, j, ldv)]);
+                        Fp[idx2D(j, i, ldf)] = -tp[i] * (Fp[idx2D(j, i, ldf)] + Vp[idx2D(i, j, ldv)]);
                     }
                 }
-                // Fp[j + i * ldf] = Vp[i + j * ldv];
                 else
                 {
                     if(!add_fp)
@@ -170,7 +168,7 @@ ROCSOLVER_KERNEL void set_triangular(const rocblas_int n,
         Fp = F + b * strideF;
 
         if(j == i)
-            Fp[j + i * ldf] = 1 / tp[i];
+            Fp[idx2D(j, i, ldf)] = tp[i];
         else if(direct == rocblas_forward_direction)
         {
             if(j < i)
@@ -179,14 +177,14 @@ ROCSOLVER_KERNEL void set_triangular(const rocblas_int n,
                 {
                     if(!add_fp)
                     {
-                        Fp[idx2D(j, i, ldf)] = conj(Vp[idx2D(i, j, ldv)]);
+                        Fp[idx2D(j, i, ldf)] = -tp[i] * conj(Vp[idx2D(i, j, ldv)]);
                     }
                     else
                     {
-                        Fp[idx2D(j, i, ldf)] = (Fp[idx2D(j, i, ldf)] + conj(Vp[idx2D(i, j, ldv)]));
+                        Fp[idx2D(j, i, ldf)]
+                            = -tp[i] * (Fp[idx2D(j, i, ldf)] + conj(Vp[idx2D(i, j, ldv)]));
                     }
                 }
-                // Fp[j + i * ldf] = conj(Vp[i + j * ldv]);
                 else
                 {
                     if(!add_fp)
@@ -510,15 +508,6 @@ rocblas_status rocsolver_larft_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-template <typename T, typename U>
-rocblas_status rocsolver_trtri_impl(rocblas_handle handle,
-                                    const rocblas_fill uplo,
-                                    const rocblas_diagonal diag,
-                                    const rocblas_int n,
-                                    U A,
-                                    const rocblas_int lda,
-                                    rocblas_int* info);
-
 template <typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
 rocblas_status rocsolver_larft_template(rocblas_handle handle,
                                         const rocblas_direct direct,
@@ -623,26 +612,21 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
         //      IT WILL WORK ON THE ENTIRE MATRIX/VECTOR REGARDLESS OF
         //      ZERO ENTRIES ****
 
-        // if(k <= LARFT_SWITCHSIZE && lmemsize <= props.sharedMemPerBlock)
-        // {
-        //     ROCSOLVER_LAUNCH_KERNEL(larft_kernel_forward, dim3(1, batch_count), dim3(BS1, 1),
-        //                             lmemsize, stream, storev, u1_n, k, V, shiftV, ldv, strideV, tau,
-        //                             strideT, F, ldf, strideF);
-        // }
-        // else
+        if(k <= LARFT_SWITCHSIZE && lmemsize <= props.sharedMemPerBlock)
+        {
+            ROCSOLVER_LAUNCH_KERNEL(larft_kernel_forward, dim3(1, batch_count), dim3(BS1, 1),
+                                    lmemsize, stream, storev, u1_n, k, V, shiftV, ldv, strideV, tau,
+                                    strideT, F, ldf, strideF);
+        }
+        else
         {
             for(rocblas_int i = 1; i < k; ++i)
             {
                 // compute the matrix vector product, using the householder vectors
                 if(storev == rocblas_column_wise)
                 {
-                    // trans = rocblas_operation_conjugate_transpose;
-                    // rocblasCall_gemv<T>(handle, trans, n - 1 - i, i, scalars + 2, strideT, V,
-                    //                     shiftV + idx2D(i + 1, 0, ldv), ldv, strideV, V,
-                    //                     shiftV + idx2D(i + 1, i, ldv), 1, strideV, scalars + 2, 0, F,
-                    //                     idx2D(0, i, ldf), 1, strideF, batch_count, workArr);
                     trans = rocblas_operation_conjugate_transpose;
-                    rocblasCall_gemv<T>(handle, trans, u1_n - 1 - i, i, scalars + 2, strideT, V,
+                    rocblasCall_gemv<T>(handle, trans, u1_n - 1 - i, i, tau + i, strideT, V,
                                         shiftV + idx2D(i + 1, 0, ldv), ldv, strideV, V,
                                         shiftV + idx2D(i + 1, i, ldv), 1, strideV, scalars + 2, 0,
                                         F, idx2D(0, i, ldf), 1, strideF, batch_count, workArr);
@@ -667,12 +651,9 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
                 }
 
                 // multiply by the previous triangular factor
-                if(storev != rocblas_column_wise)
-                {
-                    trans = rocblas_operation_none;
-                    rocblasCall_trmv<T>(handle, uplo, trans, diag, i, F, 0, ldf, strideF, F,
-                                        idx2D(0, i, ldf), 1, strideF, work, stridew, batch_count);
-                }
+                trans = rocblas_operation_none;
+                rocblasCall_trmv<T>(handle, uplo, trans, diag, i, F, 0, ldf, strideF, F,
+                                    idx2D(0, i, ldf), 1, strideF, work, stridew, batch_count);
             }
         }
     }
@@ -735,56 +716,6 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
     // restore tau
     ROCSOLVER_LAUNCH_KERNEL(set_tau, dim3(blocks, batch_count), dim3(32, 1), 0, stream, k, tau,
                             strideT);
-
-    if(direct == rocblas_forward_direction && storev == rocblas_column_wise)
-    {
-        size_t size_w1, size_w2, size_w3, size_w4, size_tmp, size_work;
-        bool optim_mem;
-        // rocsolver_trtri_getMemorySize(rocblas_diagonal_non_unit, k,
-        //                            batch_count,
-        //                            &size_w1,
-        //                            &size_w2,
-        //                            &size_w3,
-        //                            &size_w4,
-        //                            &size_tmp,
-        //                            &size_work,
-        //                            &optim_mem);
-        void *w1, *w2, *w3, *w4, *tmp, *work1;
-        rocblas_int* info;
-        // HIP_CHECK(hipMalloc(&info, sizeof(rocblas_int)));
-        // HIP_CHECK(hipMalloc(&w1, sizeof(size_w1)));
-        // HIP_CHECK(hipMalloc(&w2, sizeof(size_w2)));
-        // HIP_CHECK(hipMalloc(&w3, sizeof(size_w3)));
-        // HIP_CHECK(hipMalloc(&w4, sizeof(size_w4)));
-        // HIP_CHECK(hipMalloc(&tmp, sizeof(size_tmp)));
-        // HIP_CHECK(hipMalloc(&work1, sizeof(size_work)));
-        // rocsolver_trtri_impl<T>(handle, rocblas_fill_upper, rocblas_diagonal_non_unit, k,
-        //     F,
-        //     ldf,
-        //     info);
-        // rocsolver_trtri_template(handle,
-        //                                 rocblas_fill_upper, rocblas_diagonal_non_unit, k,
-        //                                 F,
-        //                                 0,
-        //                                 ldf,
-        //                                 strideF,
-        //                                 info,
-        //                                 batch_count,
-        //                                 w1,
-        //                                 w2,
-        //                                 w3,
-        //                                 w4,
-        //                                 (T*)tmp,
-        //                                 (T**)work1,
-        //                                 optim_mem);
-        // HIP_CHECK(hipFree(info));
-        // HIP_CHECK(hipFree(w1));
-        // HIP_CHECK(hipFree(w2));
-        // HIP_CHECK(hipFree(w3));
-        // HIP_CHECK(hipFree(w4));
-        // HIP_CHECK(hipFree(tmp));
-        // HIP_CHECK(hipFree(work1));
-    }
 
     rocblas_set_pointer_mode(handle, old_mode);
     return rocblas_status_success;

--- a/library/src/auxiliary/rocauxiliary_larft.hpp
+++ b/library/src/auxiliary/rocauxiliary_larft.hpp
@@ -722,7 +722,8 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
 }
 
 template <typename T, typename U>
-ROCSOLVER_KERNEL void set_tri(const rocblas_int k,
+ROCSOLVER_KERNEL void set_tri(const rocblas_fill uplo,
+                              const rocblas_int k,
                               U A,
                               const rocblas_int shiftA,
                               const rocblas_int lda,
@@ -736,9 +737,12 @@ ROCSOLVER_KERNEL void set_tri(const rocblas_int k,
     const rocblas_int ldb = k;
     const rocblas_stride strideB = rocblas_stride(ldb) * k;
 
+    const bool upper = (uplo == rocblas_fill_upper);
+    const bool lower = (uplo == rocblas_fill_lower);
+
     if(i < k && j < k)
     {
-        if(j >= i)
+        if((upper && j >= i) || (lower && i >= j))
         {
             T* Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
             T* Bp = &buffer[b * strideB];
@@ -746,14 +750,15 @@ ROCSOLVER_KERNEL void set_tri(const rocblas_int k,
             // copy A to buffer
             Bp[i + j * ldb] = Ap[i + j * lda];
 
-            // set A to lower unit triangular
+            // set A to unit triangular
             Ap[i + j * lda] = (i == j) ? 1 : 0;
         }
     }
 }
 
 template <typename T, typename U>
-ROCSOLVER_KERNEL void restore_tri(const rocblas_int k,
+ROCSOLVER_KERNEL void restore_tri(const rocblas_fill uplo,
+                                  const rocblas_int k,
                                   U A,
                                   const rocblas_int shiftA,
                                   const rocblas_int lda,
@@ -767,9 +772,12 @@ ROCSOLVER_KERNEL void restore_tri(const rocblas_int k,
     const rocblas_int ldb = k;
     const rocblas_stride strideB = rocblas_stride(ldb) * k;
 
+    const bool upper = (uplo == rocblas_fill_upper);
+    const bool lower = (uplo == rocblas_fill_lower);
+
     if(i < k && j < k)
     {
-        if(j >= i)
+        if((upper && j >= i) || (lower && i >= j))
         {
             T* Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
             T* Bp = &buffer[b * strideB];
@@ -848,11 +856,6 @@ rocblas_status rocsolver_larft_inverse_template(rocblas_handle handle,
     ROCSOLVER_ENTER("larft_inverse", "direct:", direct, "storev:", storev, "n:", n, "k:", k,
                     "shiftV:", shiftV, "ldv:", ldv, "ldf:", ldf, "bc:", batch_count);
 
-    if(direct != rocblas_forward_direction || storev != rocblas_column_wise)
-    {
-        return rocblas_status_not_implemented;
-    }
-
     // quick return
     if(n == 0 || batch_count == 0)
         return rocblas_status_success;
@@ -868,26 +871,47 @@ rocblas_status rocsolver_larft_inverse_template(rocblas_handle handle,
     T one = 1;
     T zero = 0;
 
+    const bool colwise = (storev == rocblas_column_wise);
+    const bool forward = (direct == rocblas_forward_direction);
+
+    rocblas_operation transA
+        = colwise ? rocblas_operation_conjugate_transpose : rocblas_operation_none;
+    rocblas_operation transB
+        = colwise ? rocblas_operation_none : rocblas_operation_conjugate_transpose;
+
+    rocblas_int tri_offset;
+    rocblas_fill tri_uplo;
+
+    if(colwise)
+    {
+        tri_uplo = forward ? rocblas_fill_upper : rocblas_fill_lower;
+        tri_offset = (!forward && n > k) ? idx2D(n - k, 0, ldv) : 0;
+    }
+    else
+    {
+        tri_uplo = forward ? rocblas_fill_lower : rocblas_fill_upper;
+        tri_offset = (!forward && n > k) ? idx2D(0, n - k, ldv) : 0;
+    }
+
     rocblas_int blocks = (k - 1) / 32 + 1;
     dim3 gridTri(blocks, blocks, batch_count);
     dim3 blockTri(32, 32);
 
     // set V to unit triangular/trapezoidal
-    ROCSOLVER_LAUNCH_KERNEL((set_tri), gridTri, blockTri, 0, stream, k, V, shiftV, ldv, strideV,
-                            work);
+    ROCSOLVER_LAUNCH_KERNEL((set_tri), gridTri, blockTri, 0, stream, tri_uplo, k, V,
+                            shiftV + tri_offset, ldv, strideV, work);
 
-    // compute: V' * V
-    rocsolver_gemm(handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, k, k, n,
-                   &one, V, shiftV, ldv, strideV, V, shiftV, ldv, strideV, &zero, F, 0, ldf,
-                   strideF, batch_count, workArr);
+    // compute: V' * V or V * V'
+    rocsolver_gemm(handle, transA, transB, k, k, n, &one, V, shiftV, ldv, strideV, V, shiftV, ldv,
+                   strideV, &zero, F, 0, ldf, strideF, batch_count, workArr);
 
-    // set V diag to 1 / tau
+    // set F diag to 1 / tau
     ROCSOLVER_LAUNCH_KERNEL(set_diag, dim3(blocks, 1, batch_count), dim3(32, 1), 0, stream, k, tau,
                             strideT, F, ldf, strideF);
 
     // restore original V
-    ROCSOLVER_LAUNCH_KERNEL((restore_tri), gridTri, blockTri, 0, stream, k, V, shiftV, ldv, strideV,
-                            work);
+    ROCSOLVER_LAUNCH_KERNEL((restore_tri), gridTri, blockTri, 0, stream, tri_uplo, k, V,
+                            shiftV + tri_offset, ldv, strideV, work);
 
     rocblas_set_pointer_mode(handle, old_mode);
     return rocblas_status_success;

--- a/library/src/auxiliary/rocauxiliary_larft.hpp
+++ b/library/src/auxiliary/rocauxiliary_larft.hpp
@@ -871,16 +871,21 @@ rocblas_status rocsolver_larft_inverse_template(rocblas_handle handle,
     rocblas_int blocks = (k - 1) / 32 + 1;
     dim3 gridTri(blocks, blocks, batch_count);
     dim3 blockTri(32, 32);
+
+    // set V to unit triangular/trapezoidal
     ROCSOLVER_LAUNCH_KERNEL((set_tri), gridTri, blockTri, 0, stream, k, V, shiftV, ldv, strideV,
                             work);
 
+    // compute: V' * V
     rocsolver_gemm(handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, k, k, n,
                    &one, V, shiftV, ldv, strideV, V, shiftV, ldv, strideV, &zero, F, 0, ldf,
                    strideF, batch_count, workArr);
 
+    // set V diag to 1 / tau
     ROCSOLVER_LAUNCH_KERNEL(set_diag, dim3(blocks, 1, batch_count), dim3(32, 1), 0, stream, k, tau,
                             strideT, F, ldf, strideF);
 
+    // restore original V
     ROCSOLVER_LAUNCH_KERNEL((restore_tri), gridTri, blockTri, 0, stream, k, V, shiftV, ldv, strideV,
                             work);
 

--- a/library/src/auxiliary/rocauxiliary_larft.hpp
+++ b/library/src/auxiliary/rocauxiliary_larft.hpp
@@ -790,4 +790,171 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
     return rocblas_status_success;
 }
 
+template <typename T, typename U>
+ROCSOLVER_KERNEL void set_tri(const rocblas_int k,
+                              U A,
+                              const rocblas_int shiftA,
+                              const rocblas_int lda,
+                              const rocblas_stride strideA,
+                              T* buffer)
+{
+    const auto b = hipBlockIdx_z;
+    const auto j = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    const auto i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+
+    const rocblas_int ldb = k;
+    const rocblas_stride strideB = rocblas_stride(ldb) * k;
+
+    if(i < k && j < k)
+    {
+        if(j >= i)
+        {
+            T* Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
+            T* Bp = &buffer[b * strideB];
+
+            // copy A to buffer
+            Bp[i + j * ldb] = Ap[i + j * lda];
+
+            // set A to lower unit triangular
+            Ap[i + j * lda] = (i == j) ? 1 : 0;
+        }
+    }
+}
+
+template <typename T, typename U>
+ROCSOLVER_KERNEL void restore_tri(const rocblas_int k,
+                                  U A,
+                                  const rocblas_int shiftA,
+                                  const rocblas_int lda,
+                                  const rocblas_stride strideA,
+                                  T* buffer)
+{
+    const auto b = hipBlockIdx_z;
+    const auto j = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    const auto i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+
+    const rocblas_int ldb = k;
+    const rocblas_stride strideB = rocblas_stride(ldb) * k;
+
+    if(i < k && j < k)
+    {
+        if(j >= i)
+        {
+            T* Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
+            T* Bp = &buffer[b * strideB];
+
+            // copy buffer to A
+            Ap[i + j * lda] = Bp[i + j * ldb];
+        }
+    }
+}
+
+template <typename T>
+ROCSOLVER_KERNEL void set_diag(rocblas_int k,
+                               T* tau,
+                               const rocblas_stride strideT,
+                               T* F,
+                               const rocblas_int ldf,
+                               const rocblas_stride strideF)
+{
+    const auto b = hipBlockIdx_z;
+    const auto i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+
+    if(i < k)
+    {
+        T *tp, *Fp;
+        tp = tau + b * strideT;
+        Fp = F + b * strideF;
+
+        Fp[i + i * ldf] = 1 / tp[i];
+    }
+}
+
+template <bool BATCHED, typename T>
+void rocsolver_larft_inverse_getMemorySize(const rocblas_int n,
+                                           const rocblas_int k,
+                                           const rocblas_int batch_count,
+                                           size_t* size_work,
+                                           size_t* size_workArr)
+{
+    // if quick return, no workspace is needed
+    if(n == 0 || batch_count == 0)
+    {
+        *size_work = 0;
+        *size_workArr = 0;
+        return;
+    }
+
+    // size of re-usable workspace
+    *size_work = sizeof(T) * k * k * batch_count;
+
+    // size of array of pointers to workspace
+    if(BATCHED)
+        *size_workArr = sizeof(T*) * batch_count;
+    else
+        *size_workArr = 0;
+}
+
+template <typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
+rocblas_status rocsolver_larft_inverse_template(rocblas_handle handle,
+                                                const rocblas_direct direct,
+                                                const rocblas_storev storev,
+                                                const rocblas_int n,
+                                                const rocblas_int k,
+                                                U V,
+                                                const rocblas_int shiftV,
+                                                const rocblas_int ldv,
+                                                const rocblas_stride strideV,
+                                                T* tau,
+                                                const rocblas_stride strideT,
+                                                T* F,
+                                                const rocblas_int ldf,
+                                                const rocblas_stride strideF,
+                                                const rocblas_int batch_count,
+                                                T* work,
+                                                T** workArr)
+{
+    ROCSOLVER_ENTER("larft_inverse", "direct:", direct, "storev:", storev, "n:", n, "k:", k,
+                    "shiftV:", shiftV, "ldv:", ldv, "ldf:", ldf, "bc:", batch_count);
+
+    if(direct != rocblas_forward_direction || storev != rocblas_column_wise)
+    {
+        return rocblas_status_not_implemented;
+    }
+
+    // quick return
+    if(n == 0 || batch_count == 0)
+        return rocblas_status_success;
+
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    // everything must be executed with scalars on the device
+    rocblas_pointer_mode old_mode;
+    rocblas_get_pointer_mode(handle, &old_mode);
+    rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
+
+    T one = 1;
+    T zero = 0;
+
+    rocblas_int blocks = (k - 1) / 32 + 1;
+    dim3 gridTri(blocks, blocks, batch_count);
+    dim3 blockTri(32, 32);
+    ROCSOLVER_LAUNCH_KERNEL((set_tri), gridTri, blockTri, 0, stream, k, V, shiftV, ldv, strideV,
+                            work);
+
+    rocsolver_gemm(handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, k, k, n,
+                   &one, V, shiftV, ldv, strideV, V, shiftV, ldv, strideV, &zero, F, 0, ldf,
+                   strideF, batch_count, workArr);
+
+    ROCSOLVER_LAUNCH_KERNEL(set_diag, dim3(blocks, 1, batch_count), dim3(32, 1), 0, stream, k, tau,
+                            strideT, F, ldf, strideF);
+
+    ROCSOLVER_LAUNCH_KERNEL((restore_tri), gridTri, blockTri, 0, stream, k, V, shiftV, ldv, strideV,
+                            work);
+
+    rocblas_set_pointer_mode(handle, old_mode);
+    return rocblas_status_success;
+}
+
 ROCSOLVER_END_NAMESPACE

--- a/library/src/auxiliary/rocauxiliary_larft.hpp
+++ b/library/src/auxiliary/rocauxiliary_larft.hpp
@@ -722,13 +722,13 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
 }
 
 template <typename T, typename U>
-ROCSOLVER_KERNEL void set_tri(const rocblas_fill uplo,
-                              const rocblas_int k,
-                              U A,
-                              const rocblas_int shiftA,
-                              const rocblas_int lda,
-                              const rocblas_stride strideA,
-                              T* buffer)
+ROCSOLVER_KERNEL void larft_set_tri(const rocblas_fill uplo,
+                                    const rocblas_int k,
+                                    U A,
+                                    const rocblas_int shiftA,
+                                    const rocblas_int lda,
+                                    const rocblas_stride strideA,
+                                    T* buffer)
 {
     const auto b = hipBlockIdx_z;
     const auto j = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
@@ -757,13 +757,13 @@ ROCSOLVER_KERNEL void set_tri(const rocblas_fill uplo,
 }
 
 template <typename T, typename U>
-ROCSOLVER_KERNEL void restore_tri(const rocblas_fill uplo,
-                                  const rocblas_int k,
-                                  U A,
-                                  const rocblas_int shiftA,
-                                  const rocblas_int lda,
-                                  const rocblas_stride strideA,
-                                  T* buffer)
+ROCSOLVER_KERNEL void larft_restore_tri(const rocblas_fill uplo,
+                                        const rocblas_int k,
+                                        U A,
+                                        const rocblas_int shiftA,
+                                        const rocblas_int lda,
+                                        const rocblas_stride strideA,
+                                        T* buffer)
 {
     const auto b = hipBlockIdx_z;
     const auto j = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
@@ -789,12 +789,12 @@ ROCSOLVER_KERNEL void restore_tri(const rocblas_fill uplo,
 }
 
 template <typename T>
-ROCSOLVER_KERNEL void set_diag(rocblas_int k,
-                               T* tau,
-                               const rocblas_stride strideT,
-                               T* F,
-                               const rocblas_int ldf,
-                               const rocblas_stride strideF)
+ROCSOLVER_KERNEL void larft_set_diag(rocblas_int k,
+                                     T* tau,
+                                     const rocblas_stride strideT,
+                                     T* F,
+                                     const rocblas_int ldf,
+                                     const rocblas_stride strideF)
 {
     const auto b = hipBlockIdx_z;
     const auto i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
@@ -898,7 +898,7 @@ rocblas_status rocsolver_larft_inverse_template(rocblas_handle handle,
     dim3 blockTri(32, 32);
 
     // set V to unit triangular/trapezoidal
-    ROCSOLVER_LAUNCH_KERNEL((set_tri), gridTri, blockTri, 0, stream, tri_uplo, k, V,
+    ROCSOLVER_LAUNCH_KERNEL((larft_set_tri), gridTri, blockTri, 0, stream, tri_uplo, k, V,
                             shiftV + tri_offset, ldv, strideV, work);
 
     // compute: V' * V or V * V'
@@ -906,11 +906,11 @@ rocblas_status rocsolver_larft_inverse_template(rocblas_handle handle,
                    strideV, &zero, F, 0, ldf, strideF, batch_count, workArr);
 
     // set F diag to 1 / tau
-    ROCSOLVER_LAUNCH_KERNEL(set_diag, dim3(blocks, 1, batch_count), dim3(32, 1), 0, stream, k, tau,
-                            strideT, F, ldf, strideF);
+    ROCSOLVER_LAUNCH_KERNEL(larft_set_diag, dim3(blocks, 1, batch_count), dim3(32, 1), 0, stream, k,
+                            tau, strideT, F, ldf, strideF);
 
     // restore original V
-    ROCSOLVER_LAUNCH_KERNEL((restore_tri), gridTri, blockTri, 0, stream, tri_uplo, k, V,
+    ROCSOLVER_LAUNCH_KERNEL((larft_restore_tri), gridTri, blockTri, 0, stream, tri_uplo, k, V,
                             shiftV + tri_offset, ldv, strideV, work);
 
     rocblas_set_pointer_mode(handle, old_mode);

--- a/library/src/auxiliary/rocauxiliary_ormql_unmql.hpp
+++ b/library/src/auxiliary/rocauxiliary_ormql_unmql.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -78,6 +78,68 @@ void rocsolver_ormql_unmql_getMemorySize(const rocblas_side side,
         // requirements for calling larfb
         rocsolver_larfb_getMemorySize<BATCHED, T>(side, m, n, std::min(jb, k), batch_count,
                                                   size_diagORtmptr, &unused);
+
+        // size of temporary array for triangular factor
+        *size_trfact = sizeof(T) * jb * jb * batch_count;
+    }
+    else
+        *size_trfact = 0;
+}
+
+template <bool BATCHED, bool STRIDED, typename T>
+void rocsolver_ormql_unmql_getMemorySize(const rocblas_side side,
+                                         const rocblas_operation trans,
+                                         const rocblas_int m,
+                                         const rocblas_int n,
+                                         const rocblas_int k,
+                                         const rocblas_int batch_count,
+                                         size_t* size_scalars,
+                                         size_t* size_AbyxORwork,
+                                         size_t* size_work2,
+                                         size_t* size_work3,
+                                         size_t* size_work4,
+                                         size_t* size_diagORtmptr,
+                                         size_t* size_trfact,
+                                         size_t* size_workArr,
+                                         bool* optim_mem)
+{
+    *size_scalars = 0;
+    *size_AbyxORwork = 0;
+    *size_diagORtmptr = 0;
+    *size_trfact = 0;
+    *size_workArr = 0;
+    *size_work2 = 0;
+    *size_work3 = 0;
+    *size_work4 = 0;
+    *optim_mem = true;
+
+    // if quick return no workspace needed
+    if(m == 0 || n == 0 || k == 0 || batch_count == 0)
+    {
+        return;
+    }
+
+    size_t unused;
+    rocsolver_orm2l_unm2l_getMemorySize<BATCHED, T>(side, m, n, k, batch_count, size_scalars,
+                                                    size_AbyxORwork, size_diagORtmptr, size_workArr);
+
+    if(k > xxMQx_BLOCKSIZE)
+    {
+        size_t w1, w2;
+
+        rocblas_int jb = xxMQx_BLOCKSIZE;
+
+        // requirements for calling larft
+        rocsolver_larft_inverse_getMemorySize<BATCHED, T>(std::max(m, n), std::min(jb, k),
+                                                          batch_count, &w1, &unused);
+        *size_AbyxORwork = std::max(w1, *size_AbyxORwork);
+
+        // requirements for calling larfb
+        rocsolver_larfb_inverse_getMemorySize<BATCHED, STRIDED, T>(
+            side, trans, m, n, std::min(jb, k), batch_count, &w2, &w1, size_work2, size_work3,
+            size_work4, &unused, optim_mem);
+        *size_AbyxORwork = std::max(w1, *size_AbyxORwork);
+        *size_diagORtmptr = std::max(w2, *size_diagORtmptr);
 
         // size of temporary array for triangular factor
         *size_trfact = sizeof(T) * jb * jb * batch_count;
@@ -190,6 +252,119 @@ rocblas_status rocsolver_ormql_unmql_template(rocblas_handle handle,
             handle, side, trans, rocblas_backward_direction, rocblas_column_wise, nrow, ncol, ib, A,
             shiftA + idx2D(0, i, lda), lda, strideA, trfact, 0, ldw, strideW, C, shiftC, ldc,
             strideC, batch_count, diagORtmptr, workArr);
+    }
+
+    return rocblas_status_success;
+}
+
+template <bool BATCHED, bool STRIDED, typename T, typename U>
+rocblas_status rocsolver_ormql_unmql_template(rocblas_handle handle,
+                                              const rocblas_side side,
+                                              const rocblas_operation trans,
+                                              const rocblas_int m,
+                                              const rocblas_int n,
+                                              const rocblas_int k,
+                                              U A,
+                                              const rocblas_int shiftA,
+                                              const rocblas_int lda,
+                                              const rocblas_stride strideA,
+                                              T* ipiv,
+                                              const rocblas_stride strideP,
+                                              U C,
+                                              const rocblas_int shiftC,
+                                              const rocblas_int ldc,
+                                              const rocblas_stride strideC,
+                                              const rocblas_int batch_count,
+                                              T* scalars,
+                                              T* AbyxORwork,
+                                              void* work2,
+                                              void* work3,
+                                              void* work4,
+                                              T* diagORtmptr,
+                                              T* trfact,
+                                              T** workArr,
+                                              bool optim_mem)
+{
+    ROCSOLVER_ENTER("ormql_unmql", "side:", side, "trans:", trans, "m:", m, "n:", n, "k:", k,
+                    "shiftA:", shiftA, "lda:", lda, "shiftC:", shiftC, "ldc:", ldc,
+                    "bc:", batch_count);
+
+    // quick return
+    if(!n || !m || !k || !batch_count)
+        return rocblas_status_success;
+
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    // if the matrix is small, use the unblocked variant of the algorithm
+    if(k <= xxMQx_BLOCKSIZE)
+        return rocsolver_orm2l_unm2l_template<T>(
+            handle, side, trans, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, C, shiftC, ldc,
+            strideC, batch_count, scalars, AbyxORwork, diagORtmptr, workArr);
+
+    rocblas_int ldw = xxMQx_BLOCKSIZE;
+    rocblas_stride strideW = rocblas_stride(ldw) * ldw;
+
+    // determine limits and indices
+    bool left = (side == rocblas_side_left);
+    bool transpose = (trans != rocblas_operation_none);
+    rocblas_int start, step, nq, ncol, nrow;
+    if(left)
+    {
+        nq = m;
+        ncol = n;
+        if(!transpose)
+        {
+            start = 0;
+            step = 1;
+        }
+        else
+        {
+            start = (k - 1) / ldw * ldw;
+            step = -1;
+        }
+    }
+    else
+    {
+        nq = n;
+        nrow = m;
+        if(!transpose)
+        {
+            start = (k - 1) / ldw * ldw;
+            step = -1;
+        }
+        else
+        {
+            start = 0;
+            step = 1;
+        }
+    }
+
+    rocblas_int i, ib;
+    for(rocblas_int j = 0; j < k; j += ldw)
+    {
+        i = start + step * j; // current householder block
+        ib = std::min(ldw, k - i);
+        if(left)
+        {
+            nrow = m - k + i + ib;
+        }
+        else
+        {
+            ncol = n - k + i + ib;
+        }
+
+        // generate triangular factor of current block reflector
+        rocsolver_larft_inverse_template<T>(handle, rocblas_backward_direction, rocblas_column_wise,
+                                            nq - k + i + ib, ib, A, shiftA + idx2D(0, i, lda), lda,
+                                            strideA, ipiv + i, strideP, trfact, ldw, strideW,
+                                            batch_count, AbyxORwork, workArr);
+
+        // apply current block reflector
+        rocsolver_larfb_inverse_template<BATCHED, STRIDED, T>(
+            handle, side, trans, rocblas_backward_direction, rocblas_column_wise, nrow, ncol, ib, A,
+            shiftA + idx2D(0, i, lda), lda, strideA, trfact, 0, ldw, strideW, C, shiftC, ldc,
+            strideC, batch_count, diagORtmptr, AbyxORwork, work2, work3, work4, workArr, optim_mem);
     }
 
     return rocblas_status_success;

--- a/library/src/auxiliary/rocauxiliary_ormqr_unmqr.hpp
+++ b/library/src/auxiliary/rocauxiliary_ormqr_unmqr.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -78,6 +78,68 @@ void rocsolver_ormqr_unmqr_getMemorySize(const rocblas_side side,
         // requirements for calling larfb
         rocsolver_larfb_getMemorySize<BATCHED, T>(side, m, n, std::min(jb, k), batch_count,
                                                   size_diagORtmptr, &unused);
+
+        // size of temporary array for triangular factor
+        *size_trfact = sizeof(T) * jb * jb * batch_count;
+    }
+    else
+        *size_trfact = 0;
+}
+
+template <bool BATCHED, bool STRIDED, typename T>
+void rocsolver_ormqr_unmqr_getMemorySize(const rocblas_side side,
+                                         const rocblas_operation trans,
+                                         const rocblas_int m,
+                                         const rocblas_int n,
+                                         const rocblas_int k,
+                                         const rocblas_int batch_count,
+                                         size_t* size_scalars,
+                                         size_t* size_AbyxORwork,
+                                         size_t* size_work2,
+                                         size_t* size_work3,
+                                         size_t* size_work4,
+                                         size_t* size_diagORtmptr,
+                                         size_t* size_trfact,
+                                         size_t* size_workArr,
+                                         bool* optim_mem)
+{
+    *size_scalars = 0;
+    *size_AbyxORwork = 0;
+    *size_diagORtmptr = 0;
+    *size_trfact = 0;
+    *size_workArr = 0;
+    *size_work2 = 0;
+    *size_work3 = 0;
+    *size_work4 = 0;
+    *optim_mem = true;
+
+    // if quick return no workspace needed
+    if(m == 0 || n == 0 || k == 0 || batch_count == 0)
+    {
+        return;
+    }
+
+    size_t unused;
+    rocsolver_orm2r_unm2r_getMemorySize<BATCHED, T>(side, m, n, k, batch_count, size_scalars,
+                                                    size_AbyxORwork, size_diagORtmptr, size_workArr);
+
+    if(k > xxMQx_BLOCKSIZE)
+    {
+        size_t w1, w2;
+
+        rocblas_int jb = xxMQx_BLOCKSIZE;
+
+        // requirements for calling larft
+        rocsolver_larft_inverse_getMemorySize<BATCHED, T>(std::max(m, n), std::min(jb, k),
+                                                          batch_count, &w1, &unused);
+        *size_AbyxORwork = std::max(w1, *size_AbyxORwork);
+
+        // requirements for calling larfb
+        rocsolver_larfb_inverse_getMemorySize<BATCHED, STRIDED, T>(
+            side, trans, m, n, std::min(jb, k), batch_count, &w2, &w1, size_work2, size_work3,
+            size_work4, &unused, optim_mem);
+        *size_AbyxORwork = std::max(w1, *size_AbyxORwork);
+        *size_diagORtmptr = std::max(w2, *size_diagORtmptr);
 
         // size of temporary array for triangular factor
         *size_trfact = sizeof(T) * jb * jb * batch_count;
@@ -194,6 +256,125 @@ rocblas_status rocsolver_ormqr_unmqr_template(rocblas_handle handle,
             handle, side, trans, rocblas_forward_direction, rocblas_column_wise, nrow, ncol, ib, A,
             shiftA + idx2D(i, i, lda), lda, strideA, trfact, 0, ldw, strideW, C,
             shiftC + idx2D(ic, jc, ldc), ldc, strideC, batch_count, diagORtmptr, workArr);
+    }
+
+    return rocblas_status_success;
+}
+
+template <bool BATCHED, bool STRIDED, typename T, typename U>
+rocblas_status rocsolver_ormqr_unmqr_template(rocblas_handle handle,
+                                              const rocblas_side side,
+                                              const rocblas_operation trans,
+                                              const rocblas_int m,
+                                              const rocblas_int n,
+                                              const rocblas_int k,
+                                              U A,
+                                              const rocblas_int shiftA,
+                                              const rocblas_int lda,
+                                              const rocblas_stride strideA,
+                                              T* ipiv,
+                                              const rocblas_stride strideP,
+                                              U C,
+                                              const rocblas_int shiftC,
+                                              const rocblas_int ldc,
+                                              const rocblas_stride strideC,
+                                              const rocblas_int batch_count,
+                                              T* scalars,
+                                              T* AbyxORwork,
+                                              void* work2,
+                                              void* work3,
+                                              void* work4,
+                                              T* diagORtmptr,
+                                              T* trfact,
+                                              T** workArr,
+                                              bool optim_mem,
+                                              T** workArr2 = nullptr)
+{
+    ROCSOLVER_ENTER("ormqr_unmqr", "side:", side, "trans:", trans, "m:", m, "n:", n, "k:", k,
+                    "shiftA:", shiftA, "lda:", lda, "shiftC:", shiftC, "ldc:", ldc,
+                    "bc:", batch_count);
+
+    // quick return
+    if(!n || !m || !k || !batch_count)
+        return rocblas_status_success;
+
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    // if the matrix is small, use the unblocked variant of the algorithm
+    if(k <= xxMQx_BLOCKSIZE)
+        return rocsolver_orm2r_unm2r_template<T>(
+            handle, side, trans, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, C, shiftC, ldc,
+            strideC, batch_count, scalars, AbyxORwork, diagORtmptr, workArr);
+
+    rocblas_int ldw = xxMQx_BLOCKSIZE;
+    rocblas_stride strideW = rocblas_stride(ldw) * ldw;
+
+    // determine limits and indices
+    bool left = (side == rocblas_side_left);
+    bool transpose = (trans != rocblas_operation_none);
+    rocblas_int start, step, nq, ncol, nrow, ic, jc;
+    if(left)
+    {
+        nq = m;
+        ncol = n;
+        jc = 0;
+        if(transpose)
+        {
+            start = 0;
+            step = 1;
+        }
+        else
+        {
+            start = (k - 1) / ldw * ldw;
+            step = -1;
+        }
+    }
+    else
+    {
+        nq = n;
+        nrow = m;
+        ic = 0;
+        if(transpose)
+        {
+            start = (k - 1) / ldw * ldw;
+            step = -1;
+        }
+        else
+        {
+            start = 0;
+            step = 1;
+        }
+    }
+
+    rocblas_int i, ib;
+    for(rocblas_int j = 0; j < k; j += ldw)
+    {
+        i = start + step * j; // current householder block
+        ib = std::min(ldw, k - i);
+        if(left)
+        {
+            nrow = m - i;
+            ic = i;
+        }
+        else
+        {
+            ncol = n - i;
+            jc = i;
+        }
+
+        // generate triangular factor of current block reflector
+        rocsolver_larft_inverse_template<T>(handle, rocblas_forward_direction, rocblas_column_wise,
+                                            nq - i, ib, A, shiftA + idx2D(i, i, lda), lda, strideA,
+                                            ipiv + i, strideP, trfact, ldw, strideW, batch_count,
+                                            AbyxORwork, workArr);
+
+        // apply current block reflector
+        rocsolver_larfb_inverse_template<BATCHED, STRIDED, T>(
+            handle, side, trans, rocblas_forward_direction, rocblas_column_wise, nrow, ncol, ib, A,
+            shiftA + idx2D(i, i, lda), lda, strideA, trfact, 0, ldw, strideW, C,
+            shiftC + idx2D(ic, jc, ldc), ldc, strideC, batch_count, diagORtmptr, AbyxORwork, work2,
+            work3, work4, workArr, optim_mem);
     }
 
     return rocblas_status_success;

--- a/library/src/auxiliary/rocauxiliary_ormtr_unmtr.cpp
+++ b/library/src/auxiliary/rocauxiliary_ormtr_unmtr.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -67,37 +67,43 @@ rocblas_status rocsolver_ormtr_unmtr_impl(rocblas_handle handle,
 
     // memory workspace sizes:
     // requirements for calling ORMQL/UNMQL or ORMQR/UNMQR
+    bool optim_mem;
     size_t size_scalars;
-    size_t size_AbyxORwork, size_diagORtmptr;
+    size_t size_AbyxORwork, size_work2, size_work3, size_work4, size_diagORtmptr;
     size_t size_trfact;
     size_t size_workArr;
-    rocsolver_ormtr_unmtr_getMemorySize<false, T>(side, uplo, m, n, batch_count, &size_scalars,
-                                                  &size_AbyxORwork, &size_diagORtmptr, &size_trfact,
-                                                  &size_workArr);
+    rocsolver_ormtr_unmtr_getMemorySize<false, false, T>(
+        side, uplo, trans, m, n, batch_count, &size_scalars, &size_AbyxORwork, &size_work2,
+        &size_work3, &size_work4, &size_diagORtmptr, &size_trfact, &size_workArr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_AbyxORwork,
+                                                      size_work2, size_work3, size_work4,
                                                       size_diagORtmptr, size_trfact, size_workArr);
 
     // memory workspace allocation
-    void *scalars, *AbyxORwork, *diagORtmptr, *trfact, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_AbyxORwork, size_diagORtmptr, size_trfact,
-                              size_workArr);
+    void *scalars, *AbyxORwork, *work2, *work3, *work4, *diagORtmptr, *trfact, *workArr;
+    rocblas_device_malloc mem(handle, size_scalars, size_AbyxORwork, size_work2, size_work3,
+                              size_work4, size_diagORtmptr, size_trfact, size_workArr);
     if(!mem)
         return rocblas_status_memory_error;
 
     scalars = mem[0];
     AbyxORwork = mem[1];
-    diagORtmptr = mem[2];
-    trfact = mem[3];
-    workArr = mem[4];
+    work2 = mem[2];
+    work3 = mem[3];
+    work4 = mem[4];
+    diagORtmptr = mem[5];
+    trfact = mem[6];
+    workArr = mem[7];
     if(size_scalars > 0)
         init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_ormtr_unmtr_template<false, false, T>(
         handle, side, uplo, trans, m, n, A, shiftA, lda, strideA, ipiv, strideP, C, shiftC, ldc,
-        strideC, batch_count, (T*)scalars, (T*)AbyxORwork, (T*)diagORtmptr, (T*)trfact, (T**)workArr);
+        strideC, batch_count, (T*)scalars, (T*)AbyxORwork, work2, work3, work4, (T*)diagORtmptr,
+        (T*)trfact, (T**)workArr, optim_mem);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/library/src/auxiliary/rocauxiliary_ormtr_unmtr.hpp
+++ b/library/src/auxiliary/rocauxiliary_ormtr_unmtr.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -74,6 +74,53 @@ void rocsolver_ormtr_unmtr_getMemorySize(const rocblas_side side,
         rocsolver_ormqr_unmqr_getMemorySize<BATCHED, T>(side, m, n, nq, batch_count, size_scalars,
                                                         size_AbyxORwork, size_diagORtmptr,
                                                         size_trfact, size_workArr);
+}
+
+template <bool BATCHED, bool STRIDED, typename T>
+void rocsolver_ormtr_unmtr_getMemorySize(const rocblas_side side,
+                                         const rocblas_fill uplo,
+                                         const rocblas_operation trans,
+                                         const rocblas_int m,
+                                         const rocblas_int n,
+                                         const rocblas_int batch_count,
+                                         size_t* size_scalars,
+                                         size_t* size_AbyxORwork,
+                                         size_t* size_work2,
+                                         size_t* size_work3,
+                                         size_t* size_work4,
+                                         size_t* size_diagORtmptr,
+                                         size_t* size_trfact,
+                                         size_t* size_workArr,
+                                         bool* optim_mem)
+{
+    *size_scalars = 0;
+    *size_AbyxORwork = 0;
+    *size_diagORtmptr = 0;
+    *size_trfact = 0;
+    *size_workArr = 0;
+    *size_work2 = 0;
+    *size_work3 = 0;
+    *size_work4 = 0;
+    *optim_mem = true;
+
+    // if quick return no workspace needed
+    if(m == 0 || n == 0 || batch_count == 0)
+    {
+        return;
+    }
+
+    rocblas_int nq = side == rocblas_side_left ? m : n;
+
+    // requirements for calling ORMQL/UNMQL or ORMQR/UNMQR
+    if(uplo == rocblas_fill_upper)
+        rocsolver_ormql_unmql_getMemorySize<BATCHED, STRIDED, T>(
+            side, trans, m, n, nq, batch_count, size_scalars, size_AbyxORwork, size_work2,
+            size_work3, size_work4, size_diagORtmptr, size_trfact, size_workArr, optim_mem);
+
+    else
+        rocsolver_ormqr_unmqr_getMemorySize<BATCHED, STRIDED, T>(
+            side, trans, m, n, nq, batch_count, size_scalars, size_AbyxORwork, size_work2,
+            size_work3, size_work4, size_diagORtmptr, size_trfact, size_workArr, optim_mem);
 }
 
 template <bool COMPLEX, typename T, typename U>
@@ -185,6 +232,80 @@ rocblas_status rocsolver_ormtr_unmtr_template(rocblas_handle handle,
             handle, side, trans, rows, cols, nq - 1, A, shiftA + idx2D(1, 0, lda), lda, strideA,
             ipiv, strideP, C, shiftC + idx2D(rowC, colC, ldc), ldc, strideC, batch_count, scalars,
             AbyxORwork, diagORtmptr, trfact, workArr);
+    }
+
+    return rocblas_status_success;
+}
+
+template <bool BATCHED, bool STRIDED, typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
+rocblas_status rocsolver_ormtr_unmtr_template(rocblas_handle handle,
+                                              const rocblas_side side,
+                                              const rocblas_fill uplo,
+                                              const rocblas_operation trans,
+                                              const rocblas_int m,
+                                              const rocblas_int n,
+                                              U A,
+                                              const rocblas_int shiftA,
+                                              const rocblas_int lda,
+                                              const rocblas_stride strideA,
+                                              T* ipiv,
+                                              const rocblas_stride strideP,
+                                              U C,
+                                              const rocblas_int shiftC,
+                                              const rocblas_int ldc,
+                                              const rocblas_stride strideC,
+                                              const rocblas_int batch_count,
+                                              T* scalars,
+                                              T* AbyxORwork,
+                                              void* work2,
+                                              void* work3,
+                                              void* work4,
+                                              T* diagORtmptr,
+                                              T* trfact,
+                                              T** workArr,
+                                              bool optim_mem)
+{
+    ROCSOLVER_ENTER("ormtr_unmtr", "side:", side, "uplo:", uplo, "trans:", trans, "m:", m, "n:", n,
+                    "shiftA:", shiftA, "lda:", lda, "shiftC:", shiftC, "ldc:", ldc,
+                    "bc:", batch_count);
+
+    // quick return
+    if(!n || !m || !batch_count)
+        return rocblas_status_success;
+
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    rocblas_int nq = side == rocblas_side_left ? m : n;
+    rocblas_int cols, rows, colC, rowC;
+    if(side == rocblas_side_left)
+    {
+        rows = m - 1;
+        cols = n;
+        rowC = 1;
+        colC = 0;
+    }
+    else
+    {
+        rows = m;
+        cols = n - 1;
+        rowC = 0;
+        colC = 1;
+    }
+
+    if(uplo == rocblas_fill_upper)
+    {
+        rocsolver_ormql_unmql_template<BATCHED, STRIDED, T>(
+            handle, side, trans, rows, cols, nq - 1, A, shiftA + idx2D(0, 1, lda), lda, strideA,
+            ipiv, strideP, C, shiftC, ldc, strideC, batch_count, scalars, AbyxORwork, work2, work3,
+            work4, diagORtmptr, trfact, workArr, optim_mem);
+    }
+    else
+    {
+        rocsolver_ormqr_unmqr_template<BATCHED, STRIDED, T>(
+            handle, side, trans, rows, cols, nq - 1, A, shiftA + idx2D(1, 0, lda), lda, strideA,
+            ipiv, strideP, C, shiftC + idx2D(rowC, colC, ldc), ldc, strideC, batch_count, scalars,
+            AbyxORwork, work2, work3, work4, diagORtmptr, trfact, workArr, optim_mem);
     }
 
     return rocblas_status_success;

--- a/library/src/auxiliary/rocauxiliary_ormtr_unmtr.hpp
+++ b/library/src/auxiliary/rocauxiliary_ormtr_unmtr.hpp
@@ -349,4 +349,45 @@ rocblas_status rocsolver_ormtr_unmtr_template(rocblas_handle handle,
         diagORtmptr, trfact, workArr + batch_count);
 }
 
+template <bool BATCHED, bool STRIDED, typename T>
+rocblas_status rocsolver_ormtr_unmtr_template(rocblas_handle handle,
+                                              const rocblas_side side,
+                                              const rocblas_fill uplo,
+                                              const rocblas_operation trans,
+                                              const rocblas_int m,
+                                              const rocblas_int n,
+                                              T* const A[],
+                                              const rocblas_int shiftA,
+                                              const rocblas_int lda,
+                                              const rocblas_stride strideA,
+                                              T* ipiv,
+                                              const rocblas_stride strideP,
+                                              T* C,
+                                              const rocblas_int shiftC,
+                                              const rocblas_int ldc,
+                                              const rocblas_stride strideC,
+                                              const rocblas_int batch_count,
+                                              T* scalars,
+                                              T* AbyxORwork,
+                                              void* work2,
+                                              void* work3,
+                                              void* work4,
+                                              T* diagORtmptr,
+                                              T* trfact,
+                                              T** workArr,
+                                              bool optim_mem)
+{
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    rocblas_int blocks = (batch_count - 1) / 256 + 1;
+    ROCSOLVER_LAUNCH_KERNEL(get_array, dim3(blocks), dim3(256), 0, stream, workArr, C, strideC,
+                            batch_count);
+
+    return rocsolver_ormtr_unmtr_template<BATCHED, STRIDED>(
+        handle, side, uplo, trans, m, n, A, shiftA, lda, strideA, ipiv, strideP,
+        cast2constType(workArr), shiftC, ldc, strideC, batch_count, scalars, AbyxORwork, work2,
+        work3, work4, diagORtmptr, trfact, workArr + batch_count, optim_mem);
+}
+
 ROCSOLVER_END_NAMESPACE

--- a/library/src/lapack/roclapack_geqrf.cpp
+++ b/library/src/lapack/roclapack_geqrf.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -55,39 +55,46 @@ rocblas_status
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of arrays of pointers (for batched cases) and re-usable workspace
-    size_t size_work_workArr, size_workArr;
+    bool optim_mem;
+    size_t size_work_workArr_work1, size_work2, size_work3, size_work4, size_workArr;
     // extra requirements for calling GEQR2 and to store temporary triangular factor
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GEQR2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_geqrf_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
-                                            &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr);
+    rocsolver_geqrf_getMemorySize<false, false, T>(
+        m, n, batch_count, &size_scalars, &size_work_workArr_work1, &size_work2, &size_work3,
+        &size_work4, &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_workArr,
-                                                      size_Abyx_norms_trfact, size_diag_tmptr,
-                                                      size_workArr);
+        return rocblas_set_optimal_device_memory_size(
+            handle, size_scalars, size_work_workArr_work1, size_work2, size_work3, size_work4,
+            size_Abyx_norms_trfact, size_diag_tmptr, size_workArr);
 
     // memory workspace allocation
-    void *scalars, *work_workArr, *Abyx_norms_trfact, *diag_tmptr, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms_trfact,
-                              size_diag_tmptr, size_workArr);
+    void *scalars, *work_workArr_work1, *work2, *work3, *work4, *Abyx_norms_trfact, *diag_tmptr,
+        *workArr;
+    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr_work1, size_work2, size_work3,
+                              size_work4, size_Abyx_norms_trfact, size_diag_tmptr, size_workArr);
 
     if(!mem)
         return rocblas_status_memory_error;
 
     scalars = mem[0];
-    work_workArr = mem[1];
-    Abyx_norms_trfact = mem[2];
-    diag_tmptr = mem[3];
-    workArr = mem[4];
+    work_workArr_work1 = mem[1];
+    work2 = mem[2];
+    work3 = mem[3];
+    work4 = mem[4];
+    Abyx_norms_trfact = mem[5];
+    diag_tmptr = mem[6];
+    workArr = mem[7];
     if(size_scalars > 0)
         init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_geqrf_template<false, false, T>(
         handle, m, n, A, shiftA, lda, strideA, ipiv, stridep, batch_count, (T*)scalars,
-        work_workArr, (T*)Abyx_norms_trfact, (T*)diag_tmptr, (T**)workArr);
+        work_workArr_work1, work2, work3, work4, (T*)Abyx_norms_trfact, (T*)diag_tmptr,
+        (T**)workArr, optim_mem);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/library/src/lapack/roclapack_geqrf.hpp
+++ b/library/src/lapack/roclapack_geqrf.hpp
@@ -81,7 +81,7 @@ void rocsolver_geqrf_getMemorySize(const I m,
         *size_Abyx_norms_trfact = std::max(s2, *size_Abyx_norms_trfact);
 
         // requirements for calling LARFT
-        rocsolver_larft_inverse_getMemorySize<BATCHED, T>(m, jb, batch_count, &w2, size_workArr);
+        rocsolver_larft_getMemorySize<BATCHED, T>(m, jb, batch_count, &unused, &w2, size_workArr);
 
         // requirements for calling LARFB
         rocsolver_larfb_getMemorySize<BATCHED, T>(rocblas_side_left, m, n - jb, jb, batch_count,
@@ -151,10 +151,10 @@ rocblas_status rocsolver_geqrf_template(rocblas_handle handle,
         if(j + jb < n)
         {
             // compute block reflector
-            rocsolver_larft_inverse_template<T>(
-                handle, rocblas_forward_direction, rocblas_column_wise, m - j, jb, A,
-                shiftA + idx2D(j, j, lda), lda, strideA, (ipiv + j), strideP, Abyx_norms_trfact,
-                ldw, strideW, batch_count, (T*)work_workArr, workArr);
+            rocsolver_larft_template<T>(handle, rocblas_forward_direction, rocblas_column_wise,
+                                        m - j, jb, A, shiftA + idx2D(j, j, lda), lda, strideA,
+                                        (ipiv + j), strideP, Abyx_norms_trfact, ldw, strideW,
+                                        batch_count, scalars, (T*)work_workArr, workArr);
 
             // apply the block reflector
             rocsolver_larfb_template<BATCHED, STRIDED, T>(

--- a/library/src/lapack/roclapack_geqrf.hpp
+++ b/library/src/lapack/roclapack_geqrf.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     November 2019
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -81,7 +81,7 @@ void rocsolver_geqrf_getMemorySize(const I m,
         *size_Abyx_norms_trfact = std::max(s2, *size_Abyx_norms_trfact);
 
         // requirements for calling LARFT
-        rocsolver_larft_getMemorySize<BATCHED, T>(m, jb, batch_count, &unused, &w2, size_workArr);
+        rocsolver_larft_inverse_getMemorySize<BATCHED, T>(m, jb, batch_count, &w2, size_workArr);
 
         // requirements for calling LARFB
         rocsolver_larfb_getMemorySize<BATCHED, T>(rocblas_side_left, m, n - jb, jb, batch_count,
@@ -151,10 +151,10 @@ rocblas_status rocsolver_geqrf_template(rocblas_handle handle,
         if(j + jb < n)
         {
             // compute block reflector
-            rocsolver_larft_template<T>(handle, rocblas_forward_direction, rocblas_column_wise,
-                                        m - j, jb, A, shiftA + idx2D(j, j, lda), lda, strideA,
-                                        (ipiv + j), strideP, Abyx_norms_trfact, ldw, strideW,
-                                        batch_count, scalars, (T*)work_workArr, workArr);
+            rocsolver_larft_inverse_template<T>(
+                handle, rocblas_forward_direction, rocblas_column_wise, m - j, jb, A,
+                shiftA + idx2D(j, j, lda), lda, strideA, (ipiv + j), strideP, Abyx_norms_trfact,
+                ldw, strideW, batch_count, (T*)work_workArr, workArr);
 
             // apply the block reflector
             rocsolver_larfb_template<BATCHED, STRIDED, T>(
@@ -171,6 +171,157 @@ rocblas_status rocsolver_geqrf_template(rocblas_handle handle,
         rocsolver_geqr2_template<T>(handle, m - j, n - j, A, shiftA + idx2D(j, j, lda), lda,
                                     strideA, (ipiv + j), strideP, batch_count, scalars,
                                     work_workArr, Abyx_norms_trfact, diag_tmptr);
+
+    return rocblas_status_success;
+}
+
+template <bool BATCHED, bool STRIDED, typename T, typename I>
+void rocsolver_geqrf_getMemorySize(const I m,
+                                   const I n,
+                                   const I batch_count,
+                                   size_t* size_scalars,
+                                   size_t* size_work_workArr_work1,
+                                   size_t* size_work2,
+                                   size_t* size_work3,
+                                   size_t* size_work4,
+                                   size_t* size_Abyx_norms_trfact,
+                                   size_t* size_diag_tmptr,
+                                   size_t* size_workArr,
+                                   bool* optim_mem)
+{
+    *size_scalars = 0;
+    *size_work_workArr_work1 = 0;
+    *size_Abyx_norms_trfact = 0;
+    *size_diag_tmptr = 0;
+    *size_workArr = 0;
+    *size_work2 = 0;
+    *size_work3 = 0;
+    *size_work4 = 0;
+    *optim_mem = true;
+
+    // if quick return no workspace needed
+    if(m == 0 || n == 0 || batch_count == 0)
+    {
+        return;
+    }
+
+    if(m <= GEQxF_GEQx2_SWITCHSIZE || n <= GEQxF_GEQx2_SWITCHSIZE)
+    {
+        // requirements for a single GEQR2 call
+        rocsolver_geqr2_getMemorySize<BATCHED, T>(m, n, batch_count, size_scalars,
+                                                  size_work_workArr_work1, size_Abyx_norms_trfact,
+                                                  size_diag_tmptr);
+        *size_workArr = 0;
+    }
+    else
+    {
+        size_t w1, w2, unused, s1, s2;
+        I jb = GEQxF_BLOCKSIZE;
+
+        // size to store the temporary triangular factor
+        *size_Abyx_norms_trfact = sizeof(T) * jb * jb * batch_count;
+
+        // requirements for calling GEQR2 with sub blocks
+        rocsolver_geqr2_getMemorySize<BATCHED, T>(m, jb, batch_count, size_scalars, &w1, &s2, &s1);
+        *size_Abyx_norms_trfact = std::max(s2, *size_Abyx_norms_trfact);
+
+        // requirements for calling LARFT
+        rocsolver_larft_inverse_getMemorySize<BATCHED, T>(m, jb, batch_count, &w2, size_workArr);
+        *size_work_workArr_work1 = std::max(w1, w2);
+
+        // requirements for calling LARFB
+        rocsolver_larfb_inverse_getMemorySize<BATCHED, STRIDED, T>(
+            rocblas_side_left, rocblas_operation_conjugate_transpose, m, n - jb, jb, batch_count,
+            &s2, &w2, size_work2, size_work3, size_work4, &unused, optim_mem);
+        *size_work_workArr_work1 = std::max(w2, *size_work_workArr_work1);
+
+        *size_diag_tmptr = std::max(s1, s2);
+
+        // size of workArr is double to accommodate
+        // LARFB's TRMM calls in the batched case
+        if(BATCHED)
+            *size_workArr *= 2;
+    }
+}
+
+template <bool BATCHED, bool STRIDED, typename T, typename I, typename U>
+rocblas_status rocsolver_geqrf_template(rocblas_handle handle,
+                                        const I m,
+                                        const I n,
+                                        U A,
+                                        const rocblas_stride shiftA,
+                                        const I lda,
+                                        const rocblas_stride strideA,
+                                        T* ipiv,
+                                        const rocblas_stride strideP,
+                                        const I batch_count,
+                                        T* scalars,
+                                        void* work_workArr_work1,
+                                        void* work2,
+                                        void* work3,
+                                        void* work4,
+                                        T* Abyx_norms_trfact,
+                                        T* diag_tmptr,
+                                        T** workArr,
+                                        bool optim_mem)
+{
+    ROCSOLVER_ENTER("geqrf", "m:", m, "n:", n, "shiftA:", shiftA, "lda:", lda, "bc:", batch_count);
+
+    // quick return
+    if(m == 0 || n == 0 || batch_count == 0)
+        return rocblas_status_success;
+
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    // if the matrix is small, use the unblocked (BLAS-levelII) variant of the
+    // algorithm
+    if(m <= GEQxF_GEQx2_SWITCHSIZE || n <= GEQxF_GEQx2_SWITCHSIZE)
+    {
+        rocsolver_geqr2_template<T>(handle, m, n, A, shiftA, lda, strideA, ipiv, strideP, batch_count,
+                                    scalars, work_workArr_work1, Abyx_norms_trfact, diag_tmptr);
+        return rocblas_status_success;
+    }
+
+    I dim = std::min(m, n); // total number of pivots
+    I jb, j = 0;
+
+    I nb = GEQxF_BLOCKSIZE;
+    I ldw = GEQxF_BLOCKSIZE;
+    rocblas_stride strideW = rocblas_stride(ldw) * ldw;
+
+    while(j < dim - GEQxF_GEQx2_SWITCHSIZE)
+    {
+        // Factor diagonal and subdiagonal blocks
+        jb = std::min(dim - j, nb); // number of columns in the block
+        rocsolver_geqr2_template<T>(handle, m - j, jb, A, shiftA + idx2D(j, j, lda), lda, strideA,
+                                    (ipiv + j), strideP, batch_count, scalars, work_workArr_work1,
+                                    Abyx_norms_trfact, diag_tmptr);
+
+        // apply transformation to the rest of the matrix
+        if(j + jb < n)
+        {
+            // compute block reflector
+            rocsolver_larft_inverse_template<T>(
+                handle, rocblas_forward_direction, rocblas_column_wise, m - j, jb, A,
+                shiftA + idx2D(j, j, lda), lda, strideA, (ipiv + j), strideP, Abyx_norms_trfact,
+                ldw, strideW, batch_count, (T*)work_workArr_work1, workArr);
+
+            rocsolver_larfb_inverse_template<BATCHED, STRIDED, T>(
+                handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                rocblas_forward_direction, rocblas_column_wise, m - j, n - j - jb, jb, A,
+                shiftA + idx2D(j, j, lda), lda, strideA, Abyx_norms_trfact, 0, ldw, strideW, A,
+                shiftA + idx2D(j, j + jb, lda), lda, strideA, batch_count, diag_tmptr,
+                work_workArr_work1, work2, work3, work4, workArr, optim_mem);
+        }
+        j += nb;
+    }
+
+    // factor last block
+    if(j < dim)
+        rocsolver_geqr2_template<T>(handle, m - j, n - j, A, shiftA + idx2D(j, j, lda), lda,
+                                    strideA, (ipiv + j), strideP, batch_count, scalars,
+                                    work_workArr_work1, Abyx_norms_trfact, diag_tmptr);
 
     return rocblas_status_success;
 }

--- a/library/src/lapack/roclapack_geqrf_batched.cpp
+++ b/library/src/lapack/roclapack_geqrf_batched.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -60,39 +60,46 @@ rocblas_status rocsolver_geqrf_batched_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of arrays of pointers (for batched cases) and re-usable workspace
-    size_t size_work_workArr, size_workArr;
+    bool optim_mem;
+    size_t size_work_workArr_work1, size_work2, size_work3, size_work4, size_workArr;
     // extra requirements for calling GEQR2 and to store temporary triangular factor
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GEQR2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_geqrf_getMemorySize<true, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
-                                           &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr);
+    rocsolver_geqrf_getMemorySize<true, false, T>(
+        m, n, batch_count, &size_scalars, &size_work_workArr_work1, &size_work2, &size_work3,
+        &size_work4, &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_workArr,
-                                                      size_Abyx_norms_trfact, size_diag_tmptr,
-                                                      size_workArr);
+        return rocblas_set_optimal_device_memory_size(
+            handle, size_scalars, size_work_workArr_work1, size_work2, size_work3, size_work4,
+            size_Abyx_norms_trfact, size_diag_tmptr, size_workArr);
 
     // memory workspace allocation
-    void *scalars, *work_workArr, *Abyx_norms_trfact, *diag_tmptr, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms_trfact,
-                              size_diag_tmptr, size_workArr);
+    void *scalars, *work_workArr_work1, *work2, *work3, *work4, *Abyx_norms_trfact, *diag_tmptr,
+        *workArr;
+    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr_work1, size_work2, size_work3,
+                              size_work4, size_Abyx_norms_trfact, size_diag_tmptr, size_workArr);
 
     if(!mem)
         return rocblas_status_memory_error;
 
     scalars = mem[0];
-    work_workArr = mem[1];
-    Abyx_norms_trfact = mem[2];
-    diag_tmptr = mem[3];
-    workArr = mem[4];
+    work_workArr_work1 = mem[1];
+    work2 = mem[2];
+    work3 = mem[3];
+    work4 = mem[4];
+    Abyx_norms_trfact = mem[5];
+    diag_tmptr = mem[6];
+    workArr = mem[7];
     if(size_scalars > 0)
         init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_geqrf_template<true, false, T>(
         handle, m, n, A, shiftA, lda, strideA, ipiv, stridep, batch_count, (T*)scalars,
-        work_workArr, (T*)Abyx_norms_trfact, (T*)diag_tmptr, (T**)workArr);
+        work_workArr_work1, work2, work3, work4, (T*)Abyx_norms_trfact, (T*)diag_tmptr,
+        (T**)workArr, optim_mem);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/library/src/lapack/roclapack_geqrf_ptr_batched.cpp
+++ b/library/src/lapack/roclapack_geqrf_ptr_batched.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -78,43 +78,51 @@ rocblas_status rocsolver_geqrf_ptr_batched_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of arrays of pointers (for batched cases) and re-usable workspace
-    size_t size_work_workArr, size_workArr;
+    bool optim_mem;
+    size_t size_work_workArr_work1, size_work2, size_work3, size_work4, size_workArr;
     // extra requirements for calling GEQR2 and to store temporary triangular factor
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GEQR2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_geqrf_getMemorySize<true, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
-                                           &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr);
+    rocsolver_geqrf_getMemorySize<true, false, T>(
+        m, n, batch_count, &size_scalars, &size_work_workArr_work1, &size_work2, &size_work3,
+        &size_work4, &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr, &optim_mem);
 
     // this is to mamange tau as a simple array ipiv
     size_t size_ipiv = sizeof(T) * strideP * batch_count;
 
     if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_workArr,
-                                                      size_Abyx_norms_trfact, size_diag_tmptr,
-                                                      size_workArr, size_ipiv);
+        return rocblas_set_optimal_device_memory_size(
+            handle, size_scalars, size_work_workArr_work1, size_work2, size_work3, size_work4,
+            size_Abyx_norms_trfact, size_diag_tmptr, size_workArr, size_ipiv);
 
     // memory workspace allocation
-    void *scalars, *work_workArr, *Abyx_norms_trfact, *diag_tmptr, *workArr, *ipiv;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms_trfact,
-                              size_diag_tmptr, size_workArr, size_ipiv);
+    void *scalars, *work_workArr_work1, *work2, *work3, *work4, *Abyx_norms_trfact, *diag_tmptr,
+        *workArr, *ipiv;
+    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr_work1, size_work2, size_work3,
+                              size_work4, size_Abyx_norms_trfact, size_diag_tmptr, size_workArr,
+                              size_ipiv);
 
     if(!mem)
         return rocblas_status_memory_error;
 
     scalars = mem[0];
-    work_workArr = mem[1];
-    Abyx_norms_trfact = mem[2];
-    diag_tmptr = mem[3];
-    workArr = mem[4];
-    ipiv = mem[5];
+    work_workArr_work1 = mem[1];
+    work2 = mem[2];
+    work3 = mem[3];
+    work4 = mem[4];
+    Abyx_norms_trfact = mem[5];
+    diag_tmptr = mem[6];
+    workArr = mem[7];
+    ipiv = mem[8];
     if(size_scalars > 0)
         init_scalars(handle, (T*)scalars);
 
     // execution
     rocblas_status status = rocsolver_geqrf_template<true, false, T>(
         handle, m, n, A, shiftA, lda, strideA, (T*)ipiv, strideP, batch_count, (T*)scalars,
-        work_workArr, (T*)Abyx_norms_trfact, (T*)diag_tmptr, (T**)workArr);
+        work_workArr_work1, work2, work3, work4, (T*)Abyx_norms_trfact, (T*)diag_tmptr,
+        (T**)workArr, optim_mem);
 
     // copy ipiv into tau
     if(size_ipiv > 0)

--- a/library/src/lapack/roclapack_geqrf_strided_batched.cpp
+++ b/library/src/lapack/roclapack_geqrf_strided_batched.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -58,39 +58,46 @@ rocblas_status rocsolver_geqrf_strided_batched_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of arrays of pointers (for batched cases) and re-usable workspace
-    size_t size_work_workArr, size_workArr;
+    bool optim_mem;
+    size_t size_work_workArr_work1, size_work2, size_work3, size_work4, size_workArr;
     // extra requirements for calling GEQR2 and to store temporary triangular factor
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GEQR2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_geqrf_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
-                                            &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr);
+    rocsolver_geqrf_getMemorySize<false, true, T>(
+        m, n, batch_count, &size_scalars, &size_work_workArr_work1, &size_work2, &size_work3,
+        &size_work4, &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_workArr,
-                                                      size_Abyx_norms_trfact, size_diag_tmptr,
-                                                      size_workArr);
+        return rocblas_set_optimal_device_memory_size(
+            handle, size_scalars, size_work_workArr_work1, size_work2, size_work3, size_work4,
+            size_Abyx_norms_trfact, size_diag_tmptr, size_workArr);
 
     // memory workspace allocation
-    void *scalars, *work_workArr, *Abyx_norms_trfact, *diag_tmptr, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms_trfact,
-                              size_diag_tmptr, size_workArr);
+    void *scalars, *work_workArr_work1, *work2, *work3, *work4, *Abyx_norms_trfact, *diag_tmptr,
+        *workArr;
+    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr_work1, size_work2, size_work3,
+                              size_work4, size_Abyx_norms_trfact, size_diag_tmptr, size_workArr);
 
     if(!mem)
         return rocblas_status_memory_error;
 
     scalars = mem[0];
-    work_workArr = mem[1];
-    Abyx_norms_trfact = mem[2];
-    diag_tmptr = mem[3];
-    workArr = mem[4];
+    work_workArr_work1 = mem[1];
+    work2 = mem[2];
+    work3 = mem[3];
+    work4 = mem[4];
+    Abyx_norms_trfact = mem[5];
+    diag_tmptr = mem[6];
+    workArr = mem[7];
     if(size_scalars > 0)
         init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_geqrf_template<false, true, T>(
         handle, m, n, A, shiftA, lda, strideA, ipiv, stridep, batch_count, (T*)scalars,
-        work_workArr, (T*)Abyx_norms_trfact, (T*)diag_tmptr, (T**)workArr);
+        work_workArr_work1, work2, work3, work4, (T*)Abyx_norms_trfact, (T*)diag_tmptr,
+        (T**)workArr, optim_mem);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/library/src/lapack/roclapack_syevd_heevd.cpp
+++ b/library/src/lapack/roclapack_syevd_heevd.cpp
@@ -38,12 +38,14 @@ rocblas_status rocsolver_syevd_heevd_impl(rocblas_handle handle,
     rocblas_int batch_count = 1;
 
     // memory workspace sizes:
+    bool optim_mem;
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspaces
     size_t size_work1;
     size_t size_work2;
     size_t size_work3;
+    size_t size_work4;
     size_t size_tmptau_W;
     // extra space for call stedc
     size_t size_splits, size_tmpz;
@@ -52,19 +54,19 @@ rocblas_status rocsolver_syevd_heevd_impl(rocblas_handle handle,
     // size for temporary householder scalars
     size_t size_tau;
 
-    rocsolver_syevd_heevd_getMemorySize<false, T, S>(
+    rocsolver_syevd_heevd_getMemorySize<false, false, T, S>(
         handle, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
-        &size_tmpz, &size_splits, &size_tmptau_W, &size_tau, &size_workArr);
+        &size_work4, &size_tmpz, &size_splits, &size_tmptau_W, &size_tau, &size_workArr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
-                                                      size_work3, size_tmpz, size_splits,
+                                                      size_work3, size_work4, size_tmpz, size_splits,
                                                       size_tmptau_W, size_tau, size_workArr);
 
     // memory workspace allocation
-    void *scalars, *work1, *work2, *work3, *tmpz, *splits, *tmptau_W, *tau, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work1, size_work2, size_work3, size_tmpz,
-                              size_splits, size_tmptau_W, size_tau, size_workArr);
+    void *scalars, *work1, *work2, *work3, *work4, *tmpz, *splits, *tmptau_W, *tau, *workArr;
+    rocblas_device_malloc mem(handle, size_scalars, size_work1, size_work2, size_work3, size_work4,
+                              size_tmpz, size_splits, size_tmptau_W, size_tau, size_workArr);
 
     if(!mem)
         return rocblas_status_memory_error;
@@ -73,19 +75,20 @@ rocblas_status rocsolver_syevd_heevd_impl(rocblas_handle handle,
     work1 = mem[1];
     work2 = mem[2];
     work3 = mem[3];
-    tmpz = mem[4];
-    splits = mem[5];
-    tmptau_W = mem[6];
-    tau = mem[7];
-    workArr = mem[8];
+    work4 = mem[4];
+    tmpz = mem[5];
+    splits = mem[6];
+    tmptau_W = mem[7];
+    tau = mem[8];
+    workArr = mem[9];
     if(size_scalars > 0)
         init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_syevd_heevd_template<false, false, T>(
         handle, evect, uplo, n, A, shiftA, lda, strideA, D, strideD, E, strideE, info, batch_count,
-        (T*)scalars, work1, work2, work3, (S*)tmpz, (rocblas_int*)splits, (T*)tmptau_W, (T*)tau,
-        (T**)workArr);
+        (T*)scalars, work1, work2, work3, work4, (S*)tmpz, (rocblas_int*)splits, (T*)tmptau_W,
+        (T*)tau, (T**)workArr, optim_mem);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/library/src/lapack/roclapack_syevd_heevd.hpp
+++ b/library/src/lapack/roclapack_syevd_heevd.hpp
@@ -1,4 +1,4 @@
-/************************************************************************ 
+/************************************************************************
  * Derived from the BSD3-licensed
  * LAPACK routine (version 3.7.0) --
  *     Univ. of Tennessee, Univ. of California Berkeley,
@@ -125,6 +125,93 @@ void rocsolver_syevd_heevd_getMemorySize(rocblas_handle handle,
         *size_workArr = 0;
 }
 
+template <bool BATCHED, bool STRIDED, typename T, typename S>
+void rocsolver_syevd_heevd_getMemorySize(rocblas_handle handle,
+                                         const rocblas_evect evect,
+                                         const rocblas_fill uplo,
+                                         const rocblas_int n,
+                                         const rocblas_int batch_count,
+                                         size_t* size_scalars,
+                                         size_t* size_work1,
+                                         size_t* size_work2,
+                                         size_t* size_work3,
+                                         size_t* size_work4,
+                                         size_t* size_tmpz,
+                                         size_t* size_splits,
+                                         size_t* size_tmptau_W,
+                                         size_t* size_tau,
+                                         size_t* size_workArr,
+                                         bool* optim_mem)
+{
+    *size_scalars = 0;
+    *size_work1 = 0;
+    *size_work2 = 0;
+    *size_work3 = 0;
+    *size_work4 = 0;
+    *size_tmptau_W = 0;
+    *size_tau = 0;
+    *size_workArr = 0;
+    *size_splits = 0;
+    *size_tmpz = 0;
+    *optim_mem = true;
+
+    // if quick return, set workspace to zero
+    if(n <= 1 || batch_count == 0)
+    {
+        return;
+    }
+
+    rocsolver_alg_mode alg_mode;
+    rocsolver_get_alg_mode(handle, rocsolver_function_sterf, &alg_mode);
+
+    size_t unused;
+    size_t w11 = 0, w12 = 0, w13 = 0;
+    size_t w21 = 0, w22 = 0, w23 = 0;
+    size_t w31 = 0, w32 = 0;
+    size_t t1 = 0, t2 = 0;
+    size_t s1 = 0, s2 = 0;
+    size_t z1 = 0, z2 = 0;
+
+    // requirements for tridiagonalization (sytrd/hetrd)
+    rocsolver_sytrd_hetrd_getMemorySize<BATCHED, T>(n, batch_count, size_scalars, &w11, &w21, &t1,
+                                                    &unused, false);
+
+    if(alg_mode != rocsolver_alg_mode_hybrid || evect == rocblas_evect_original)
+    {
+        // extra requirements for computing eigenvalues and vectors (stedc)
+        rocsolver_stedc_getMemorySize<BATCHED, T, S>(rocblas_evect_tridiagonal, n, batch_count,
+                                                     &w31, &w22, &w12, &z1, &s1, &unused);
+    }
+
+    if(evect == rocblas_evect_original)
+    {
+        // extra requirements for ormtr/unmtr
+        rocsolver_ormtr_unmtr_getMemorySize<BATCHED, STRIDED, T>(
+            rocblas_side_left, uplo, rocblas_operation_none, n, n, batch_count, &unused, &w23, &z2,
+            &s2, size_work4, &w13, &w32, &unused, optim_mem);
+    }
+
+    // size of array for temporary matrix products
+    t2 = sizeof(T) * n * n * batch_count;
+
+    // get max values
+    *size_work1 = std::max({w11, w12, w13});
+    *size_work2 = std::max({w21, w22, w23});
+    *size_work3 = std::max(w31, w32);
+    *size_tmptau_W = std::max(t1, t2);
+    *size_splits = std::max(s1, s2);
+    *size_tmpz = std::max(z1, z2);
+
+    // size of array for temporary householder scalars
+    *size_tau = sizeof(T) * n * batch_count;
+
+    // size of array of pointers to workspace
+    if(BATCHED)
+        *size_workArr = 2 * sizeof(T*) * batch_count;
+    else
+        *size_workArr = 0;
+}
+
 template <bool BATCHED, bool STRIDED, typename T, typename S, typename W>
 rocblas_status rocsolver_syevd_heevd_template(rocblas_handle handle,
                                               const rocblas_evect evect,
@@ -213,6 +300,108 @@ rocblas_status rocsolver_syevd_heevd_template(rocblas_handle handle,
                 handle, rocblas_side_left, uplo, rocblas_operation_none, n, n, A, shiftA, lda,
                 strideA, tau, n, tmptau_W, 0, ldw, strideW, batch_count, scalars, (T*)work2,
                 (T*)work1, (T*)work3, workArr);
+
+            // copy matrix product into A
+            const rocblas_int copyblocks = (n - 1) / BS2 + 1;
+            ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(copyblocks, copyblocks, batch_count),
+                                    dim3(BS2, BS2), 0, stream, n, n, tmptau_W, 0, ldw, strideW, A,
+                                    shiftA, lda, strideA);
+        }
+    }
+
+    return rocblas_status_success;
+}
+
+template <bool BATCHED, bool STRIDED, typename T, typename S, typename W>
+rocblas_status rocsolver_syevd_heevd_template(rocblas_handle handle,
+                                              const rocblas_evect evect,
+                                              const rocblas_fill uplo,
+                                              const rocblas_int n,
+                                              W A,
+                                              const rocblas_int shiftA,
+                                              const rocblas_int lda,
+                                              const rocblas_stride strideA,
+                                              S* D,
+                                              const rocblas_stride strideD,
+                                              S* E,
+                                              const rocblas_stride strideE,
+                                              rocblas_int* info,
+                                              const rocblas_int batch_count,
+                                              T* scalars,
+                                              void* work1,
+                                              void* work2,
+                                              void* work3,
+                                              void* work4,
+                                              S* tmpz,
+                                              rocblas_int* splits,
+                                              T* tmptau_W,
+                                              T* tau,
+                                              T** workArr,
+                                              bool optim_mem)
+{
+    ROCSOLVER_ENTER("syevd_heevd", "evect:", evect, "uplo:", uplo, "n:", n, "shiftA:", shiftA,
+                    "lda:", lda, "bc:", batch_count);
+
+    // quick return
+    if(batch_count == 0)
+        return rocblas_status_success;
+
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    rocsolver_alg_mode sterf_mode;
+    ROCBLAS_CHECK(rocsolver_get_alg_mode(handle, rocsolver_function_sterf, &sterf_mode));
+
+    rocblas_int blocksReset = (batch_count - 1) / BS1 + 1;
+    dim3 gridReset(blocksReset, 1, 1);
+    dim3 threads(BS1, 1, 1);
+
+    // info = 0
+    ROCSOLVER_LAUNCH_KERNEL(reset_info, gridReset, threads, 0, stream, info, batch_count, 0);
+
+    // quick return
+    if(n == 0)
+        return rocblas_status_success;
+
+    // quick return for n = 1 (scalar case)
+    if(n == 1)
+    {
+        ROCSOLVER_LAUNCH_KERNEL(scalar_case<T>, gridReset, threads, 0, stream, evect, A, strideA, D,
+                                strideD, batch_count);
+        return rocblas_status_success;
+    }
+
+    // TODO: Scale the matrix
+
+    // reduce A to tridiagonal form
+    rocsolver_sytrd_hetrd_template<BATCHED>(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,
+                                            strideE, tau, n, batch_count, scalars, (T*)work1,
+                                            (T*)work2, tmptau_W, workArr, false);
+
+    if(sterf_mode == rocsolver_alg_mode_hybrid && evect != rocblas_evect_original)
+    {
+        // only in hybrid mode, compute eigenvalues using sterf
+        rocsolver_sterf_template<S>(handle, n, D, 0, strideD, E, 0, strideE, info, batch_count,
+                                    (rocblas_int*)work1);
+    }
+    else
+    {
+        // for performance reasons, we use stedc to compute eigenvalues even if the eigenvectors are ignored
+        constexpr bool ISBATCHED = BATCHED || STRIDED;
+        const rocblas_int ldw = n;
+        const rocblas_stride strideW = n * n;
+
+        rocsolver_stedc_template<false, ISBATCHED, T>(
+            handle, rocblas_evect_tridiagonal, n, D, 0, strideD, E, 0, strideE, tmptau_W, 0, ldw,
+            strideW, info, batch_count, work3, (S*)work2, (S*)work1, tmpz, splits, (S**)workArr);
+
+        // update the eigenvectors (if applicable)
+        if(evect == rocblas_evect_original)
+        {
+            rocsolver_ormtr_unmtr_template<BATCHED, STRIDED>(
+                handle, rocblas_side_left, uplo, rocblas_operation_none, n, n, A, shiftA, lda,
+                strideA, tau, n, tmptau_W, 0, ldw, strideW, batch_count, scalars, (T*)work2, tmpz,
+                splits, work4, (T*)work1, (T*)work3, workArr, optim_mem);
 
             // copy matrix product into A
             const rocblas_int copyblocks = (n - 1) / BS2 + 1;

--- a/library/src/lapack/roclapack_syevd_heevd_batched.cpp
+++ b/library/src/lapack/roclapack_syevd_heevd_batched.cpp
@@ -63,12 +63,14 @@ rocblas_status rocsolver_syevd_heevd_batched_impl(rocblas_handle handle,
     rocblas_stride strideA = 0;
 
     // memory workspace sizes:
+    bool optim_mem;
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspaces
     size_t size_work1;
     size_t size_work2;
     size_t size_work3;
+    size_t size_work4;
     size_t size_tmptau_W;
     // extra space for call stedc
     size_t size_splits, size_tmpz;
@@ -77,19 +79,19 @@ rocblas_status rocsolver_syevd_heevd_batched_impl(rocblas_handle handle,
     // size for temporary householder scalars
     size_t size_tau;
 
-    rocsolver_syevd_heevd_getMemorySize<true, T, S>(
+    rocsolver_syevd_heevd_getMemorySize<true, false, T, S>(
         handle, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
-        &size_tmpz, &size_splits, &size_tmptau_W, &size_tau, &size_workArr);
+        &size_work4, &size_tmpz, &size_splits, &size_tmptau_W, &size_tau, &size_workArr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
-                                                      size_work3, size_tmpz, size_splits,
+                                                      size_work3, size_work4, size_tmpz, size_splits,
                                                       size_tmptau_W, size_tau, size_workArr);
 
     // memory workspace allocation
-    void *scalars, *work1, *work2, *work3, *tmpz, *splits, *tmptau_W, *tau, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work1, size_work2, size_work3, size_tmpz,
-                              size_splits, size_tmptau_W, size_tau, size_workArr);
+    void *scalars, *work1, *work2, *work3, *work4, *tmpz, *splits, *tmptau_W, *tau, *workArr;
+    rocblas_device_malloc mem(handle, size_scalars, size_work1, size_work2, size_work3, size_work4,
+                              size_tmpz, size_splits, size_tmptau_W, size_tau, size_workArr);
 
     if(!mem)
         return rocblas_status_memory_error;
@@ -98,19 +100,20 @@ rocblas_status rocsolver_syevd_heevd_batched_impl(rocblas_handle handle,
     work1 = mem[1];
     work2 = mem[2];
     work3 = mem[3];
-    tmpz = mem[4];
-    splits = mem[5];
-    tmptau_W = mem[6];
-    tau = mem[7];
-    workArr = mem[8];
+    work4 = mem[4];
+    tmpz = mem[5];
+    splits = mem[6];
+    tmptau_W = mem[7];
+    tau = mem[8];
+    workArr = mem[9];
     if(size_scalars > 0)
         init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_syevd_heevd_template<true, false, T>(
         handle, evect, uplo, n, A, shiftA, lda, strideA, D, strideD, E, strideE, info, batch_count,
-        (T*)scalars, work1, work2, work3, (S*)tmpz, (rocblas_int*)splits, (T*)tmptau_W, (T*)tau,
-        (T**)workArr);
+        (T*)scalars, work1, work2, work3, work4, (S*)tmpz, (rocblas_int*)splits, (T*)tmptau_W,
+        (T*)tau, (T**)workArr, optim_mem);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/library/src/lapack/roclapack_syevd_heevd_strided_batched.cpp
+++ b/library/src/lapack/roclapack_syevd_heevd_strided_batched.cpp
@@ -62,12 +62,14 @@ rocblas_status rocsolver_syevd_heevd_strided_batched_impl(rocblas_handle handle,
     rocblas_int shiftA = 0;
 
     // memory workspace sizes:
+    bool optim_mem;
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspaces
     size_t size_work1;
     size_t size_work2;
     size_t size_work3;
+    size_t size_work4;
     size_t size_tmptau_W;
     // extra space for call stedc
     size_t size_splits, size_tmpz;
@@ -76,19 +78,19 @@ rocblas_status rocsolver_syevd_heevd_strided_batched_impl(rocblas_handle handle,
     // size for temporary householder scalars
     size_t size_tau;
 
-    rocsolver_syevd_heevd_getMemorySize<false, T, S>(
+    rocsolver_syevd_heevd_getMemorySize<false, true, T, S>(
         handle, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
-        &size_tmpz, &size_splits, &size_tmptau_W, &size_tau, &size_workArr);
+        &size_work4, &size_tmpz, &size_splits, &size_tmptau_W, &size_tau, &size_workArr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
-                                                      size_work3, size_tmpz, size_splits,
+                                                      size_work3, size_work4, size_tmpz, size_splits,
                                                       size_tmptau_W, size_tau, size_workArr);
 
     // memory workspace allocation
-    void *scalars, *work1, *work2, *work3, *tmpz, *splits, *tmptau_W, *tau, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work1, size_work2, size_work3, size_tmpz,
-                              size_splits, size_tmptau_W, size_tau, size_workArr);
+    void *scalars, *work1, *work2, *work3, *work4, *tmpz, *splits, *tmptau_W, *tau, *workArr;
+    rocblas_device_malloc mem(handle, size_scalars, size_work1, size_work2, size_work3, size_work4,
+                              size_tmpz, size_splits, size_tmptau_W, size_tau, size_workArr);
 
     if(!mem)
         return rocblas_status_memory_error;
@@ -97,19 +99,20 @@ rocblas_status rocsolver_syevd_heevd_strided_batched_impl(rocblas_handle handle,
     work1 = mem[1];
     work2 = mem[2];
     work3 = mem[3];
-    tmpz = mem[4];
-    splits = mem[5];
-    tmptau_W = mem[6];
-    tau = mem[7];
-    workArr = mem[8];
+    work4 = mem[4];
+    tmpz = mem[5];
+    splits = mem[6];
+    tmptau_W = mem[7];
+    tau = mem[8];
+    workArr = mem[9];
     if(size_scalars > 0)
         init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_syevd_heevd_template<false, true, T>(
         handle, evect, uplo, n, A, shiftA, lda, strideA, D, strideD, E, strideE, info, batch_count,
-        (T*)scalars, work1, work2, work3, (S*)tmpz, (rocblas_int*)splits, (T*)tmptau_W, (T*)tau,
-        (T**)workArr);
+        (T*)scalars, work1, work2, work3, work4, (S*)tmpz, (rocblas_int*)splits, (T*)tmptau_W,
+        (T*)tau, (T**)workArr, optim_mem);
 }
 
 ROCSOLVER_END_NAMESPACE


### PR DESCRIPTION
This PR adds LARFT and LARFB functions which compute and operate on the inverse triangular factor. These are used in GEQRF (non-batched) to improve performance. The new functions are called from new overloads of existing templates; these overloads are used in performance critical areas.