### PR TITLE
Small size kernel for geqr2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
 ### Changed
 ### Removed
 ### Optimized
+
+* Improved the performance of LARFT and downstream functions such as GEQRF and ORMTR
+* Improved the performance of LARF and downstream functions such as GEQR2
+* Improved the performance of ORMTR and downstream functions such as SYEVD
+* Improved the performance of GEQR2 and downstream functions such as GEQRF
+
 ### Resolved issues
 ### Known issues
 ### Upcoming changes

--- a/library/src/lapack/roclapack_geqr2.hpp
+++ b/library/src/lapack/roclapack_geqr2.hpp
@@ -40,6 +40,137 @@
 
 ROCSOLVER_BEGIN_NAMESPACE
 
+template <int MAX_THDS, typename T, typename I, typename S, typename U>
+ROCSOLVER_KERNEL void __launch_bounds__(MAX_THDS)
+    geqr2_kernel_small(const I m,
+                             const I n,
+                             U AA,
+                             const rocblas_stride shiftA,
+                             const I lda,
+                             const rocblas_stride strideA,
+                             S* diagA,
+                             const rocblas_stride strideD,
+                             T* tauA,
+                             const rocblas_stride strideP)
+{
+    I bid = blockIdx.z;
+    I tid = threadIdx.x;
+
+    // select batch instance
+    T* A = load_ptr_batch<T>(AA, bid, shiftA, strideA);
+    S* diag = load_ptr_batch<S>(diagA, bid, 0, strideD);
+    T* tau = load_ptr_batch<T>(tauA, bid, 0, strideP);
+
+    // shared variables
+    extern __shared__ double lmem[];
+    T* tmptau = reinterpret_cast<T*>(lmem);
+    T* a = reinterpret_cast<T*>(tmptau + 1);
+    T* x = reinterpret_cast<T*>(a + m * n);
+    T* w = reinterpret_cast<T*>(x + m);
+    T* sval = reinterpret_cast<T*>(w + n);
+
+    I dim = std::min(m, n); // total number of pivots
+
+    // load A to lds
+    for(I i = tid % (MAX_THDS / 2); i < m; i += (MAX_THDS / 2))
+    {
+        const auto tidy = tid / (MAX_THDS / 2);
+        for(I j = tidy; j < n; j += 2)
+        {
+            a[i + j * m] = A[i + j * lda];
+        }
+    }
+
+    __syncthreads();
+
+    // main loop running forwards (for each column)
+    for(rocblas_int j = 0; j < dim; ++j)
+    {
+        I mm = m - j;
+        I nn = n - j;
+
+        // ----- 1. generate Householder reflector to annihilate A(j+1:m-1,j) -----
+        // load A(j:m-1,j) into x
+        for(I i = tid; i < mm; i += MAX_THDS)
+            x[i] = a[(i + j) + j * m];
+        __syncthreads();
+
+        // larfg
+        T norm2 = 0;
+        for(I i = tid; i < mm - 1; i += MAX_THDS)
+            norm2 += x[i + 1] * conj(x[i + 1]);
+
+        // reduce squared entries to find squared norm of x
+        norm2 += shift_left(norm2, 1);
+        norm2 += shift_left(norm2, 2);
+        norm2 += shift_left(norm2, 4);
+        norm2 += shift_left(norm2, 8);
+        norm2 += shift_left(norm2, 16);
+        if(warpSize > 32)
+            norm2 += shift_left(norm2, 32);
+        if(tid % warpSize == 0)
+            sval[tid / warpSize] = norm2;
+        __syncthreads();
+        if(tid == 0)
+        {
+            for(I k = 1; k < MAX_THDS / warpSize; k++)
+                norm2 += sval[k];
+
+            // set tau, beta, and put scaling factor into sval[0]
+            run_set_taubeta<T>(tmptau, &norm2, x, diag + j);
+
+            tau[j] = tmptau[0];
+            sval[0] = norm2;
+
+            tmptau[0] = conj(tmptau[0]);
+        }
+        __syncthreads();
+
+        // scale x by scaling factor
+        for(I i = tid; i < mm - 1; i += MAX_THDS)
+            x[i + 1] *= sval[0];
+        __syncthreads();
+
+        // ----- 2. compute w = tau'*v'*A -----
+        // gemv
+        for(I i = tid; i < nn - 1; i += MAX_THDS)
+        {
+            T temp = 0;
+            T* Atmp = a + j + j * m;
+            for(I jj = 0; jj < mm; jj++)
+                temp += Atmp[jj + (i + 1) * m] * conj(x[jj]);
+            w[i] = tmptau[0] * temp;
+        }
+
+        // copy x back to A(j:m-1,j)
+        for(I i = tid; i < mm; i += MAX_THDS)
+            a[(i + j) + j * m] = x[i];
+        __syncthreads();
+
+        // ----- 3. apply the Householder reflector to A as a rank-1 update: A = A - v*w -----
+        // ger
+        for(I i = tid; i < mm; i += MAX_THDS)
+        {
+            T* Atmp = a + j + j * m;
+            for(I jj = 0; jj < nn - 1; jj++)
+            {
+                Atmp[i + (jj + 1) * m] = Atmp[i + (jj + 1) * m] - x[i] * w[jj];
+            }
+        }
+        __syncthreads();
+    }
+
+    // write lds back to A
+    for(I i = tid % (MAX_THDS / 2); i < m; i += (MAX_THDS / 2))
+    {
+        const auto tidy = tid / (MAX_THDS / 2);
+        for(I j = tidy; j < n; j += 2)
+        {
+            A[i + j * lda] = a[i + j * m];
+        }
+    }
+}
+
 template <bool BATCHED, typename T, typename I>
 void rocsolver_geqr2_getMemorySize(const I m,
                                    const I n,
@@ -129,8 +260,24 @@ rocblas_status rocsolver_geqr2_template(rocblas_handle handle,
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
 
+    // get device prop
+    int device;
+    HIP_CHECK(hipGetDevice(&device));
+    hipDeviceProp_t props;
+    HIP_CHECK(hipGetDeviceProperties(&props, device));
+
     I dim = std::min(m, n); // total number of pivots
 
+    const size_t lmemsize = ((256 / props.warpSize) + m + n + 1 + m * n) * sizeof(T);
+    if(lmemsize <= props.sharedMemPerBlock)
+    {
+        ROCSOLVER_LAUNCH_KERNEL((geqr2_kernel_small<256, T>), dim3(1, 1, batch_count),
+                                dim3(256), lmemsize, stream, m, n, A,
+                                shiftA, lda, strideA, (S*)diag, dim,
+                                ipiv, strideP);
+    }
+    else
+    {
     for(I j = 0; j < dim; ++j)
     {
         // generate Householder reflector to work on column j
@@ -154,6 +301,7 @@ rocblas_status rocsolver_geqr2_template(rocblas_handle handle,
             if(COMPLEX)
                 rocsolver_lacgv_template<T>(handle, (I)1, ipiv, j, (I)1, strideP, batch_count);
         }
+    }
     }
 
     // restore diagonal values of A

--- a/library/src/lapack/roclapack_geqr2.hpp
+++ b/library/src/lapack/roclapack_geqr2.hpp
@@ -41,17 +41,16 @@
 ROCSOLVER_BEGIN_NAMESPACE
 
 template <int MAX_THDS, typename T, typename I, typename S, typename U>
-ROCSOLVER_KERNEL void __launch_bounds__(MAX_THDS)
-    geqr2_kernel_small(const I m,
-                             const I n,
-                             U AA,
-                             const rocblas_stride shiftA,
-                             const I lda,
-                             const rocblas_stride strideA,
-                             S* diagA,
-                             const rocblas_stride strideD,
-                             T* tauA,
-                             const rocblas_stride strideP)
+ROCSOLVER_KERNEL void __launch_bounds__(MAX_THDS) geqr2_kernel_small(const I m,
+                                                                     const I n,
+                                                                     U AA,
+                                                                     const rocblas_stride shiftA,
+                                                                     const I lda,
+                                                                     const rocblas_stride strideA,
+                                                                     S* diagA,
+                                                                     const rocblas_stride strideD,
+                                                                     T* tauA,
+                                                                     const rocblas_stride strideP)
 {
     I bid = blockIdx.z;
     I tid = threadIdx.x;
@@ -63,11 +62,12 @@ ROCSOLVER_KERNEL void __launch_bounds__(MAX_THDS)
 
     // shared variables
     extern __shared__ double lmem[];
-    T* tmptau = reinterpret_cast<T*>(lmem);
-    T* a = reinterpret_cast<T*>(tmptau + 1);
-    T* x = reinterpret_cast<T*>(a + m * n);
-    T* w = reinterpret_cast<T*>(x + m);
-    T* sval = reinterpret_cast<T*>(w + n);
+    T* a = reinterpret_cast<T*>(lmem);
+    T* w = reinterpret_cast<T*>(a + m * n);
+    T* tmptau = reinterpret_cast<T*>(w + n);
+    T* sval = reinterpret_cast<T*>(tmptau + 1);
+
+    T* x;
 
     I dim = std::min(m, n); // total number of pivots
 
@@ -91,9 +91,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(MAX_THDS)
 
         // ----- 1. generate Householder reflector to annihilate A(j+1:m-1,j) -----
         // load A(j:m-1,j) into x
-        for(I i = tid; i < mm; i += MAX_THDS)
-            x[i] = a[(i + j) + j * m];
-        __syncthreads();
+        x = a + j + j * m;
 
         // larfg
         T norm2 = 0;
@@ -141,10 +139,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(MAX_THDS)
                 temp += Atmp[jj + (i + 1) * m] * conj(x[jj]);
             w[i] = tmptau[0] * temp;
         }
-
-        // copy x back to A(j:m-1,j)
-        for(I i = tid; i < mm; i += MAX_THDS)
-            a[(i + j) + j * m] = x[i];
         __syncthreads();
 
         // ----- 3. apply the Householder reflector to A as a rank-1 update: A = A - v*w -----
@@ -267,19 +261,20 @@ rocblas_status rocsolver_geqr2_template(rocblas_handle handle,
     HIP_CHECK(hipGetDeviceProperties(&props, device));
 
     I dim = std::min(m, n); // total number of pivots
-
-    const size_t lmemsize = ((256 / props.warpSize) + m + n + 1 + m * n) * sizeof(T);
-    if(lmemsize <= props.sharedMemPerBlock)
-    {
-        ROCSOLVER_LAUNCH_KERNEL((geqr2_kernel_small<256, T>), dim3(1, 1, batch_count),
-                                dim3(256), lmemsize, stream, m, n, A,
-                                shiftA, lda, strideA, (S*)diag, dim,
-                                ipiv, strideP);
-    }
-    else
-    {
     for(I j = 0; j < dim; ++j)
     {
+        I mm = m - j;
+        I nn = n - j;
+
+        const size_t lmemsize = ((256 / props.warpSize) + mm + nn + 1 + mm * nn) * sizeof(T);
+        if(lmemsize <= props.sharedMemPerBlock && nn == mm)
+        {
+            ROCSOLVER_LAUNCH_KERNEL((geqr2_kernel_small<256, T>), dim3(1, 1, batch_count), dim3(256),
+                                    lmemsize, stream, mm, nn, A, shiftA + idx2D(j, j, lda), lda,
+                                    strideA, (S*)diag + j, dim, ipiv + j, strideP);
+            break;
+        }
+
         // generate Householder reflector to work on column j
         rocsolver_larfg_template<T>(handle, m - j, A, shiftA + idx2D(j, j, lda), (S*)diag, j, dim,
                                     A, shiftA + idx2D(std::min(j + 1, m - 1), j, lda), (I)1, strideA,
@@ -301,7 +296,6 @@ rocblas_status rocsolver_geqr2_template(rocblas_handle handle,
             if(COMPLEX)
                 rocsolver_lacgv_template<T>(handle, (I)1, ipiv, j, (I)1, strideP, batch_count);
         }
-    }
     }
 
     // restore diagonal values of A


### PR DESCRIPTION
This PR adds a kernel for small size geqr2 problems. Testing shows that it is ~2x faster for square matrices with size of m <= 64 for single precision case; non square matrices appear to run slower with the kernel so it's only enabled for the square case.