### PR TITLE
Small performance improvements in stedc

### DIFF
--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1463,33 +1463,15 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
             // Order the elements in tmpd and zz using a simple parallel selection/bubble sort.
             // This will allow us to find initial intervals for eigenvalue guesses
-            for(int i = 0; i < tsz; ++i)
+            for(int i = 0; i < dd; i++)
             {
-                if(i < dd)
+                for(int j = 2 * iam + i % 2; j < dd - 1; j += 2 * bdm)
                 {
-                    if(i % 2 == 0)
+                    if(tmpd[j] > tmpd[j + 1])
                     {
-                        for(int j = iam; j < dd / 2; j += bdm)
-                        {
-                            if(tmpd[2 * j] > tmpd[2 * j + 1])
-                            {
-                                swap(tmpd[2 * j], tmpd[2 * j + 1]);
-                                swap(zz[2 * j], zz[2 * j + 1]);
-                                swap(per[2 * j], per[2 * j + 1]);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        for(int j = iam; j < (dd - 1) / 2; j += bdm)
-                        {
-                            if(tmpd[2 * j + 1] > tmpd[2 * j + 2])
-                            {
-                                swap(tmpd[2 * j + 1], tmpd[2 * j + 2]);
-                                swap(zz[2 * j + 1], zz[2 * j + 2]);
-                                swap(per[2 * j + 1], per[2 * j + 2]);
-                            }
-                        }
+                        swap(tmpd[j], tmpd[j + 1]);
+                        swap(zz[j], zz[j + 1]);
+                        swap(per[j], per[j + 1]);
                     }
                 }
                 __syncthreads();
@@ -1500,10 +1482,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             // eigenvalues (D - lambda_i) are updated while computing each eigenvalue.
             // This will prevent collapses and division by zero when an eigenvalue
             // is too close to a pole.
-            for(int j = iam + 1; j < sz; j += bdm)
+            for(int i = iam; i < dd; i += bdm)
             {
-                for(int i = 0; i < dd; ++i)
-                    tmpd[i + j * n] = tmpd[i];
+                for(int j = i + n; j < i + sz * n; j += n)
+                    tmpd[j] = tmpd[i];
             }
 
             // finally copy over all diagonal elements in ev. ev will be overwritten
@@ -1523,14 +1505,19 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 if(mask[j] == 1)
                 {
                     // find position in the ordered array
-                    int cc = 0;
                     valf = p < 0 ? -ev[j] : ev[j];
-                    for(int jj = 0; jj < dd; ++jj)
+                    int count = dd, cc = 0;
+                    while(count > 0)
                     {
-                        if(tmpd[jj + j * n] == valf)
-                            break;
+                        auto step = count / 2;
+                        auto it = cc + step;
+                        if(tmpd[it + j * n] < valf)
+                        {
+                            cc = ++it;
+                            count -= step + 1;
+                        }
                         else
-                            cc++;
+                            count = step;
                     }
 
                     // computed zero will overwrite 'ev' at the corresponding position.

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1463,8 +1463,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
             // Order the elements in tmpd and zz using a simple parallel selection/bubble sort.
             // This will allow us to find initial intervals for eigenvalue guesses
-#if 1
-            // bubble sort
             for(int i = 0; i < dd; i++)
             {
                 for(int j = 2 * iam + i % 2; j < dd - 1; j += 2 * bdm)
@@ -1478,34 +1476,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 }
                 __syncthreads();
             }
-#else
-            // shell sort
-            for(int m = dd / 2; m > 0; m /= 2)
-            {
-                for(int i = iam; i < m; i += bdm)
-                {
-                    for(int j = m; j < dd - i; j += m)
-                    {
-                        int l = i + j;
-                        auto key_tmpd = tmpd[l];
-                        auto key_zz = zz[l];
-                        auto key_per = per[l];
-                        while(l >= m && tmpd[l - m] > key_tmpd)
-                        {
-                            tmpd[l] = tmpd[l - m];
-                            zz[l] = zz[l - m];
-                            per[l] = per[l - m];
-                            l -= m;
-                        }
-                        tmpd[l] = key_tmpd;
-                        zz[l] = key_zz;
-                        per[l] = key_per;
-                    }
-                }
-                __syncthreads();
-            }
-
-#endif
 
             // make dd copies of the non-deflated ordered diagonal elements
             // (i.e. the poles of the secular eqn) so that the distances to the

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1463,6 +1463,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
             // Order the elements in tmpd and zz using a simple parallel selection/bubble sort.
             // This will allow us to find initial intervals for eigenvalue guesses
+#if 1
+            // bubble sort
             for(int i = 0; i < dd; i++)
             {
                 for(int j = 2 * iam + i % 2; j < dd - 1; j += 2 * bdm)
@@ -1476,6 +1478,34 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 }
                 __syncthreads();
             }
+#else
+            // shell sort
+            for(int m = dd / 2; m > 0; m /= 2)
+            {
+                for(int i = iam; i < m; i += bdm)
+                {
+                    for(int j = m; j < dd - i; j += m)
+                    {
+                        int l = i + j;
+                        auto key_tmpd = tmpd[l];
+                        auto key_zz = zz[l];
+                        auto key_per = per[l];
+                        while(l >= m && tmpd[l - m] > key_tmpd)
+                        {
+                            tmpd[l] = tmpd[l - m];
+                            zz[l] = zz[l - m];
+                            per[l] = per[l - m];
+                            l -= m;
+                        }
+                        tmpd[l] = key_tmpd;
+                        zz[l] = key_zz;
+                        per[l] = key_per;
+                    }
+                }
+                __syncthreads();
+            }
+
+#endif
 
             // make dd copies of the non-deflated ordered diagonal elements
             // (i.e. the poles of the secular eqn) so that the distances to the


### PR DESCRIPTION
Simplify bubble sort.
Use coalesced accesses.
Use binary search instead of loop.

For 
`./rocsolver-bench -f syevd -n 2048 --evect V --iters 3 --perf 1 -r s  --profile 10 --profile_kernels 1`
I get 21%  improvement for `stedc_mergeValues_kernel`, and 5% for `rocsolver_syevd_heevd_template`. (on MI300X)


