### PR TITLE
New STEDC sort

### DIFF
--- a/clients/common/auxiliary/testing_stedc.hpp
+++ b/clients/common/auxiliary/testing_stedc.hpp
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include "common/matrix_utils/matrix_utils.hpp"
 #include "common/misc/client_util.hpp"
 #include "common/misc/clientcommon.hpp"
 #include "common/misc/lapack_host_reference.hpp"
@@ -94,19 +95,236 @@ void testing_stedc_bad_arg()
     stedc_checkBadArgs(handle, evect, n, dD.data(), dE.data(), dC.data(), ldc, dInfo.data());
 }
 
+// For `n > 1`, creates a symmetrized `n` by `n` tridiagonal, Clement matrix T of the following form:
+//
+//             (   sqrt(n - 1)   sqrt(2(n - 2))     sqrt((n - 2)2)   sqrt(n - 1)   )
+// T = tridiag ( 0             0                ...                0             0 )
+//             (   sqrt(n - 1)   sqrt(2(n - 2))     sqrt((n - 2)2)   sqrt(n - 1)   )
+//
+// were the `i-th` off-diagonal entry is sqrt(i(n - i)), 1 <= i < n.
+//
 template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
-void stedc_initData(const rocblas_handle handle,
-                    const rocblas_evect evect,
-                    const rocblas_int n,
-                    Sd& dD,
-                    Sd& dE,
-                    Td& dC,
-                    const rocblas_int ldc,
-                    Ud& dInfo,
-                    Sh& hD,
-                    Sh& hE,
-                    Th& hC,
-                    Uh& hInfo)
+void stedc_clement_initData(const rocblas_handle handle,
+                            const rocblas_evect evect,
+                            const rocblas_int n,
+                            Sd& dD,
+                            Sd& dE,
+                            Td& dC,
+                            const rocblas_int ldc,
+                            Ud& /* dInfo */,
+                            Sh& hD,
+                            Sh& hE,
+                            Th& hC,
+                            Uh& /* hInfo */)
+{
+    using S = decltype(std::real(T{}));
+    rocblas_int bc = 1;
+
+    if(CPU)
+    {
+        rocblas_init<T>(hC, true);
+
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMatT = HostMatrix<T, rocblas_int>;
+            using HMatS = HostMatrix<S, rocblas_int>;
+            using BDesc = typename HMatT::BlockDescriptor;
+
+            auto hCw = HMatT::Wrap(hC[b], ldc, n);
+            hCw->set_to_zero();
+            auto hDw = HMatS::Wrap(hD[b], n, 1);
+            hDw->set_to_zero();
+            auto hEw = HMatS::Wrap(hE[b], n, 1);
+            hEw->set_to_zero();
+
+            if(hCw && hDw && hEw) // update matrices if n >= 1
+            {
+                auto C = HMatT::Eye(n, n);
+                auto D = HMatS::Zeros(n, 1);
+                auto E = HMatS::Ones(n - 1, 1);
+
+                for(rocblas_int i = 1; i < n; ++i)
+                {
+                    E[i - 1] = std::sqrt(i * (n - i));
+                }
+
+                hCw->copy_data_from(C);
+                hDw->copy_data_from(D);
+                hEw->copy_data_from(E);
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dD.transfer_from(hD));
+        CHECK_HIP_ERROR(dE.transfer_from(hE));
+
+        if(evect == rocblas_evect_original)
+            CHECK_HIP_ERROR(dC.transfer_from(hC));
+    }
+}
+
+// Creates an `n` by `n` tridiagonal, Toeplitz matrix T of the following form:
+//
+//             (   1         1         1    )
+// T = tridiag ( 2   2 ... 2   2 ... 2    2 )
+//             (   1         1         1    )
+//
+template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+void stedc_toeplitz_initData(const rocblas_handle handle,
+                             const rocblas_evect evect,
+                             const rocblas_int n,
+                             Sd& dD,
+                             Sd& dE,
+                             Td& dC,
+                             const rocblas_int ldc,
+                             Ud& /* dInfo */,
+                             Sh& hD,
+                             Sh& hE,
+                             Th& hC,
+                             Uh& /* hInfo */)
+{
+    using S = decltype(std::real(T{}));
+    rocblas_int bc = 1;
+
+    if(CPU)
+    {
+        rocblas_init<T>(hC, true);
+
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMatT = HostMatrix<T, rocblas_int>;
+            using HMatS = HostMatrix<S, rocblas_int>;
+            using BDesc = typename HMatT::BlockDescriptor;
+
+            auto hCw = HMatT::Wrap(hC[b], ldc, n);
+            hCw->set_to_zero();
+            auto hDw = HMatS::Wrap(hD[b], n, 1);
+            hDw->set_to_zero();
+            auto hEw = HMatS::Wrap(hE[b], n, 1);
+            hEw->set_to_zero();
+
+            if(hCw && hDw && hEw) // update matrices if n >= 1
+            {
+                auto C = HMatT::Eye(n, n);
+                auto D = 2 * HMatS::Ones(n, 1);
+                auto E = HMatS::Ones(n - 1, 1);
+
+                hCw->copy_data_from(C);
+                hDw->copy_data_from(D);
+                hEw->copy_data_from(E);
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dD.transfer_from(hD));
+        CHECK_HIP_ERROR(dE.transfer_from(hE));
+
+        if(evect == rocblas_evect_original)
+            CHECK_HIP_ERROR(dC.transfer_from(hC));
+    }
+}
+
+// Creates an `n` by `n` tridiagonal, Wilkinson matrix, which is formed as follows:
+//
+// 1. If `n` is even:
+//                      (   1          1            1          1   )
+// W_{2m + 1} = tridiag ( m   (m - 1) ... 0.5 0.5 ... (m - 1)    m )
+//                      (   1          1            1          1   )
+//
+// 2. If `n` is odd:
+//                      (   1          1         1          1   )
+// W_{2m + 1} = tridiag ( m   (m - 1) ... 1 0 1 ... (m - 1)   m )
+//                      (   1          1         1          1   )
+//
+// where `n = 2m + 1`.
+//
+template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+void stedc_wilkinson_initData(const rocblas_handle handle,
+                              const rocblas_evect evect,
+                              const rocblas_int n,
+                              Sd& dD,
+                              Sd& dE,
+                              Td& dC,
+                              const rocblas_int ldc,
+                              Ud& /* dInfo */,
+                              Sh& hD,
+                              Sh& hE,
+                              Th& hC,
+                              Uh& /* hInfo */)
+{
+    using S = decltype(std::real(T{}));
+    rocblas_int bc = 1;
+
+    if(CPU)
+    {
+        rocblas_init<T>(hC, true);
+
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMatT = HostMatrix<T, rocblas_int>;
+            using HMatS = HostMatrix<S, rocblas_int>;
+            using BDesc = typename HMatT::BlockDescriptor;
+
+            auto hCw = HMatT::Wrap(hC[b], ldc, n);
+            hCw->set_to_zero();
+            auto hDw = HMatS::Wrap(hD[b], n, 1);
+            hDw->set_to_zero();
+            auto hEw = HMatS::Wrap(hE[b], n, 1);
+            hEw->set_to_zero();
+
+            if(hCw && hDw && hEw) // update matrices if n >= 1
+            {
+                S m = (n - 1) / S(2);
+                auto C = HMatT::Eye(n, n);
+                auto D = HMatS::Zeros(n, 1);
+                auto E = HMatS::Ones(n - 1, 1);
+
+                for(rocblas_int i = 0; i < n / 2; ++i)
+                {
+                    D[i] = m - i;
+                    D[n - 1 - i] = m - i;
+                }
+
+                hCw->copy_data_from(C);
+                hDw->copy_data_from(D);
+                hEw->copy_data_from(E);
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dD.transfer_from(hD));
+        CHECK_HIP_ERROR(dE.transfer_from(hE));
+
+        if(evect == rocblas_evect_original)
+            CHECK_HIP_ERROR(dC.transfer_from(hC));
+    }
+}
+
+template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+void stedc_default_initData(const rocblas_handle handle,
+                            const rocblas_evect evect,
+                            const rocblas_int n,
+                            Sd& dD,
+                            Sd& dE,
+                            Td& dC,
+                            const rocblas_int ldc,
+                            Ud& /* dInfo */,
+                            Sh& hD,
+                            Sh& hE,
+                            Th& hC,
+                            Uh& /* hInfo */)
 {
     if(CPU)
     {
@@ -238,6 +456,46 @@ void stedc_initData(const rocblas_handle handle,
         if(evect == rocblas_evect_original)
             CHECK_HIP_ERROR(dC.transfer_from(hC));
     }
+}
+
+template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+void stedc_initData(const rocblas_handle handle,
+                    const rocblas_evect evect,
+                    const rocblas_int n,
+                    Sd& dD,
+                    Sd& dE,
+                    Td& dC,
+                    const rocblas_int ldc,
+                    Ud& dInfo,
+                    Sh& hD,
+                    Sh& hE,
+                    Th& hC,
+                    Uh& hInfo)
+{
+    if((std::getenv("TEST_WILKINSON") != nullptr) || (std::getenv("STEDC_TEST_WILKINSON") != nullptr))
+    {
+        stedc_wilkinson_initData<CPU, GPU, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
+                                              hInfo);
+    }
+    else if((std::getenv("TEST_CLEMENT") != nullptr)
+            || (std::getenv("STEDC_TEST_CLEMENT") != nullptr))
+    {
+        stedc_clement_initData<CPU, GPU, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
+                                            hInfo);
+    }
+    else if((std::getenv("TEST_TOEPLITZ") != nullptr)
+            || (std::getenv("STEDC_TEST_TOEPLITZ") != nullptr))
+    {
+        stedc_toeplitz_initData<CPU, GPU, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
+                                             hInfo);
+    }
+    else
+    {
+        stedc_default_initData<CPU, GPU, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
+                                            hInfo);
+    }
+
+    return;
 }
 
 template <typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>

--- a/clients/common/auxiliary/testing_stedc.hpp
+++ b/clients/common/auxiliary/testing_stedc.hpp
@@ -232,6 +232,67 @@ void stedc_toeplitz_initData(const rocblas_handle handle,
     }
 }
 
+// Creates an `n` by `n` identity matrix.
+//
+template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+void stedc_identity_initData(const rocblas_handle handle,
+                             const rocblas_evect evect,
+                             const rocblas_int n,
+                             Sd& dD,
+                             Sd& dE,
+                             Td& dC,
+                             const rocblas_int ldc,
+                             Ud& /* dInfo */,
+                             Sh& hD,
+                             Sh& hE,
+                             Th& hC,
+                             Uh& /* hInfo */)
+{
+    using S = decltype(std::real(T{}));
+    rocblas_int bc = 1;
+
+    if(CPU)
+    {
+        rocblas_init<T>(hC, true);
+
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMatT = HostMatrix<T, rocblas_int>;
+            using HMatS = HostMatrix<S, rocblas_int>;
+            using BDesc = typename HMatT::BlockDescriptor;
+
+            auto hCw = HMatT::Wrap(hC[b], ldc, n);
+            hCw->set_to_zero();
+            auto hDw = HMatS::Wrap(hD[b], n, 1);
+            hDw->set_to_zero();
+            auto hEw = HMatS::Wrap(hE[b], n, 1);
+            hEw->set_to_zero();
+
+            if(hCw && hDw && hEw) // update matrices if n >= 1
+            {
+                auto C = HMatT::Eye(n, n);
+                auto D = HMatS::Ones(n, 1);
+                auto E = HMatS::Zeros(n - 1, 1);
+
+                hCw->copy_data_from(C);
+                hDw->copy_data_from(D);
+                hEw->copy_data_from(E);
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dD.transfer_from(hD));
+        CHECK_HIP_ERROR(dE.transfer_from(hE));
+
+        if(evect == rocblas_evect_original)
+            CHECK_HIP_ERROR(dC.transfer_from(hC));
+    }
+}
+
 // Creates an `n` by `n` tridiagonal, Wilkinson matrix, which is formed as follows:
 //
 // 1. If `n` is even:
@@ -489,6 +550,12 @@ void stedc_initData(const rocblas_handle handle,
         stedc_toeplitz_initData<CPU, GPU, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
                                              hInfo);
     }
+    else if((std::getenv("TEST_IDENTITY") != nullptr)
+            || (std::getenv("STEDC_TEST_IDENTITY") != nullptr))
+    {
+        stedc_identity_initData<CPU, GPU, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
+                                             hInfo);
+    }
     else
     {
         stedc_default_initData<CPU, GPU, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
@@ -520,6 +587,11 @@ void stedc_getError(const rocblas_handle handle,
 {
     constexpr bool COMPLEX = rocblas_is_complex<T>;
     using S = decltype(std::real(T{}));
+
+    using HMatT = HostMatrix<T, rocblas_int>;
+    using HMatS = HostMatrix<S, rocblas_int>;
+    using BDescT = typename HMatT::BlockDescriptor;
+    using BDescS = typename HMatS::BlockDescriptor;
 
     int lgn = floor(log(n - 1) / log(2)) + 1;
     size_t lwork = (COMPLEX) ? n * n : 0;
@@ -565,6 +637,14 @@ void stedc_getError(const rocblas_handle handle,
     // CPU lapack
     cpu_stedc(evect, n, hD[0], hE[0], hC[0], ldc, work.data(), lwork, rwork.data(), lrwork,
               iwork.data(), liwork, hInfo[0]);
+    auto AorT = HMatT::Empty();
+    if((evect != rocblas_evect_none) && (n > 0))
+    {
+        auto C = HMatT::Wrap(hCRes[0], ldc, n)->block(BDescT().nrows(n).ncols(n));
+        auto d = HMatT::Convert(hDRes[0], 1, n)->block(BDescT().nrows(1).ncols(n));
+        auto D = HMatT::Zeros(n, n).diag(d);
+        AorT = C * D * adjoint(C);
+    }
 
     // check info
     EXPECT_EQ(hInfo[0][0], hInfoRes[0][0]);
@@ -575,7 +655,7 @@ void stedc_getError(const rocblas_handle handle,
 
     double err;
 
-    if(hInfo[0][0] == 0)
+    if((hInfo[0][0] == 0) && (n > 0))
     {
         // check that eigenvalues are correct and in order
         // error is ||hD - hDRes|| / ||hD||
@@ -586,23 +666,38 @@ void stedc_getError(const rocblas_handle handle,
         // check eigenvectors if required
         if(evect != rocblas_evect_none)
         {
-            // both eigenvalues and eigenvectors needed; need to implicitly test
-            // eigenvectors due to non-uniqueness of eigenvectors under scaling
+            // New matrix initialization
+            auto C = HMatT::Wrap(hCRes[0], ldc, n)->block(BDescT().nrows(n).ncols(n));
+            auto d = HMatT::Convert(hDRes[0], 1, n)->block(BDescT().nrows(1).ncols(n));
+            auto D = HMatT::Zeros(n, n).diag(d);
+            /* std::cout << "--- Computed eigenvalues: " << std::endl; */
+            /* d.print(); */
 
-            // multiply A with each of the n eigenvectors and divide by corresponding
-            // eigenvalues
-            T alpha;
-            T beta = 0;
-            for(int j = 0; j < n; j++)
-            {
-                alpha = T(1) / hDRes[0][j];
-                cpu_symv_hemv(rocblas_fill_upper, n, alpha, hA[0], lda, hCRes[0] + j * ldc, 1, beta,
-                              hC[0] + j * ldc, 1);
-            }
+            auto OE = adjoint(C) * C - HMatT::Eye(n, n);
+            err = OE.max_col_norm();
+            *max_err = err > *max_err ? err : *max_err;
 
-            // error is ||hC - hCRes|| / ||hC||
-            // using frobenius norm
-            *max_errv = norm_error('F', n, n, ldc, hCRes[0], hC[0]);
+            auto AE = AorT - C * D * adjoint(C);
+            err = AE.norm() / AorT.norm();
+            *max_err = err > *max_err ? err : *max_err;
+
+            /* // both eigenvalues and eigenvectors needed; need to implicitly test */
+            /* // eigenvectors due to non-uniqueness of eigenvectors under scaling */
+
+            /* // multiply A with each of the n eigenvectors and divide by corresponding */
+            /* // eigenvalues */
+            /* T alpha; */
+            /* T beta = 0; */
+            /* for(int j = 0; j < n; j++) */
+            /* { */
+            /*     alpha = T(1) / hDRes[0][j]; */
+            /*     cpu_symv_hemv(rocblas_fill_upper, n, alpha, hA[0], lda, hCRes[0] + j * ldc, 1, beta, */
+            /*                   hC[0] + j * ldc, 1); */
+            /* } */
+
+            /* // error is ||hC - hCRes|| / ||hC|| */
+            /* // using frobenius norm */
+            /* *max_errv = norm_error('F', n, n, ldc, hCRes[0], hC[0]); */
         }
     }
 }

--- a/clients/common/auxiliary/testing_stedc.hpp
+++ b/clients/common/auxiliary/testing_stedc.hpp
@@ -640,8 +640,8 @@ void stedc_getError(const rocblas_handle handle,
     auto AorT = HMatT::Empty();
     if((evect != rocblas_evect_none) && (n > 0))
     {
-        auto C = HMatT::Wrap(hCRes[0], ldc, n)->block(BDescT().nrows(n).ncols(n));
-        auto d = HMatT::Convert(hDRes[0], 1, n)->block(BDescT().nrows(1).ncols(n));
+        auto C = HMatT::Wrap(hC[0], ldc, n)->block(BDescT().nrows(n).ncols(n));
+        auto d = HMatT::Convert(hD[0], 1, n)->block(BDescT().nrows(1).ncols(n));
         auto D = HMatT::Zeros(n, n).diag(d);
         AorT = C * D * adjoint(C);
     }
@@ -654,6 +654,7 @@ void stedc_getError(const rocblas_handle handle,
         *max_err = 0;
 
     double err;
+    *max_errv = 0;
 
     if((hInfo[0][0] == 0) && (n > 0))
     {
@@ -673,11 +674,13 @@ void stedc_getError(const rocblas_handle handle,
             /* std::cout << "--- Computed eigenvalues: " << std::endl; */
             /* d.print(); */
 
-            auto OE = adjoint(C) * C - HMatT::Eye(n, n);
+            auto OE = C * adjoint(C) - HMatT::Eye(n, n);
             err = OE.max_col_norm();
-            *max_err = err > *max_err ? err : *max_err;
+            /* std::cout << "--- Orthogonal error: " << err << std::endl; */
+            *max_errv = err > *max_err ? err : *max_err;
 
             auto AE = AorT - C * D * adjoint(C);
+            /* std::cout << "--- Residual error: " << err << std::endl; */
             err = AE.norm() / AorT.norm();
             *max_err = err > *max_err ? err : *max_err;
 
@@ -886,7 +889,7 @@ void testing_stedc(Arguments& argus)
     {
         ROCSOLVER_TEST_CHECK(T, max_err, n);
         if(evect != rocblas_evect_none)
-            ROCSOLVER_TEST_CHECK(T, max_errv, n * n);
+            ROCSOLVER_TEST_CHECK(T, max_errv, n);
     }
 
     // output results for rocsolver-bench

--- a/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/clients/common/lapack/testing_syevd_heevd.hpp
@@ -478,19 +478,22 @@ void syevd_heevd_initData(const rocblas_handle handle,
                           std::vector<T>& A,
                           bool test = true)
 {
-    if(std::getenv("SYEVD_TEST_EIG7") != nullptr)
+    if((std::getenv("TEST_EIG7") != nullptr) || (std::getenv("SYEVD_TEST_EIG7") != nullptr))
     {
         syevd_heevd_eig7_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
     }
-    else if(std::getenv("SYEVD_TEST_WILKINSON") != nullptr)
+    else if((std::getenv("TEST_WILKINSON") != nullptr)
+            || (std::getenv("SYEVD_TEST_WILKINSON") != nullptr))
     {
         syevd_heevd_wilkinson_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
     }
-    else if(std::getenv("SYEVD_TEST_CLEMENT") != nullptr)
+    else if((std::getenv("TEST_CLEMENT") != nullptr)
+            || (std::getenv("SYEVD_TEST_CLEMENT") != nullptr))
     {
         syevd_heevd_clement_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
     }
-    else if(std::getenv("SYEVD_TEST_TOEPLITZ") != nullptr)
+    else if((std::getenv("TEST_TOEPLITZ") != nullptr)
+            || (std::getenv("SYEVD_TEST_TOEPLITZ") != nullptr))
     {
         syevd_heevd_toeplitz_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
     }

--- a/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/clients/common/lapack/testing_syevd_heevd.hpp
@@ -173,7 +173,10 @@ void syevd_heevd_default_initData(const rocblas_handle handle,
                     else
                     {
                         hA[b][i + j * lda] -= 4;
-                        hA[b][j + i * lda] = hA[b][i + j * lda];
+                        if constexpr(rocblas_is_complex<T>)
+                            hA[b][j + i * lda] = std::conj(hA[b][i + j * lda]);
+                        else
+                            hA[b][j + i * lda] = hA[b][i + j * lda];
                     }
                 }
             }

--- a/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/clients/common/lapack/testing_syevd_heevd.hpp
@@ -166,12 +166,15 @@ void syevd_heevd_default_initData(const rocblas_handle handle,
         {
             for(rocblas_int i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(rocblas_int j = i; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] = std::real(hA[b][i + j * lda]) + 400;
                     else
+                    {
                         hA[b][i + j * lda] -= 4;
+                        hA[b][j + i * lda] = hA[b][i + j * lda];
+                    }
                 }
             }
 
@@ -525,7 +528,8 @@ void syevd_heevd_getError(const rocblas_handle handle,
                           Sh& hDres,
                           Ih& hinfo,
                           Ih& hinfoRes,
-                          double* max_err)
+                          double* max_err,
+                          double* max_errv)
 {
     constexpr bool COMPLEX = rocblas_is_complex<T>;
     using S = decltype(std::real(T{}));
@@ -608,6 +612,9 @@ void syevd_heevd_getError(const rocblas_handle handle,
                 // New matrix initialization
                 auto M
                     = HMatT::Wrap(A.data() + b * lda * n, lda, n)->block(BDescT().nrows(n).ncols(n));
+                /* std::cout << "--- Input matrix: " << std::endl; */
+                /* M.print(); */
+
                 auto U = HMatT::Wrap(hAres[b], lda, n)->block(BDescT().nrows(n).ncols(n));
                 auto d = HMatT::Convert(hDres[b], 1, n)->block(BDescT().nrows(1).ncols(n));
                 auto D = HMatT::Zeros(n, n).diag(d);
@@ -616,10 +623,13 @@ void syevd_heevd_getError(const rocblas_handle handle,
 
                 auto OE = U * adjoint(U) - HMatT::Eye(n, n);
                 err = OE.max_col_norm();
-                *max_err = err > *max_err ? err : *max_err;
+                /* std::cout << "--- Orthogonal error: " << err << std::endl; */
+                *max_errv = err > *max_err ? err : *max_err;
 
                 auto AE = M - U * D * adjoint(U);
                 err = AE.norm() / M.norm();
+                /* std::cout << "--- Residual error: " << err << std::endl; */
+                /* AE.print(); */
                 *max_err = err > *max_err ? err : *max_err;
 
                 /* // multiply A with each of the n eigenvectors and divide by corresponding */
@@ -797,7 +807,7 @@ void testing_syevd_heevd(Arguments& argus)
     size_t size_Ares = (argus.unit_check || argus.norm_check) ? size_A : 0;
     size_t size_Dres = (argus.unit_check || argus.norm_check) ? size_D : 0;
 
-    double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
+    double max_error = 0, max_ortho_error = 0, gpu_time_used = 0, cpu_time_used = 0;
 
     // check invalid sizes
     bool invalid_size = (n < 0 || lda < n || bc < 0);
@@ -883,7 +893,7 @@ void testing_syevd_heevd(Arguments& argus)
         {
             syevd_heevd_getError<STRIDED, T>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE, stE,
                                              dinfo, bc, hA, hAres, hD, hDres, hinfo, hinfoRes,
-                                             &max_error);
+                                             &max_error, &max_ortho_error);
         }
 
         // collect performance data
@@ -923,7 +933,7 @@ void testing_syevd_heevd(Arguments& argus)
         {
             syevd_heevd_getError<STRIDED, T>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE, stE,
                                              dinfo, bc, hA, hAres, hD, hDres, hinfo, hinfoRes,
-                                             &max_error);
+                                             &max_error, &max_ortho_error);
         }
 
         // collect performance data
@@ -939,7 +949,11 @@ void testing_syevd_heevd(Arguments& argus)
     // validate results for rocsolver-test
     // using 10 * n * machine_precision as tolerance
     if(argus.unit_check)
+    {
         ROCSOLVER_TEST_CHECK(T, max_error, 10 * n);
+        if(evect != rocblas_evect_none)
+            ROCSOLVER_TEST_CHECK(T, max_ortho_error, 10 * n);
+    }
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/clients/common/lapack/testing_syevd_heevd.hpp
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include "common/matrix_utils/matrix_utils.hpp"
 #include "common/misc/client_util.hpp"
 #include "common/misc/clientcommon.hpp"
 #include "common/misc/lapack_host_reference.hpp"
@@ -146,15 +147,15 @@ void testing_syevd_heevd_bad_arg()
 }
 
 template <bool CPU, bool GPU, typename T, typename Td, typename Th>
-void syevd_heevd_initData(const rocblas_handle handle,
-                          const rocblas_evect evect,
-                          const rocblas_int n,
-                          Td& dA,
-                          const rocblas_int lda,
-                          const rocblas_int bc,
-                          Th& hA,
-                          std::vector<T>& A,
-                          bool test = true)
+void syevd_heevd_default_initData(const rocblas_handle handle,
+                                  const rocblas_evect evect,
+                                  const rocblas_int n,
+                                  Td& dA,
+                                  const rocblas_int lda,
+                                  const rocblas_int bc,
+                                  Th& hA,
+                                  std::vector<T>& A,
+                                  bool test = true)
 {
     if(CPU)
     {
@@ -191,6 +192,171 @@ void syevd_heevd_initData(const rocblas_handle handle,
         // now copy to the GPU
         CHECK_HIP_ERROR(dA.transfer_from(hA));
     }
+}
+
+// Creates an `n` by `n` matrix `A` with the following eigenvalues:
+//
+// spectrum(A) = { l_i = ulp * i, for 1 <= i <= n - 1; l_n = 1 }
+//
+// where `ulp` is the smallest floating point number such that `1 + ulp > 1`.
+//
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void syevd_heevd_eig7_initData(const rocblas_handle handle,
+                               const rocblas_evect evect,
+                               const rocblas_int n,
+                               Td& dA,
+                               const rocblas_int lda,
+                               const rocblas_int bc,
+                               Th& hA,
+                               std::vector<T>& A,
+                               bool test = true)
+{
+    using S = decltype(std::real(T{}));
+
+    if(CPU)
+    {
+        rocblas_init<T>(hA, true);
+
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMat = HostMatrix<T, rocblas_int>;
+            using BDesc = typename HMat::BlockDescriptor;
+
+            auto hAw = HMat::Wrap(hA[b], lda, n);
+            if(hAw) // update matrix hA if n >= 1
+            {
+                auto eigs = std::numeric_limits<S>::epsilon() * HMat::FromRange(1, n - 1, n - 1);
+                eigs = cat(eigs, HMat::Ones(1, 1));
+                auto [Q, _] = qr((*hAw).block(BDesc().nrows(n).ncols(n)));
+                hAw->set_to_zero();
+
+                hAw->copy_data_from(Q * HMat::Zeros(n).diag(eigs) * adjoint(Q));
+            }
+
+            // make copy of original data to test vectors if required
+            if(test && evect == rocblas_evect_original)
+            {
+                for(rocblas_int i = 0; i < n; i++)
+                {
+                    for(rocblas_int j = 0; j < n; j++)
+                        A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
+                }
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+    }
+}
+
+// Creates an `n` by `n` Wilkinson matrix, which is formed as follows:
+//
+// 1. If `n` is even:
+//                      (   1          1            1          1   )
+// W_{2m + 1} = tridiag ( m   (m - 1) ... 0.5 0.5 ... (m - 1)    m )
+//                      (   1          1            1          1   )
+//
+// 2. If `n` is odd:
+//                      (   1          1         1          1   )
+// W_{2m + 1} = tridiag ( m   (m - 1) ... 1 0 1 ... (m - 1)   m )
+//                      (   1          1         1          1   )
+//
+// where `n = 2m + 1`.
+//
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void syevd_heevd_wilkinson_initData(const rocblas_handle handle,
+                                    const rocblas_evect evect,
+                                    const rocblas_int n,
+                                    Td& dA,
+                                    const rocblas_int lda,
+                                    const rocblas_int bc,
+                                    Th& hA,
+                                    std::vector<T>& A,
+                                    bool test = true)
+{
+    using S = decltype(std::real(T{}));
+
+    if(CPU)
+    {
+        rocblas_init<T>(hA, true);
+
+        // scale A to avoid singularities
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMat = HostMatrix<T, rocblas_int>;
+            using BDesc = typename HMat::BlockDescriptor;
+
+            auto hAw = HMat::Wrap(hA[b], lda, n);
+            if(hAw) // update matrix hA if n >= 1
+            {
+                S m = (n - 1) / S(2);
+                auto A = HMat::Zeros(n, n);
+                auto E = HMat::Ones(n - 1, 1);
+                auto D = HMat::Zeros(n, 1);
+
+                for(rocblas_int i = 0; i < n / 2; ++i)
+                {
+                    D[i] = m - i;
+                    D[n - 1 - i] = m - i;
+                }
+
+                A.diag(D);
+                A.sup_diag(E);
+                A.sub_diag(E);
+
+                hAw->set_to_zero();
+                hAw->copy_data_from(A);
+            }
+
+            // make copy of original data to test vectors if required
+            if(test && evect == rocblas_evect_original)
+            {
+                for(rocblas_int i = 0; i < n; i++)
+                {
+                    for(rocblas_int j = 0; j < n; j++)
+                        A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
+                }
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+    }
+}
+
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void syevd_heevd_initData(const rocblas_handle handle,
+                          const rocblas_evect evect,
+                          const rocblas_int n,
+                          Td& dA,
+                          const rocblas_int lda,
+                          const rocblas_int bc,
+                          Th& hA,
+                          std::vector<T>& A,
+                          bool test = true)
+{
+    if(std::getenv("SYEVD_TEST_EIG7") != nullptr)
+    {
+        syevd_heevd_eig7_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+    }
+    else if(std::getenv("SYEVD_TEST_WILKINSON") != nullptr)
+    {
+        syevd_heevd_wilkinson_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+    }
+    else
+    {
+        syevd_heevd_default_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+    }
+
+    return;
 }
 
 template <bool STRIDED, typename T, typename Sd, typename Td, typename Id, typename Sh, typename Th, typename Ih>
@@ -602,9 +768,9 @@ void testing_syevd_heevd(Arguments& argus)
     }
 
     // validate results for rocsolver-test
-    // using n * machine_precision as tolerance
+    // using 3 * n * machine_precision as tolerance
     if(argus.unit_check)
-        ROCSOLVER_TEST_CHECK(T, max_error, n);
+        ROCSOLVER_TEST_CHECK(T, max_error, 3 * n);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/clients/common/lapack/testing_syevd_heevd.hpp
@@ -253,7 +253,7 @@ void syevd_heevd_eig7_initData(const rocblas_handle handle,
     }
 }
 
-// Creates an `n` by `n` Wilkinson matrix, which is formed as follows:
+// Creates an `n` by `n` tridiagonal, Wilkinson matrix, which is formed as follows:
 //
 // 1. If `n` is even:
 //                      (   1          1            1          1   )
@@ -332,6 +332,141 @@ void syevd_heevd_wilkinson_initData(const rocblas_handle handle,
     }
 }
 
+// Creates an `n` by `n` tridiagonal, Toeplitz matrix T of the following form:
+//
+//             (   1         1         1    )
+// T = tridiag ( 2   2 ... 2   2 ... 2    2 )
+//             (   1         1         1    )
+//
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void syevd_heevd_toeplitz_initData(const rocblas_handle handle,
+                                   const rocblas_evect evect,
+                                   const rocblas_int n,
+                                   Td& dA,
+                                   const rocblas_int lda,
+                                   const rocblas_int bc,
+                                   Th& hA,
+                                   std::vector<T>& A,
+                                   bool test = true)
+{
+    using S = decltype(std::real(T{}));
+
+    if(CPU)
+    {
+        rocblas_init<T>(hA, true);
+
+        // scale A to avoid singularities
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMat = HostMatrix<T, rocblas_int>;
+            using BDesc = typename HMat::BlockDescriptor;
+
+            auto hAw = HMat::Wrap(hA[b], lda, n);
+            if(hAw) // update matrix hA if n >= 1
+            {
+                auto A = HMat::Zeros(n, n);
+                auto E = HMat::Ones(n - 1, 1);
+                auto D = 2 * HMat::Ones(n, 1);
+
+                A.diag(D);
+                A.sup_diag(E);
+                A.sub_diag(E);
+
+                hAw->set_to_zero();
+                hAw->copy_data_from(A);
+            }
+
+            // make copy of original data to test vectors if required
+            if(test && evect == rocblas_evect_original)
+            {
+                for(rocblas_int i = 0; i < n; i++)
+                {
+                    for(rocblas_int j = 0; j < n; j++)
+                        A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
+                }
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+    }
+}
+
+// For `n > 1`, creates a symmetrized `n` by `n` tridiagonal, Clement matrix T of the following form:
+//
+//             (   sqrt(n - 1)   sqrt(2(n - 2))     sqrt((n - 2)2)   sqrt(n - 1)   )
+// T = tridiag ( 0             0                ...                0             0 )
+//             (   sqrt(n - 1)   sqrt(2(n - 2))     sqrt((n - 2)2)   sqrt(n - 1)   )
+//
+// were the `i-th` off-diagonal entry is sqrt(i(n - i)), 1 <= i < n.
+//
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void syevd_heevd_clement_initData(const rocblas_handle handle,
+                                  const rocblas_evect evect,
+                                  const rocblas_int n,
+                                  Td& dA,
+                                  const rocblas_int lda,
+                                  const rocblas_int bc,
+                                  Th& hA,
+                                  std::vector<T>& A,
+                                  bool test = true)
+{
+    using S = decltype(std::real(T{}));
+
+    if(CPU)
+    {
+        rocblas_init<T>(hA, true);
+
+        // scale A to avoid singularities
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMat = HostMatrix<T, rocblas_int>;
+            using BDesc = typename HMat::BlockDescriptor;
+
+            auto hAw = HMat::Wrap(hA[b], lda, n);
+            if(hAw) // update matrix hA if n >= 1
+            {
+                auto A = HMat::Zeros(n, n);
+                auto E = HMat::Ones(n - 1, 1);
+                auto D = HMat::Zeros(n, 1);
+
+                for(rocblas_int i = 1; i < n; ++i)
+                {
+                    E[i - 1] = std::sqrt(i * (n - i));
+                }
+
+                A.diag(D);
+                A.sup_diag(E);
+                A.sub_diag(E);
+
+                hAw->set_to_zero();
+                hAw->copy_data_from(A);
+            }
+
+            // make copy of original data to test vectors if required
+            if(test && evect == rocblas_evect_original)
+            {
+                for(rocblas_int i = 0; i < n; i++)
+                {
+                    for(rocblas_int j = 0; j < n; j++)
+                        A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
+                }
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+    }
+}
+
 template <bool CPU, bool GPU, typename T, typename Td, typename Th>
 void syevd_heevd_initData(const rocblas_handle handle,
                           const rocblas_evect evect,
@@ -350,6 +485,14 @@ void syevd_heevd_initData(const rocblas_handle handle,
     else if(std::getenv("SYEVD_TEST_WILKINSON") != nullptr)
     {
         syevd_heevd_wilkinson_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+    }
+    else if(std::getenv("SYEVD_TEST_CLEMENT") != nullptr)
+    {
+        syevd_heevd_clement_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+    }
+    else if(std::getenv("SYEVD_TEST_TOEPLITZ") != nullptr)
+    {
+        syevd_heevd_toeplitz_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
     }
     else
     {
@@ -768,9 +911,9 @@ void testing_syevd_heevd(Arguments& argus)
     }
 
     // validate results for rocsolver-test
-    // using 3 * n * machine_precision as tolerance
+    // using 10 * n * machine_precision as tolerance
     if(argus.unit_check)
-        ROCSOLVER_TEST_CHECK(T, max_error, 3 * n);
+        ROCSOLVER_TEST_CHECK(T, max_error, 10 * n);
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/clients/common/lapack/testing_syevd_heevd.hpp
@@ -530,6 +530,12 @@ void syevd_heevd_getError(const rocblas_handle handle,
     constexpr bool COMPLEX = rocblas_is_complex<T>;
     using S = decltype(std::real(T{}));
 
+    using HMatT = HostMatrix<T, rocblas_int>;
+    using HMatS = HostMatrix<S, rocblas_int>;
+    using BDescT = typename HMatT::BlockDescriptor;
+    using BDescS = typename HMatS::BlockDescriptor;
+
+    int lgn = floor(log(n - 1) / log(2)) + 1;
     int sizeE, lwork;
     if(!COMPLEX)
     {
@@ -597,23 +603,40 @@ void syevd_heevd_getError(const rocblas_handle handle,
         {
             // both eigenvalues and eigenvectors needed; need to implicitly test
             // eigenvectors due to non-uniqueness of eigenvectors under scaling
-            if(hinfo[b][0] == 0)
+            if((hinfo[b][0] == 0) && (n > 0))
             {
-                // multiply A with each of the n eigenvectors and divide by corresponding
-                // eigenvalues
-                T alpha;
-                T beta = 0;
-                for(int j = 0; j < n; j++)
-                {
-                    alpha = T(1) / hDres[b][j];
-                    cpu_symv_hemv(uplo, n, alpha, A.data() + b * lda * n, lda, hAres[b] + j * lda,
-                                  1, beta, hA[b] + j * lda, 1);
-                }
+                // New matrix initialization
+                auto M
+                    = HMatT::Wrap(A.data() + b * lda * n, lda, n)->block(BDescT().nrows(n).ncols(n));
+                auto U = HMatT::Wrap(hAres[b], lda, n)->block(BDescT().nrows(n).ncols(n));
+                auto d = HMatT::Convert(hDres[b], 1, n)->block(BDescT().nrows(1).ncols(n));
+                auto D = HMatT::Zeros(n, n).diag(d);
+                /* std::cout << "--- Computed eigenvalues: " << std::endl; */
+                /* d.print(); */
 
-                // error is ||hA - hARes|| / ||hA||
-                // using frobenius norm
-                err = norm_error('F', n, n, lda, hA[b], hAres[b]);
+                auto OE = U * adjoint(U) - HMatT::Eye(n, n);
+                err = OE.max_col_norm();
                 *max_err = err > *max_err ? err : *max_err;
+
+                auto AE = M - U * D * adjoint(U);
+                err = AE.norm() / M.norm();
+                *max_err = err > *max_err ? err : *max_err;
+
+                /* // multiply A with each of the n eigenvectors and divide by corresponding */
+                /* // eigenvalues */
+                /* T alpha; */
+                /* T beta = 0; */
+                /* for(int j = 0; j < n; j++) */
+                /* { */
+                /*     alpha = T(1) / hDres[b][j]; */
+                /*     cpu_symv_hemv(uplo, n, alpha, A.data() + b * lda * n, lda, hAres[b] + j * lda, */
+                /*                   1, beta, hA[b] + j * lda, 1); */
+                /* } */
+
+                /* // error is ||hA - hARes|| / ||hA|| */
+                /* // using frobenius norm */
+                /* err = norm_error('F', n, n, lda, hA[b], hAres[b]); */
+                /* *max_err = err > *max_err ? err : *max_err; */
             }
         }
     }

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -40,6 +40,7 @@
 #include "rocsolver_run_specialized_kernels.hpp"
 
 #include <algorithm>
+#include <rocprim/rocprim.hpp>
 
 ROCSOLVER_BEGIN_NAMESPACE
 
@@ -1994,6 +1995,88 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     }
 }
 
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(BS1) stedc_prep_sort(const rocblas_int n,
+                                                             const rocblas_int batch_count,
+                                                             S* DD,
+                                                             const rocblas_stride strideD,
+                                                             S* tmpD,
+                                                             rocblas_int* mmap,
+                                                             rocblas_int* offsets)
+{
+    // -----------------------------------
+    // use z-grid dimension as batch index
+    // -----------------------------------
+    rocblas_int bid_start = hipBlockIdx_z;
+    rocblas_int bid_inc = hipGridDim_z;
+
+    int gid = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
+    int dim = hipBlockDim_x * hipGridDim_x;
+
+    rocblas_int* const map = mmap + bid_start * ((int64_t)n);
+
+    for(auto bid = bid_start; bid < batch_count; bid += bid_inc)
+    {
+        // ---------------------------------------------
+        // select batch instance to work with
+        // (avoiding arithmetics with possible nullptrs)
+        // ---------------------------------------------
+
+        // intialize batch offset
+        if(gid == 0)
+        {
+            offsets[bid] = n * bid;
+
+            if(bid == batch_count - 1)
+            {
+                offsets[bid + 1] = n * (bid + 1);
+            }
+        }
+
+        S* D = DD + (bid * strideD);
+
+        // initialize map & tmpD
+        for(auto i = gid; i < n; i += dim)
+        {
+            map[i] = i;
+            tmpD[i + (bid * n)] = D[i];
+        }
+    }
+}
+
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(BS1) stedc_copy_eval(const rocblas_int n,
+                                                             const rocblas_int batch_count,
+                                                             S* DD,
+                                                             const rocblas_stride strideD,
+                                                             S* tmpD)
+{
+    // -----------------------------------
+    // use z-grid dimension as batch index
+    // -----------------------------------
+    rocblas_int bid_start = hipBlockIdx_z;
+    rocblas_int bid_inc = hipGridDim_z;
+
+    int gid = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
+    int dim = hipBlockDim_x * hipGridDim_x;
+
+    for(auto bid = bid_start; bid < batch_count; bid += bid_inc)
+    {
+        // ---------------------------------------------
+        // select batch instance to work with
+        // (avoiding arithmetics with possible nullptrs)
+        // ---------------------------------------------
+
+        S* D = DD + (bid * strideD);
+
+        // copy tmpD to D
+        for(auto i = gid; i < n; i += dim)
+        {
+            D[i] = tmpD[i + (bid * n)];
+        }
+    }
+}
+
 /** STEDC_SORT_EVAL sorts computed eigenvalues increasing order **/
 template <typename T, typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(BS1) stedc_sort_eval(const rocblas_int n,
@@ -2392,6 +2475,8 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         return rocblas_status_success;
 
     auto const splits_map = splits;
+    auto const splits_map_out = splits_map + n * batch_count;
+    auto const sort_offsets = splits_map_out + n * batch_count;
 
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
@@ -2568,14 +2653,39 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             HIP_CHECK(hipEventCreate(&sort_events[i]));
 
         HIP_CHECK(hipEventRecord(sort_events[0], stream));
-        ROCSOLVER_LAUNCH_KERNEL((stedc_sort_eval<T>), dim3(1, 1, batch_count), dim3(BS1), 0, stream,
-                                n, D + shiftD, strideD, batch_count, splits_map);
+        // ROCSOLVER_LAUNCH_KERNEL((stedc_sort_eval<T>), dim3(1, 1, batch_count), dim3(BS1), 0, stream,
+        //                         n, D + shiftD, strideD, batch_count, splits_map);
+
+        ROCSOLVER_LAUNCH_KERNEL((stedc_prep_sort), dim3(((n - 1) / BS1 + 1), 1, batch_count),
+                                dim3(BS1), 0, stream, n, batch_count, D + shiftD, strideD, tmpz,
+                                splits_map, sort_offsets);
+
+        size_t temporary_storage_size_bytes = 0;
+        void* temporary_storage_ptr = nullptr;
+        // Get required size of the temporary storage
+        HIP_CHECK(rocprim::segmented_radix_sort_pairs(
+            temporary_storage_ptr, temporary_storage_size_bytes, tmpz, tmpz + (n * batch_count),
+            splits_map, splits_map_out, n * batch_count, batch_count, sort_offsets,
+            sort_offsets + 1, 0, 8 * sizeof(S), stream, false));
+
+        HIP_CHECK(hipMallocAsync(&temporary_storage_ptr, temporary_storage_size_bytes, stream));
+
+        HIP_CHECK(rocprim::segmented_radix_sort_pairs(
+            temporary_storage_ptr, temporary_storage_size_bytes, tmpz, tmpz + (n * batch_count),
+            splits_map, splits_map_out, n * batch_count, batch_count, sort_offsets,
+            sort_offsets + 1, 0, 8 * sizeof(S), stream, false));
+
+        HIP_CHECK(hipFreeAsync(temporary_storage_ptr, stream));
+
+        ROCSOLVER_LAUNCH_KERNEL((stedc_copy_eval), dim3(((n - 1) / BS1 + 1), 1, batch_count),
+                                dim3(BS1), 0, stream, n, batch_count, D + shiftD, strideD,
+                                tmpz + (n * batch_count));
 
         const auto nblocks = (n - 1) / BS2 + 1;
         HIP_CHECK(hipEventRecord(sort_events[1], stream));
         ROCSOLVER_LAUNCH_KERNEL((stedc_sort_evec<T>), dim3(nblocks, nblocks, batch_count),
                                 dim3(BS2, BS2), 0, stream, n, C, shiftC, ldc, strideC, (T*)tempgemm,
-                                batch_count, splits_map);
+                                batch_count, splits_map_out);
         HIP_CHECK(hipEventRecord(sort_events[2], stream));
         ROCSOLVER_LAUNCH_KERNEL((stedc_copy_evec<T>), dim3(nblocks, nblocks, batch_count),
                                 dim3(BS2, BS2), 0, stream, n, C, shiftC, ldc, strideC, (T*)tempgemm,

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -2389,9 +2389,9 @@ void rocsolver_stedc_getMemorySize(const rocblas_evect evect,
         rocsolver_steqr_getMemorySize<T, S>(evect, n, batch_count, &w1);
 
         auto status = rocprim::segmented_radix_sort_pairs(
-            nullptr, w2, (S*)nullptr, (S*)nullptr,
-            (rocblas_int*)nullptr, (rocblas_int*)nullptr, n * batch_count, batch_count, (rocblas_int*)nullptr,
-            (rocblas_int*)nullptr, 0, 8 * sizeof(S), 0, false);
+            nullptr, w2, (S*)nullptr, (S*)nullptr, (rocblas_int*)nullptr, (rocblas_int*)nullptr,
+            n * batch_count, batch_count, (rocblas_int*)nullptr, (rocblas_int*)nullptr, 0,
+            8 * sizeof(S), 0, false);
 
         *size_work_stack = std::max(w1, w2);
 
@@ -2666,19 +2666,18 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                 dim3(BS1), 0, stream, n, batch_count, D + shiftD, strideD, tmpz,
                                 splits_map, sort_offsets);
 
-
         HIP_CHECK(hipEventRecord(sort_events[1], stream));
         // Get required size of the temporary storage
         size_t temporary_storage_size_bytes = 0;
         HIP_CHECK(rocprim::segmented_radix_sort_pairs(
-            nullptr, temporary_storage_size_bytes, (S*)nullptr, (S*)nullptr,
-            (rocblas_int*)nullptr, (rocblas_int*)nullptr, n * batch_count, batch_count, (rocblas_int*)nullptr,
+            nullptr, temporary_storage_size_bytes, (S*)nullptr, (S*)nullptr, (rocblas_int*)nullptr,
+            (rocblas_int*)nullptr, n * batch_count, batch_count, (rocblas_int*)nullptr,
             (rocblas_int*)nullptr, 0, 8 * sizeof(S), 0, false));
 
         HIP_CHECK(rocprim::segmented_radix_sort_pairs(
-            work_stack, temporary_storage_size_bytes, tmpz, tmpz + (n * batch_count),
-            splits_map, splits_map_out, n * batch_count, batch_count, sort_offsets,
-            sort_offsets + 1, 0, 8 * sizeof(S), stream, false));
+            work_stack, temporary_storage_size_bytes, tmpz, tmpz + (n * batch_count), splits_map,
+            splits_map_out, n * batch_count, batch_count, sort_offsets, sort_offsets + 1, 0,
+            8 * sizeof(S), stream, false));
 
         HIP_CHECK(hipEventRecord(sort_events[2], stream));
         ROCSOLVER_LAUNCH_KERNEL((stedc_copy_eval), dim3(((n - 1) / BS1 + 1), 1, batch_count),
@@ -2712,9 +2711,7 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                "\t\tstedc_copy_eval: %f\n"
                "\tstedc_sort_evec: %f\n"
                "\tstedc_copy_evec: %f\n",
-               elapsed[0], elapsed[1], elapsed[2],
-               elapsed[3], elapsed[4], elapsed[5]
-            );
+               elapsed[0], elapsed[1], elapsed[2], elapsed[3], elapsed[4], elapsed[5]);
 
         rocblas_set_pointer_mode(handle, old_mode);
     }

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -2666,7 +2666,7 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                 dim3(BS1), 0, stream, n, batch_count, D + shiftD, strideD, tmpz,
                                 splits_map, sort_offsets);
 
-                                
+
         HIP_CHECK(hipEventRecord(sort_events[1], stream));
         // Get required size of the temporary storage
         size_t temporary_storage_size_bytes = 0;

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -2563,16 +2563,38 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         }
 
         // finally sort eigenvalues and eigenvectors
+        hipEvent_t sort_events[4];
+        for(int i = 0; i < 4; i++)
+            HIP_CHECK(hipEventCreate(&sort_events[i]));
+
+        HIP_CHECK(hipEventRecord(sort_events[0], stream));
         ROCSOLVER_LAUNCH_KERNEL((stedc_sort_eval<T>), dim3(1, 1, batch_count), dim3(BS1), 0, stream,
                                 n, D + shiftD, strideD, batch_count, splits_map);
 
         const auto nblocks = (n - 1) / BS2 + 1;
+        HIP_CHECK(hipEventRecord(sort_events[1], stream));
         ROCSOLVER_LAUNCH_KERNEL((stedc_sort_evec<T>), dim3(nblocks, nblocks, batch_count),
                                 dim3(BS2, BS2), 0, stream, n, C, shiftC, ldc, strideC, (T*)tempgemm,
                                 batch_count, splits_map);
+        HIP_CHECK(hipEventRecord(sort_events[2], stream));
         ROCSOLVER_LAUNCH_KERNEL((stedc_copy_evec<T>), dim3(nblocks, nblocks, batch_count),
                                 dim3(BS2, BS2), 0, stream, n, C, shiftC, ldc, strideC, (T*)tempgemm,
                                 batch_count);
+        HIP_CHECK(hipEventRecord(sort_events[3], stream));
+
+        HIP_CHECK(hipStreamSynchronize(stream));
+
+        float elapsed[3];
+        for(int i = 0; i < 3; i++)
+            HIP_CHECK(hipEventElapsedTime(&elapsed[i], sort_events[i], sort_events[i + 1]));
+        for(int i = 0; i < 4; i++)
+            HIP_CHECK(hipEventDestroy(sort_events[i]));
+
+        printf("STEDC Kernel Timings:\n"
+               "\tstedc_sort_eval: %f\n"
+               "\tstedc_sort_evec: %f\n"
+               "\tstedc_copy_evec: %f\n",
+               elapsed[0], elapsed[1], elapsed[2]);
 
         rocblas_set_pointer_mode(handle, old_mode);
     }

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -2048,6 +2048,159 @@ ROCSOLVER_KERNEL void __launch_bounds__(BS1) stedc_sort(const rocblas_int n,
     }
 }
 
+/** STEDC_SORT_EVAL sorts computed eigenvalues increasing order **/
+template <typename T, typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(BS1) stedc_sort_eval(const rocblas_int n,
+                                                        S* DD,
+                                                        const rocblas_stride strideD,
+                                                        const rocblas_int batch_count,
+                                                        rocblas_int* mmap,
+                                                        rocblas_int* nev = nullptr)
+{
+    // -----------------------------------
+    // use z-grid dimension as batch index
+    // -----------------------------------
+    rocblas_int bid_start = hipBlockIdx_z;
+    rocblas_int bid_inc = hipGridDim_z;
+
+    int tid = hipThreadIdx_x;
+
+    rocblas_int* const map = mmap + bid_start * ((int64_t)n);
+
+    for(auto bid = bid_start; bid < batch_count; bid += bid_inc)
+    {
+        // ---------------------------------------------
+        // select batch instance to work with
+        // (avoiding arithmetics with possible nullptrs)
+        // ---------------------------------------------
+        S* D = DD + (bid * strideD);
+        rocblas_int nn;
+        if(nev)
+            nn = nev[bid];
+        else
+            nn = n;
+
+        bool constexpr use_shell_sort = true;
+
+        __syncthreads();
+
+        if(use_shell_sort)
+            shell_sort(nn, D, map);
+        else
+            selection_sort(nn, D, map);
+        __syncthreads();
+    }
+}
+
+/** STEDC_SORT_EVEC sorts computed eigenvectors based on map into temp storage **/
+template <typename T, typename U>
+ROCSOLVER_KERNEL void __launch_bounds__(BS2 * BS2) stedc_sort_evec(const rocblas_int n,
+                                                        U CC,
+                                                        const rocblas_int shiftC,
+                                                        const rocblas_int ldc,
+                                                        const rocblas_stride strideC,
+                                                        T* tmpC,
+                                                        const rocblas_int batch_count,
+                                                        rocblas_int* mmap,
+                                                        rocblas_int* nev = nullptr)
+{
+    // -----------------------------------
+    // use z-grid dimension as batch index
+    // -----------------------------------
+    rocblas_int bid_start = hipBlockIdx_z;
+    rocblas_int bid_inc = hipGridDim_z;
+
+    int gidx = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
+    int gidy = hipThreadIdx_y + hipBlockIdx_y * hipBlockDim_y;
+
+    int dimx = hipBlockDim_x * hipGridDim_x;
+    int dimy = hipBlockDim_y * hipGridDim_y;
+
+    rocblas_int* const map = mmap + bid_start * ((int64_t)n);
+
+    rocblas_int ldd = n;
+    rocblas_stride strideD = n * n;
+
+    if(!CC)
+        return;
+
+    for(auto bid = bid_start; bid < batch_count; bid += bid_inc)
+    {
+        // ---------------------------------------------
+        // select batch instance to work with
+        // (avoiding arithmetics with possible nullptrs)
+        // ---------------------------------------------
+        T* C = load_ptr_batch<T>(CC, bid, shiftC, strideC);
+        T* dest = tmpC + (bid * strideD);
+        rocblas_int nn;
+        if(nev)
+            nn = nev[bid];
+        else
+            nn = n;
+
+        for(auto j = gidy; j < nn; j+= dimy)
+        {
+            for(auto i = gidx; i < n; i+= dimx)
+            {
+                dest[i + j * ldd] = C[i + map[j] * ldc];
+            }
+        }
+    }
+}
+
+/** STEDC_COPY_EVEC copies eigenvectors in to C from temp storage **/
+template <typename T, typename U>
+ROCSOLVER_KERNEL void __launch_bounds__(BS2 * BS2) stedc_copy_evec(const rocblas_int n,
+                                                        U CC,
+                                                        const rocblas_int shiftC,
+                                                        const rocblas_int ldc,
+                                                        const rocblas_stride strideC,
+                                                        T* tmpC,
+                                                        const rocblas_int batch_count,
+                                                        rocblas_int* nev = nullptr)
+{
+    // -----------------------------------
+    // use z-grid dimension as batch index
+    // -----------------------------------
+    rocblas_int bid_start = hipBlockIdx_z;
+    rocblas_int bid_inc = hipGridDim_z;
+
+    int gidx = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
+    int gidy = hipThreadIdx_y + hipBlockIdx_y * hipBlockDim_y;
+
+    int dimx = hipBlockDim_x * hipGridDim_x;
+    int dimy = hipBlockDim_y * hipGridDim_y;
+
+    rocblas_int ldd = n;
+    rocblas_stride strideD = n * n;
+
+    if(!CC)
+        return;
+
+    for(auto bid = bid_start; bid < batch_count; bid += bid_inc)
+    {
+        // ---------------------------------------------
+        // select batch instance to work with
+        // (avoiding arithmetics with possible nullptrs)
+        // ---------------------------------------------
+        T* C = load_ptr_batch<T>(CC, bid, shiftC, strideC);
+        T* dest = tmpC + (bid * strideD);
+        rocblas_int nn;
+        if(nev)
+            nn = nev[bid];
+        else
+            nn = n;
+
+        for(auto j = gidy; j < nn; j+= dimy)
+        {
+            for(auto i = gidx; i < n; i+= dimx)
+            {
+                C[i + j * ldc] = dest[i + j * ldd];
+            }
+        }
+    }
+}
+
 /******************* Host functions *********************************************/
 /*******************************************************************************/
 
@@ -2464,10 +2617,14 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         }
 
         // finally sort eigenvalues and eigenvectors
-        auto const nblocks = batch_count;
-        ROCSOLVER_LAUNCH_KERNEL((stedc_sort<T>), dim3(1, 1, nblocks), dim3(BS1), 0, stream, n,
-                                D + shiftD, strideD, C, shiftC, ldc, strideC, batch_count,
-                                splits_map);
+        ROCSOLVER_LAUNCH_KERNEL((stedc_sort_eval<T>), dim3(1, 1, batch_count), dim3(BS1), 0, stream, n,
+                                D + shiftD, strideD, batch_count, splits_map);
+
+        const auto nblocks = (n - 1) / BS2 + 1;
+        ROCSOLVER_LAUNCH_KERNEL((stedc_sort_evec<T>), dim3(nblocks, nblocks, batch_count), dim3(BS2, BS2), 0, stream, n,
+                                C, shiftC, ldc, strideC, (T*)tempgemm, batch_count, splits_map);
+        ROCSOLVER_LAUNCH_KERNEL((stedc_copy_evec<T>), dim3(nblocks, nblocks, batch_count), dim3(BS2, BS2), 0, stream, n,
+                                C, shiftC, ldc, strideC, (T*)tempgemm, batch_count);
 
         rocblas_set_pointer_mode(handle, old_mode);
     }

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1994,68 +1994,14 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     }
 }
 
-/** STEDC_SORT sorts computed eigenvalues and eigenvectors in increasing order **/
-template <typename T, typename S, typename U>
-ROCSOLVER_KERNEL void __launch_bounds__(BS1) stedc_sort(const rocblas_int n,
-                                                        S* DD,
-                                                        const rocblas_stride strideD,
-                                                        U CC,
-                                                        const rocblas_int shiftC,
-                                                        const rocblas_int ldc,
-                                                        const rocblas_stride strideC,
-                                                        const rocblas_int batch_count,
-                                                        rocblas_int* work,
-                                                        rocblas_int* nev = nullptr)
-{
-    // -----------------------------------
-    // use z-grid dimension as batch index
-    // -----------------------------------
-    rocblas_int bid_start = hipBlockIdx_z;
-    rocblas_int bid_inc = hipGridDim_z;
-
-    int tid = hipThreadIdx_x;
-
-    rocblas_int* const map = work + bid_start * ((int64_t)n);
-
-    for(auto bid = bid_start; bid < batch_count; bid += bid_inc)
-    {
-        // ---------------------------------------------
-        // select batch instance to work with
-        // (avoiding arithmetics with possible nullptrs)
-        // ---------------------------------------------
-        T* C = nullptr;
-        if(CC)
-            C = load_ptr_batch<T>(CC, bid, shiftC, strideC);
-        S* D = DD + (bid * strideD);
-        rocblas_int nn;
-        if(nev)
-            nn = nev[bid];
-        else
-            nn = n;
-
-        bool constexpr use_shell_sort = true;
-
-        __syncthreads();
-
-        if(use_shell_sort)
-            shell_sort(nn, D, map);
-        else
-            selection_sort(nn, D, map);
-        __syncthreads();
-
-        permute_swap(n, C, ldc, map, nn);
-        __syncthreads();
-    }
-}
-
 /** STEDC_SORT_EVAL sorts computed eigenvalues increasing order **/
 template <typename T, typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(BS1) stedc_sort_eval(const rocblas_int n,
-                                                        S* DD,
-                                                        const rocblas_stride strideD,
-                                                        const rocblas_int batch_count,
-                                                        rocblas_int* mmap,
-                                                        rocblas_int* nev = nullptr)
+                                                             S* DD,
+                                                             const rocblas_stride strideD,
+                                                             const rocblas_int batch_count,
+                                                             rocblas_int* mmap,
+                                                             rocblas_int* nev = nullptr)
 {
     // -----------------------------------
     // use z-grid dimension as batch index
@@ -2094,15 +2040,15 @@ ROCSOLVER_KERNEL void __launch_bounds__(BS1) stedc_sort_eval(const rocblas_int n
 
 /** STEDC_SORT_EVEC sorts computed eigenvectors based on map into temp storage **/
 template <typename T, typename U>
-ROCSOLVER_KERNEL void __launch_bounds__(BS2 * BS2) stedc_sort_evec(const rocblas_int n,
-                                                        U CC,
-                                                        const rocblas_int shiftC,
-                                                        const rocblas_int ldc,
-                                                        const rocblas_stride strideC,
-                                                        T* tmpC,
-                                                        const rocblas_int batch_count,
-                                                        rocblas_int* mmap,
-                                                        rocblas_int* nev = nullptr)
+ROCSOLVER_KERNEL void __launch_bounds__(BS2* BS2) stedc_sort_evec(const rocblas_int n,
+                                                                  U CC,
+                                                                  const rocblas_int shiftC,
+                                                                  const rocblas_int ldc,
+                                                                  const rocblas_stride strideC,
+                                                                  T* tmpC,
+                                                                  const rocblas_int batch_count,
+                                                                  rocblas_int* mmap,
+                                                                  rocblas_int* nev = nullptr)
 {
     // -----------------------------------
     // use z-grid dimension as batch index
@@ -2138,9 +2084,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(BS2 * BS2) stedc_sort_evec(const rocblas
         else
             nn = n;
 
-        for(auto j = gidy; j < nn; j+= dimy)
+        for(auto j = gidy; j < nn; j += dimy)
         {
-            for(auto i = gidx; i < n; i+= dimx)
+            for(auto i = gidx; i < n; i += dimx)
             {
                 dest[i + j * ldd] = C[i + map[j] * ldc];
             }
@@ -2150,14 +2096,14 @@ ROCSOLVER_KERNEL void __launch_bounds__(BS2 * BS2) stedc_sort_evec(const rocblas
 
 /** STEDC_COPY_EVEC copies eigenvectors in to C from temp storage **/
 template <typename T, typename U>
-ROCSOLVER_KERNEL void __launch_bounds__(BS2 * BS2) stedc_copy_evec(const rocblas_int n,
-                                                        U CC,
-                                                        const rocblas_int shiftC,
-                                                        const rocblas_int ldc,
-                                                        const rocblas_stride strideC,
-                                                        T* tmpC,
-                                                        const rocblas_int batch_count,
-                                                        rocblas_int* nev = nullptr)
+ROCSOLVER_KERNEL void __launch_bounds__(BS2* BS2) stedc_copy_evec(const rocblas_int n,
+                                                                  U CC,
+                                                                  const rocblas_int shiftC,
+                                                                  const rocblas_int ldc,
+                                                                  const rocblas_stride strideC,
+                                                                  T* tmpC,
+                                                                  const rocblas_int batch_count,
+                                                                  rocblas_int* nev = nullptr)
 {
     // -----------------------------------
     // use z-grid dimension as batch index
@@ -2191,9 +2137,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(BS2 * BS2) stedc_copy_evec(const rocblas
         else
             nn = n;
 
-        for(auto j = gidy; j < nn; j+= dimy)
+        for(auto j = gidy; j < nn; j += dimy)
         {
-            for(auto i = gidx; i < n; i+= dimx)
+            for(auto i = gidx; i < n; i += dimx)
             {
                 C[i + j * ldc] = dest[i + j * ldd];
             }
@@ -2617,14 +2563,16 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         }
 
         // finally sort eigenvalues and eigenvectors
-        ROCSOLVER_LAUNCH_KERNEL((stedc_sort_eval<T>), dim3(1, 1, batch_count), dim3(BS1), 0, stream, n,
-                                D + shiftD, strideD, batch_count, splits_map);
+        ROCSOLVER_LAUNCH_KERNEL((stedc_sort_eval<T>), dim3(1, 1, batch_count), dim3(BS1), 0, stream,
+                                n, D + shiftD, strideD, batch_count, splits_map);
 
         const auto nblocks = (n - 1) / BS2 + 1;
-        ROCSOLVER_LAUNCH_KERNEL((stedc_sort_evec<T>), dim3(nblocks, nblocks, batch_count), dim3(BS2, BS2), 0, stream, n,
-                                C, shiftC, ldc, strideC, (T*)tempgemm, batch_count, splits_map);
-        ROCSOLVER_LAUNCH_KERNEL((stedc_copy_evec<T>), dim3(nblocks, nblocks, batch_count), dim3(BS2, BS2), 0, stream, n,
-                                C, shiftC, ldc, strideC, (T*)tempgemm, batch_count);
+        ROCSOLVER_LAUNCH_KERNEL((stedc_sort_evec<T>), dim3(nblocks, nblocks, batch_count),
+                                dim3(BS2, BS2), 0, stream, n, C, shiftC, ldc, strideC, (T*)tempgemm,
+                                batch_count, splits_map);
+        ROCSOLVER_LAUNCH_KERNEL((stedc_copy_evec<T>), dim3(nblocks, nblocks, batch_count),
+                                dim3(BS2, BS2), 0, stream, n, C, shiftC, ldc, strideC, (T*)tempgemm,
+                                batch_count);
 
         rocblas_set_pointer_mode(handle, old_mode);
     }

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -2385,7 +2385,15 @@ void rocsolver_stedc_getMemorySize(const rocblas_evect evect,
     else
     {
         // requirements for solver of small independent blocks
-        rocsolver_steqr_getMemorySize<T, S>(evect, n, batch_count, size_work_stack);
+        size_t w1, w2;
+        rocsolver_steqr_getMemorySize<T, S>(evect, n, batch_count, &w1);
+
+        auto status = rocprim::segmented_radix_sort_pairs(
+            nullptr, w2, (S*)nullptr, (S*)nullptr,
+            (rocblas_int*)nullptr, (rocblas_int*)nullptr, n * batch_count, batch_count, (rocblas_int*)nullptr,
+            (rocblas_int*)nullptr, 0, 8 * sizeof(S), 0, false);
+
+        *size_work_stack = std::max(w1, w2);
 
         // extra requirements for original eigenvectors of small independent blocks
         if(evect != rocblas_evect_tridiagonal)
@@ -2648,63 +2656,65 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         }
 
         // finally sort eigenvalues and eigenvectors
-        hipEvent_t sort_events[4];
-        for(int i = 0; i < 4; i++)
+        hipEvent_t sort_events[6];
+        for(int i = 0; i < 6; i++)
             HIP_CHECK(hipEventCreate(&sort_events[i]));
 
         HIP_CHECK(hipEventRecord(sort_events[0], stream));
-        // ROCSOLVER_LAUNCH_KERNEL((stedc_sort_eval<T>), dim3(1, 1, batch_count), dim3(BS1), 0, stream,
-        //                         n, D + shiftD, strideD, batch_count, splits_map);
 
         ROCSOLVER_LAUNCH_KERNEL((stedc_prep_sort), dim3(((n - 1) / BS1 + 1), 1, batch_count),
                                 dim3(BS1), 0, stream, n, batch_count, D + shiftD, strideD, tmpz,
                                 splits_map, sort_offsets);
 
-        size_t temporary_storage_size_bytes = 0;
-        void* temporary_storage_ptr = nullptr;
+                                
+        HIP_CHECK(hipEventRecord(sort_events[1], stream));
         // Get required size of the temporary storage
+        size_t temporary_storage_size_bytes = 0;
         HIP_CHECK(rocprim::segmented_radix_sort_pairs(
-            temporary_storage_ptr, temporary_storage_size_bytes, tmpz, tmpz + (n * batch_count),
+            nullptr, temporary_storage_size_bytes, (S*)nullptr, (S*)nullptr,
+            (rocblas_int*)nullptr, (rocblas_int*)nullptr, n * batch_count, batch_count, (rocblas_int*)nullptr,
+            (rocblas_int*)nullptr, 0, 8 * sizeof(S), 0, false));
+
+        HIP_CHECK(rocprim::segmented_radix_sort_pairs(
+            work_stack, temporary_storage_size_bytes, tmpz, tmpz + (n * batch_count),
             splits_map, splits_map_out, n * batch_count, batch_count, sort_offsets,
             sort_offsets + 1, 0, 8 * sizeof(S), stream, false));
 
-        HIP_CHECK(hipMallocAsync(&temporary_storage_ptr, temporary_storage_size_bytes, stream));
-
-        HIP_CHECK(rocprim::segmented_radix_sort_pairs(
-            temporary_storage_ptr, temporary_storage_size_bytes, tmpz, tmpz + (n * batch_count),
-            splits_map, splits_map_out, n * batch_count, batch_count, sort_offsets,
-            sort_offsets + 1, 0, 8 * sizeof(S), stream, false));
-
-        HIP_CHECK(hipFreeAsync(temporary_storage_ptr, stream));
-
+        HIP_CHECK(hipEventRecord(sort_events[2], stream));
         ROCSOLVER_LAUNCH_KERNEL((stedc_copy_eval), dim3(((n - 1) / BS1 + 1), 1, batch_count),
                                 dim3(BS1), 0, stream, n, batch_count, D + shiftD, strideD,
                                 tmpz + (n * batch_count));
 
         const auto nblocks = (n - 1) / BS2 + 1;
-        HIP_CHECK(hipEventRecord(sort_events[1], stream));
+        HIP_CHECK(hipEventRecord(sort_events[3], stream));
         ROCSOLVER_LAUNCH_KERNEL((stedc_sort_evec<T>), dim3(nblocks, nblocks, batch_count),
                                 dim3(BS2, BS2), 0, stream, n, C, shiftC, ldc, strideC, (T*)tempgemm,
                                 batch_count, splits_map_out);
-        HIP_CHECK(hipEventRecord(sort_events[2], stream));
+        HIP_CHECK(hipEventRecord(sort_events[4], stream));
         ROCSOLVER_LAUNCH_KERNEL((stedc_copy_evec<T>), dim3(nblocks, nblocks, batch_count),
                                 dim3(BS2, BS2), 0, stream, n, C, shiftC, ldc, strideC, (T*)tempgemm,
                                 batch_count);
-        HIP_CHECK(hipEventRecord(sort_events[3], stream));
+        HIP_CHECK(hipEventRecord(sort_events[5], stream));
 
         HIP_CHECK(hipStreamSynchronize(stream));
 
-        float elapsed[3];
-        for(int i = 0; i < 3; i++)
-            HIP_CHECK(hipEventElapsedTime(&elapsed[i], sort_events[i], sort_events[i + 1]));
-        for(int i = 0; i < 4; i++)
+        float elapsed[6];
+        HIP_CHECK(hipEventElapsedTime(&elapsed[0], sort_events[0], sort_events[3]));
+        for(int i = 0; i < 5; i++)
+            HIP_CHECK(hipEventElapsedTime(&elapsed[i + 1], sort_events[i], sort_events[i + 1]));
+        for(int i = 0; i < 6; i++)
             HIP_CHECK(hipEventDestroy(sort_events[i]));
 
         printf("STEDC Kernel Timings:\n"
                "\tstedc_sort_eval: %f\n"
+               "\t\tstedc_prep_sort: %f\n"
+               "\t\trocprim sort: %f\n"
+               "\t\tstedc_copy_eval: %f\n"
                "\tstedc_sort_evec: %f\n"
                "\tstedc_copy_evec: %f\n",
-               elapsed[0], elapsed[1], elapsed[2]);
+               elapsed[0], elapsed[1], elapsed[2],
+               elapsed[3], elapsed[4], elapsed[5]
+            );
 
         rocblas_set_pointer_mode(handle, old_mode);
     }

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -2656,17 +2656,10 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         }
 
         // finally sort eigenvalues and eigenvectors
-        hipEvent_t sort_events[6];
-        for(int i = 0; i < 6; i++)
-            HIP_CHECK(hipEventCreate(&sort_events[i]));
-
-        HIP_CHECK(hipEventRecord(sort_events[0], stream));
-
         ROCSOLVER_LAUNCH_KERNEL((stedc_prep_sort), dim3(((n - 1) / BS1 + 1), 1, batch_count),
                                 dim3(BS1), 0, stream, n, batch_count, D + shiftD, strideD, tmpz,
                                 splits_map, sort_offsets);
 
-        HIP_CHECK(hipEventRecord(sort_events[1], stream));
         // Get required size of the temporary storage
         size_t temporary_storage_size_bytes = 0;
         HIP_CHECK(rocprim::segmented_radix_sort_pairs(
@@ -2679,39 +2672,17 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             splits_map_out, n * batch_count, batch_count, sort_offsets, sort_offsets + 1, 0,
             8 * sizeof(S), stream, false));
 
-        HIP_CHECK(hipEventRecord(sort_events[2], stream));
         ROCSOLVER_LAUNCH_KERNEL((stedc_copy_eval), dim3(((n - 1) / BS1 + 1), 1, batch_count),
                                 dim3(BS1), 0, stream, n, batch_count, D + shiftD, strideD,
                                 tmpz + (n * batch_count));
 
         const auto nblocks = (n - 1) / BS2 + 1;
-        HIP_CHECK(hipEventRecord(sort_events[3], stream));
         ROCSOLVER_LAUNCH_KERNEL((stedc_sort_evec<T>), dim3(nblocks, nblocks, batch_count),
                                 dim3(BS2, BS2), 0, stream, n, C, shiftC, ldc, strideC, (T*)tempgemm,
                                 batch_count, splits_map_out);
-        HIP_CHECK(hipEventRecord(sort_events[4], stream));
         ROCSOLVER_LAUNCH_KERNEL((stedc_copy_evec<T>), dim3(nblocks, nblocks, batch_count),
                                 dim3(BS2, BS2), 0, stream, n, C, shiftC, ldc, strideC, (T*)tempgemm,
                                 batch_count);
-        HIP_CHECK(hipEventRecord(sort_events[5], stream));
-
-        HIP_CHECK(hipStreamSynchronize(stream));
-
-        float elapsed[6];
-        HIP_CHECK(hipEventElapsedTime(&elapsed[0], sort_events[0], sort_events[3]));
-        for(int i = 0; i < 5; i++)
-            HIP_CHECK(hipEventElapsedTime(&elapsed[i + 1], sort_events[i], sort_events[i + 1]));
-        for(int i = 0; i < 6; i++)
-            HIP_CHECK(hipEventDestroy(sort_events[i]));
-
-        printf("STEDC Kernel Timings:\n"
-               "\tstedc_sort_eval: %f\n"
-               "\t\tstedc_prep_sort: %f\n"
-               "\t\trocprim sort: %f\n"
-               "\t\tstedc_copy_eval: %f\n"
-               "\tstedc_sort_evec: %f\n"
-               "\tstedc_copy_evec: %f\n",
-               elapsed[0], elapsed[1], elapsed[2], elapsed[3], elapsed[4], elapsed[5]);
 
         rocblas_set_pointer_mode(handle, old_mode);
     }

--- a/library/src/auxiliary/rocauxiliary_stedcj.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedcj.hpp
@@ -312,7 +312,7 @@ void rocsolver_stedcj_getMemorySize(const rocblas_evect evect,
         return;
     }
 
-    size_t s1, s2;
+    size_t s1, s2, s3;
 
     // requirements for solver of small independent blocks
     s1 = sizeof(S) * (n * n + 2) * batch_count;
@@ -328,7 +328,13 @@ void rocsolver_stedcj_getMemorySize(const rocblas_evect evect,
         *size_workArr = sizeof(S*) * batch_count;
     else
         *size_workArr = 0;
-    *size_work_stack = std::max(s1, s2);
+
+    auto status = rocprim::segmented_radix_sort_pairs(
+        nullptr, s3, (S*)nullptr, (S*)nullptr, (rocblas_int*)nullptr, (rocblas_int*)nullptr,
+        n * batch_count, batch_count, (rocblas_int*)nullptr, (rocblas_int*)nullptr, 0,
+        8 * sizeof(S), 0, false);
+
+    *size_work_stack = std::max({s1, s2, s3});
 
     // size for split blocks and sub-blocks positions
     *size_splits_map = sizeof(rocblas_int) * (5 * n + 2) * batch_count;
@@ -369,6 +375,9 @@ rocblas_status rocsolver_stedcj_template(rocblas_handle handle,
     // quick return
     if(batch_count == 0)
         return rocblas_status_success;
+
+    auto const splits_map_out = splits_map + n * batch_count;
+    auto const sort_offsets = splits_map_out + n * batch_count;
 
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
@@ -473,13 +482,29 @@ rocblas_status rocsolver_stedcj_template(rocblas_handle handle,
                                     static_cast<S*>(work_stack), 0, ldt, strideT, batch_count,
                                     workArr);
 
-    ROCSOLVER_LAUNCH_KERNEL((stedc_sort_eval<T>), dim3(1, 1, batch_count), dim3(BS1), 0, stream, n,
-                            D, strideD, batch_count, splits_map);
+    // finally sort eigenvalues and eigenvectors
+    ROCSOLVER_LAUNCH_KERNEL((stedc_prep_sort), dim3(((n - 1) / BS1 + 1), 1, batch_count), dim3(BS1),
+                            0, stream, n, batch_count, D, strideD, tmpz, splits_map, sort_offsets);
+
+    // Get required size of the temporary storage
+    size_t temporary_storage_size_bytes = 0;
+    HIP_CHECK(rocprim::segmented_radix_sort_pairs(
+        nullptr, temporary_storage_size_bytes, (S*)nullptr, (S*)nullptr, (rocblas_int*)nullptr,
+        (rocblas_int*)nullptr, n * batch_count, batch_count, (rocblas_int*)nullptr,
+        (rocblas_int*)nullptr, 0, 8 * sizeof(S), 0, false));
+
+    HIP_CHECK(rocprim::segmented_radix_sort_pairs(
+        work_stack, temporary_storage_size_bytes, tmpz, tmpz + (n * batch_count), splits_map,
+        splits_map_out, n * batch_count, batch_count, sort_offsets, sort_offsets + 1, 0,
+        8 * sizeof(S), stream, false));
+
+    ROCSOLVER_LAUNCH_KERNEL((stedc_copy_eval), dim3(((n - 1) / BS1 + 1), 1, batch_count), dim3(BS1),
+                            0, stream, n, batch_count, D, strideD, tmpz + (n * batch_count));
 
     const auto nblocks = (n - 1) / BS2 + 1;
     ROCSOLVER_LAUNCH_KERNEL((stedc_sort_evec<T>), dim3(nblocks, nblocks, batch_count),
                             dim3(BS2, BS2), 0, stream, n, C, shiftC, ldc, strideC, (T*)tempgemm,
-                            batch_count, splits_map);
+                            batch_count, splits_map_out);
     ROCSOLVER_LAUNCH_KERNEL((stedc_copy_evec<T>), dim3(nblocks, nblocks, batch_count), dim3(BS2, BS2),
                             0, stream, n, C, shiftC, ldc, strideC, (T*)tempgemm, batch_count);
 

--- a/library/src/auxiliary/rocauxiliary_stedcj.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedcj.hpp
@@ -1,5 +1,5 @@
 /************************************************************************
- * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -473,8 +473,15 @@ rocblas_status rocsolver_stedcj_template(rocblas_handle handle,
                                     static_cast<S*>(work_stack), 0, ldt, strideT, batch_count,
                                     workArr);
 
-    ROCSOLVER_LAUNCH_KERNEL((stedc_sort<T>), dim3(1, 1, batch_count), dim3(BS1), 0, stream, n, D,
-                            strideD, C, shiftC, ldc, strideC, batch_count, splits_map);
+    ROCSOLVER_LAUNCH_KERNEL((stedc_sort_eval<T>), dim3(1, 1, batch_count), dim3(BS1), 0, stream, n,
+                            D, strideD, batch_count, splits_map);
+
+    const auto nblocks = (n - 1) / BS2 + 1;
+    ROCSOLVER_LAUNCH_KERNEL((stedc_sort_evec<T>), dim3(nblocks, nblocks, batch_count),
+                            dim3(BS2, BS2), 0, stream, n, C, shiftC, ldc, strideC, (T*)tempgemm,
+                            batch_count, splits_map);
+    ROCSOLVER_LAUNCH_KERNEL((stedc_copy_evec<T>), dim3(nblocks, nblocks, batch_count), dim3(BS2, BS2),
+                            0, stream, n, C, shiftC, ldc, strideC, (T*)tempgemm, batch_count);
 
     return rocblas_status_success;
 }

--- a/library/src/auxiliary/rocauxiliary_stedcx.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedcx.hpp
@@ -606,8 +606,15 @@ rocblas_status rocsolver_stedcx_template(rocblas_handle handle,
                                     work_stack, 0, ldt, strideT, batch_count, workArr);
 
     // sort eigenvalues and eigenvectors
-    ROCSOLVER_LAUNCH_KERNEL((stedc_sort<T>), dim3(1, 1, batch_count), dim3(BS1), 0, stream, n, W,
-                            strideW, C, shiftC, ldc, strideC, batch_count, splits, nev);
+    ROCSOLVER_LAUNCH_KERNEL((stedc_sort_eval<T>), dim3(1, 1, batch_count), dim3(BS1), 0, stream, n,
+                            W, strideW, batch_count, splits, nev);
+
+    const auto nblocks = (n - 1) / BS2 + 1;
+    ROCSOLVER_LAUNCH_KERNEL((stedc_sort_evec<T>), dim3(nblocks, nblocks, batch_count),
+                            dim3(BS2, BS2), 0, stream, n, C, shiftC, ldc, strideC, (T*)tempgemm,
+                            batch_count, splits, nev);
+    ROCSOLVER_LAUNCH_KERNEL((stedc_copy_evec<T>), dim3(nblocks, nblocks, batch_count), dim3(BS2, BS2),
+                            0, stream, n, C, shiftC, ldc, strideC, (T*)tempgemm, batch_count, nev);
 
     return rocblas_status_success;
 }


### PR DESCRIPTION
## Motivation
Improve stedc performance

## Technical Details
Split STEDC’s sort kernel in two:
a) Kernel to sort eigenvalues;
b) Kernel to move eigenvectors into sorted order (out-of-place).

Use rocprim to sort eigenvalues

## Test Plan
Compare new sort performance to old sort.

## Test Result
0.6 ms vs 100 ms

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
