### PR TITLE
Speedup stedc_mergeValues_kernel

### DIFF
--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1288,6 +1288,154 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     }
 }
 
+
+template <typename S>
+void __device__ inline sort_tmpd_zz(const rocblas_int dd,
+                                    const rocblas_int iam,
+                                    const rocblas_int bdm,
+                                    S* tmpd,
+                                    S* zz,
+                                    rocblas_int* per)
+{
+    // Order the elements in tmpd and zz using a simple parallel selection/bubble sort.
+    // This will allow us to find initial intervals for eigenvalue guesses
+    for(int i = 0; i < dd; i++)
+    {
+        for(int j = 2 * iam + i % 2; j < dd - 1; j += 2 * bdm)
+        {
+            if(tmpd[j] > tmpd[j + 1])
+            {
+                swap(tmpd[j], tmpd[j + 1]);
+                swap(zz[j], zz[j + 1]);
+                swap(per[j], per[j + 1]);
+            }
+        }
+        __syncthreads();
+    }
+}
+
+template <typename S>
+void __device__ inline copy_d_ev(const rocblas_int dd,
+                                 const rocblas_int iam,
+                                 const rocblas_int bdm,
+                                 const rocblas_int sz,
+                                 const rocblas_int n,
+                                 S* tmpd,
+                                 S* ev,
+                                 S* diag)
+{
+    // make dd copies of the non-deflated ordered diagonal elements
+    // (i.e. the poles of the secular eqn) so that the distances to the
+    // eigenvalues (D - lambda_i) are updated while computing each eigenvalue.
+    // This will prevent collapses and division by zero when an eigenvalue
+    // is too close to a pole.
+    for(int i = iam; i < dd; i += bdm)
+    {
+        for(int j = i + n; j < i + sz * n; j += n)
+            tmpd[j] = tmpd[i];
+    }
+
+    // finally copy over all diagonal elements in ev. ev will be overwritten
+    // by the new computed eigenvalues of the merged block
+    for(int i = iam; i < sz; i += bdm)
+        ev[i] = diag[i];
+}
+
+template <typename S>
+void __device__ inline solve_seq_eqns(const rocblas_int dd,
+                                      const rocblas_int iam,
+                                      const rocblas_int bdm,
+                                      const rocblas_int sz,
+                                      const rocblas_int n,
+                                      const S p,
+                                      const S eps,
+                                      const S ssfmin,
+                                      const S ssfmax,
+                                      const rocblas_int* mask,
+                                            S* tmpd,
+                                            S* ev,
+                                      const S* zz)
+{
+    /* ----------------------------------------------------------------- */
+
+    // 3e. Solve secular eqns, i.e. find the dd zeros
+    // corresponding to non-deflated new eigenvalues of the merged block
+    /* ----------------------------------------------------------------- */
+    // each thread will find a different zero in parallel
+    S a, b;
+    for(int j = iam; j < sz; j += bdm)
+    {
+        if(mask[j] == 1)
+        {
+            // find position in the ordered array
+            S valf = p < 0 ? -ev[j] : ev[j];
+            int count = dd, cc = 0;
+            while(count > 0)
+            {
+                auto step = count / 2;
+                auto it = cc + step;
+                if(tmpd[it + j * n] < valf)
+                {
+                    cc = ++it;
+                    count -= step + 1;
+                }
+                else
+                    count = step;
+            }
+
+            // computed zero will overwrite 'ev' at the corresponding position.
+            // 'tmpd' will be updated with the distances D - lambda_i.
+            // deflated values are not changed.
+            rocblas_int linfo;
+
+#if defined(ROCSOLVER_USE_REFERENCE_SECULAR_EQUATIONS_SOLVER)
+            linfo = slaed4(dd, cc, tmpd + j * n, zz, std::abs(p), ev[j]);
+#else
+            if(cc == dd - 1)
+                linfo = seq_solve_ext(dd, tmpd + j * n, zz, (p < 0 ? -p : p), ev + j, eps, ssfmin,
+                                      ssfmax);
+            else
+                linfo = seq_solve(dd, tmpd + j * n, zz, (p < 0 ? -p : p), cc, ev + j, eps, ssfmin,
+                                  ssfmax);
+#endif
+
+            if(p < 0)
+                ev[j] *= -1;
+        }
+    }
+}
+
+
+template <typename S>
+void __device__ inline rescale_z(const rocblas_int dd,
+                                 const rocblas_int iam,
+                                 const rocblas_int bdm,
+                                 const rocblas_int sz,
+                                 const rocblas_int n,
+                                 const rocblas_int* per,
+                                 const rocblas_int* mask,
+                                 const S* tmpd,
+                                 const S* diag,
+                                       S* zz)
+{
+    // Re-scale vector Z to avoid bad numerics when an eigenvalue
+    // is too close to a pole
+    for(int i = iam; i < dd; i += bdm)
+    {
+        S valf = 1;
+        for(int j = 0; j < sz; ++j)
+        {
+            if(mask[j] == 1)
+            {
+                S valg = tmpd[i + j * n];
+                valf *= (per[i] == j) ? valg : valg / (diag[per[i]] - diag[j]);
+            }
+        }
+        valf = sqrt(std::abs(valf));
+        zz[i] = zz[i] < 0 ? -valf : valf;
+    }
+}
+
 //--------------------------------------------------------------------------------------//
 /** STEDC_MERGEVALUES_KERNEL solves the secular equation for
     every pair of sub-blocks that need to be merged in a split block. A matrix in the batch
@@ -1373,7 +1521,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // number of level of division
     rocblas_int levs;
     // other aux variables
-    S p;
     rocblas_int *ns, *ps;
     /* --------------------------------------------------- */
 
@@ -1404,7 +1551,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         if(mid < tn)
         {
             rocblas_int iam, sz, bdm, dim;
-            S valf, valg;
             rocblas_int bd = 1 << k;
             bdm = bd << 1;
             dim = hipBlockDim_x / 2;
@@ -1424,7 +1570,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 sz += ns[tid + j];
             // with this, all threads involved in a merge
             // will point to the same row of C and the same off-diag element
-            p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
+            S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
 
             // determine boundaries of what would be the new merged sub-block
             // 'in' will be its initial position.
@@ -1461,104 +1607,16 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                     dd++;
             }
 
-            // Order the elements in tmpd and zz using a simple parallel selection/bubble sort.
-            // This will allow us to find initial intervals for eigenvalue guesses
-            for(int i = 0; i < dd; i++)
-            {
-                for(int j = 2 * iam + i % 2; j < dd - 1; j += 2 * bdm)
-                {
-                    if(tmpd[j] > tmpd[j + 1])
-                    {
-                        swap(tmpd[j], tmpd[j + 1]);
-                        swap(zz[j], zz[j + 1]);
-                        swap(per[j], per[j + 1]);
-                    }
-                }
-                __syncthreads();
-            }
+            sort_tmpd_zz(dd, iam, bdm, tmpd, zz, per);
+            copy_d_ev(dd, iam, bdm, sz, n, tmpd, ev, diag);
 
-            // make dd copies of the non-deflated ordered diagonal elements
-            // (i.e. the poles of the secular eqn) so that the distances to the
-            // eigenvalues (D - lambda_i) are updated while computing each eigenvalue.
-            // This will prevent collapses and division by zero when an eigenvalue
-            // is too close to a pole.
-            for(int i = iam; i < dd; i += bdm)
-            {
-                for(int j = i + n; j < i + sz * n; j += n)
-                    tmpd[j] = tmpd[i];
-            }
-
-            // finally copy over all diagonal elements in ev. ev will be overwritten
-            // by the new computed eigenvalues of the merged block
-            for(int i = iam; i < sz; i += bdm)
-                ev[i] = diag[i];
             __syncthreads();
-            /* ----------------------------------------------------------------- */
+            
+            solve_seq_eqns(dd, iam, bdm, sz, n, p, eps, ssfmin, ssfmax, mask, tmpd, ev, zz);
 
-            // 3e. Solve secular eqns, i.e. find the dd zeros
-            // corresponding to non-deflated new eigenvalues of the merged block
-            /* ----------------------------------------------------------------- */
-            // each thread will find a different zero in parallel
-            S a, b;
-            for(int j = iam; j < sz; j += bdm)
-            {
-                if(mask[j] == 1)
-                {
-                    // find position in the ordered array
-                    valf = p < 0 ? -ev[j] : ev[j];
-                    int count = dd, cc = 0;
-                    while(count > 0)
-                    {
-                        auto step = count / 2;
-                        auto it = cc + step;
-                        if(tmpd[it + j * n] < valf)
-                        {
-                            cc = ++it;
-                            count -= step + 1;
-                        }
-                        else
-                            count = step;
-                    }
-
-                    // computed zero will overwrite 'ev' at the corresponding position.
-                    // 'tmpd' will be updated with the distances D - lambda_i.
-                    // deflated values are not changed.
-                    rocblas_int linfo;
-
-#if defined(ROCSOLVER_USE_REFERENCE_SECULAR_EQUATIONS_SOLVER)
-                    linfo = slaed4(dd, cc, tmpd + j * n, zz, std::abs(p), ev[j]);
-#else
-                    if(cc == dd - 1)
-                        linfo = seq_solve_ext(dd, tmpd + j * n, zz, (p < 0 ? -p : p), ev + j, eps,
-                                              ssfmin, ssfmax);
-                    else
-                        linfo = seq_solve(dd, tmpd + j * n, zz, (p < 0 ? -p : p), cc, ev + j, eps,
-                                          ssfmin, ssfmax);
-#endif
-
-                    if(p < 0)
-                        ev[j] *= -1;
-                }
-            }
             __syncthreads();
 
-            // Re-scale vector Z to avoid bad numerics when an eigenvalue
-            // is too close to a pole
-            for(int i = iam; i < dd; i += bdm)
-            {
-                valf = 1;
-                for(int j = 0; j < sz; ++j)
-                {
-                    if(mask[j] == 1)
-                    {
-                        valg = tmpd[i + j * n];
-                        valf *= (per[i] == j) ? valg : valg / (diag[per[i]] - diag[j]);
-                    }
-                }
-                valf = sqrt(std::abs(valf));
-                zz[i] = zz[i] < 0 ? -valf : valf;
-            }
-            /* ----------------------------------------------------------------- */
+            rescale_z(dd, iam, bdm, sz, n, per, mask, tmpd, diag, zz);
         }
     }
 }

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1622,6 +1622,504 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 }
 
 //--------------------------------------------------------------------------------------//
+/** STEDC_MERGEVALUES_SORT_KERNEL is the first kernel of the multikernel version of the STEDC_MERGEVALUES_KERNEL**/
+template <rocsolver_stedc_mode MODE, typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+    stedc_mergeValues_Sort_kernel(const rocblas_int k,
+                                  const rocblas_int n,
+                                  S* DD,
+                                  const rocblas_stride strideD,
+                                  S* EE,
+                                  const rocblas_stride strideE,
+                                  S* tmpzA,
+                                  S* vecsA,
+                                  rocblas_int* splitsA,
+                                  const S eps,
+                                  const S ssfmin,
+                                  const S ssfmax)
+{
+    // threads and groups indices
+    /* --------------------------------------------------- */
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_z;
+    // split block id
+    rocblas_int sid = hipBlockIdx_y;
+    // merge sub-block id
+    rocblas_int mid = hipBlockIdx_x;
+    // thread id
+    rocblas_int tidb = hipThreadIdx_x;
+    rocblas_int tid;
+    /* --------------------------------------------------- */
+
+    // select batch instance to work with
+    /* --------------------------------------------------- */
+    S* D = DD + bid * strideD;
+    S* E = EE + bid * strideE;
+    /* --------------------------------------------------- */
+
+    // temporary arrays in global memory
+    /* --------------------------------------------------- */
+    // contains the beginning of split blocks
+    rocblas_int* splits = splitsA + bid * (5 * n + 2);
+    // the sub-blocks sizes
+    rocblas_int* nsA = splits + n + 2;
+    // the sub-blocks initial positions
+    rocblas_int* psA = nsA + n;
+    // if idd[i] = 0, the value in position i has been deflated
+    rocblas_int* idd = psA + n;
+    // container of permutations when solving the secular eqns
+    rocblas_int* pers = idd + n;
+    // the rank-1 modification vectors in the merges
+    S* z = tmpzA + bid * (2 * n);
+    // roots of secular equations
+    S* evs = z + n;
+    // updated eigenvectors after merges
+    S* vecs = vecsA + bid * 2 * (n * n);
+    // temp values during the merges
+    S* temps = vecs + (n * n);
+    /* --------------------------------------------------- */
+
+    // local variables
+    /* --------------------------------------------------- */
+    // total number of split blocks
+    rocblas_int nb = splits[n + 1];
+    // size of split block
+    rocblas_int bs;
+    // beginning of split block
+    rocblas_int p1;
+    // beginning of sub-block
+    rocblas_int p2;
+    // number of sub-blocks
+    rocblas_int blks;
+    rocblas_int tn;
+    // number of level of division
+    rocblas_int levs;
+    // other aux variables
+    rocblas_int *ns, *ps;
+    /* --------------------------------------------------- */
+
+    // work with STEDC_NUM_SPLIT_BLKS split blocks in parallel
+    /* --------------------------------------------------- */
+    for(int kb = sid; kb < nb; kb += STEDC_NUM_SPLIT_BLKS)
+    {
+        __syncthreads();
+
+        // Select current split block
+        p1 = splits[kb];
+        p2 = splits[kb + 1];
+        bs = p2 - p1;
+        ns = nsA + p1;
+        ps = psA + p1;
+
+        // determine ideal number of sub-blocks
+        // tn is the number of thread-groups needed
+        levs = stedc_num_levels<MODE>(bs);
+        blks = levs - 1 - k;
+        tn = (blks < 0) ? 0 : 1 << blks;
+        blks = 1 << levs;
+
+        // 3. MERGE PHASE
+        /* ----------------------------------------------------------------- */
+        // Work with merges on level k. A thread-group works with two leaves in the merge tree;
+        // all threads work together to solve the secular equation.
+        if(mid < tn)
+        {
+            rocblas_int iam, sz, bdm, dim;
+            rocblas_int bd = 1 << k;
+            bdm = bd << 1;
+            dim = hipBlockDim_x / 2;
+
+            // tid indexes the sub-blocks in the entire split block
+            // iam indexes the sub-blocks in the context of the merge
+            // (according to its level in the merge tree)
+            iam = tidb / dim;
+            tid = mid * bdm + iam * bd;
+            p2 = ps[tid];
+
+            // Find off-diagonal element of the merge
+            // Threads with iam = 0 work with components below the merge point;
+            // threads with iam = 1 work above the merge point
+            sz = ns[tid];
+            for(int j = 1; j < bd; ++j)
+                sz += ns[tid + j];
+            // with this, all threads involved in a merge
+            // will point to the same row of C and the same off-diag element
+            S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
+
+            // determine boundaries of what would be the new merged sub-block
+            // 'in' will be its initial position.
+            // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
+            rocblas_int in = tid - iam * bd;
+            sz = ns[in];
+            for(int i = 1; i < bdm; ++i)
+                sz += ns[in + i];
+            in = ps[in];
+
+            // 3d.2. Organize data with non-deflated values to prepare secular equation
+            /* ----------------------------------------------------------------- */
+            rocblas_int tsz = 1 << (levs - 1 - k);
+            tsz = (bs - 1) / tsz + 1;
+
+            // All threads of the group participating in the merge will work together
+            // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
+            iam = tidb;
+            bdm = hipBlockDim_x;
+
+            // define shifted arrays
+            S* tmpd = temps + in * n;
+            S* ev = evs + in;
+            S* diag = D + in;
+            rocblas_int* mask = idd + in;
+            S* zz = z + in;
+            rocblas_int* per = pers + in;
+
+            // find degree of secular equation
+            rocblas_int dd = 0;
+            for(int i = 0; i < sz; ++i)
+            {
+                if(mask[i] == 1)
+                    dd++;
+            }
+
+            sort_tmpd_zz(dd, iam, bdm, tmpd, zz, per);
+            copy_d_ev(dd, iam, bdm, sz, n, tmpd, ev, diag);
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+/** STEDC_MERGEVALUES_SOLVE_KERNEL is the second kernel of the multikernel version of the STEDC_MERGEVALUES_KERNEL**/
+template <rocsolver_stedc_mode MODE, typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+    stedc_mergeValues_Solve_kernel(const rocblas_int k,
+                                  const rocblas_int n,
+                                  S* DD,
+                                  const rocblas_stride strideD,
+                                  S* EE,
+                                  const rocblas_stride strideE,
+                                  S* tmpzA,
+                                  S* vecsA,
+                                  rocblas_int* splitsA,
+                                  const S eps,
+                                  const S ssfmin,
+                                  const S ssfmax,
+                                  const rocblas_int groups_per_merge)
+{
+    // threads and groups indices
+    /* --------------------------------------------------- */
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_z;
+    // split block id
+    rocblas_int sid = hipBlockIdx_y;
+    // merge sub-block id
+    rocblas_int mid = hipBlockIdx_x / groups_per_merge;
+    rocblas_int group_in_subblock = hipBlockIdx_x % groups_per_merge;
+    // thread id
+    rocblas_int tidb = hipThreadIdx_x + group_in_subblock * hipBlockDim_x;
+    rocblas_int tid;
+    /* --------------------------------------------------- */
+
+    // select batch instance to work with
+    /* --------------------------------------------------- */
+    S* D = DD + bid * strideD;
+    S* E = EE + bid * strideE;
+    /* --------------------------------------------------- */
+
+    // temporary arrays in global memory
+    /* --------------------------------------------------- */
+    // contains the beginning of split blocks
+    rocblas_int* splits = splitsA + bid * (5 * n + 2);
+    // the sub-blocks sizes
+    rocblas_int* nsA = splits + n + 2;
+    // the sub-blocks initial positions
+    rocblas_int* psA = nsA + n;
+    // if idd[i] = 0, the value in position i has been deflated
+    rocblas_int* idd = psA + n;
+    // container of permutations when solving the secular eqns
+    rocblas_int* pers = idd + n;
+    // the rank-1 modification vectors in the merges
+    S* z = tmpzA + bid * (2 * n);
+    // roots of secular equations
+    S* evs = z + n;
+    // updated eigenvectors after merges
+    S* vecs = vecsA + bid * 2 * (n * n);
+    // temp values during the merges
+    S* temps = vecs + (n * n);
+    /* --------------------------------------------------- */
+
+    // local variables
+    /* --------------------------------------------------- */
+    // total number of split blocks
+    rocblas_int nb = splits[n + 1];
+    // size of split block
+    rocblas_int bs;
+    // beginning of split block
+    rocblas_int p1;
+    // beginning of sub-block
+    rocblas_int p2;
+    // number of sub-blocks
+    rocblas_int blks;
+    rocblas_int tn;
+    // number of level of division
+    rocblas_int levs;
+    // other aux variables
+    rocblas_int *ns, *ps;
+    /* --------------------------------------------------- */
+
+    // work with STEDC_NUM_SPLIT_BLKS split blocks in parallel
+    /* --------------------------------------------------- */
+    for(int kb = sid; kb < nb; kb += STEDC_NUM_SPLIT_BLKS)
+    {
+        __syncthreads();
+
+        // Select current split block
+        p1 = splits[kb];
+        p2 = splits[kb + 1];
+        bs = p2 - p1;
+        ns = nsA + p1;
+        ps = psA + p1;
+
+        // determine ideal number of sub-blocks
+        // tn is the number of thread-groups needed
+        levs = stedc_num_levels<MODE>(bs);
+        blks = levs - 1 - k;
+        tn = (blks < 0) ? 0 : 1 << blks;
+        blks = 1 << levs;
+
+        // 3. MERGE PHASE
+        /* ----------------------------------------------------------------- */
+        // Work with merges on level k. A thread-group works with two leaves in the merge tree;
+        // all threads work together to solve the secular equation.
+        if(mid < tn)
+        {
+            rocblas_int iam, sz, bdm, dim;
+            rocblas_int bd = 1 << k;
+            bdm = bd << 1;
+            dim = (hipBlockDim_x * groups_per_merge) / 2;
+
+            // tid indexes the sub-blocks in the entire split block
+            // iam indexes the sub-blocks in the context of the merge
+            // (according to its level in the merge tree)
+            iam = tidb / dim;
+            tid = mid * bdm + iam * bd;
+            p2 = ps[tid];
+
+            // Find off-diagonal element of the merge
+            // Threads with iam = 0 work with components below the merge point;
+            // threads with iam = 1 work above the merge point
+            sz = ns[tid];
+            for(int j = 1; j < bd; ++j)
+                sz += ns[tid + j];
+            // with this, all threads involved in a merge
+            // will point to the same row of C and the same off-diag element
+            S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
+
+            // determine boundaries of what would be the new merged sub-block
+            // 'in' will be its initial position.
+            // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
+            rocblas_int in = tid - iam * bd;
+            sz = ns[in];
+            for(int i = 1; i < bdm; ++i)
+                sz += ns[in + i];
+            in = ps[in];
+
+            // 3d.2. Organize data with non-deflated values to prepare secular equation
+            /* ----------------------------------------------------------------- */
+            rocblas_int tsz = 1 << (levs - 1 - k);
+            tsz = (bs - 1) / tsz + 1;
+
+            // All threads of the group participating in the merge will work together
+            // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
+            iam = tidb;
+            bdm = hipBlockDim_x * groups_per_merge;
+
+            // define shifted arrays
+            S* tmpd = temps + in * n;
+            S* ev = evs + in;
+            S* diag = D + in;
+            rocblas_int* mask = idd + in;
+            S* zz = z + in;
+            rocblas_int* per = pers + in;
+
+            // find degree of secular equation
+            rocblas_int dd = 0;
+            for(int i = 0; i < sz; ++i)
+            {
+                if(mask[i] == 1)
+                    dd++;
+            }
+
+            solve_seq_eqns(dd, iam, bdm, sz, n, p, eps, ssfmin, ssfmax, mask, tmpd, ev, zz);
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+/** STEDC_MERGEVALUES_RESCALE_KERNEL is the third and the last kernel of the multikernel version of the STEDC_MERGEVALUES_KERNEL**/
+template <rocsolver_stedc_mode MODE, typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+    stedc_mergeValues_Rescale_kernel(const rocblas_int k,
+                                     const rocblas_int n,
+                                     S* DD,
+                                     const rocblas_stride strideD,
+                                     S* EE,
+                                     const rocblas_stride strideE,
+                                     S* tmpzA,
+                                     S* vecsA,
+                                     rocblas_int* splitsA,
+                                     const S eps,
+                                     const S ssfmin,
+                                     const S ssfmax)
+{
+    // threads and groups indices
+    /* --------------------------------------------------- */
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_z;
+    // split block id
+    rocblas_int sid = hipBlockIdx_y;
+    // merge sub-block id
+    rocblas_int mid = hipBlockIdx_x;
+    // thread id
+    rocblas_int tidb = hipThreadIdx_x;
+    rocblas_int tid;
+    /* --------------------------------------------------- */
+
+    // select batch instance to work with
+    /* --------------------------------------------------- */
+    S* D = DD + bid * strideD;
+    S* E = EE + bid * strideE;
+    /* --------------------------------------------------- */
+
+    // temporary arrays in global memory
+    /* --------------------------------------------------- */
+    // contains the beginning of split blocks
+    rocblas_int* splits = splitsA + bid * (5 * n + 2);
+    // the sub-blocks sizes
+    rocblas_int* nsA = splits + n + 2;
+    // the sub-blocks initial positions
+    rocblas_int* psA = nsA + n;
+    // if idd[i] = 0, the value in position i has been deflated
+    rocblas_int* idd = psA + n;
+    // container of permutations when solving the secular eqns
+    rocblas_int* pers = idd + n;
+    // the rank-1 modification vectors in the merges
+    S* z = tmpzA + bid * (2 * n);
+    // roots of secular equations
+    S* evs = z + n;
+    // updated eigenvectors after merges
+    S* vecs = vecsA + bid * 2 * (n * n);
+    // temp values during the merges
+    S* temps = vecs + (n * n);
+    /* --------------------------------------------------- */
+
+    // local variables
+    /* --------------------------------------------------- */
+    // total number of split blocks
+    rocblas_int nb = splits[n + 1];
+    // size of split block
+    rocblas_int bs;
+    // beginning of split block
+    rocblas_int p1;
+    // beginning of sub-block
+    rocblas_int p2;
+    // number of sub-blocks
+    rocblas_int blks;
+    rocblas_int tn;
+    // number of level of division
+    rocblas_int levs;
+    // other aux variables
+    rocblas_int *ns, *ps;
+    /* --------------------------------------------------- */
+
+    // work with STEDC_NUM_SPLIT_BLKS split blocks in parallel
+    /* --------------------------------------------------- */
+    for(int kb = sid; kb < nb; kb += STEDC_NUM_SPLIT_BLKS)
+    {
+        __syncthreads();
+
+        // Select current split block
+        p1 = splits[kb];
+        p2 = splits[kb + 1];
+        bs = p2 - p1;
+        ns = nsA + p1;
+        ps = psA + p1;
+
+        // determine ideal number of sub-blocks
+        // tn is the number of thread-groups needed
+        levs = stedc_num_levels<MODE>(bs);
+        blks = levs - 1 - k;
+        tn = (blks < 0) ? 0 : 1 << blks;
+        blks = 1 << levs;
+
+        // 3. MERGE PHASE
+        /* ----------------------------------------------------------------- */
+        // Work with merges on level k. A thread-group works with two leaves in the merge tree;
+        // all threads work together to solve the secular equation.
+        if(mid < tn)
+        {
+            rocblas_int iam, sz, bdm, dim;
+            rocblas_int bd = 1 << k;
+            bdm = bd << 1;
+            dim = hipBlockDim_x / 2;
+
+            // tid indexes the sub-blocks in the entire split block
+            // iam indexes the sub-blocks in the context of the merge
+            // (according to its level in the merge tree)
+            iam = tidb / dim;
+            tid = mid * bdm + iam * bd;
+            p2 = ps[tid];
+
+            // Find off-diagonal element of the merge
+            // Threads with iam = 0 work with components below the merge point;
+            // threads with iam = 1 work above the merge point
+            sz = ns[tid];
+            for(int j = 1; j < bd; ++j)
+                sz += ns[tid + j];
+            // with this, all threads involved in a merge
+            // will point to the same row of C and the same off-diag element
+            S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
+
+            // determine boundaries of what would be the new merged sub-block
+            // 'in' will be its initial position.
+            // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
+            rocblas_int in = tid - iam * bd;
+            sz = ns[in];
+            for(int i = 1; i < bdm; ++i)
+                sz += ns[in + i];
+            in = ps[in];
+
+            // 3d.2. Organize data with non-deflated values to prepare secular equation
+            /* ----------------------------------------------------------------- */
+            rocblas_int tsz = 1 << (levs - 1 - k);
+            tsz = (bs - 1) / tsz + 1;
+
+            // All threads of the group participating in the merge will work together
+            // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
+            iam = tidb;
+            bdm = hipBlockDim_x;
+
+            // define shifted arrays
+            S* tmpd = temps + in * n;
+            S* ev = evs + in;
+            S* diag = D + in;
+            rocblas_int* mask = idd + in;
+            S* zz = z + in;
+            rocblas_int* per = pers + in;
+
+            // find degree of secular equation
+            rocblas_int dd = 0;
+            for(int i = 0; i < sz; ++i)
+            {
+                if(mask[i] == 1)
+                    dd++;
+            }
+
+            rescale_z(dd, iam, bdm, sz, n, per, mask, tmpd, diag, zz);
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------//
 /** STEDC_MERGEVECTORS_KERNEL prepares vectors from the secular equation for
     every pair of sub-blocks that need to be merged in a split block. A matrix in the batch
     could have many split-blocks, and each split-block could be divided in a maximum of nn sub-blocks.
@@ -2464,10 +2962,33 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     eps);
 
             // b. solve to find merged eigen values
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_kernel<rocsolver_stedc_mode_qr, S>),
-                                    dim3(numgrps2, STEDC_NUM_SPLIT_BLKS, batch_count),
-                                    dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD, strideD,
-                                    E + shiftE, strideE, tmpz, tempgemm, splits, eps, ssfmin, ssfmax);
+            rocblas_int max_n_per_merge = (n + numgrps2 - 1) / numgrps2;
+            if(max_n_per_merge <= STEDC_BDIM)
+            {
+                // compute in one dispatch for small merges
+                ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_kernel<rocsolver_stedc_mode_qr, S>),
+                                        dim3(numgrps2, STEDC_NUM_SPLIT_BLKS, batch_count),
+                                        dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD, strideD,
+                                        E + shiftE, strideE, tmpz, tempgemm, splits, eps, ssfmin, ssfmax);
+            }
+            else {
+                // split mergeValues into stages to run seqular eqns solver using more groups
+                ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Sort_kernel<rocsolver_stedc_mode_qr, S>),
+                                        dim3(numgrps2, STEDC_NUM_SPLIT_BLKS, batch_count),
+                                        dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD, strideD,
+                                        E + shiftE, strideE, tmpz, tempgemm, splits, eps, ssfmin, ssfmax);
+
+                rocblas_int groups_per_merge = (max_n_per_merge + STEDC_BDIM - 1) / STEDC_BDIM;
+                ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Solve_kernel<rocsolver_stedc_mode_qr, S>),
+                                        dim3(numgrps2 * groups_per_merge, STEDC_NUM_SPLIT_BLKS, batch_count),
+                                        dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD, strideD,
+                                        E + shiftE, strideE, tmpz, tempgemm, splits, eps, ssfmin, ssfmax,
+                                        groups_per_merge);
+                ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Rescale_kernel<rocsolver_stedc_mode_qr, S>),
+                                        dim3(numgrps2, STEDC_NUM_SPLIT_BLKS, batch_count),
+                                        dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD, strideD,
+                                        E + shiftE, strideE, tmpz, tempgemm, splits, eps, ssfmin, ssfmax);
+            }
 
             // c. find merged eigen vectors
             ROCSOLVER_LAUNCH_KERNEL(


### PR DESCRIPTION
The PR speeds up "merge Values" stage of the stedc for big cases (n > 1024) by splitting the stedc_mergeValues_kernel into multiple kernels and thus allowing to solve secular equations with full parallelism (original code had a limitation on the number of groups). Smaller merges are still done using nonsplitted stedc_mergeValues_kernel to avoid overhead.

The PR doesn't change algorithm or numerical properties of calculations and the output of the stedc is supposed to be bit exact to the previous implementation. However, only basic tests were done and PR might need additional testing and verification.