### PR TITLE
Add missing assert header

### DIFF
--- a/library/src/include/lib_device_helpers.hpp
+++ b/library/src/include/lib_device_helpers.hpp
@@ -27,6 +27,8 @@
 
 #pragma once
 
+#include <cassert>
+
 #include <hip/hip_runtime.h>
 
 #include "ideal_sizes.hpp"


### PR DESCRIPTION
This PR adds a missing header file that is required to compile rocsolver in debug mode.