### PR TITLE
Small-size sytd2 ignore imaginary values on the diagonal

### DIFF
--- a/library/src/lapack/roclapack_sytd2_hetd2.hpp
+++ b/library/src/lapack/roclapack_sytd2_hetd2.hpp
@@ -87,6 +87,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(MAX_THDS)
         const auto tidy = tid / (MAX_THDS / 2);
         for(I j = tidy; j < n; j += 2)
         {
+            // ignore imaginary part of the diagonal
+            if(i == j)
+                a[i + j * n] = std::real(a[i + j * n]);
+            // copy lower triangle to upper triangle
             if(i < j)
                 a[i + j * n] = conj(a[j + i * n]);
         }
@@ -258,6 +262,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(MAX_THDS)
         const auto tidy = tid / (MAX_THDS / 2);
         for(I j = tidy; j < n; j += 2)
         {
+            // ignore imaginary part of the diagonal
+            if(i == j)
+                a[i + j * n] = std::real(a[i + j * n]);
+            // copy upper triangle to lower triangle
             if(i > j)
                 a[i + j * n] = conj(a[j + i * n]);
         }


### PR DESCRIPTION
Unlike previous versions of SYTRD, the new small-size SYTD2 kernels do not ignore imaginary values on the diagonal. This causing hipSOLVER tests to fail, since those tests do not explicitly remove the imaginary component from the diagonal.