### PR TITLE
Clear syevd workspace

### DIFF
--- a/library/src/lapack/roclapack_syevd_heevd.hpp
+++ b/library/src/lapack/roclapack_syevd_heevd.hpp
@@ -378,6 +378,38 @@ rocblas_status rocsolver_syevd_heevd_template(rocblas_handle handle,
 
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
+    {
+        // memory workspace sizes:
+        // size for constants in rocblas calls
+        size_t size_scalars;
+        // size of reusable workspaces
+        size_t size_work1;
+        size_t size_work2;
+        size_t size_work3;
+        size_t size_work4;
+        size_t size_tmptau_W;
+        // extra space for stedc call
+        size_t size_splits, size_tmpz;
+        // size of array of pointers (only for batched case)
+        size_t size_workArr;
+        // size for temporary householder scalars
+        size_t size_tau;
+
+        rocsolver_syevd_heevd_getMemorySize<BATCHED, STRIDED, T, S>(
+            handle, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2,
+            &size_work3, &size_work4, &size_tmpz, &size_splits, &size_tmptau_W, &size_tau, &size_workArr, &optim_mem);
+
+        // Memory in `scalars` has already been initialized at this point
+        HIP_CHECK(hipMemsetAsync((void*)work1, 0, size_work1, stream));
+        HIP_CHECK(hipMemsetAsync((void*)work2, 0, size_work2, stream));
+        HIP_CHECK(hipMemsetAsync((void*)work3, 0, size_work3, stream));
+        HIP_CHECK(hipMemsetAsync((void*)work4, 0, size_work4, stream));
+        HIP_CHECK(hipMemsetAsync((void*)tmpz, 0, size_tmpz, stream));
+        HIP_CHECK(hipMemsetAsync((void*)splits, 0, size_splits, stream));
+        HIP_CHECK(hipMemsetAsync((void*)tmptau_W, 0, size_tmptau_W, stream));
+        HIP_CHECK(hipMemsetAsync((void*)tau, 0, size_tau, stream));
+        HIP_CHECK(hipMemsetAsync((void*)workArr, 0, size_workArr, stream));
+    }
 
     rocsolver_alg_mode sterf_mode;
     ROCBLAS_CHECK(rocsolver_get_alg_mode(handle, rocsolver_function_sterf, &sterf_mode));


### PR DESCRIPTION
This PR clears the workspace of SYEVD (and HEEVD) to avoid possible corruption resulting from using uninitialized memory.