### PR TITLE
Extend syevd tests to allow using new input matrices

### DIFF
--- a/clients/common/auxiliary/testing_stedc.hpp
+++ b/clients/common/auxiliary/testing_stedc.hpp
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include "common/matrix_utils/matrix_utils.hpp"
 #include "common/misc/client_util.hpp"
 #include "common/misc/clientcommon.hpp"
 #include "common/misc/lapack_host_reference.hpp"
@@ -94,19 +95,236 @@ void testing_stedc_bad_arg()
     stedc_checkBadArgs(handle, evect, n, dD.data(), dE.data(), dC.data(), ldc, dInfo.data());
 }
 
+// For `n > 1`, creates a symmetrized `n` by `n` tridiagonal, Clement matrix T of the following form:
+//
+//             (   sqrt(n - 1)   sqrt(2(n - 2))     sqrt((n - 2)2)   sqrt(n - 1)   )
+// T = tridiag ( 0             0                ...                0             0 )
+//             (   sqrt(n - 1)   sqrt(2(n - 2))     sqrt((n - 2)2)   sqrt(n - 1)   )
+//
+// were the `i-th` off-diagonal entry is sqrt(i(n - i)), 1 <= i < n.
+//
 template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
-void stedc_initData(const rocblas_handle handle,
-                    const rocblas_evect evect,
-                    const rocblas_int n,
-                    Sd& dD,
-                    Sd& dE,
-                    Td& dC,
-                    const rocblas_int ldc,
-                    Ud& dInfo,
-                    Sh& hD,
-                    Sh& hE,
-                    Th& hC,
-                    Uh& hInfo)
+void stedc_clement_initData(const rocblas_handle handle,
+                            const rocblas_evect evect,
+                            const rocblas_int n,
+                            Sd& dD,
+                            Sd& dE,
+                            Td& dC,
+                            const rocblas_int ldc,
+                            Ud& /* dInfo */,
+                            Sh& hD,
+                            Sh& hE,
+                            Th& hC,
+                            Uh& /* hInfo */)
+{
+    using S = decltype(std::real(T{}));
+    rocblas_int bc = 1;
+
+    if(CPU)
+    {
+        rocblas_init<T>(hC, true);
+
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMatT = HostMatrix<T, rocblas_int>;
+            using HMatS = HostMatrix<S, rocblas_int>;
+            using BDesc = typename HMatT::BlockDescriptor;
+
+            auto hCw = HMatT::Wrap(hC[b], ldc, n);
+            hCw->set_to_zero();
+            auto hDw = HMatS::Wrap(hD[b], n, 1);
+            hDw->set_to_zero();
+            auto hEw = HMatS::Wrap(hE[b], n, 1);
+            hEw->set_to_zero();
+
+            if(hCw && hDw && hEw) // update matrices if n >= 1
+            {
+                auto C = HMatT::Eye(n, n);
+                auto D = HMatS::Zeros(n, 1);
+                auto E = HMatS::Ones(n - 1, 1);
+
+                for(rocblas_int i = 1; i < n; ++i)
+                {
+                    E[i - 1] = std::sqrt(i * (n - i));
+                }
+
+                hCw->copy_data_from(C);
+                hDw->copy_data_from(D);
+                hEw->copy_data_from(E);
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dD.transfer_from(hD));
+        CHECK_HIP_ERROR(dE.transfer_from(hE));
+
+        if(evect == rocblas_evect_original)
+            CHECK_HIP_ERROR(dC.transfer_from(hC));
+    }
+}
+
+// Creates an `n` by `n` tridiagonal, Toeplitz matrix T of the following form:
+//
+//             (   1         1         1    )
+// T = tridiag ( 2   2 ... 2   2 ... 2    2 )
+//             (   1         1         1    )
+//
+template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+void stedc_toeplitz_initData(const rocblas_handle handle,
+                             const rocblas_evect evect,
+                             const rocblas_int n,
+                             Sd& dD,
+                             Sd& dE,
+                             Td& dC,
+                             const rocblas_int ldc,
+                             Ud& /* dInfo */,
+                             Sh& hD,
+                             Sh& hE,
+                             Th& hC,
+                             Uh& /* hInfo */)
+{
+    using S = decltype(std::real(T{}));
+    rocblas_int bc = 1;
+
+    if(CPU)
+    {
+        rocblas_init<T>(hC, true);
+
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMatT = HostMatrix<T, rocblas_int>;
+            using HMatS = HostMatrix<S, rocblas_int>;
+            using BDesc = typename HMatT::BlockDescriptor;
+
+            auto hCw = HMatT::Wrap(hC[b], ldc, n);
+            hCw->set_to_zero();
+            auto hDw = HMatS::Wrap(hD[b], n, 1);
+            hDw->set_to_zero();
+            auto hEw = HMatS::Wrap(hE[b], n, 1);
+            hEw->set_to_zero();
+
+            if(hCw && hDw && hEw) // update matrices if n >= 1
+            {
+                auto C = HMatT::Eye(n, n);
+                auto D = 2 * HMatS::Ones(n, 1);
+                auto E = HMatS::Ones(n - 1, 1);
+
+                hCw->copy_data_from(C);
+                hDw->copy_data_from(D);
+                hEw->copy_data_from(E);
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dD.transfer_from(hD));
+        CHECK_HIP_ERROR(dE.transfer_from(hE));
+
+        if(evect == rocblas_evect_original)
+            CHECK_HIP_ERROR(dC.transfer_from(hC));
+    }
+}
+
+// Creates an `n` by `n` tridiagonal, Wilkinson matrix, which is formed as follows:
+//
+// 1. If `n` is even:
+//                      (   1          1            1          1   )
+// W_{2m + 1} = tridiag ( m   (m - 1) ... 0.5 0.5 ... (m - 1)    m )
+//                      (   1          1            1          1   )
+//
+// 2. If `n` is odd:
+//                      (   1          1         1          1   )
+// W_{2m + 1} = tridiag ( m   (m - 1) ... 1 0 1 ... (m - 1)   m )
+//                      (   1          1         1          1   )
+//
+// where `n = 2m + 1`.
+//
+template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+void stedc_wilkinson_initData(const rocblas_handle handle,
+                              const rocblas_evect evect,
+                              const rocblas_int n,
+                              Sd& dD,
+                              Sd& dE,
+                              Td& dC,
+                              const rocblas_int ldc,
+                              Ud& /* dInfo */,
+                              Sh& hD,
+                              Sh& hE,
+                              Th& hC,
+                              Uh& /* hInfo */)
+{
+    using S = decltype(std::real(T{}));
+    rocblas_int bc = 1;
+
+    if(CPU)
+    {
+        rocblas_init<T>(hC, true);
+
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMatT = HostMatrix<T, rocblas_int>;
+            using HMatS = HostMatrix<S, rocblas_int>;
+            using BDesc = typename HMatT::BlockDescriptor;
+
+            auto hCw = HMatT::Wrap(hC[b], ldc, n);
+            hCw->set_to_zero();
+            auto hDw = HMatS::Wrap(hD[b], n, 1);
+            hDw->set_to_zero();
+            auto hEw = HMatS::Wrap(hE[b], n, 1);
+            hEw->set_to_zero();
+
+            if(hCw && hDw && hEw) // update matrices if n >= 1
+            {
+                S m = (n - 1) / S(2);
+                auto C = HMatT::Eye(n, n);
+                auto D = HMatS::Zeros(n, 1);
+                auto E = HMatS::Ones(n - 1, 1);
+
+                for(rocblas_int i = 0; i < n / 2; ++i)
+                {
+                    D[i] = m - i;
+                    D[n - 1 - i] = m - i;
+                }
+
+                hCw->copy_data_from(C);
+                hDw->copy_data_from(D);
+                hEw->copy_data_from(E);
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dD.transfer_from(hD));
+        CHECK_HIP_ERROR(dE.transfer_from(hE));
+
+        if(evect == rocblas_evect_original)
+            CHECK_HIP_ERROR(dC.transfer_from(hC));
+    }
+}
+
+template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+void stedc_default_initData(const rocblas_handle handle,
+                            const rocblas_evect evect,
+                            const rocblas_int n,
+                            Sd& dD,
+                            Sd& dE,
+                            Td& dC,
+                            const rocblas_int ldc,
+                            Ud& /* dInfo */,
+                            Sh& hD,
+                            Sh& hE,
+                            Th& hC,
+                            Uh& /* hInfo */)
 {
     if(CPU)
     {
@@ -238,6 +456,46 @@ void stedc_initData(const rocblas_handle handle,
         if(evect == rocblas_evect_original)
             CHECK_HIP_ERROR(dC.transfer_from(hC));
     }
+}
+
+template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+void stedc_initData(const rocblas_handle handle,
+                    const rocblas_evect evect,
+                    const rocblas_int n,
+                    Sd& dD,
+                    Sd& dE,
+                    Td& dC,
+                    const rocblas_int ldc,
+                    Ud& dInfo,
+                    Sh& hD,
+                    Sh& hE,
+                    Th& hC,
+                    Uh& hInfo)
+{
+    if((std::getenv("TEST_WILKINSON") != nullptr) || (std::getenv("STEDC_TEST_WILKINSON") != nullptr))
+    {
+        stedc_wilkinson_initData<CPU, GPU, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
+                                              hInfo);
+    }
+    else if((std::getenv("TEST_CLEMENT") != nullptr)
+            || (std::getenv("STEDC_TEST_CLEMENT") != nullptr))
+    {
+        stedc_clement_initData<CPU, GPU, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
+                                            hInfo);
+    }
+    else if((std::getenv("TEST_TOEPLITZ") != nullptr)
+            || (std::getenv("STEDC_TEST_TOEPLITZ") != nullptr))
+    {
+        stedc_toeplitz_initData<CPU, GPU, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
+                                             hInfo);
+    }
+    else
+    {
+        stedc_default_initData<CPU, GPU, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
+                                            hInfo);
+    }
+
+    return;
 }
 
 template <typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>

--- a/clients/common/auxiliary/testing_stedc.hpp
+++ b/clients/common/auxiliary/testing_stedc.hpp
@@ -693,6 +693,21 @@ void stedc_getError(const rocblas_handle handle,
     // CPU lapack
     cpu_stedc(evect, n, hD[0], hE[0], hC[0], ldc, work.data(), lwork, rwork.data(), lrwork,
               iwork.data(), liwork, hInfo[0]);
+
+    // Depending on `evect`, stedc can return the eigenvectors of the original
+    // matrix (A) or the eigenvectors of the tridiagonal matrix (T).  Thus,
+    // given a pair U, D of eigenvectors and eigenvalues computed by stedc the
+    // reconstructed matrix
+    //
+    // U * D * adjoint(U)
+    //
+    // can be either A or T.  The following code uses lapack to compute
+    //
+    // AorT = U * D * adjoint(U),
+    //
+    // which will be later used to compare with the eigenvectors and
+    // eigenvalues computed by rocSOLVER.
+    //
     auto AorT = HMatT::Empty();
     if((evect != rocblas_evect_none) && (n > 0))
     {
@@ -723,40 +738,22 @@ void stedc_getError(const rocblas_handle handle,
         // check eigenvectors if required
         if(evect != rocblas_evect_none)
         {
-            // New matrix initialization
+            // Input matrix
             auto C = HMatT::Wrap(hCRes[0], ldc, n)->block(BDescT().nrows(n).ncols(n));
+            // Computed eigenvalues
             auto d = HMatT::Convert(hDRes[0], 1, n)->block(BDescT().nrows(1).ncols(n));
+            // Diagonal matrix of size n by n with computed eigenvalues
             auto D = HMatT::Zeros(n, n).diag(d);
-            /* std::cout << "--- Computed eigenvalues: " << std::endl; */
-            /* d.print(); */
 
+            // Orthogonal error
             auto OE = C * adjoint(C) - HMatT::Eye(n, n);
             err = OE.max_col_norm();
-            /* std::cout << "--- Orthogonal error: " << err << std::endl; */
             *max_errv = err > *max_err ? err : *max_err;
 
-            auto AE = AorT - C * D * adjoint(C);
-            /* std::cout << "--- Residual error: " << err << std::endl; */
-            err = AE.norm() / AorT.norm();
+            // Residual error
+            auto RE = AorT - C * D * adjoint(C);
+            err = RE.norm() / AorT.norm();
             *max_err = err > *max_err ? err : *max_err;
-
-            /* // both eigenvalues and eigenvectors needed; need to implicitly test */
-            /* // eigenvectors due to non-uniqueness of eigenvectors under scaling */
-
-            /* // multiply A with each of the n eigenvectors and divide by corresponding */
-            /* // eigenvalues */
-            /* T alpha; */
-            /* T beta = 0; */
-            /* for(int j = 0; j < n; j++) */
-            /* { */
-            /*     alpha = T(1) / hDRes[0][j]; */
-            /*     cpu_symv_hemv(rocblas_fill_upper, n, alpha, hA[0], lda, hCRes[0] + j * ldc, 1, beta, */
-            /*                   hC[0] + j * ldc, 1); */
-            /* } */
-
-            /* // error is ||hC - hCRes|| / ||hC|| */
-            /* // using frobenius norm */
-            /* *max_errv = norm_error('F', n, n, ldc, hCRes[0], hC[0]); */
         }
     }
 }

--- a/clients/common/auxiliary/testing_stedc.hpp
+++ b/clients/common/auxiliary/testing_stedc.hpp
@@ -232,6 +232,67 @@ void stedc_toeplitz_initData(const rocblas_handle handle,
     }
 }
 
+// Creates an `n` by `n` identity matrix.
+//
+template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+void stedc_identity_initData(const rocblas_handle handle,
+                             const rocblas_evect evect,
+                             const rocblas_int n,
+                             Sd& dD,
+                             Sd& dE,
+                             Td& dC,
+                             const rocblas_int ldc,
+                             Ud& /* dInfo */,
+                             Sh& hD,
+                             Sh& hE,
+                             Th& hC,
+                             Uh& /* hInfo */)
+{
+    using S = decltype(std::real(T{}));
+    rocblas_int bc = 1;
+
+    if(CPU)
+    {
+        rocblas_init<T>(hC, true);
+
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMatT = HostMatrix<T, rocblas_int>;
+            using HMatS = HostMatrix<S, rocblas_int>;
+            using BDesc = typename HMatT::BlockDescriptor;
+
+            auto hCw = HMatT::Wrap(hC[b], ldc, n);
+            hCw->set_to_zero();
+            auto hDw = HMatS::Wrap(hD[b], n, 1);
+            hDw->set_to_zero();
+            auto hEw = HMatS::Wrap(hE[b], n, 1);
+            hEw->set_to_zero();
+
+            if(hCw && hDw && hEw) // update matrices if n >= 1
+            {
+                auto C = HMatT::Eye(n, n);
+                auto D = HMatS::Ones(n, 1);
+                auto E = HMatS::Zeros(n - 1, 1);
+
+                hCw->copy_data_from(C);
+                hDw->copy_data_from(D);
+                hEw->copy_data_from(E);
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dD.transfer_from(hD));
+        CHECK_HIP_ERROR(dE.transfer_from(hE));
+
+        if(evect == rocblas_evect_original)
+            CHECK_HIP_ERROR(dC.transfer_from(hC));
+    }
+}
+
 // Creates an `n` by `n` tridiagonal, Wilkinson matrix, which is formed as follows:
 //
 // 1. If `n` is even:
@@ -489,6 +550,12 @@ void stedc_initData(const rocblas_handle handle,
         stedc_toeplitz_initData<CPU, GPU, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
                                              hInfo);
     }
+    else if((std::getenv("TEST_IDENTITY") != nullptr)
+            || (std::getenv("STEDC_TEST_IDENTITY") != nullptr))
+    {
+        stedc_identity_initData<CPU, GPU, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
+                                             hInfo);
+    }
     else
     {
         stedc_default_initData<CPU, GPU, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
@@ -520,6 +587,11 @@ void stedc_getError(const rocblas_handle handle,
 {
     constexpr bool COMPLEX = rocblas_is_complex<T>;
     using S = decltype(std::real(T{}));
+
+    using HMatT = HostMatrix<T, rocblas_int>;
+    using HMatS = HostMatrix<S, rocblas_int>;
+    using BDescT = typename HMatT::BlockDescriptor;
+    using BDescS = typename HMatS::BlockDescriptor;
 
     int lgn = floor(log(n - 1) / log(2)) + 1;
     size_t lwork = (COMPLEX) ? n * n : 0;
@@ -565,6 +637,14 @@ void stedc_getError(const rocblas_handle handle,
     // CPU lapack
     cpu_stedc(evect, n, hD[0], hE[0], hC[0], ldc, work.data(), lwork, rwork.data(), lrwork,
               iwork.data(), liwork, hInfo[0]);
+    auto AorT = HMatT::Empty();
+    if((evect != rocblas_evect_none) && (n > 0))
+    {
+        auto C = HMatT::Wrap(hCRes[0], ldc, n)->block(BDescT().nrows(n).ncols(n));
+        auto d = HMatT::Convert(hDRes[0], 1, n)->block(BDescT().nrows(1).ncols(n));
+        auto D = HMatT::Zeros(n, n).diag(d);
+        AorT = C * D * adjoint(C);
+    }
 
     // check info
     EXPECT_EQ(hInfo[0][0], hInfoRes[0][0]);
@@ -575,7 +655,7 @@ void stedc_getError(const rocblas_handle handle,
 
     double err;
 
-    if(hInfo[0][0] == 0)
+    if((hInfo[0][0] == 0) && (n > 0))
     {
         // check that eigenvalues are correct and in order
         // error is ||hD - hDRes|| / ||hD||
@@ -586,23 +666,38 @@ void stedc_getError(const rocblas_handle handle,
         // check eigenvectors if required
         if(evect != rocblas_evect_none)
         {
-            // both eigenvalues and eigenvectors needed; need to implicitly test
-            // eigenvectors due to non-uniqueness of eigenvectors under scaling
+            // New matrix initialization
+            auto C = HMatT::Wrap(hCRes[0], ldc, n)->block(BDescT().nrows(n).ncols(n));
+            auto d = HMatT::Convert(hDRes[0], 1, n)->block(BDescT().nrows(1).ncols(n));
+            auto D = HMatT::Zeros(n, n).diag(d);
+            /* std::cout << "--- Computed eigenvalues: " << std::endl; */
+            /* d.print(); */
 
-            // multiply A with each of the n eigenvectors and divide by corresponding
-            // eigenvalues
-            T alpha;
-            T beta = 0;
-            for(int j = 0; j < n; j++)
-            {
-                alpha = T(1) / hDRes[0][j];
-                cpu_symv_hemv(rocblas_fill_upper, n, alpha, hA[0], lda, hCRes[0] + j * ldc, 1, beta,
-                              hC[0] + j * ldc, 1);
-            }
+            auto OE = adjoint(C) * C - HMatT::Eye(n, n);
+            err = OE.max_col_norm();
+            *max_err = err > *max_err ? err : *max_err;
 
-            // error is ||hC - hCRes|| / ||hC||
-            // using frobenius norm
-            *max_errv = norm_error('F', n, n, ldc, hCRes[0], hC[0]);
+            auto AE = AorT - C * D * adjoint(C);
+            err = AE.norm() / AorT.norm();
+            *max_err = err > *max_err ? err : *max_err;
+
+            /* // both eigenvalues and eigenvectors needed; need to implicitly test */
+            /* // eigenvectors due to non-uniqueness of eigenvectors under scaling */
+
+            /* // multiply A with each of the n eigenvectors and divide by corresponding */
+            /* // eigenvalues */
+            /* T alpha; */
+            /* T beta = 0; */
+            /* for(int j = 0; j < n; j++) */
+            /* { */
+            /*     alpha = T(1) / hDRes[0][j]; */
+            /*     cpu_symv_hemv(rocblas_fill_upper, n, alpha, hA[0], lda, hCRes[0] + j * ldc, 1, beta, */
+            /*                   hC[0] + j * ldc, 1); */
+            /* } */
+
+            /* // error is ||hC - hCRes|| / ||hC|| */
+            /* // using frobenius norm */
+            /* *max_errv = norm_error('F', n, n, ldc, hCRes[0], hC[0]); */
         }
     }
 }

--- a/clients/common/auxiliary/testing_stedc.hpp
+++ b/clients/common/auxiliary/testing_stedc.hpp
@@ -640,8 +640,8 @@ void stedc_getError(const rocblas_handle handle,
     auto AorT = HMatT::Empty();
     if((evect != rocblas_evect_none) && (n > 0))
     {
-        auto C = HMatT::Wrap(hCRes[0], ldc, n)->block(BDescT().nrows(n).ncols(n));
-        auto d = HMatT::Convert(hDRes[0], 1, n)->block(BDescT().nrows(1).ncols(n));
+        auto C = HMatT::Wrap(hC[0], ldc, n)->block(BDescT().nrows(n).ncols(n));
+        auto d = HMatT::Convert(hD[0], 1, n)->block(BDescT().nrows(1).ncols(n));
         auto D = HMatT::Zeros(n, n).diag(d);
         AorT = C * D * adjoint(C);
     }
@@ -654,6 +654,7 @@ void stedc_getError(const rocblas_handle handle,
         *max_err = 0;
 
     double err;
+    *max_errv = 0;
 
     if((hInfo[0][0] == 0) && (n > 0))
     {
@@ -673,11 +674,13 @@ void stedc_getError(const rocblas_handle handle,
             /* std::cout << "--- Computed eigenvalues: " << std::endl; */
             /* d.print(); */
 
-            auto OE = adjoint(C) * C - HMatT::Eye(n, n);
+            auto OE = C * adjoint(C) - HMatT::Eye(n, n);
             err = OE.max_col_norm();
-            *max_err = err > *max_err ? err : *max_err;
+            /* std::cout << "--- Orthogonal error: " << err << std::endl; */
+            *max_errv = err > *max_err ? err : *max_err;
 
             auto AE = AorT - C * D * adjoint(C);
+            /* std::cout << "--- Residual error: " << err << std::endl; */
             err = AE.norm() / AorT.norm();
             *max_err = err > *max_err ? err : *max_err;
 
@@ -886,7 +889,7 @@ void testing_stedc(Arguments& argus)
     {
         ROCSOLVER_TEST_CHECK(T, max_err, n);
         if(evect != rocblas_evect_none)
-            ROCSOLVER_TEST_CHECK(T, max_errv, n * n);
+            ROCSOLVER_TEST_CHECK(T, max_errv, n);
     }
 
     // output results for rocsolver-bench

--- a/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/clients/common/lapack/testing_syevd_heevd.hpp
@@ -478,19 +478,22 @@ void syevd_heevd_initData(const rocblas_handle handle,
                           std::vector<T>& A,
                           bool test = true)
 {
-    if(std::getenv("SYEVD_TEST_EIG7") != nullptr)
+    if((std::getenv("TEST_EIG7") != nullptr) || (std::getenv("SYEVD_TEST_EIG7") != nullptr))
     {
         syevd_heevd_eig7_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
     }
-    else if(std::getenv("SYEVD_TEST_WILKINSON") != nullptr)
+    else if((std::getenv("TEST_WILKINSON") != nullptr)
+            || (std::getenv("SYEVD_TEST_WILKINSON") != nullptr))
     {
         syevd_heevd_wilkinson_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
     }
-    else if(std::getenv("SYEVD_TEST_CLEMENT") != nullptr)
+    else if((std::getenv("TEST_CLEMENT") != nullptr)
+            || (std::getenv("SYEVD_TEST_CLEMENT") != nullptr))
     {
         syevd_heevd_clement_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
     }
-    else if(std::getenv("SYEVD_TEST_TOEPLITZ") != nullptr)
+    else if((std::getenv("TEST_TOEPLITZ") != nullptr)
+            || (std::getenv("SYEVD_TEST_TOEPLITZ") != nullptr))
     {
         syevd_heevd_toeplitz_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
     }

--- a/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/clients/common/lapack/testing_syevd_heevd.hpp
@@ -173,7 +173,10 @@ void syevd_heevd_default_initData(const rocblas_handle handle,
                     else
                     {
                         hA[b][i + j * lda] -= 4;
-                        hA[b][j + i * lda] = hA[b][i + j * lda];
+                        if constexpr(rocblas_is_complex<T>)
+                            hA[b][j + i * lda] = std::conj(hA[b][i + j * lda]);
+                        else
+                            hA[b][j + i * lda] = hA[b][i + j * lda];
                     }
                 }
             }

--- a/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/clients/common/lapack/testing_syevd_heevd.hpp
@@ -166,12 +166,15 @@ void syevd_heevd_default_initData(const rocblas_handle handle,
         {
             for(rocblas_int i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(rocblas_int j = i; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] = std::real(hA[b][i + j * lda]) + 400;
                     else
+                    {
                         hA[b][i + j * lda] -= 4;
+                        hA[b][j + i * lda] = hA[b][i + j * lda];
+                    }
                 }
             }
 
@@ -525,7 +528,8 @@ void syevd_heevd_getError(const rocblas_handle handle,
                           Sh& hDres,
                           Ih& hinfo,
                           Ih& hinfoRes,
-                          double* max_err)
+                          double* max_err,
+                          double* max_errv)
 {
     constexpr bool COMPLEX = rocblas_is_complex<T>;
     using S = decltype(std::real(T{}));
@@ -608,6 +612,9 @@ void syevd_heevd_getError(const rocblas_handle handle,
                 // New matrix initialization
                 auto M
                     = HMatT::Wrap(A.data() + b * lda * n, lda, n)->block(BDescT().nrows(n).ncols(n));
+                /* std::cout << "--- Input matrix: " << std::endl; */
+                /* M.print(); */
+
                 auto U = HMatT::Wrap(hAres[b], lda, n)->block(BDescT().nrows(n).ncols(n));
                 auto d = HMatT::Convert(hDres[b], 1, n)->block(BDescT().nrows(1).ncols(n));
                 auto D = HMatT::Zeros(n, n).diag(d);
@@ -616,10 +623,13 @@ void syevd_heevd_getError(const rocblas_handle handle,
 
                 auto OE = U * adjoint(U) - HMatT::Eye(n, n);
                 err = OE.max_col_norm();
-                *max_err = err > *max_err ? err : *max_err;
+                /* std::cout << "--- Orthogonal error: " << err << std::endl; */
+                *max_errv = err > *max_err ? err : *max_err;
 
                 auto AE = M - U * D * adjoint(U);
                 err = AE.norm() / M.norm();
+                /* std::cout << "--- Residual error: " << err << std::endl; */
+                /* AE.print(); */
                 *max_err = err > *max_err ? err : *max_err;
 
                 /* // multiply A with each of the n eigenvectors and divide by corresponding */
@@ -797,7 +807,7 @@ void testing_syevd_heevd(Arguments& argus)
     size_t size_Ares = (argus.unit_check || argus.norm_check) ? size_A : 0;
     size_t size_Dres = (argus.unit_check || argus.norm_check) ? size_D : 0;
 
-    double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
+    double max_error = 0, max_ortho_error = 0, gpu_time_used = 0, cpu_time_used = 0;
 
     // check invalid sizes
     bool invalid_size = (n < 0 || lda < n || bc < 0);
@@ -883,7 +893,7 @@ void testing_syevd_heevd(Arguments& argus)
         {
             syevd_heevd_getError<STRIDED, T>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE, stE,
                                              dinfo, bc, hA, hAres, hD, hDres, hinfo, hinfoRes,
-                                             &max_error);
+                                             &max_error, &max_ortho_error);
         }
 
         // collect performance data
@@ -923,7 +933,7 @@ void testing_syevd_heevd(Arguments& argus)
         {
             syevd_heevd_getError<STRIDED, T>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE, stE,
                                              dinfo, bc, hA, hAres, hD, hDres, hinfo, hinfoRes,
-                                             &max_error);
+                                             &max_error, &max_ortho_error);
         }
 
         // collect performance data
@@ -939,7 +949,11 @@ void testing_syevd_heevd(Arguments& argus)
     // validate results for rocsolver-test
     // using 10 * n * machine_precision as tolerance
     if(argus.unit_check)
+    {
         ROCSOLVER_TEST_CHECK(T, max_error, 10 * n);
+        if(evect != rocblas_evect_none)
+            ROCSOLVER_TEST_CHECK(T, max_ortho_error, 10 * n);
+    }
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/clients/common/lapack/testing_syevd_heevd.hpp
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include "common/matrix_utils/matrix_utils.hpp"
 #include "common/misc/client_util.hpp"
 #include "common/misc/clientcommon.hpp"
 #include "common/misc/lapack_host_reference.hpp"
@@ -146,15 +147,15 @@ void testing_syevd_heevd_bad_arg()
 }
 
 template <bool CPU, bool GPU, typename T, typename Td, typename Th>
-void syevd_heevd_initData(const rocblas_handle handle,
-                          const rocblas_evect evect,
-                          const rocblas_int n,
-                          Td& dA,
-                          const rocblas_int lda,
-                          const rocblas_int bc,
-                          Th& hA,
-                          std::vector<T>& A,
-                          bool test = true)
+void syevd_heevd_default_initData(const rocblas_handle handle,
+                                  const rocblas_evect evect,
+                                  const rocblas_int n,
+                                  Td& dA,
+                                  const rocblas_int lda,
+                                  const rocblas_int bc,
+                                  Th& hA,
+                                  std::vector<T>& A,
+                                  bool test = true)
 {
     if(CPU)
     {
@@ -191,6 +192,171 @@ void syevd_heevd_initData(const rocblas_handle handle,
         // now copy to the GPU
         CHECK_HIP_ERROR(dA.transfer_from(hA));
     }
+}
+
+// Creates an `n` by `n` matrix `A` with the following eigenvalues:
+//
+// spectrum(A) = { l_i = ulp * i, for 1 <= i <= n - 1; l_n = 1 }
+//
+// where `ulp` is the smallest floating point number such that `1 + ulp > 1`.
+//
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void syevd_heevd_eig7_initData(const rocblas_handle handle,
+                               const rocblas_evect evect,
+                               const rocblas_int n,
+                               Td& dA,
+                               const rocblas_int lda,
+                               const rocblas_int bc,
+                               Th& hA,
+                               std::vector<T>& A,
+                               bool test = true)
+{
+    using S = decltype(std::real(T{}));
+
+    if(CPU)
+    {
+        rocblas_init<T>(hA, true);
+
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMat = HostMatrix<T, rocblas_int>;
+            using BDesc = typename HMat::BlockDescriptor;
+
+            auto hAw = HMat::Wrap(hA[b], lda, n);
+            if(hAw) // update matrix hA if n >= 1
+            {
+                auto eigs = std::numeric_limits<S>::epsilon() * HMat::FromRange(1, n - 1, n - 1);
+                eigs = cat(eigs, HMat::Ones(1, 1));
+                auto [Q, _] = qr((*hAw).block(BDesc().nrows(n).ncols(n)));
+                hAw->set_to_zero();
+
+                hAw->copy_data_from(Q * HMat::Zeros(n).diag(eigs) * adjoint(Q));
+            }
+
+            // make copy of original data to test vectors if required
+            if(test && evect == rocblas_evect_original)
+            {
+                for(rocblas_int i = 0; i < n; i++)
+                {
+                    for(rocblas_int j = 0; j < n; j++)
+                        A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
+                }
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+    }
+}
+
+// Creates an `n` by `n` Wilkinson matrix, which is formed as follows:
+//
+// 1. If `n` is even:
+//                      (   1          1            1          1   )
+// W_{2m + 1} = tridiag ( m   (m - 1) ... 0.5 0.5 ... (m - 1)    m )
+//                      (   1          1            1          1   )
+//
+// 2. If `n` is odd:
+//                      (   1          1         1          1   )
+// W_{2m + 1} = tridiag ( m   (m - 1) ... 1 0 1 ... (m - 1)   m )
+//                      (   1          1         1          1   )
+//
+// where `n = 2m + 1`.
+//
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void syevd_heevd_wilkinson_initData(const rocblas_handle handle,
+                                    const rocblas_evect evect,
+                                    const rocblas_int n,
+                                    Td& dA,
+                                    const rocblas_int lda,
+                                    const rocblas_int bc,
+                                    Th& hA,
+                                    std::vector<T>& A,
+                                    bool test = true)
+{
+    using S = decltype(std::real(T{}));
+
+    if(CPU)
+    {
+        rocblas_init<T>(hA, true);
+
+        // scale A to avoid singularities
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMat = HostMatrix<T, rocblas_int>;
+            using BDesc = typename HMat::BlockDescriptor;
+
+            auto hAw = HMat::Wrap(hA[b], lda, n);
+            if(hAw) // update matrix hA if n >= 1
+            {
+                S m = (n - 1) / S(2);
+                auto A = HMat::Zeros(n, n);
+                auto E = HMat::Ones(n - 1, 1);
+                auto D = HMat::Zeros(n, 1);
+
+                for(rocblas_int i = 0; i < n / 2; ++i)
+                {
+                    D[i] = m - i;
+                    D[n - 1 - i] = m - i;
+                }
+
+                A.diag(D);
+                A.sup_diag(E);
+                A.sub_diag(E);
+
+                hAw->set_to_zero();
+                hAw->copy_data_from(A);
+            }
+
+            // make copy of original data to test vectors if required
+            if(test && evect == rocblas_evect_original)
+            {
+                for(rocblas_int i = 0; i < n; i++)
+                {
+                    for(rocblas_int j = 0; j < n; j++)
+                        A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
+                }
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+    }
+}
+
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void syevd_heevd_initData(const rocblas_handle handle,
+                          const rocblas_evect evect,
+                          const rocblas_int n,
+                          Td& dA,
+                          const rocblas_int lda,
+                          const rocblas_int bc,
+                          Th& hA,
+                          std::vector<T>& A,
+                          bool test = true)
+{
+    if(std::getenv("SYEVD_TEST_EIG7") != nullptr)
+    {
+        syevd_heevd_eig7_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+    }
+    else if(std::getenv("SYEVD_TEST_WILKINSON") != nullptr)
+    {
+        syevd_heevd_wilkinson_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+    }
+    else
+    {
+        syevd_heevd_default_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+    }
+
+    return;
 }
 
 template <bool STRIDED, typename T, typename Sd, typename Td, typename Id, typename Sh, typename Th, typename Ih>
@@ -602,9 +768,9 @@ void testing_syevd_heevd(Arguments& argus)
     }
 
     // validate results for rocsolver-test
-    // using n * machine_precision as tolerance
+    // using 3 * n * machine_precision as tolerance
     if(argus.unit_check)
-        ROCSOLVER_TEST_CHECK(T, max_error, n);
+        ROCSOLVER_TEST_CHECK(T, max_error, 3 * n);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/clients/common/lapack/testing_syevd_heevd.hpp
@@ -173,10 +173,7 @@ void syevd_heevd_default_initData(const rocblas_handle handle,
                     else
                     {
                         hA[b][i + j * lda] -= 4;
-                        if constexpr(rocblas_is_complex<T>)
-                            hA[b][j + i * lda] = std::conj(hA[b][i + j * lda]);
-                        else
-                            hA[b][j + i * lda] = hA[b][i + j * lda];
+                        hA[b][j + i * lda] = sconj(hA[b][i + j * lda]);
                     }
                 }
             }

--- a/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/clients/common/lapack/testing_syevd_heevd.hpp
@@ -253,7 +253,7 @@ void syevd_heevd_eig7_initData(const rocblas_handle handle,
     }
 }
 
-// Creates an `n` by `n` Wilkinson matrix, which is formed as follows:
+// Creates an `n` by `n` tridiagonal, Wilkinson matrix, which is formed as follows:
 //
 // 1. If `n` is even:
 //                      (   1          1            1          1   )
@@ -332,6 +332,141 @@ void syevd_heevd_wilkinson_initData(const rocblas_handle handle,
     }
 }
 
+// Creates an `n` by `n` tridiagonal, Toeplitz matrix T of the following form:
+//
+//             (   1         1         1    )
+// T = tridiag ( 2   2 ... 2   2 ... 2    2 )
+//             (   1         1         1    )
+//
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void syevd_heevd_toeplitz_initData(const rocblas_handle handle,
+                                   const rocblas_evect evect,
+                                   const rocblas_int n,
+                                   Td& dA,
+                                   const rocblas_int lda,
+                                   const rocblas_int bc,
+                                   Th& hA,
+                                   std::vector<T>& A,
+                                   bool test = true)
+{
+    using S = decltype(std::real(T{}));
+
+    if(CPU)
+    {
+        rocblas_init<T>(hA, true);
+
+        // scale A to avoid singularities
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMat = HostMatrix<T, rocblas_int>;
+            using BDesc = typename HMat::BlockDescriptor;
+
+            auto hAw = HMat::Wrap(hA[b], lda, n);
+            if(hAw) // update matrix hA if n >= 1
+            {
+                auto A = HMat::Zeros(n, n);
+                auto E = HMat::Ones(n - 1, 1);
+                auto D = 2 * HMat::Ones(n, 1);
+
+                A.diag(D);
+                A.sup_diag(E);
+                A.sub_diag(E);
+
+                hAw->set_to_zero();
+                hAw->copy_data_from(A);
+            }
+
+            // make copy of original data to test vectors if required
+            if(test && evect == rocblas_evect_original)
+            {
+                for(rocblas_int i = 0; i < n; i++)
+                {
+                    for(rocblas_int j = 0; j < n; j++)
+                        A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
+                }
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+    }
+}
+
+// For `n > 1`, creates a symmetrized `n` by `n` tridiagonal, Clement matrix T of the following form:
+//
+//             (   sqrt(n - 1)   sqrt(2(n - 2))     sqrt((n - 2)2)   sqrt(n - 1)   )
+// T = tridiag ( 0             0                ...                0             0 )
+//             (   sqrt(n - 1)   sqrt(2(n - 2))     sqrt((n - 2)2)   sqrt(n - 1)   )
+//
+// were the `i-th` off-diagonal entry is sqrt(i(n - i)), 1 <= i < n.
+//
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void syevd_heevd_clement_initData(const rocblas_handle handle,
+                                  const rocblas_evect evect,
+                                  const rocblas_int n,
+                                  Td& dA,
+                                  const rocblas_int lda,
+                                  const rocblas_int bc,
+                                  Th& hA,
+                                  std::vector<T>& A,
+                                  bool test = true)
+{
+    using S = decltype(std::real(T{}));
+
+    if(CPU)
+    {
+        rocblas_init<T>(hA, true);
+
+        // scale A to avoid singularities
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMat = HostMatrix<T, rocblas_int>;
+            using BDesc = typename HMat::BlockDescriptor;
+
+            auto hAw = HMat::Wrap(hA[b], lda, n);
+            if(hAw) // update matrix hA if n >= 1
+            {
+                auto A = HMat::Zeros(n, n);
+                auto E = HMat::Ones(n - 1, 1);
+                auto D = HMat::Zeros(n, 1);
+
+                for(rocblas_int i = 1; i < n; ++i)
+                {
+                    E[i - 1] = std::sqrt(i * (n - i));
+                }
+
+                A.diag(D);
+                A.sup_diag(E);
+                A.sub_diag(E);
+
+                hAw->set_to_zero();
+                hAw->copy_data_from(A);
+            }
+
+            // make copy of original data to test vectors if required
+            if(test && evect == rocblas_evect_original)
+            {
+                for(rocblas_int i = 0; i < n; i++)
+                {
+                    for(rocblas_int j = 0; j < n; j++)
+                        A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
+                }
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+    }
+}
+
 template <bool CPU, bool GPU, typename T, typename Td, typename Th>
 void syevd_heevd_initData(const rocblas_handle handle,
                           const rocblas_evect evect,
@@ -350,6 +485,14 @@ void syevd_heevd_initData(const rocblas_handle handle,
     else if(std::getenv("SYEVD_TEST_WILKINSON") != nullptr)
     {
         syevd_heevd_wilkinson_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+    }
+    else if(std::getenv("SYEVD_TEST_CLEMENT") != nullptr)
+    {
+        syevd_heevd_clement_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+    }
+    else if(std::getenv("SYEVD_TEST_TOEPLITZ") != nullptr)
+    {
+        syevd_heevd_toeplitz_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
     }
     else
     {
@@ -768,9 +911,9 @@ void testing_syevd_heevd(Arguments& argus)
     }
 
     // validate results for rocsolver-test
-    // using 3 * n * machine_precision as tolerance
+    // using 10 * n * machine_precision as tolerance
     if(argus.unit_check)
-        ROCSOLVER_TEST_CHECK(T, max_error, 3 * n);
+        ROCSOLVER_TEST_CHECK(T, max_error, 10 * n);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/clients/common/lapack/testing_syevd_heevd.hpp
@@ -530,6 +530,12 @@ void syevd_heevd_getError(const rocblas_handle handle,
     constexpr bool COMPLEX = rocblas_is_complex<T>;
     using S = decltype(std::real(T{}));
 
+    using HMatT = HostMatrix<T, rocblas_int>;
+    using HMatS = HostMatrix<S, rocblas_int>;
+    using BDescT = typename HMatT::BlockDescriptor;
+    using BDescS = typename HMatS::BlockDescriptor;
+
+    int lgn = floor(log(n - 1) / log(2)) + 1;
     int sizeE, lwork;
     if(!COMPLEX)
     {
@@ -597,23 +603,40 @@ void syevd_heevd_getError(const rocblas_handle handle,
         {
             // both eigenvalues and eigenvectors needed; need to implicitly test
             // eigenvectors due to non-uniqueness of eigenvectors under scaling
-            if(hinfo[b][0] == 0)
+            if((hinfo[b][0] == 0) && (n > 0))
             {
-                // multiply A with each of the n eigenvectors and divide by corresponding
-                // eigenvalues
-                T alpha;
-                T beta = 0;
-                for(int j = 0; j < n; j++)
-                {
-                    alpha = T(1) / hDres[b][j];
-                    cpu_symv_hemv(uplo, n, alpha, A.data() + b * lda * n, lda, hAres[b] + j * lda,
-                                  1, beta, hA[b] + j * lda, 1);
-                }
+                // New matrix initialization
+                auto M
+                    = HMatT::Wrap(A.data() + b * lda * n, lda, n)->block(BDescT().nrows(n).ncols(n));
+                auto U = HMatT::Wrap(hAres[b], lda, n)->block(BDescT().nrows(n).ncols(n));
+                auto d = HMatT::Convert(hDres[b], 1, n)->block(BDescT().nrows(1).ncols(n));
+                auto D = HMatT::Zeros(n, n).diag(d);
+                /* std::cout << "--- Computed eigenvalues: " << std::endl; */
+                /* d.print(); */
 
-                // error is ||hA - hARes|| / ||hA||
-                // using frobenius norm
-                err = norm_error('F', n, n, lda, hA[b], hAres[b]);
+                auto OE = U * adjoint(U) - HMatT::Eye(n, n);
+                err = OE.max_col_norm();
                 *max_err = err > *max_err ? err : *max_err;
+
+                auto AE = M - U * D * adjoint(U);
+                err = AE.norm() / M.norm();
+                *max_err = err > *max_err ? err : *max_err;
+
+                /* // multiply A with each of the n eigenvectors and divide by corresponding */
+                /* // eigenvalues */
+                /* T alpha; */
+                /* T beta = 0; */
+                /* for(int j = 0; j < n; j++) */
+                /* { */
+                /*     alpha = T(1) / hDres[b][j]; */
+                /*     cpu_symv_hemv(uplo, n, alpha, A.data() + b * lda * n, lda, hAres[b] + j * lda, */
+                /*                   1, beta, hA[b] + j * lda, 1); */
+                /* } */
+
+                /* // error is ||hA - hARes|| / ||hA|| */
+                /* // using frobenius norm */
+                /* err = norm_error('F', n, n, lda, hA[b], hAres[b]); */
+                /* *max_err = err > *max_err ? err : *max_err; */
             }
         }
     }

--- a/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/clients/common/lapack/testing_syevd_heevd.hpp
@@ -534,10 +534,8 @@ void syevd_heevd_getError(const rocblas_handle handle,
     constexpr bool COMPLEX = rocblas_is_complex<T>;
     using S = decltype(std::real(T{}));
 
-    using HMatT = HostMatrix<T, rocblas_int>;
-    using HMatS = HostMatrix<S, rocblas_int>;
-    using BDescT = typename HMatT::BlockDescriptor;
-    using BDescS = typename HMatS::BlockDescriptor;
+    using HMat = HostMatrix<T, rocblas_int>;
+    using BDesc = typename HMat::BlockDescriptor;
 
     int lgn = floor(log(n - 1) / log(2)) + 1;
     int sizeE, lwork;
@@ -595,7 +593,7 @@ void syevd_heevd_getError(const rocblas_handle handle,
     {
         if(evect != rocblas_evect_original)
         {
-            // only eigenvalues needed; can compare with LAPACK
+            // only eigenvalues needed; compare with LAPACK
 
             // error is ||hD - hDRes|| / ||hD||
             // using frobenius norm
@@ -605,48 +603,29 @@ void syevd_heevd_getError(const rocblas_handle handle,
         }
         else
         {
-            // both eigenvalues and eigenvectors needed; need to implicitly test
-            // eigenvectors due to non-uniqueness of eigenvectors under scaling
+            // both eigenvalues and eigenvectors needed; compare with input
+            // matrix
             if((hinfo[b][0] == 0) && (n > 0))
             {
-                // New matrix initialization
-                auto M
-                    = HMatT::Wrap(A.data() + b * lda * n, lda, n)->block(BDescT().nrows(n).ncols(n));
-                /* std::cout << "--- Input matrix: " << std::endl; */
-                /* M.print(); */
+                // Input matrix
+                auto M = HMat::Wrap(A.data() + b * lda * n, lda, n)->block(BDesc().nrows(n).ncols(n));
 
-                auto U = HMatT::Wrap(hAres[b], lda, n)->block(BDescT().nrows(n).ncols(n));
-                auto d = HMatT::Convert(hDres[b], 1, n)->block(BDescT().nrows(1).ncols(n));
-                auto D = HMatT::Zeros(n, n).diag(d);
-                /* std::cout << "--- Computed eigenvalues: " << std::endl; */
-                /* d.print(); */
+                // Computed eigenvectors
+                auto U = HMat::Wrap(hAres[b], lda, n)->block(BDesc().nrows(n).ncols(n));
+                // Computed eigenvalues
+                auto d = HMat::Convert(hDres[b], 1, n)->block(BDesc().nrows(1).ncols(n));
+                // Diagonal matrix of size n by n with computed eigenvalues
+                auto D = HMat::Zeros(n, n).diag(d);
 
-                auto OE = U * adjoint(U) - HMatT::Eye(n, n);
+                // Orthogonal error
+                auto OE = U * adjoint(U) - HMat::Eye(n, n);
                 err = OE.max_col_norm();
-                /* std::cout << "--- Orthogonal error: " << err << std::endl; */
                 *max_errv = err > *max_err ? err : *max_err;
 
-                auto AE = M - U * D * adjoint(U);
-                err = AE.norm() / M.norm();
-                /* std::cout << "--- Residual error: " << err << std::endl; */
-                /* AE.print(); */
+                // Residual error
+                auto RE = M - U * D * adjoint(U);
+                err = RE.norm() / M.norm();
                 *max_err = err > *max_err ? err : *max_err;
-
-                /* // multiply A with each of the n eigenvectors and divide by corresponding */
-                /* // eigenvalues */
-                /* T alpha; */
-                /* T beta = 0; */
-                /* for(int j = 0; j < n; j++) */
-                /* { */
-                /*     alpha = T(1) / hDres[b][j]; */
-                /*     cpu_symv_hemv(uplo, n, alpha, A.data() + b * lda * n, lda, hAres[b] + j * lda, */
-                /*                   1, beta, hA[b] + j * lda, 1); */
-                /* } */
-
-                /* // error is ||hA - hARes|| / ||hA|| */
-                /* // using frobenius norm */
-                /* err = norm_error('F', n, n, lda, hA[b], hAres[b]); */
-                /* *max_err = err > *max_err ? err : *max_err; */
             }
         }
     }


### PR DESCRIPTION
This PR adds several classes of input matrices to be used in syevd and stedc tests and benchmarks, most importantly:
    1. Wilkinson matrices;
    2. Symmetrized Clement matrices;
    3. Toeplitz (1-2-1) matrices;
    4. Matrices with the following eigenvalue distribution: { l_i = ulp*i, 1 <= i <= n - 1; l_n = 1 }.