### PR TITLE
Allow rocblas_DIR env var to be unset on Windows.

### DIFF
--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -197,11 +197,15 @@ if(WIN32)
       ARGS -E copy ${file_i} $<TARGET_FILE_DIR:rocsolver-test>
     )
   endforeach()
-  add_custom_command(TARGET rocsolver-test
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND}
-    ARGS -E copy_directory $ENV{rocblas_DIR}/bin/rocblas/library $<TARGET_FILE_DIR:rocsolver-test>/library
-  )
+  if(DEFINED ENV{rocblas_DIR})
+    add_custom_command(TARGET rocsolver-test
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND}
+      ARGS -E copy_directory $ENV{rocblas_DIR}/bin/rocblas/library $<TARGET_FILE_DIR:rocsolver-test>/library
+    )
+  else()
+    message(WARNING "rocblas_DIR not set. rocBLAS Tensile runtime kernels will not be copied to client staging directory (insitu testing affected).")
+  endif()
 endif()
 
 target_link_libraries(rocsolver-test PRIVATE


### PR DESCRIPTION
This is the same style of patch as https://github.com/ROCm/hipBLAS/pull/1020.

When built from https://github.com/ROCm/TheRock, we propagate dependencies through standard CMake project discovery, not environment variables, so this environment variable is not set. When the variable is unset, this code tried to copy from a non-existent `/bin/rocblas/library` directory.

TheRock also populates this `library/` folder in the dist directory through a different mechanism, so skipping this code path is safe and still allows tests to run:
```
D:\projects\TheRock\build\math-libs\BLAS\rocSOLVER\dist\bin (users/marbre/rocsolver-clients -> upstream)
λ rocsolver-test.exe
rocSOLVER version 3.30.0.3c2c234-dirty (with rocBLAS 5.1.0.924139f2)
Query device success: there are 2 devices
-------------------------------------------------------------------------------
Device ID 0 : AMD Radeon PRO W7900 Dual Slot
with 48.3 GB memory, max. SCLK 1760 MHz, max. MCLK 1125 MHz, compute capability 11.0
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 32
-------------------------------------------------------------------------------
Device ID 1 : AMD Radeon PRO W7900 Dual Slot
with 48.3 GB memory, max. SCLK 1760 MHz, max. MCLK 1125 MHz, compute capability 11.0
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 32
-------------------------------------------------------------------------------
[==========] Running 67833 tests from 320 test suites.
[----------] Global test environment set-up.
[----------] 17 tests from checkin_misc_LOGGING
[ RUN      ] checkin_misc_LOGGING.rocsolver_log_path
[       OK ] checkin_misc_LOGGING.rocsolver_log_path (78 ms)
...
```