### PR TITLE
Use HIP events to instrument SYEVD performance

### DIFF
--- a/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/clients/common/lapack/testing_syevd_heevd.hpp
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include "common/matrix_utils/matrix_utils.hpp"
 #include "common/misc/client_util.hpp"
 #include "common/misc/clientcommon.hpp"
 #include "common/misc/lapack_host_reference.hpp"
@@ -146,15 +147,15 @@ void testing_syevd_heevd_bad_arg()
 }
 
 template <bool CPU, bool GPU, typename T, typename Td, typename Th>
-void syevd_heevd_initData(const rocblas_handle handle,
-                          const rocblas_evect evect,
-                          const rocblas_int n,
-                          Td& dA,
-                          const rocblas_int lda,
-                          const rocblas_int bc,
-                          Th& hA,
-                          std::vector<T>& A,
-                          bool test = true)
+void syevd_heevd_default_initData(const rocblas_handle handle,
+                                  const rocblas_evect evect,
+                                  const rocblas_int n,
+                                  Td& dA,
+                                  const rocblas_int lda,
+                                  const rocblas_int bc,
+                                  Th& hA,
+                                  std::vector<T>& A,
+                                  bool test = true)
 {
     if(CPU)
     {
@@ -191,6 +192,171 @@ void syevd_heevd_initData(const rocblas_handle handle,
         // now copy to the GPU
         CHECK_HIP_ERROR(dA.transfer_from(hA));
     }
+}
+
+// Creates an `n` by `n` matrix `A` with the following eigenvalues:
+//
+// spectrum(A) = { l_i = ulp * i, for 1 <= i <= n - 1; l_n = 1 }
+//
+// where `ulp` is the smallest floating point number such that `1 + ulp > 1`.
+//
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void syevd_heevd_eig7_initData(const rocblas_handle handle,
+                               const rocblas_evect evect,
+                               const rocblas_int n,
+                               Td& dA,
+                               const rocblas_int lda,
+                               const rocblas_int bc,
+                               Th& hA,
+                               std::vector<T>& A,
+                               bool test = true)
+{
+    using S = decltype(std::real(T{}));
+
+    if(CPU)
+    {
+        rocblas_init<T>(hA, true);
+
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMat = HostMatrix<T, rocblas_int>;
+            using BDesc = typename HMat::BlockDescriptor;
+
+            auto hAw = HMat::Wrap(hA[b], lda, n);
+            if(hAw) // update matrix hA if n >= 1
+            {
+                auto eigs = std::numeric_limits<S>::epsilon() * HMat::FromRange(1, n - 1, n - 1);
+                eigs = cat(eigs, HMat::Ones(1, 1));
+                auto [Q, _] = qr((*hAw).block(BDesc().nrows(n).ncols(n)));
+                hAw->set_to_zero();
+
+                hAw->copy_data_from(Q * HMat::Zeros(n).diag(eigs) * adjoint(Q));
+            }
+
+            // make copy of original data to test vectors if required
+            if(test && evect == rocblas_evect_original)
+            {
+                for(rocblas_int i = 0; i < n; i++)
+                {
+                    for(rocblas_int j = 0; j < n; j++)
+                        A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
+                }
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+    }
+}
+
+// Creates an `n` by `n` Wilkinson matrix, which is formed as follows:
+//
+// 1. If `n` is even:
+//                      (   1          1            1          1   )
+// W_{2m + 1} = tridiag ( m   (m - 1) ... 0.5 0.5 ... (m - 1)    m )
+//                      (   1          1            1          1   )
+//
+// 2. If `n` is odd:
+//                      (   1          1         1          1   )
+// W_{2m + 1} = tridiag ( m   (m - 1) ... 1 0 1 ... (m - 1)   m )
+//                      (   1          1         1          1   )
+//
+// where `n = 2m + 1`.
+//
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void syevd_heevd_wilkinson_initData(const rocblas_handle handle,
+                                    const rocblas_evect evect,
+                                    const rocblas_int n,
+                                    Td& dA,
+                                    const rocblas_int lda,
+                                    const rocblas_int bc,
+                                    Th& hA,
+                                    std::vector<T>& A,
+                                    bool test = true)
+{
+    using S = decltype(std::real(T{}));
+
+    if(CPU)
+    {
+        rocblas_init<T>(hA, true);
+
+        // scale A to avoid singularities
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMat = HostMatrix<T, rocblas_int>;
+            using BDesc = typename HMat::BlockDescriptor;
+
+            auto hAw = HMat::Wrap(hA[b], lda, n);
+            if(hAw) // update matrix hA if n >= 1
+            {
+                S m = (n - 1) / S(2);
+                auto A = HMat::Zeros(n, n);
+                auto E = HMat::Ones(n - 1, 1);
+                auto D = HMat::Zeros(n, 1);
+
+                for(rocblas_int i = 0; i < n / 2; ++i)
+                {
+                    D[i] = m - i;
+                    D[n - 1 - i] = m - i;
+                }
+
+                A.diag(D);
+                A.sup_diag(E);
+                A.sub_diag(E);
+
+                hAw->set_to_zero();
+                hAw->copy_data_from(A);
+            }
+
+            // make copy of original data to test vectors if required
+            if(test && evect == rocblas_evect_original)
+            {
+                for(rocblas_int i = 0; i < n; i++)
+                {
+                    for(rocblas_int j = 0; j < n; j++)
+                        A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
+                }
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+    }
+}
+
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void syevd_heevd_initData(const rocblas_handle handle,
+                          const rocblas_evect evect,
+                          const rocblas_int n,
+                          Td& dA,
+                          const rocblas_int lda,
+                          const rocblas_int bc,
+                          Th& hA,
+                          std::vector<T>& A,
+                          bool test = true)
+{
+    if(std::getenv("SYEVD_TEST_EIG7") != nullptr)
+    {
+        syevd_heevd_eig7_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+    }
+    else if(std::getenv("SYEVD_TEST_WILKINSON") != nullptr)
+    {
+        syevd_heevd_wilkinson_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+    }
+    else
+    {
+        syevd_heevd_default_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+    }
+
+    return;
 }
 
 template <bool STRIDED, typename T, typename Sd, typename Td, typename Id, typename Sh, typename Th, typename Ih>
@@ -602,9 +768,9 @@ void testing_syevd_heevd(Arguments& argus)
     }
 
     // validate results for rocsolver-test
-    // using n * machine_precision as tolerance
+    // using 3 * n * machine_precision as tolerance
     if(argus.unit_check)
-        ROCSOLVER_TEST_CHECK(T, max_error, n);
+        ROCSOLVER_TEST_CHECK(T, max_error, 3 * n);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/clients/common/lapack/testing_syevd_heevd.hpp
@@ -253,7 +253,7 @@ void syevd_heevd_eig7_initData(const rocblas_handle handle,
     }
 }
 
-// Creates an `n` by `n` Wilkinson matrix, which is formed as follows:
+// Creates an `n` by `n` tridiagonal, Wilkinson matrix, which is formed as follows:
 //
 // 1. If `n` is even:
 //                      (   1          1            1          1   )
@@ -332,6 +332,141 @@ void syevd_heevd_wilkinson_initData(const rocblas_handle handle,
     }
 }
 
+// Creates an `n` by `n` tridiagonal, Toeplitz matrix T of the following form:
+//
+//             (   1         1         1    )
+// T = tridiag ( 2   2 ... 2   2 ... 2    2 )
+//             (   1         1         1    )
+//
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void syevd_heevd_toeplitz_initData(const rocblas_handle handle,
+                                   const rocblas_evect evect,
+                                   const rocblas_int n,
+                                   Td& dA,
+                                   const rocblas_int lda,
+                                   const rocblas_int bc,
+                                   Th& hA,
+                                   std::vector<T>& A,
+                                   bool test = true)
+{
+    using S = decltype(std::real(T{}));
+
+    if(CPU)
+    {
+        rocblas_init<T>(hA, true);
+
+        // scale A to avoid singularities
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMat = HostMatrix<T, rocblas_int>;
+            using BDesc = typename HMat::BlockDescriptor;
+
+            auto hAw = HMat::Wrap(hA[b], lda, n);
+            if(hAw) // update matrix hA if n >= 1
+            {
+                auto A = HMat::Zeros(n, n);
+                auto E = HMat::Ones(n - 1, 1);
+                auto D = 2 * HMat::Ones(n, 1);
+
+                A.diag(D);
+                A.sup_diag(E);
+                A.sub_diag(E);
+
+                hAw->set_to_zero();
+                hAw->copy_data_from(A);
+            }
+
+            // make copy of original data to test vectors if required
+            if(test && evect == rocblas_evect_original)
+            {
+                for(rocblas_int i = 0; i < n; i++)
+                {
+                    for(rocblas_int j = 0; j < n; j++)
+                        A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
+                }
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+    }
+}
+
+// For `n > 1`, creates a symmetrized `n` by `n` tridiagonal, Clement matrix T of the following form:
+//
+//             (   sqrt(n - 1)   sqrt(2(n - 2))     sqrt((n - 2)2)   sqrt(n - 1)   )
+// T = tridiag ( 0             0                ...                0             0 )
+//             (   sqrt(n - 1)   sqrt(2(n - 2))     sqrt((n - 2)2)   sqrt(n - 1)   )
+//
+// were the `i-th` off-diagonal entry is sqrt(i(n - i)), 1 <= i < n.
+//
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void syevd_heevd_clement_initData(const rocblas_handle handle,
+                                  const rocblas_evect evect,
+                                  const rocblas_int n,
+                                  Td& dA,
+                                  const rocblas_int lda,
+                                  const rocblas_int bc,
+                                  Th& hA,
+                                  std::vector<T>& A,
+                                  bool test = true)
+{
+    using S = decltype(std::real(T{}));
+
+    if(CPU)
+    {
+        rocblas_init<T>(hA, true);
+
+        // scale A to avoid singularities
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMat = HostMatrix<T, rocblas_int>;
+            using BDesc = typename HMat::BlockDescriptor;
+
+            auto hAw = HMat::Wrap(hA[b], lda, n);
+            if(hAw) // update matrix hA if n >= 1
+            {
+                auto A = HMat::Zeros(n, n);
+                auto E = HMat::Ones(n - 1, 1);
+                auto D = HMat::Zeros(n, 1);
+
+                for(rocblas_int i = 1; i < n; ++i)
+                {
+                    E[i - 1] = std::sqrt(i * (n - i));
+                }
+
+                A.diag(D);
+                A.sup_diag(E);
+                A.sub_diag(E);
+
+                hAw->set_to_zero();
+                hAw->copy_data_from(A);
+            }
+
+            // make copy of original data to test vectors if required
+            if(test && evect == rocblas_evect_original)
+            {
+                for(rocblas_int i = 0; i < n; i++)
+                {
+                    for(rocblas_int j = 0; j < n; j++)
+                        A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
+                }
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+    }
+}
+
 template <bool CPU, bool GPU, typename T, typename Td, typename Th>
 void syevd_heevd_initData(const rocblas_handle handle,
                           const rocblas_evect evect,
@@ -350,6 +485,14 @@ void syevd_heevd_initData(const rocblas_handle handle,
     else if(std::getenv("SYEVD_TEST_WILKINSON") != nullptr)
     {
         syevd_heevd_wilkinson_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+    }
+    else if(std::getenv("SYEVD_TEST_CLEMENT") != nullptr)
+    {
+        syevd_heevd_clement_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+    }
+    else if(std::getenv("SYEVD_TEST_TOEPLITZ") != nullptr)
+    {
+        syevd_heevd_toeplitz_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
     }
     else
     {
@@ -768,9 +911,9 @@ void testing_syevd_heevd(Arguments& argus)
     }
 
     // validate results for rocsolver-test
-    // using 3 * n * machine_precision as tolerance
+    // using 10 * n * machine_precision as tolerance
     if(argus.unit_check)
-        ROCSOLVER_TEST_CHECK(T, max_error, 3 * n);
+        ROCSOLVER_TEST_CHECK(T, max_error, 10 * n);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -2328,6 +2328,12 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
     // otherwise use divide and conquer algorithm:
     else
     {
+        hipEvent_t setup_events[5];
+
+        for(int i = 0; i < 5; i++)
+            HIP_CHECK(hipEventCreate(&setup_events[i]));
+
+
         // initialize temporary array for vector updates
         size_t size_tempgemm = sizeof(S) * 2 * n * n * batch_count;
         HIP_CHECK(hipMemsetAsync((void*)tempgemm, 0, size_tempgemm, stream));
@@ -2363,18 +2369,23 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             ldv = (rocblas_int)(sizeof(T) / sizeof(S)) * ldc;
             strideV = (rocblas_int)(sizeof(T) / sizeof(S)) * strideC;
         }
+
+        HIP_CHECK(hipEventRecord(setup_events[0], stream));
         ROCSOLVER_LAUNCH_KERNEL(init_ident<S>, dim3(blocksn, blocksn, batch_count), dim3(BS2, BS2),
                                 0, stream, n, n, V, 0, ldv, strideV);
-
+        HIP_CHECK(hipEventRecord(setup_events[1]));
+        
         // find independent split blocks in matrix
         ROCSOLVER_LAUNCH_KERNEL(stedc_split, dim3(batch_count), dim3(1), 0, stream, n, D + shiftD,
                                 strideD, E + shiftE, strideE, splits_map, eps);
+        HIP_CHECK(hipEventRecord(setup_events[2], stream));
 
         // 1. divide phase
         //-----------------------------
         ROCSOLVER_LAUNCH_KERNEL((stedc_divide_kernel<rocsolver_stedc_mode_qr, S>),
                                 dim3(batch_count), dim3(STEDC_BDIM), 0, stream, n, D + shiftD,
                                 strideD, E + shiftE, strideE, splits);
+        HIP_CHECK(hipEventRecord(setup_events[3], stream));
 
         // 2. solve phase
         //-----------------------------
@@ -2382,23 +2393,43 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                 dim3(maxblks, STEDC_NUM_SPLIT_BLKS, batch_count), dim3(1), 0,
                                 stream, n, D + shiftD, strideD, E + shiftE, strideE, V, 0, ldv,
                                 strideV, info, (S*)work_stack, splits, eps, ssfmin, ssfmax);
-
+        HIP_CHECK(hipEventRecord(setup_events[4], stream));
+                    
         // 3. merge phase
         //----------------
         size_t lmemsize1 = sizeof(S) * 2 * STEDC_BDIM;
         size_t lmemsize3 = sizeof(S) * STEDC_BDIM;
         rocblas_int numgrps3 = ((n - 1) / maxblks + 1) * maxblks;
 
+        HIP_CHECK(hipStreamSynchronize(stream));
+
+        float elapsed[4];
+        for(int i = 0; i < 4; i++)
+            HIP_CHECK(hipEventElapsedTime(&elapsed[i], setup_events[i], setup_events[i+1]));
+        for(int i = 0; i < 5; i++)
+            HIP_CHECK(hipEventDestroy(setup_events[i]));
+
+        printf("STEDC Kernel Timings:\n"
+               "\tinit_ident         : %f\n"
+               "\tstedc_split        : %f\n"
+               "\tstedc_divide_kernel: %f\n"
+               "\tstedc_solve_kernel : %f\n",
+                elapsed[0], elapsed[1], elapsed[2], elapsed[3]);
         // launch merge for level k
         // TODO: using max number of levels for now. Kernels return immediately when surpassing
         // the actual number of levels in the split block. We should explore if synchronizing
         // to copy back the actual number of levels makes any difference.
         // TODO: the code computing the context of the level (first part of each kernel) could be
         // reused.
+        hipEvent_t merge_events[6];            
+        for(int i = 0; i < 6; i++)
+            HIP_CHECK(hipEventCreate(&merge_events[i]));
+
         for(rocblas_int k = 0; k < maxlevs; ++k)
         {
             // a. prepare secular equations
             rocblas_int numgrps2 = 1 << (maxlevs - 1 - k);
+            HIP_CHECK(hipEventRecord(merge_events[0], stream));
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_kernel<rocsolver_stedc_mode_qr, S>),
                                     dim3(numgrps2, STEDC_NUM_SPLIT_BLKS, batch_count),
                                     dim3(STEDC_BDIM), lmemsize1, stream, k, n, D + shiftD, strideD,
@@ -2406,18 +2437,21 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     eps);
 
             // b. solve to find merged eigen values
+            HIP_CHECK(hipEventRecord(merge_events[1], stream));
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_kernel<rocsolver_stedc_mode_qr, S>),
                                     dim3(numgrps2, STEDC_NUM_SPLIT_BLKS, batch_count),
                                     dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD, strideD,
                                     E + shiftE, strideE, tmpz, tempgemm, splits, eps, ssfmin, ssfmax);
 
             // c. find merged eigen vectors
+            HIP_CHECK(hipEventRecord(merge_events[2], stream));
             ROCSOLVER_LAUNCH_KERNEL(
                 (stedc_mergeVectors_kernel<rocsolver_stedc_mode_qr, STEDC_EXTERNAL_GEMM, S>),
                 dim3(numgrps3, STEDC_NUM_SPLIT_BLKS, batch_count), dim3(STEDC_BDIM), lmemsize3,
                 stream, k, n, D + shiftD, strideD, E + shiftE, strideE, V, 0, ldv, strideV, tmpz,
                 tempgemm, splits);
 
+            HIP_CHECK(hipEventRecord(merge_events[3], stream));
             if(STEDC_EXTERNAL_GEMM)
             {
                 // using external gemms with padded matrices to do the vector update
@@ -2431,11 +2465,32 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             }
 
             // d. update level
+            HIP_CHECK(hipEventRecord(merge_events[4], stream));
+
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeUpdate_kernel<rocsolver_stedc_mode_qr, S>),
                                     dim3(numgrps3, STEDC_NUM_SPLIT_BLKS, batch_count),
                                     dim3(STEDC_BDIM), lmemsize3, stream, k, n, D + shiftD, strideD,
                                     V, 0, ldv, strideV, tmpz, tempgemm, splits);
+            
+            HIP_CHECK(hipEventRecord(merge_events[5], stream));
+
+            HIP_CHECK(hipStreamSynchronize(stream));
+            float merge_elapsed[5];
+
+            for(int i = 0; i < 5; i++)
+                HIP_CHECK(hipEventElapsedTime(&merge_elapsed[i], merge_events[i], merge_events[i+1]));
+            
+            printf("\tmergePrepare       : %f\n"
+                   "\tmergeValues        : %f\n"
+                   "\tmergeVectors       : %f\n"
+                   "\tGEMM               : %f\n"
+                   "\tmergeUpdate        : %f\n",
+                merge_elapsed[0], merge_elapsed[1], merge_elapsed[2], merge_elapsed[3], merge_elapsed[4]);
+            fflush(stdout);
         }
+
+        for(int i = 0; i < 6; i++)
+            HIP_CHECK(hipEventDestroy(merge_events[i]));
 
         // 4. update and sort
         //----------------------
@@ -2465,9 +2520,20 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
 
         // finally sort eigenvalues and eigenvectors
         auto const nblocks = batch_count;
+        hipEvent_t event_sort_start, event_sort_finish;
+        HIP_CHECK(hipEventCreate(&event_sort_start));
+        HIP_CHECK(hipEventCreate(&event_sort_finish));
+
+        HIP_CHECK(hipEventRecord(event_sort_start, stream));
         ROCSOLVER_LAUNCH_KERNEL((stedc_sort<T>), dim3(1, 1, nblocks), dim3(BS1), 0, stream, n,
                                 D + shiftD, strideD, C, shiftC, ldc, strideC, batch_count,
                                 splits_map);
+        HIP_CHECK(hipEventRecord(event_sort_finish, stream));
+        HIP_CHECK(hipStreamSynchronize(stream));
+        float elapsed_sort;
+        HIP_CHECK(hipEventElapsedTime(&elapsed_sort, event_sort_start, event_sort_finish));
+
+        printf("\tstedc_sort         : %f\n", elapsed_sort);
 
         rocblas_set_pointer_mode(handle, old_mode);
     }

--- a/library/src/lapack/roclapack_syevd_heevd.hpp
+++ b/library/src/lapack/roclapack_syevd_heevd.hpp
@@ -167,6 +167,12 @@ rocblas_status rocsolver_syevd_heevd_template(rocblas_handle handle,
     dim3 gridReset(blocksReset, 1, 1);
     dim3 threads(BS1, 1, 1);
 
+    hipEvent_t events[4];
+
+    for(int i = 0; i < 4; i++)
+        HIP_CHECK(hipEventCreate(&events[i]));
+
+
     // info = 0
     ROCSOLVER_LAUNCH_KERNEL(reset_info, gridReset, threads, 0, stream, info, batch_count, 0);
 
@@ -185,6 +191,7 @@ rocblas_status rocsolver_syevd_heevd_template(rocblas_handle handle,
     // TODO: Scale the matrix
 
     // reduce A to tridiagonal form
+    HIP_CHECK(hipEventRecord(events[0], stream));
     rocsolver_sytrd_hetrd_template<BATCHED>(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,
                                             strideE, tau, n, batch_count, scalars, (T*)work1,
                                             (T*)work2, tmptau_W, workArr, false);
@@ -202,13 +209,15 @@ rocblas_status rocsolver_syevd_heevd_template(rocblas_handle handle,
         const rocblas_int ldw = n;
         const rocblas_stride strideW = n * n;
 
-        rocsolver_stedc_template<false, ISBATCHED, T>(
+        HIP_CHECK(hipEventRecord(events[1], stream));
+        ROCBLAS_CHECK(rocsolver_stedc_template<false, ISBATCHED, T>(
             handle, rocblas_evect_tridiagonal, n, D, 0, strideD, E, 0, strideE, tmptau_W, 0, ldw,
-            strideW, info, batch_count, work3, (S*)work2, (S*)work1, tmpz, splits, (S**)workArr);
+            strideW, info, batch_count, work3, (S*)work2, (S*)work1, tmpz, splits, (S**)workArr));
 
         // update the eigenvectors (if applicable)
         if(evect == rocblas_evect_original)
         {
+            HIP_CHECK(hipEventRecord(events[2], stream));
             rocsolver_ormtr_unmtr_template<BATCHED, STRIDED>(
                 handle, rocblas_side_left, uplo, rocblas_operation_none, n, n, A, shiftA, lda,
                 strideA, tau, n, tmptau_W, 0, ldw, strideW, batch_count, scalars, (T*)work2,
@@ -219,8 +228,19 @@ rocblas_status rocsolver_syevd_heevd_template(rocblas_handle handle,
             ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(copyblocks, copyblocks, batch_count),
                                     dim3(BS2, BS2), 0, stream, n, n, tmptau_W, 0, ldw, strideW, A,
                                     shiftA, lda, strideA);
+            HIP_CHECK(hipEventRecord(events[3], stream));
+            HIP_CHECK(hipStreamSynchronize(stream));
+
+            float elapsed[3];
+            for(int i = 0; i < 3; i++)
+                HIP_CHECK(hipEventElapsedTime(&elapsed[i], events[i], events[i+1]));
+
+            printf("\nSYTRD: %f\nSTEDC: %f\nORMTR: %f\n", elapsed[0], elapsed[1], elapsed[2]);
+            printf("------------------\n\n");
         }
     }
+    for(int i = 0; i < 3; i++)
+        HIP_CHECK(hipEventDestroy(events[i]));
 
     return rocblas_status_success;
 }


### PR DESCRIPTION
Use hipEventElapsedTime() to get GPU timing information for sections of SYEVD.  This is not intended to be merged, as the current implementation requires hipStreamSynchronize() and therefore isn't graph safe.  It also isn't very robust.