### PR TITLE
Improved stedc (reshuffle gemm)

### DIFF
--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -44,6 +44,8 @@
 
 ROCSOLVER_BEGIN_NAMESPACE
 
+#define DEBUG_OUTPUT 1
+
 #define STEDC_BDIM 512 // Number of threads per thread-block used in main stedc kernels
 #define STEDC_SOLVE_BDIM 4  // Number of threads per thread-block used in solver kernel
 
@@ -558,20 +560,20 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     int pos = lt + eq;
     __shared__ int lpos[STEDC_BDIM];
     __shared__ int ldd[STEDC_BDIM];
-    // Reduction (sum of pos across all lanes in a workgroup)
-    // on each iteration reduction is done within a subgroup of size of 2*bit
-    // by xoring corresponding bit of an address.
-    // The faster implementation should use dpp + a single trip through lds
-    // but keeping code simple for now.
-    int bit = 1;
-    while (bit < STEDC_BDIM) {
-        lpos[hipThreadIdx_x ^ bit] = pos;
-        ldd[hipThreadIdx_x ^ bit] = dd;
+
+    // reduction
+    lpos[hipThreadIdx_x] = pos;
+    ldd[hipThreadIdx_x] = dd;
+    for(int r = hipBlockDim_x / 2; r > 0; r /= 2)
+    {
         __syncthreads();
-        pos += lpos[hipThreadIdx_x];
-        dd += ldd[hipThreadIdx_x];
-        __syncthreads();
-        bit *= 2;
+        if(hipThreadIdx_x < r)
+        {
+            pos += lpos[hipThreadIdx_x + r];
+            dd += ldd[hipThreadIdx_x + r];
+            lpos[hipThreadIdx_x] = pos;
+            ldd[hipThreadIdx_x] = dd;
+        }
     }
 
     if (hipThreadIdx_x == 0) {
@@ -1309,19 +1311,19 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             nrm += valf * valf;
             putvec[i + eid*n] = valf;
         }
-        inrms[tidb] = nrm;
-        __syncthreads();
 
         // reduction (for the norms)
+        inrms[tidb] = nrm;
         for(int r = dim / 2; r > 0; r /= 2)
         {
+            __syncthreads();
             if(tidb < r)
             {
                 nrm += inrms[tidb + r];
                 inrms[tidb] = nrm;
             }
-            __syncthreads();
         }
+        __syncthreads();
         nrm = sqrt(inrms[0]);
     }
 
@@ -1355,19 +1357,19 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 S temp = 0;
                 for(int kk = tidb; kk < dd; kk += dim)
                     temp += C[i + (p1 + kk) * ldc] * etmpd[kk + eid * n];
-                inrms[tidb] = temp;
-                __syncthreads();
 
                 // reduction
+                inrms[tidb] = temp;
                 for(int r = dim / 2; r > 0; r /= 2)
                 {
+                    __syncthreads();
                     if(tidb < r)
                     {
                         temp += inrms[tidb + r];
                         inrms[tidb] = temp;
                     }
-                    __syncthreads();
                 }
+                __syncthreads();
 
                 // result
                 if(tidb == 0)
@@ -1623,27 +1625,27 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int
         }
     }
 
+
     int pos = lt + eq;
-    __shared__ int lds[STEDC_BDIM];
-    // Reduction (sum of pos across all lanes in a workgroup)
-    // on each iteration reduction is done within a subgroup of size of 2*bit
-    // by xoring corresponding bit of an address.
-    // The faster implementation should use dpp + a single trip through lds
-    // but keeping code simple for now.
-    int bit = 1;
-    while(bit < STEDC_BDIM) {
-        lds[hipThreadIdx_x ^ bit] = pos;
+    // reduction
+    __shared__ int lpos[STEDC_BDIM];
+    lpos[hipThreadIdx_x] = pos;
+    for(int r = hipBlockDim_x / 2; r > 0; r /= 2)
+    {
         __syncthreads();
-        pos += lds[hipThreadIdx_x];
-        __syncthreads();
-        bit *= 2;
+        if(hipThreadIdx_x < r)
+        {
+            pos += lpos[hipThreadIdx_x + r];
+            lpos[hipThreadIdx_x] = pos;
+        }
     }
+    __syncthreads();
+    pos = lpos[0];
 
     if (hipThreadIdx_x == 0) {
         Dout[pos] = d;
     }
 
-    __syncthreads();
     // The NAN fp value is unordered, so it is possible that with computed
     // new positions it would be silently overwriten with non NAN value.
     // Make sure we propagate NAN. It is likely to have more NANs in the output
@@ -1690,11 +1692,13 @@ inline rocblas_int stedc_num_levels(const rocblas_int n)
     else
         levels = std::ceil(std::log2(n)) - 4;
 
+#if DEBUG_OUTPUT
     char* env_levs = std::getenv("LEVS");
     if(env_levs)
     {
         levels = std::atoi(env_levs);
     }
+#endif
 
     return levels;
 }
@@ -1837,7 +1841,6 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
     ROCSOLVER_ENTER("stedc", "evect:", evect, "n:", n, "shiftD:", shiftD, "shiftE:", shiftE,
                     "shiftC:", shiftC, "ldc:", ldc, "bc:", batch_count);
 
-#define DEBUG_OUTPUT 1
 #if DEBUG_OUTPUT
     static int global_cnt = 0;
     global_cnt++;

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -64,69 +64,36 @@ __host__ __device__ inline rocblas_int get_splits_size(const rocblas_int n)
     // n - number of eigenvalues (matrix size)
     // m - number of merges on a current level
     // struct {
-    // 0     rocblas_int sort_tmp[n];         // temp buffer used for mapping in stedc_sort()
-    // 1     rocblas_int      ;               //
-    // 2     rocblas_int      ;               //
-    // 3     rocblas_int idd[n];              // if idd[i] = 0, the value in position i has been deflated  (aka mask)
-    // 4     rocblas_int ;             //
-    // 5     rocblas_int ;      //
-    // 6     rocblas_int ;      //
-    // 7     rocblas_int dds[m], _[n-m];      // degrees of secular equation
-    // 8     rocblas_int map[n];              // 
+    // 0     rocblas_int msz[m], _[n-m];      // size of each merge
+    // 1     rocblas_int mps[m], _[n-m];      // starting position of each merge
+    // 2     rocblas_int bsz[2*m], _[n-2*m];  // size of each block
+    // 3     rocblas_int bps[2*m], _[n-2*m];  // starting position of each block
+    // 4     rocblas_int em[n];               // id of a corresponding merge (per each eigenvalue)
+    // 5     rocblas_int nsz[n];              // size of a corresponding merge (per each eigenvalue)
+    // 6     rocblas_int nps[n];              // starting position of a corresponding merge (per each eigenvalue)
+    // 7     rocblas_int ndd[n];              // degrees of secular equation (per each eigenvalue)
+    // 8     rocblas_int mask[n];             // if mask[i] = 0, the value in position i has been deflated
     // 9     rocblas_int dcount[n];           // number of deflations
-    // 10    rocblas_int esz[n];              // size of a corresponding merge (per each eigenvalue)
-    // 11    rocblas_int eps[n];              // starting position of a corresponding merge (per each eigenvalue)
-    // 12    rocblas_int cand[n];             // deflation candidate flags
-    // 13    rocblas_int sidd[n];             // sorted idd
-    // 14    rocblas_int em[n];               // id of a corresponding merge (per each eigenvalue)
-    // 15    rocblas_int msz[m], _[n-m];      // size of each merge
-    // 16    rocblas_int mps[m], _[n-m];      // starting position of each merge
-    // 17    rocblas_int bsz[2*m], _[n-2*m];  // size of each block
-    // 18    rocblas_int bps[2*m], _[n-2*m];  // starting position of each block
-    // 19    rocblas_int dbg[n];              //
+    // 10    rocblas_int map[n];              // original indices of a sorted values
+    // 11    rocblas_int cand[n];             // deflation candidate flags
+    // 12    rocblas_int dbg[n];              //
     // };
-    return 20 * n + 64*64;
+    return 13 * n;
 }
 
-template <typename S> __host__ __device__ inline S* ptr___    (rocblas_int n, S* splits) { return splits +  1 * n; }
-template <typename S> __host__ __device__ inline S* ptr____   (rocblas_int n, S* splits) { return splits +  2 * n; }
-template <typename S> __host__ __device__ inline S* ptr_idd   (rocblas_int n, S* splits) { return splits +  3 * n; }
-template <typename S> __host__ __device__ inline S* ptr_____  (rocblas_int n, S* splits) { return splits +  4 * n; }
-template <typename S> __host__ __device__ inline S* ptr_      (rocblas_int n, S* splits) { return splits +  5 * n; }
-template <typename S> __host__ __device__ inline S* ptr__     (rocblas_int n, S* splits) { return splits +  6 * n; }
-template <typename S> __host__ __device__ inline S* ptr_dds   (rocblas_int n, S* splits) { return splits +  7 * n; }
-template <typename S> __host__ __device__ inline S* ptr_map   (rocblas_int n, S* splits) { return splits +  8 * n; }
+template <typename S> __host__ __device__ inline S* ptr_msz   (rocblas_int n, S* splits) { return splits +  0 * n; }
+template <typename S> __host__ __device__ inline S* ptr_mps   (rocblas_int n, S* splits) { return splits +  1 * n; }
+template <typename S> __host__ __device__ inline S* ptr_bsz   (rocblas_int n, S* splits) { return splits +  2 * n; }
+template <typename S> __host__ __device__ inline S* ptr_bps   (rocblas_int n, S* splits) { return splits +  3 * n; }
+template <typename S> __host__ __device__ inline S* ptr_em    (rocblas_int n, S* splits) { return splits +  4 * n; }
+template <typename S> __host__ __device__ inline S* ptr_nsz   (rocblas_int n, S* splits) { return splits +  5 * n; }
+template <typename S> __host__ __device__ inline S* ptr_nps   (rocblas_int n, S* splits) { return splits +  6 * n; }
+template <typename S> __host__ __device__ inline S* ptr_ndd   (rocblas_int n, S* splits) { return splits +  7 * n; }
+template <typename S> __host__ __device__ inline S* ptr_mask  (rocblas_int n, S* splits) { return splits +  8 * n; }
 template <typename S> __host__ __device__ inline S* ptr_dcount(rocblas_int n, S* splits) { return splits +  9 * n; }
-template <typename S> __host__ __device__ inline S* ptr_esz   (rocblas_int n, S* splits) { return splits + 10 * n; }
-template <typename S> __host__ __device__ inline S* ptr_eps   (rocblas_int n, S* splits) { return splits + 11 * n; }
-template <typename S> __host__ __device__ inline S* ptr_cand  (rocblas_int n, S* splits) { return splits + 12 * n; }
-template <typename S> __host__ __device__ inline S* ptr_sidd  (rocblas_int n, S* splits) { return splits + 13 * n; }
-template <typename S> __host__ __device__ inline S* ptr_em    (rocblas_int n, S* splits) { return splits + 14 * n; }
-template <typename S> __host__ __device__ inline S* ptr_msz   (rocblas_int n, S* splits) { return splits + 15 * n; }
-template <typename S> __host__ __device__ inline S* ptr_mps   (rocblas_int n, S* splits) { return splits + 16 * n; }
-template <typename S> __host__ __device__ inline S* ptr_bsz   (rocblas_int n, S* splits) { return splits + 17 * n; }
-template <typename S> __host__ __device__ inline S* ptr_bps   (rocblas_int n, S* splits) { return splits + 18 * n; }
-template <typename S> __host__ __device__ inline S* ptr_dbg   (rocblas_int n, S* splits) { return splits + 19 * n + 64 * 0; }
-template <typename S> __host__ __device__ inline S* ptr_dbg1  (rocblas_int n, S* splits) { return splits + 19 * n + 64 * 1; }
-template <typename S> __host__ __device__ inline S* ptr_dbg2  (rocblas_int n, S* splits) { return splits + 19 * n + 64 * 2; }
-template <typename S> __host__ __device__ inline S* ptr_dbg3  (rocblas_int n, S* splits) { return splits + 19 * n + 64 * 3; }
-template <typename S> __host__ __device__ inline S* ptr_dbg4  (rocblas_int n, S* splits) { return splits + 19 * n + 64 * 4; }
-template <typename S> __host__ __device__ inline S* ptr_dbg5  (rocblas_int n, S* splits) { return splits + 19 * n + 64 * 5; }
-template <typename S> __host__ __device__ inline S* ptr_dbg6  (rocblas_int n, S* splits) { return splits + 19 * n + 64 * 6; }
-template <typename S> __host__ __device__ inline S* ptr_dbg7  (rocblas_int n, S* splits) { return splits + 19 * n + 64 * 7; }
-template <typename S> __host__ __device__ inline S* ptr_dbg8  (rocblas_int n, S* splits) { return splits + 19 * n + 64 * 8; }
-template <typename S> __host__ __device__ inline S* ptr_dbg9  (rocblas_int n, S* splits) { return splits + 19 * n + 64 * 9; }
-template <typename S> __host__ __device__ inline S* ptr_dbg10 (rocblas_int n, S* splits) { return splits + 19 * n + 64 *10; }
-template <typename S> __host__ __device__ inline S* ptr_dbg11 (rocblas_int n, S* splits) { return splits + 19 * n + 64 *11; }
-template <typename S> __host__ __device__ inline S* ptr_dbg12 (rocblas_int n, S* splits) { return splits + 19 * n + 64 *12; }
-template <typename S> __host__ __device__ inline S* ptr_dbg13 (rocblas_int n, S* splits) { return splits + 19 * n + 64 *13; }
-template <typename S> __host__ __device__ inline S* ptr_dbg14 (rocblas_int n, S* splits) { return splits + 19 * n + 64 *14; }
-template <typename S> __host__ __device__ inline S* ptr_dbg15 (rocblas_int n, S* splits) { return splits + 19 * n + 64 *15; }
-template <typename S> __host__ __device__ inline S* ptr_dbg16 (rocblas_int n, S* splits) { return splits + 19 * n + 64 *16; }
-template <typename S> __host__ __device__ inline S* ptr_dbg17 (rocblas_int n, S* splits) { return splits + 19 * n + 64 *17; }
-template <typename S> __host__ __device__ inline S* ptr_dbg18 (rocblas_int n, S* splits) { return splits + 19 * n + 64 *18; }
-template <typename S> __host__ __device__ inline S* ptr_dbg19 (rocblas_int n, S* splits) { return splits + 19 * n + 64 *19; }
-template <typename S> __host__ __device__ inline S* ptr_dbg20 (rocblas_int n, S* splits) { return splits + 19 * n + 64 *20; }
+template <typename S> __host__ __device__ inline S* ptr_map   (rocblas_int n, S* splits) { return splits + 10 * n; }
+template <typename S> __host__ __device__ inline S* ptr_cand  (rocblas_int n, S* splits) { return splits + 11 * n; }
+template <typename S> __host__ __device__ inline S* ptr_dbg   (rocblas_int n, S* splits) { return splits + 12 * n; }
 
 __host__ __device__ inline rocblas_int get_tmpz_size(const rocblas_int n)
 {
@@ -143,10 +110,9 @@ __host__ __device__ inline rocblas_int get_tmpz_size(const rocblas_int n)
     // 6    S md[n];             // sorted d values
     // 7    S cd[n];             // sorted and compacted d values
     // 8    S cz[n];             // sorted and compacted z values
-    // 9    S r1p[m], _[n-m];    // p component of the rank-1 modification
-    // 10   S sdbg[n];           //
+    // 9    S r1p[n];            // p component of the rank-1 modification
     // };
-    return 11 * n;
+    return 10 * n;
 }
 
 template <typename S> __host__ __device__ inline S* ptr_z    (rocblas_int n, S* tmpz) { return tmpz +  0 * n; }
@@ -159,15 +125,14 @@ template <typename S> __host__ __device__ inline S* ptr_md   (rocblas_int n, S* 
 template <typename S> __host__ __device__ inline S* ptr_cd   (rocblas_int n, S* tmpz) { return tmpz +  7 * n; }
 template <typename S> __host__ __device__ inline S* ptr_cz   (rocblas_int n, S* tmpz) { return tmpz +  8 * n; }
 template <typename S> __host__ __device__ inline S* ptr_r1p  (rocblas_int n, S* tmpz) { return tmpz +  9 * n; }
-template <typename S> __host__ __device__ inline S* ptr_sdbg (rocblas_int n, S* tmpz) { return tmpz + 10 * n; }
 
 
 __host__ __device__ inline rocblas_int get_tempgemm_size(const rocblas_int n)
 {
     // tempgemm layout:
     // struct {
-    // 0    S vecs[n*n];      // 
-    // 1    S etmpd[n*n];     // temp deltas used in solving secular equations
+    // 0    S vecs[n*n];      // temp vectors
+    // 1    S etmpd[n*n];     // temp deltas used in solving secular equations, also used for temp vectors
     // };
     return 2 * n * n;
 }
@@ -299,33 +264,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_solve_kernel(const roc
 
 
 //--------------------------------------------------------------------------------------//
-/** STEDC_INIT_SPLITS initialize merge block related parts of a splits struct.
-        - This kernel is to be called with 1 group in x and batch_count groups in y. 
-        - Size of groups is set to STEDC_BDIM. **/
-ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_init_splits(const rocblas_int levs,
-                                                                      const rocblas_int n,
-                                                                      rocblas_int* splitsA)
-{
-    rocblas_int bid = hipBlockIdx_y;
-    rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* em  = ptr_em(n, splits);
-    rocblas_int* msz = ptr_msz(n, splits);
-    rocblas_int* mps = ptr_mps(n, splits);
-
-    rocblas_int n_blocks = 1 << levs;
-
-    for(int i = hipThreadIdx_x; i < n_blocks; i+=hipBlockDim_x)
-    {
-        rocblas_int sz = msz[i];
-        rocblas_int p1 = mps[i];
-        for (int j = 0; j < sz; j++) {
-            em[p1 + j] = i;
-        }
-    }
-}
-
-//--------------------------------------------------------------------------------------//
-/** STEDC_UPDATE_SPLITS updates merge block related parts of a splits struct.
+/** STEDC_UPDATE_SPLITS updates merge block related parts of a splits struct for each
+    level of merge.
         - This kernel is to be called with 1 group in x and batch_count groups in y. 
         - Size of groups is set to STEDC_BDIM. **/
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_update_splits(const rocblas_int levs,
@@ -335,18 +275,31 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_update_splits(const ro
 {
     rocblas_int bid = hipBlockIdx_y;
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* em = ptr_em(n, splits);
+    rocblas_int* em  = ptr_em(n, splits);
     rocblas_int* msz = ptr_msz(n, splits);
     rocblas_int* mps = ptr_mps(n, splits);
-    rocblas_int* esz = ptr_esz(n, splits);
-    rocblas_int* eps = ptr_eps(n, splits);
+    rocblas_int* nsz = ptr_nsz(n, splits);
+    rocblas_int* nps = ptr_nps(n, splits);
     rocblas_int* bsz = ptr_bsz(n, splits);
     rocblas_int* bps = ptr_bps(n, splits);
     rocblas_int* map = ptr_map(n, splits);
     rocblas_int* dcount = ptr_dcount(n, splits);
     
-
+    rocblas_int n_blocks = 1 << levs;
     rocblas_int n_merges = 1 << (levs - k - 1);
+
+    // init em array
+    if (k == 0) {
+        for(int i = hipThreadIdx_x; i < n_blocks; i += hipBlockDim_x)
+        {
+            rocblas_int sz = msz[i];
+            rocblas_int p1 = mps[i];
+            for(int j = 0; j < sz; j++)
+            {
+                em[p1 + j] = i;
+            }
+        }
+    }
 
     // previous merges becomes blocks on a current level
     for (int i = hipThreadIdx_x; i < n_merges * 2; i += hipBlockDim_x)
@@ -356,6 +309,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_update_splits(const ro
     }
     __syncthreads();
 
+    // update sizes and initial positions
     for(int i = hipThreadIdx_x; i < n_merges; i += hipBlockDim_x)
     {
         rocblas_int sz1 = bsz[i * 2 + 0];
@@ -365,12 +319,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_update_splits(const ro
         mps[i] = p1;
     }
     __syncthreads();
-
     for (int i = hipThreadIdx_x; i < n; i += hipBlockDim_x)
     {
         rocblas_int m = em[i] / 2;
-        esz[i] = msz[m];
-        eps[i] = mps[m];
+        nsz[i] = msz[m];
+        nps[i] = mps[m];
         map[i] = 0;
         dcount[i] = 0;
     }
@@ -384,7 +337,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_update_splits(const ro
 
 
 //--------------------------------------------------------------------------------------//
-/** STEDC_MERGEPREPARE_DEFLATEZERO_KERNEL performs deflation of zero values
+/** STEDC_MERGEPREPARE_DEFLATEZERO_KERNEL finds and stores tolerances and performs
+    deflation of zero values
         - Call this kernel with batch_count groups in y, and as many groups as half of the 
           unmerged sub-blocks in current level in x. Each group works with a merge of a pair
           of sub-blocks. Groups are size STEDC_BDIM **/
@@ -393,7 +347,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     stedc_mergePrepare_DeflateZero_kernel(const rocblas_int k,
                                           const rocblas_int n,
                                           S* DD,
-                                          const rocblas_stride strideD,
+                                           const rocblas_stride strideD,
                                           S* EE,
                                           const rocblas_stride strideE,
                                           S* CC,
@@ -417,9 +371,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* idd = ptr_idd(n, splits);
-    rocblas_int* mps = ptr_mps(n, splits);
-    rocblas_int* msz = ptr_msz(n, splits);
+    rocblas_int* mask = ptr_mask(n, splits);
     rocblas_int* bsz = ptr_bsz(n, splits);
     rocblas_int* bps = ptr_bps(n, splits);
 
@@ -440,8 +392,12 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         rocblas_int p1  = bps[sid * 2 + 0];
         rocblas_int p2  = bps[sid * 2 + 1];
 
+        // Find off-diagonal element of the merge
+        // rank-1 modification component p correspond to the last element in the first sub-block
         S p = 2 * E[p2 - 1];
-        r1p[sid] = p;
+        for (int i = hipThreadIdx_x; i < sz1 + sz2; i += hipBlockDim_x) {
+            r1p[p1 + i] = p;
+        }
 
         S maxd = 0;
         S maxz = 0;
@@ -513,7 +469,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         {
             S g = z[p1 + i];
             // deflated ev if component in z is zero
-            idd[p1 + i] = (abs(p * g) <= tolZ) ? 0 : 1;
+            mask[p1 + i] = (abs(p * g) <= tolZ) ? 0 : 1;
         }
     }
 }
@@ -521,7 +477,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
 //--------------------------------------------------------------------------------------//
 /** STEDC_MERGEPREPARE_SORTD_KERNEL sorts D array and construct map of original positions
-        - Call this kernel with n groups in x and batch_count groups in y. Groups are size STEDC_BDIM **/
+        - Call this kernel with n groups in x and batch_count groups in y.
+        Groups are size STEDC_BDIM **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     stedc_mergePrepare_SortD_kernel(const rocblas_int k,
@@ -542,26 +499,27 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* idd    = ptr_idd(n, splits);
+    rocblas_int* mask    = ptr_mask(n, splits);
+    rocblas_int* ndd    = ptr_ndd(n, splits);
     rocblas_int* map    = ptr_map(n, splits);
-    rocblas_int* esz    = ptr_esz (n, splits);
-    rocblas_int* eps    = ptr_eps (n, splits); 
-    rocblas_int* sidd   = ptr_sidd(n, splits);
+    rocblas_int* nsz    = ptr_nsz (n, splits);
+    rocblas_int* nps    = ptr_nps (n, splits); 
     
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
-    S* md    = ptr_md(n, tmpz);
+    S* md   = ptr_md(n, tmpz);
 
 
     S d = D[gid];
-    rocblas_int sz = esz[gid];
-    rocblas_int p1 = eps[gid];
-    rocblas_int def = idd[gid];
+    rocblas_int sz = nsz[gid];
+    rocblas_int p1 = nps[gid];
+    rocblas_int def = mask[gid];
+    rocblas_int dd = 0;
 
     constexpr int regs = 8;
     const int chunk_width = regs * hipBlockDim_x;
     const int n_chunks = (sz - 1) / chunk_width + 1;
     S bval[regs];
-    int iddval[regs];
+    int maskval[regs];
 
 
     int nan = 0;
@@ -576,7 +534,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             if(x < sz)
             {
                 bval[i] = D[p1 + x];
-                iddval[i]  = idd[p1 + x];
+                maskval[i]  = mask[p1 + x];
             }
         }
         for(int i = 0; i < regs; i++)
@@ -584,20 +542,22 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < sz)
             {
-                nan += (bval[i] != bval[i]);
+                nan += std::isnan(bval[i]);
+                dd += maskval[i] > 0;
                 // lt - how many values are less then the current
                 // eq - how many values are equal to the current
                 // all zero deflated values have to be grouped at the end
                 // so we order any deflated value > any non-deflated value
-                // def == 0 - current is deflated, iddval[i] == 1 - other value is not deflated
-                lt += (def < iddval[i]) || (def == iddval[i] && bval[i] < d);
-                eq += (def == iddval[i]) && (bval[i] == d && (p1 + x) < gid);
+                // def == 0 - current is deflated, maskval[i] == 1 - other value is not deflated
+                lt += (def < maskval[i]) || (def == maskval[i] && bval[i] < d);
+                eq += (def == maskval[i]) && (bval[i] == d && (p1 + x) < gid);
             }
         }
     }
 
     int pos = lt + eq;
-    __shared__ int lds[STEDC_BDIM];
+    __shared__ int lpos[STEDC_BDIM];
+    __shared__ int ldd[STEDC_BDIM];
     // Reduction (sum of pos across all lanes in a workgroup)
     // on each iteration reduction is done within a subgroup of size of 2*bit
     // by xoring corresponding bit of an address.
@@ -605,17 +565,19 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // but keeping code simple for now.
     int bit = 1;
     while (bit < STEDC_BDIM) {
-        lds[hipThreadIdx_x ^ bit] = pos;
+        lpos[hipThreadIdx_x ^ bit] = pos;
+        ldd[hipThreadIdx_x ^ bit] = dd;
         __syncthreads();
-        pos += lds[hipThreadIdx_x];
+        pos += lpos[hipThreadIdx_x];
+        dd += ldd[hipThreadIdx_x];
         __syncthreads();
         bit *= 2;
     }
 
     if (hipThreadIdx_x == 0) {
-        map [pos+p1] = gid;
-        md  [pos+p1] = d;
-        sidd[pos+p1] = def;
+        ndd [pos+p1]  = dd;
+        map [pos+p1]  = gid;
+        md  [pos+p1]  = d;
     }
 
     __syncthreads();
@@ -650,9 +612,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* eps    = ptr_eps (n, splits); 
+    rocblas_int* nps    = ptr_nps (n, splits); 
+    rocblas_int* ndd    = ptr_ndd (n, splits); 
     rocblas_int* cand   = ptr_cand(n, splits); 
-    rocblas_int* sidd   = ptr_sidd(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* md    = ptr_md(n, tmpz);
@@ -673,18 +635,19 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         S d   = md[i];
         S dn  = md[next];
         S dp  = md[prev];
-        rocblas_int p1 = eps[i];
-        rocblas_int pn = eps[next];
-        rocblas_int pp = eps[prev];
+        rocblas_int dd = ndd[i];
+        rocblas_int p1 = nps[i];
+        rocblas_int pn = nps[next];
+        rocblas_int pp = nps[prev];
 
         int bcandidate =
-            sidd[i] && sidd[next]       // not yet deflated
+            (i - p1 < dd - 1)           // current and next are not yet deflated
             && p1 == pn                 // in the same merge block
             && std::abs(d - dn) <= tol  // within tolerance
             && i != (n-1)               // isn't last 
             ;
         int tcandidate =
-            sidd[i] && sidd[prev]       // not yet deflated
+            (i - p1 < dd)               // current and prev are not yet deflated
             && p1 == pp                 // in the same merge block
             && std::abs(d - dp) <= tol  // within tolerance
             && i > 0                    // isn't first
@@ -799,7 +762,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* idd    = ptr_idd(n, splits);
+    rocblas_int* mask    = ptr_mask(n, splits);
     rocblas_int* map    = ptr_map(n, splits);
     rocblas_int* dcount = ptr_dcount(n, splits);
 
@@ -844,7 +807,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             lartg(f, g, c, s, rr);
             baseval = rr;
 
-            idd[idx] = 0;
+            mask[idx] = 0;
             z[idx]   = 0;
             cc[idx]  = c;
             ss[idx]  = s;
@@ -966,12 +929,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* idd    = ptr_idd(n, splits);
-    rocblas_int* em     = ptr_em(n, splits);
+    rocblas_int* mask    = ptr_mask(n, splits);
     rocblas_int* map    = ptr_map(n, splits);
-    rocblas_int* esz    = ptr_esz (n, splits);
-    rocblas_int* eps    = ptr_eps (n, splits); 
-    rocblas_int* dds    = ptr_dds(n, splits);
+    rocblas_int* nsz    = ptr_nsz (n, splits);
+    rocblas_int* nps    = ptr_nps (n, splits); 
+    rocblas_int* ndd    = ptr_ndd(n, splits);
     
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z     = ptr_z(n, tmpz);
@@ -981,21 +943,19 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* evs   = ptr_evs(n, tmpz);
 
 
-    rocblas_int sid = em[gid];
-    S sig = (r1p[sid] < 0) ? -1 : 1;
-
+    S sig = (r1p[gid] < 0) ? -1 : 1;
     S d_  = D[gid];
     S sd_ = sig * d_;
     S z_  = z[gid];
-    rocblas_int sz = esz[gid];
-    rocblas_int p1 = eps[gid];
-    rocblas_int def = idd[gid];
+    rocblas_int sz  = nsz[gid];
+    rocblas_int p1  = nps[gid];
+    rocblas_int def = mask[gid];
 
     constexpr int regs = 8;
     const int chunk_width = regs * hipBlockDim_x;
     const int n_chunks = (sz - 1) / chunk_width + 1;
     S bval[regs];
-    int iddval[regs];
+    int maskval[regs];
 
 
     int nan = 0;
@@ -1012,7 +972,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             if(x < sz)
             {
                 bval[i] = sig * D[p1 + x];
-                iddval[i]  = idd[p1 + x];
+                maskval[i]  = mask[p1 + x];
             }
         }
         for(int i = 0; i < regs; i++)
@@ -1020,15 +980,15 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < sz)
             {
-                nan += (bval[i] != bval[i]);
+                nan += std::isnan(bval[i]);
+                dd += maskval[i] > 0;
                 // lt - how many values are less then the current
                 // eq - how many values are equal to the current
                 // all zero deflated values have to be grouped at the end
                 // so we order any deflated value > any non-deflated value
-                // def == 0 - current is deflated, iddval[i] == 1 - other value is not deflated
-                dd += iddval[i] > 0;
-                lt += (def < iddval[i]) || (def == iddval[i] && bval[i] < sd_);
-                eq += (def == iddval[i]) && (bval[i] == sd_ && (p1 + x) < gid);
+                // def == 0 - current is deflated, maskval[i] == 1 - other value is not deflated
+                lt += (def < maskval[i]) || (def == maskval[i] && bval[i] < sd_);
+                eq += (def == maskval[i]) && (bval[i] == sd_ && (p1 + x) < gid);
             }
         }
     }
@@ -1056,7 +1016,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     }
 
     if (hipThreadIdx_x == 0) {
-        dds[sid] = dd;
+        ndd [pos+p1] = dd;
         map [pos+p1] = gid;
         cd  [pos+p1] = sd_;
         cz  [pos+p1] = z_;
@@ -1094,9 +1054,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* D = DD + bid * strideD;
 
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* dds = ptr_dds(n, splits);
-    rocblas_int* em  = ptr_em(n, splits);
-    rocblas_int* mps = ptr_mps(n, splits);
+    rocblas_int* ndd = ptr_ndd(n, splits);
+    rocblas_int* nps = ptr_nps(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* evs = ptr_evs(n, tmpz);
@@ -1105,9 +1064,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
     S* etmpd = ptr_etmpd(n, tempgemm);
 
-    rocblas_int merge_id = em[eid];
-    rocblas_int dd = dds[merge_id];
-    rocblas_int p1 = mps[merge_id];
+    rocblas_int dd = ndd[eid];
+    rocblas_int p1 = nps[eid];
 
 
     // copy sorted values back to D
@@ -1156,9 +1114,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_SOLVE_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* dds = ptr_dds(n, splits);
-    rocblas_int* mps = ptr_mps(n, splits);
-    rocblas_int* em  = ptr_em(n, splits);
+    rocblas_int* ndd = ptr_ndd(n, splits);
+    rocblas_int* nps = ptr_nps(n, splits);
     
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z   = ptr_cz(n, tmpz);
@@ -1171,15 +1128,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_SOLVE_BDIM)
     int i = hipThreadIdx_x + hipBlockDim_x * hipBlockIdx_x;
     if(i < n)
     {
-        // merge block id
-        rocblas_int sid = em[i];
-
-        // Find off-diagonal element of the merge
-        // rank-1 modification component p correspond to the last element in the first sub-block
-        S p = r1p[sid];
-
-        rocblas_int p1 = mps[sid];
-        rocblas_int dd = dds[sid];
+        S p = r1p[i];
+        rocblas_int p1 = nps[i];
+        rocblas_int dd = ndd[i];
 
         /* ----------------------------------------------------------------- */
 
@@ -1239,10 +1190,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* em   = ptr_em(n, splits);
-    rocblas_int* mps  = ptr_mps(n, splits);
-    rocblas_int* msz  = ptr_msz(n, splits);
-    rocblas_int* dds  = ptr_dds(n, splits);
+    rocblas_int* nps  = ptr_nps(n, splits);
+    rocblas_int* nsz  = ptr_nsz(n, splits);
+    rocblas_int* ndd  = ptr_ndd(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z = ptr_cz(n, tmpz);
@@ -1250,10 +1200,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
     S* etmpd = ptr_etmpd(n, tempgemm);
 
-    rocblas_int sid = em[eid];
-    rocblas_int sz = msz[sid];
-    rocblas_int p1 = mps[sid];
-    rocblas_int dd = dds[sid];
+    rocblas_int sz = nsz[eid];
+    rocblas_int p1 = nps[eid];
+    rocblas_int dd = ndd[eid];
 
     // Re-scale vector Z to avoid bad numerics when an eigenvalue
     // is too close to a pole
@@ -1323,10 +1272,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* em   = ptr_em(n, splits);
-    rocblas_int* msz  = ptr_msz(n, splits);
-    rocblas_int* mps  = ptr_mps(n, splits);
-    rocblas_int* dds  = ptr_dds(n, splits);
+    rocblas_int* nsz  = ptr_nsz(n, splits);
+    rocblas_int* nps  = ptr_nps(n, splits);
+    rocblas_int* ndd  = ptr_ndd(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z    = ptr_cz(n, tmpz);
@@ -1337,10 +1285,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // Work with merges on level k. Each thread-group works with one vector.
     // determine boundaries of what would be the new merged sub-block
-    rocblas_int merge_id = em[eid];
-    rocblas_int p1 = mps[merge_id];
-    rocblas_int sz = msz[merge_id];
-    rocblas_int dd = dds[merge_id];
+    rocblas_int p1 = nps[eid];
+    rocblas_int sz = nsz[eid];
+    rocblas_int dd = ndd[eid];
 
     __syncthreads();
 
@@ -1463,10 +1410,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* em   = ptr_em(n, splits);
-    rocblas_int* dds  = ptr_dds(n, splits);
-    rocblas_int* msz  = ptr_msz(n, splits);
-    rocblas_int* mps  = ptr_mps(n, splits);
+    rocblas_int* ndd  = ptr_ndd(n, splits);
+    rocblas_int* nsz  = ptr_nsz(n, splits);
+    rocblas_int* nps  = ptr_nps(n, splits);
     
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* evs = ptr_evs(n, tmpz);
@@ -1474,10 +1420,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
     S* vecs = ptr_vecs(n, tempgemm);
 
-    rocblas_int merge_id = em[eid];
-    rocblas_int p1 = mps[merge_id];
-    rocblas_int sz = msz[merge_id];
-    rocblas_int dd = dds[merge_id];
+    rocblas_int p1 = nps[eid];
+    rocblas_int sz = nsz[eid];
+    rocblas_int dd = ndd[eid];
 
     // update D and C with computed values and vectors
     if(eid - p1 < dd)
@@ -1669,7 +1614,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < n)
             {
-                nan += (bval[i] != bval[i]);
+                nan += std::isnan(bval[i]);
                 // lt - how many values are less then the current
                 // eq - how many values are equal to the current
                 lt += (bval[i] < d);
@@ -1745,7 +1690,11 @@ inline rocblas_int stedc_num_levels(const rocblas_int n)
     else
         levels = std::ceil(std::log2(n)) - 4;
 
-    //return 3;
+    char* env_levs = std::getenv("LEVS");
+    if(env_levs)
+    {
+        levels = std::atoi(env_levs);
+    }
 
     return levels;
 }
@@ -1892,10 +1841,7 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
 #if DEBUG_OUTPUT
     static int global_cnt = 0;
     global_cnt++;
-    hipEvent_t solve_begin;
-    hipEvent_t solve_end;
-    HIP_CHECK(hipEventCreate(&solve_begin));
-    HIP_CHECK(hipEventCreate(&solve_end));
+    char* env_levs = std::getenv("LEVS");
 #endif
 
     // quick return
@@ -1958,11 +1904,6 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
 
         // find number of sub-blocks 
         rocblas_int levs = stedc_num_levels(n);
-        char* env_levs = std::getenv("LEVS");
-        if (env_levs) {
-            levs = env_levs[0] - '0';
-        }
-
         rocblas_int blks = 1 << levs;
 
         // initialize identity matrix in V
@@ -1995,9 +1936,6 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                 n, D + shiftD, strideD, E + shiftE, strideE, 
                                 V, 0, ldv, strideV, info, (S*)work_stack, splits, 
                                 eps, ssfmin, ssfmax);
-
-        ROCSOLVER_LAUNCH_KERNEL(stedc_init_splits, dim3(1, batch_count), dim3(STEDC_BDIM), 0,
-                                stream, levs, n, splits);
 
         // 3. merge phase
         //----------------
@@ -2054,24 +1992,12 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     V, 0, ldv, strideV,
                                     splits);
 
-#if DEBUG_OUTPUT
-            if(k == levs - 1)
-            {
-                HIP_CHECK(hipEventRecord(solve_begin, stream));
-            }
-#endif
             rocblas_int numgrps_solve = (n - 1) / STEDC_SOLVE_BDIM + 1;
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Solve_kernel<S>),
                                     dim3(numgrps_solve, batch_count), dim3(STEDC_SOLVE_BDIM),
                                     0, stream, k, n, D + shiftD,
                                     strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
                                     ssfmin, ssfmax);
-#if DEBUG_OUTPUT
-            if(k == levs - 1)
-            {
-                HIP_CHECK(hipEventRecord(solve_end, stream));
-            }
-#endif
 
 #if DEBUG_OUTPUT
             //hipError_t status = hipStreamSynchronize(stream);
@@ -2080,12 +2006,11 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                 std::cout << "\nk=" << k << std::endl;
                 print_device_matrix(std::cout, "msz", 1, n_merges, ptr_msz(n, splits), 1);
                 print_device_matrix(std::cout, "mps", 1, n_merges, ptr_mps(n, splits), 1);
-                print_device_matrix(std::cout, "dds", 1, n_merges, ptr_dds(n, splits), 1);
-                print_device_matrix(std::cout, "esz", 1, n, ptr_esz(n, splits), 1);
-                print_device_matrix(std::cout, "eps", 1, n, ptr_eps(n, splits), 1);
-                //print_device_matrix(std::cout, "em", 1, n, ptr_em(n, splits), 1);
-                print_device_matrix(std::cout, "idd", 1, n, ptr_idd(n, splits), 1);
-                print_device_matrix(std::cout, "dbg", 1, n, ptr_dbg(n, splits), 1);
+                print_device_matrix(std::cout, "ndd", 1, n_merges, ptr_ndd(n, splits), 1);
+                print_device_matrix(std::cout, "nsz", 1, n, ptr_nsz(n, splits), 1);
+                print_device_matrix(std::cout, "nps", 1, n, ptr_nps(n, splits), 1);
+                print_device_matrix(std::cout, "mask", 1, n, ptr_mask(n, splits), 1);
+                //print_device_matrix(std::cout, "dbg", 1, n, ptr_dbg(n, splits), 1);
                 //print_device_matrix(std::cout, "map", 1, n, ptr_map(n, splits), 1);
                 print_device_matrix(std::cout, "D", 1, n, D, 1);
                 print_device_matrix(std::cout, "cd", 1, n, ptr_cd(n, tmpz), 1);
@@ -2169,20 +2094,6 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
 
         rocblas_set_pointer_mode(handle, old_mode);
     }
-
-#if DEBUG_OUTPUT
-    HIP_CHECK(hipStreamSynchronize(stream));
-    float elapsed_solve;
-    HIP_CHECK(hipEventElapsedTime(&elapsed_solve, solve_begin, solve_end));
-    HIP_CHECK(hipEventDestroy(solve_begin));
-    HIP_CHECK(hipEventDestroy(solve_end));
-
-    char* show_time = std::getenv("ST");
-    if(global_cnt==2 && show_time && show_time[0] == '1')
-    {
-        std::cout << elapsed_solve << "\t";
-    }
-#endif
 
     return rocblas_status_success;
 }

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -45,6 +45,7 @@
 ROCSOLVER_BEGIN_NAMESPACE
 
 #define STEDC_BDIM 512 // Number of threads per thread-block used in main stedc kernels
+#define STEDC_SOLVE_BDIM 4  // Number of threads per thread-block used in solver kernel
 
 // bit indicating base deflation candidate
 #define L_F_BCAND_BIT 0
@@ -1132,10 +1133,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 /** STEDC_MERGEVALUES_KERNEL solves the secular equation for every pair of sub-blocks 
     that need to be merged. 
         - Call this kernel with batch_count groups in y, and as many groups in x as needed 
-          to cover n (i.e. n_groups_x * groups_size_x >= n). Groups are size STEDC_BDIM **/
+          to cover n (i.e. n_groups_x * groups_size_x >= n). Groups are size STEDC_SOLVE_BDIM **/
 
 template <typename S>
-ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_SOLVE_BDIM)
     stedc_mergeValues_Solve_kernel(const rocblas_int k,
                                    const rocblas_int n,
                                    S* DD,
@@ -2059,10 +2060,10 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                 HIP_CHECK(hipEventRecord(solve_begin, stream));
             }
 #endif
-            rocblas_int numgrps_solve = (n - 1) / STEDC_BDIM + 1;
+            rocblas_int numgrps_solve = (n - 1) / STEDC_SOLVE_BDIM + 1;
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Solve_kernel<S>),
-                                    dim3(numgrps_solve, batch_count),
-                                    dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD,
+                                    dim3(numgrps_solve, batch_count), dim3(STEDC_SOLVE_BDIM),
+                                    0, stream, k, n, D + shiftD,
                                     strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
                                     ssfmin, ssfmax);
 #if DEBUG_OUTPUT

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -65,7 +65,7 @@ __host__ __device__ inline rocblas_int get_splits_size(const rocblas_int n)
     // 2     rocblas_int ps[n];       // the sub-blocks initial positions
     // 3     rocblas_int idd[n];      // if idd[i] = 0, the value in position i has been deflated  (aka mask)
     // 4     rocblas_int pers[n];     // container of permutations when solving the secular eqns
-    // 5     rocblas_int szfs[n];     // sizes of the first sub-block in a merge
+    // 5     rocblas_int r1p[n];      // position of a rank-1 modification component p
     // 6     rocblas_int szs[n];      // sizes of both sub-blocks in a merge
     // 7     rocblas_int dds[n];      // degrees of secular equation
     // 8     rocblas_int map[n];      // 
@@ -85,7 +85,7 @@ template <typename S> __device__ inline S* ptr_ns    (rocblas_int n, S* splits) 
 template <typename S> __device__ inline S* ptr_ps    (rocblas_int n, S* splits) { return splits +  2 * n; }
 template <typename S> __device__ inline S* ptr_idd   (rocblas_int n, S* splits) { return splits +  3 * n; }
 template <typename S> __device__ inline S* ptr_pers  (rocblas_int n, S* splits) { return splits +  4 * n; }
-template <typename S> __device__ inline S* ptr_szfs  (rocblas_int n, S* splits) { return splits +  5 * n; }
+template <typename S> __device__ inline S* ptr_r1p   (rocblas_int n, S* splits) { return splits +  5 * n; }
 template <typename S> __device__ inline S* ptr_szs   (rocblas_int n, S* splits) { return splits +  6 * n; }
 template <typename S> __device__ inline S* ptr_dds   (rocblas_int n, S* splits) { return splits +  7 * n; }
 template <typename S> __device__ inline S* ptr_map   (rocblas_int n, S* splits) { return splits +  8 * n; }
@@ -284,7 +284,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* ns   = ptr_ns(n, splits);
     rocblas_int* ps   = ptr_ps(n, splits);
     rocblas_int* idd  = ptr_idd(n, splits);
-    rocblas_int* szfs = ptr_szfs(n, splits);
+    rocblas_int* r1p  = ptr_r1p(n, splits);
     rocblas_int* szs  = ptr_szs(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
@@ -297,13 +297,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     __shared__ S inrmsd[STEDC_BDIM];
     __shared__ S inrmsz[STEDC_BDIM];
 
-    // tn is the number of thread-groups needed in level k of the merge
     rocblas_int bd = 1 << k;
     rocblas_int bdm = bd << 1;
-    rocblas_int tn = blks / bdm;
 
     // Work with merges on level k. A thread-group works with two leaves in the merge tree.
-    if(sid < tn)
     {
         rocblas_int iam, sz, dim, dim2, p2;
 
@@ -323,7 +320,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         sz = ns[tid];
         for(int j = 1; j < bd; ++j)
             sz += ns[tid + j];
-        szfs[tid] = sz;
+        r1p[tid] = (iam == 0) ? (p2 - 1 + sz) : (p2 - 1);
         // with this, all threads involved in a merge
         // will point to the same row of C and the same off-diag element
         S* ptz = (iam == 0) ? C + p2 - 1 + sz : C + p2;
@@ -916,7 +913,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int sid = hipBlockIdx_x;
     // thread id
     rocblas_int tidb = hipThreadIdx_x;
-    rocblas_int tid, tx;
 
     // select batch instance to work with
     S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
@@ -928,7 +924,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* ps   = ptr_ps(n, splits);
     rocblas_int* idd  = ptr_idd(n, splits);
     rocblas_int* pers = ptr_pers(n, splits);
-    rocblas_int* szfs = ptr_szfs(n, splits);
+    rocblas_int* r1p  = ptr_r1p(n, splits);
     rocblas_int* szs  = ptr_szs(n, splits);
     rocblas_int* dds  = ptr_dds(n, splits);
 
@@ -940,43 +936,21 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // temp values during the merges
     S* temps = vecs + (n * n);
 
-    // tn is the number of thread-groups needed in level k of the merge
-    rocblas_int bd = 1 << k;
-    rocblas_int bdm = bd << 1;
-    rocblas_int tn = blks / bdm;
+    rocblas_int bdm = 1 << (k + 1);
 
     // Work with merges on level k. A thread-group works with two leaves in the merge tree.
-    if(sid < tn)
     {
-        rocblas_int iam, sz, dim, dim2, p2;
-
-        // tid indexes the sub-blocks in the entire matrix
-        // iam indexes the sub-blocks in the context of the merge
-        // (according to its level in the merge tree)
-        dim = hipBlockDim_x / 2;
-        iam = tidb / dim;
-        tx = tidb % dim;
-        tid = sid * bdm + iam * bd;
-        p2 = ps[tid];
-
-        // 1. find rank-1 modification components (z and p) for this merge
+        // 1. find rank-1 modification component (p) for this merge
         // ----------------------------------------------------------------
-        // Threads with iam = 0 work with components below the merge point;
-        // threads with iam = 1 work above the merge point
-        sz = szfs[tid];
-        // with this, all threads involved in a merge
-        // will point to the same row of C and the same off-diag element
-        S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
-
+        S p = 2 * E[r1p[sid * bdm]];
 
         // 3. deflate eigenvalues
         // ----------------------------------------------------------------
         // determine boundaries of what would be the new merged sub-block
         // 'in' will be its initial position.
         // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        rocblas_int in = tid - iam * bd;
-        sz = szs[in];
-        in = ps[in];
+        rocblas_int sz = szs[sid * bdm];
+        rocblas_int in = ps[sid * bdm];
 
         // 4. Organize data with non-deflated values to prepare secular equation
         // ------------------------------------------------------------------------ 
@@ -1159,37 +1133,23 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // temp values during the merges
     S* temps = vecs + (n * n);
 
-    // tn is the number of thread-groups needed in level k of the merge
-    rocblas_int bd = 1 << k;
-    rocblas_int bdm = bd << 1;
-    rocblas_int tn = blks / bdm;
+    rocblas_int bdm = 1 << (k + 1);
 
     // Work with merges on level k. A thread-group works with two leaves in the merge tree;
     // all threads work together to solve the secular equation.
-    if(sid < tn)
     {
-        rocblas_int iam, sz, dim;
-
-        // tid indexes the sub-blocks in the entire split block
-        // iam indexes the sub-blocks in the context of the merge
-        // (according to its level in the merge tree)
-        dim = hipBlockDim_x / 2;
-        iam = tidb / dim;
-        tid = sid * bdm + iam * bd;
-
         // determine boundaries of what would be the new merged sub-block
         // 'in' will be its initial position.
         // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        rocblas_int in = tid - iam * bd;
-        sz = szs[in];
-        in = ps[in];
+        rocblas_int sz = szs[sid * bdm];
+        rocblas_int in = ps[sid * bdm];
 
 
         // 1. Organize data with non-deflated values to prepare secular equation
         // ----------------------------------------------------------------- 
         // All threads of the group participating in the merge will work together
         // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
-        iam = tidb;
+        rocblas_int iam = tidb;
         bdm = hipBlockDim_x;
 
         // define shifted arrays
@@ -1202,12 +1162,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
         // find degree of secular equation
         rocblas_int dd = dds[in];
-        //rocblas_int dd = 0;
-        //for(int i = 0; i < sz; ++i)
-        //{
-        //    if(mask[i] == 1)
-        //        dd++;
-        //}
 
         // Order the elements in tmpd and zz using a simple parallel selection/bubble sort.
         // This will allow us to find initial intervals for eigenvalue guesses
@@ -1280,7 +1234,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* ps   = ptr_ps(n, splits);
     rocblas_int* idd  = ptr_idd(n, splits);
     rocblas_int* pers = ptr_pers(n, splits);
-    rocblas_int* szfs = ptr_szfs(n, splits);
+    rocblas_int* r1p  = ptr_r1p(n, splits);
     rocblas_int* szs  = ptr_szs(n, splits);
     rocblas_int* dds  = ptr_dds(n, splits);
     
@@ -1292,46 +1246,25 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // temp values during the merges
     S* temps = vecs + (n * n);
 
-    // tn is the number of thread-groups needed in level k of the merge
-    rocblas_int bd = 1 << k;
-    rocblas_int bdm = bd << 1;
-    rocblas_int tn = blks / bdm;
+    rocblas_int bdm = 1 << (k + 1);
 
     // Work with merges on level k. A thread-group works with two leaves in the merge tree;
     // all threads work together to solve the secular equation.
-    if(sid < tn)
     {
-        rocblas_int iam, sz, dim, p2;
-        S valf, valg;
-
-        // tid indexes the sub-blocks in the entire split block
-        // iam indexes the sub-blocks in the context of the merge
-        // (according to its level in the merge tree)
-        dim = (hipBlockDim_x * groups_per_merge) / 2;
-        iam = tidb / dim;
-        tid = sid * bdm + iam * bd;
-        p2 = ps[tid];
-
         // Find off-diagonal element of the merge
-        // Threads with iam = 0 work with components below the merge point;
-        // threads with iam = 1 work above the merge point
-        sz = szfs[tid];
-        // with this, all threads involved in a merge
-        // will point to the same row of C and the same off-diag element
-        S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
+        S p = 2 * E[r1p[sid * bdm]];
 
         // determine boundaries of what would be the new merged sub-block
         // 'in' will be its initial position.
         // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        rocblas_int in = tid - iam * bd;
-        sz = szs[in];
-        in = ps[in];
+        rocblas_int sz = szs[sid * bdm];
+        rocblas_int in = ps[sid * bdm];
 
         // 1. Organize data with non-deflated values to prepare secular equation
         // -----------------------------------------------------------------
         // All threads of the group participating in the merge will work together
         // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
-        iam = tidb;
+        rocblas_int iam = tidb;
         bdm = hipBlockDim_x * groups_per_merge;
 
         // define shifted arrays
@@ -1344,12 +1277,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
         // find degree of secular equation
         rocblas_int dd = dds[in];
-        //rocblas_int dd = 0;
-        //for(int i = 0; i < sz; ++i)
-        //{
-        //    if(mask[i] == 1)
-        //        dd++;
-        //}
 
         solve_seq_eqns(dd, iam, bdm, sz, n, p, eps, ssfmin, ssfmax, mask, tmpd, ev, zz);
     }
@@ -1390,7 +1317,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* ps   = ptr_ps(n, splits);
     rocblas_int* idd  = ptr_idd(n, splits);
     rocblas_int* pers = ptr_pers(n, splits);
-    rocblas_int* szfs = ptr_szfs(n, splits);
     rocblas_int* szs  = ptr_szs(n, splits);
     rocblas_int* dds  = ptr_dds(n, splits);
     
@@ -1402,37 +1328,23 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // temp values during the merges
     S* temps = vecs + (n * n);
 
-    // tn is the number of thread-groups needed in level k of the merge
-    rocblas_int bd = 1 << k;
-    rocblas_int bdm = bd << 1;
-    rocblas_int tn = blks / bdm;
+    rocblas_int bdm = 1 << (k + 1);
 
     // Work with merges on level k. A thread-group works with two leaves in the merge tree;
     // all threads work together to solve the secular equation.
-    if(sid < tn)
     {
-        rocblas_int iam, sz, dim;
-
-        // tid indexes the sub-blocks in the entire split block
-        // iam indexes the sub-blocks in the context of the merge
-        // (according to its level in the merge tree)
-        dim = hipBlockDim_x / 2;
-        iam = tidb / dim;
-        tid = sid * bdm + iam * bd;
-
         // determine boundaries of what would be the new merged sub-block
         // 'in' will be its initial position.
         // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        rocblas_int in = tid - iam * bd;
-        sz = szs[in];
-        in = ps[in];
+        rocblas_int sz = szs[sid * bdm];
+        rocblas_int in = ps[sid * bdm];
 
 
         // 1. Organize data with non-deflated values to prepare secular equation
         // ----------------------------------------------------------------- 
         // All threads of the group participating in the merge will work together
         // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
-        iam = tidb;
+        rocblas_int iam = tidb;
         bdm = hipBlockDim_x;
 
         // define shifted arrays
@@ -1445,12 +1357,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
         // find degree of secular equation
         rocblas_int dd = dds[in];
-        //rocblas_int dd = 0;
-        //for(int i = 0; i < sz; ++i)
-        //{
-        //    if(mask[i] == 1)
-        //        dd++;
-        //}
 
         rescale_z(dd, iam, bdm, sz, n, per, mask, tmpd, diag, zz);
     }
@@ -1517,8 +1423,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* inrms = reinterpret_cast<S*>(lsmem);
 
     // tn is max number of vectors in each sub-block
-    rocblas_int bd = 1 << k;
-    rocblas_int bdm = bd << 1;
+    rocblas_int bdm = 1 << (k + 1);
     rocblas_int tn = (n - 1) / blks + 1;
 
     // Work with merges on level k. Each thread-group works with one vector.
@@ -1712,8 +1617,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* vecs = vecsA + bid * 2 * (n * n);
 
     // tn is max number of vectors in each sub-block
-    rocblas_int bd = 1 << k;
-    rocblas_int bdm = bd << 1;
+    rocblas_int bdm = 1 << (k + 1);
     rocblas_int tn = (n - 1) / blks + 1;
 
     // Work with merges on level k. Each thread-group works with one vector.

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1155,7 +1155,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* msz = ptr_msz(n, splits);
     rocblas_int* dds = ptr_dds(n, splits);
     rocblas_int* mps = ptr_mps(n, splits);
     rocblas_int* em  = ptr_em(n, splits);
@@ -1178,16 +1177,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // rank-1 modification component p correspond to the last element in the first sub-block
         S p = r1p[sid];
 
-        // determine boundaries of what would be the new merged sub-block
-        // 'p1' will be its initial position.
-        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        rocblas_int sz = msz[sid];
         rocblas_int p1 = mps[sid];
-
-        // define shifted arrays
-        S* zz = z + p1;
-
-        // find degree of secular equation
         rocblas_int dd = dds[sid];
 
         /* ----------------------------------------------------------------- */
@@ -1198,21 +1188,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // each thread will find a different zero in parallel
         if((i-p1) < dd)
         {
-            // find position in the ordered array
-            S valf = p < 0 ? -evs[i] : evs[i];
-            int count = dd, cc = 0;
-            while(count > 0)
-            {
-                auto step = count / 2;
-                auto it = cc + step;
-                if(etmpd[it + i * n] < valf)
-                {
-                    cc = ++it;
-                    count -= step + 1;
-                }
-                else
-                    count = step;
-            }
+            int cc = i - p1;
 
             // computed zero will overwrite 'ev' at the corresponding position.
             // 'etmpd' will be updated with the distances D - lambda_i.
@@ -1220,13 +1196,13 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             rocblas_int linfo;
 
 #if defined(ROCSOLVER_USE_REFERENCE_SECULAR_EQUATIONS_SOLVER)
-            linfo = slaed4(dd, cc, etmpd + i * n, zz, std::abs(p), evs[i]);
+            linfo = slaed4(dd, cc, etmpd + i * n, z + p1, std::abs(p), evs[i]);
 #else
             if(cc == dd - 1)
-                linfo = seq_solve_ext(dd, etmpd + i * n, zz, (p < 0 ? -p : p), evs + i, eps,
+                linfo = seq_solve_ext(dd, etmpd + i * n, z + p1, std::abs(p), evs + i, eps,
                                         ssfmin, ssfmax);
             else
-                linfo = seq_solve(dd, etmpd + i * n, zz, (p < 0 ? -p : p), cc, evs + i, eps,
+                linfo = seq_solve(dd, etmpd + i * n, z + p1, std::abs(p), cc, evs + i, eps,
                                     ssfmin, ssfmax);
 #endif
 
@@ -2077,32 +2053,6 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     V, 0, ldv, strideV,
                                     splits);
 
-
-#if DEBUG_OUTPUT
-            //hipError_t status = hipStreamSynchronize(stream);
-            if(env_levs && global_cnt == 1)
-            {
-                std::cout << "\nk=" << k << std::endl;
-                print_device_matrix(std::cout, "msz", 1, n_merges, ptr_msz(n, splits), 1);
-                print_device_matrix(std::cout, "mps", 1, n_merges, ptr_mps(n, splits), 1);
-                print_device_matrix(std::cout, "esz", 1, n, ptr_esz(n, splits), 1);
-                print_device_matrix(std::cout, "eps", 1, n, ptr_eps(n, splits), 1);
-                //print_device_matrix(std::cout, "dds", 1, n_merges, ptr_dds(n, splits), 1);
-                //print_device_matrix(std::cout, "em", 1, n, ptr_em(n, splits), 1);
-                print_device_matrix(std::cout, "idd", 1, n, ptr_idd(n, splits), 1);
-                print_device_matrix(std::cout, "map", 1, n, ptr_map(n, splits), 1);
-                print_device_matrix(std::cout, "D", 1, n, D, 1);
-                print_device_matrix(std::cout, "cd", 1, n, ptr_cd(n, tmpz), 1);
-                //print_device_matrix(std::cout, "etmpd", n, n, tempgemm +n*n, n);
-
-                //print_device_matrix(std::cout, "dbg", 1, n, ptr_dbg(n, splits), 1);
-
-                //print_device_matrix(std::cout, "D", 1, n, D, 1);
-
-                //std::exit(0);
-            }
-#endif
-
 #if DEBUG_OUTPUT
             if(k == levs - 1)
             {
@@ -2119,6 +2069,30 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             if(k == levs - 1)
             {
                 HIP_CHECK(hipEventRecord(solve_end, stream));
+            }
+#endif
+
+#if DEBUG_OUTPUT
+            //hipError_t status = hipStreamSynchronize(stream);
+            if(env_levs && global_cnt == 1)
+            {
+                std::cout << "\nk=" << k << std::endl;
+                print_device_matrix(std::cout, "msz", 1, n_merges, ptr_msz(n, splits), 1);
+                print_device_matrix(std::cout, "mps", 1, n_merges, ptr_mps(n, splits), 1);
+                print_device_matrix(std::cout, "dds", 1, n_merges, ptr_dds(n, splits), 1);
+                print_device_matrix(std::cout, "esz", 1, n, ptr_esz(n, splits), 1);
+                print_device_matrix(std::cout, "eps", 1, n, ptr_eps(n, splits), 1);
+                //print_device_matrix(std::cout, "em", 1, n, ptr_em(n, splits), 1);
+                print_device_matrix(std::cout, "idd", 1, n, ptr_idd(n, splits), 1);
+                print_device_matrix(std::cout, "dbg", 1, n, ptr_dbg(n, splits), 1);
+                //print_device_matrix(std::cout, "map", 1, n, ptr_map(n, splits), 1);
+                print_device_matrix(std::cout, "D", 1, n, D, 1);
+                print_device_matrix(std::cout, "cd", 1, n, ptr_cd(n, tmpz), 1);
+                //print_device_matrix(std::cout, "etmpd", n, n, tempgemm +n*n, n);
+
+                //print_device_matrix(std::cout, "D", 1, n, D, 1);
+
+                //std::exit(0);
             }
 #endif
 

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1231,6 +1231,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* vecs = vecsA + bid * 2 * (n * n);
     // temp values during the merges
     S* temps = vecs + (n * n);
+    S* etmpd = temps;
 
     int i = hipThreadIdx_x + hipBlockDim_x * hipBlockIdx_x;
     if(i < n)
@@ -1249,7 +1250,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         rocblas_int p1 = mps[sid];
 
         // define shifted arrays
-        S* etmpd = temps;
         S* zz = z + p1;
 
         // find degree of secular equation
@@ -1391,8 +1391,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 //--------------------------------------------------------------------------------------//
 /** STEDC_MERGEVECTORS_KERNEL prepares vectors from the secular equation for
     every pair of sub-blocks that need to be merged.
-        - Call this kernel with batch_count groups in y, and as many groups as columns would 
-          be in the matrix if its size is exact multiple of the number of sub-blocks 'blks'.
+        - Call this kernel with batch_count groups in y, and n groups in x.
           Each group works with a column. Groups are size STEDC_BDIM.
         - If a group has an id larger than the actual number of columns it will do nothing. **/
 template <bool USEGEMM, typename S>
@@ -1417,7 +1416,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // batch instance id
     rocblas_int bid = hipBlockIdx_y;
     // merge sub-block id
-    rocblas_int sid = hipBlockIdx_x;
+    rocblas_int eid = hipBlockIdx_x;
     // thread id
     rocblas_int tidb = hipThreadIdx_x;
     rocblas_int dim = hipBlockDim_x;
@@ -1428,35 +1427,12 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* ns   = ptr_ns(n, splits);
-    rocblas_int* ps   = ptr_ps(n, splits);
+    rocblas_int* em   = ptr_em(n, splits);
     rocblas_int* idd  = ptr_idd(n, splits);
     rocblas_int* msz  = ptr_msz(n, splits);
     rocblas_int* mps  = ptr_mps(n, splits);
     rocblas_int* dds  = ptr_dds(n, splits);
     rocblas_int* pers = ptr_map(n, splits);
-
-    rocblas_int* dbg  = ptr_dbg(n, splits);
-    rocblas_int* dbg1  = ptr_dbg1(n, splits);
-    rocblas_int* dbg2  = ptr_dbg2(n, splits);
-    rocblas_int* dbg3  = ptr_dbg3(n, splits);
-    rocblas_int* dbg4  = ptr_dbg4(n, splits);
-    rocblas_int* dbg5  = ptr_dbg5(n, splits);
-    rocblas_int* dbg6  = ptr_dbg6(n, splits);
-    rocblas_int* dbg7  = ptr_dbg7(n, splits);
-    rocblas_int* dbg8  = ptr_dbg8(n, splits);
-    rocblas_int* dbg9  = ptr_dbg9(n, splits);
-    rocblas_int* dbg10 = ptr_dbg10(n, splits);
-    rocblas_int* dbg11 = ptr_dbg11(n, splits);
-    rocblas_int* dbg12 = ptr_dbg12(n, splits);
-    rocblas_int* dbg13 = ptr_dbg13(n, splits);
-    rocblas_int* dbg14 = ptr_dbg14(n, splits);
-    rocblas_int* dbg15 = ptr_dbg15(n, splits);
-    rocblas_int* dbg16 = ptr_dbg16(n, splits);
-    rocblas_int* dbg17 = ptr_dbg17(n, splits);
-    rocblas_int* dbg18 = ptr_dbg18(n, splits);
-    rocblas_int* dbg19 = ptr_dbg19(n, splits);
-    rocblas_int* dbg20 = ptr_dbg20(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z    = ptr_cz(n, tmpz);
@@ -1469,130 +1445,105 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // used to store temp values during the different reductions
     __shared__ S inrms[STEDC_BDIM];
 
-    // tn is max number of vectors in each sub-block
-    rocblas_int bdm = 1 << (k + 1);
-    rocblas_int tn = (n - 1) / blks + 1;
-
     // Work with merges on level k. Each thread-group works with one vector.
-    //if(sid < tn * blks)
+    // determine boundaries of what would be the new merged sub-block
+    rocblas_int merge_id = em[eid];
+    rocblas_int p1 = mps[merge_id];
+    rocblas_int sz = msz[merge_id];
+    rocblas_int dd = dds[merge_id];
+
+    __syncthreads();
+
+
+    // Prepare vectors corresponding to non-deflated values
+    S nrm;
+    S* putvec = USEGEMM ? vecs : temps;
+
+    if(idd[eid] == 1)
     {
-        // tid indexes the sub-blocks in the entire split block
-        rocblas_int tid = sid / tn;
-        rocblas_int p2 = ps[tid];
-        // vidb indexes the vectors associated with each sub-block
-        rocblas_int vidb = sid % tn;
-
-        rocblas_int merge_id = tid / bdm;
-        rocblas_int eid = vidb + p2;
-
-        // determine boundaries of what would be the new merged sub-block
-        rocblas_int p1 = mps[merge_id];
-        rocblas_int sz = msz[merge_id];
-        rocblas_int dd = dds[merge_id];
-
-        // define shifted arrays
-        S* diag = D + p1;
-        rocblas_int* mask = idd + p1;
-        S* zz = z + p1;
-        rocblas_int* per = pers + p1;
-
+        // compute vectors of rank-1 perturbed system and their norms
+        nrm = 0;
+        for(int i = tidb; i < dd; i += dim)
+        {
+            S valf = z[p1 + i] / temps[i + eid*n];
+            nrm += valf * valf;
+            putvec[i + eid*n] = valf;
+        }
+        inrms[tidb] = nrm;
         __syncthreads();
 
-
-        // Prepare vectors corresponding to non-deflated values
-        S temp, nrm;
-        bool go = (vidb < ns[tid]);
-        S* putvec = USEGEMM ? vecs : temps;
-
-        if(go)
+        // reduction (for the norms)
+        for(int r = dim / 2; r > 0; r /= 2)
         {
-            if(idd[eid] == 1)
+            if(tidb < r)
             {
-                // compute vectors of rank-1 perturbed system and their norms
-                nrm = 0;
-                for(int i = tidb; i < dd; i += dim)
-                {
-                    S valf = zz[i] / temps[i + eid*n];
-                    nrm += valf * valf;
-                    putvec[i + eid*n] = valf;
-                }
+                nrm += inrms[tidb + r];
                 inrms[tidb] = nrm;
+            }
+            __syncthreads();
+        }
+        nrm = sqrt(inrms[0]);
+    }
+
+    if(USEGEMM)
+    {
+        // when using external gemms for the update, we need to
+        // put vectors in padded matrix 'temps'
+        // (this is to compute 'vecs = C * temps' using external gemm call)
+        for(int i = tidb; i < p1 + sz; i += dim)
+        {
+            if(i >= p1 && idd[eid] == 1 && idd[i] == 1)
+            {
+                dd = 0;
+                for(int k = p1; k < i; ++k)
+                {
+                    if(idd[k] == 0)
+                        dd++;
+                }
+                temps[pers[i - dd] + p1 + eid * n]
+                    = vecs[i - dd - p1 + eid * n] / nrm;
+            }
+            else
+                temps[i + eid * n] = 0;
+        }
+    }
+    else
+    {
+        // otherwise, use internal gemm-like procedure to
+        // multiply by C (row by row)
+        rocblas_int tsz = 1 << (levs - 1 - k);
+        tsz = (n - 1) / tsz + 1;
+        if(idd[eid] == 1)
+        {
+            for(int ii = 0; ii < tsz; ++ii)
+            {
+                rocblas_int i = p1 + ii;
+
+                // inner products
+                S temp = 0;
+                if(ii < sz)
+                {
+                    for(int kk = tidb; kk < dd; kk += dim)
+                        temp += C[i + (pers[p1 + kk] + p1) * ldc] * temps[kk + eid * n];
+                }
+                inrms[tidb] = temp;
                 __syncthreads();
 
-                // reduction (for the norms)
+                // reduction
                 for(int r = dim / 2; r > 0; r /= 2)
                 {
-                    if(tidb < r)
+                    if(ii < sz && tidb < r)
                     {
-                        nrm += inrms[tidb + r];
-                        inrms[tidb] = nrm;
+                        temp += inrms[tidb + r];
+                        inrms[tidb] = temp;
                     }
                     __syncthreads();
                 }
-                nrm = sqrt(inrms[0]);
-            }
 
-            if(USEGEMM)
-            {
-                // when using external gemms for the update, we need to
-                // put vectors in padded matrix 'temps'
-                // (this is to compute 'vecs = C * temps' using external gemm call)
-                for(int i = tidb; i < p1 + sz; i += dim)
-                {
-                    if(i >= p1 && idd[eid] == 1 && idd[i] == 1)
-                    {
-                        dd = 0;
-                        for(int k = p1; k < i; ++k)
-                        {
-                            if(idd[k] == 0)
-                                dd++;
-                        }
-                        temps[pers[i - dd] + p1 + eid * n]
-                            = vecs[i - dd - p1 + eid * n] / nrm;
-                    }
-                    else
-                        temps[i + eid * n] = 0;
-                }
-            }
-            else
-            {
-                // otherwise, use internal gemm-like procedure to
-                // multiply by C (row by row)
-                rocblas_int tsz = 1 << (levs - 1 - k);
-                tsz = (n - 1) / tsz + 1;
-                if(idd[eid] == 1)
-                {
-                    for(int ii = 0; ii < tsz; ++ii)
-                    {
-                        rocblas_int i = p1 + ii;
-
-                        // inner products
-                        temp = 0;
-                        if(ii < sz)
-                        {
-                            for(int kk = tidb; kk < dd; kk += dim)
-                                temp += C[i + (per[kk] + p1) * ldc] * temps[kk + eid * n];
-                        }
-                        inrms[tidb] = temp;
-                        __syncthreads();
-
-                        // reduction
-                        for(int r = dim / 2; r > 0; r /= 2)
-                        {
-                            if(ii < sz && tidb < r)
-                            {
-                                temp += inrms[tidb + r];
-                                inrms[tidb] = temp;
-                            }
-                            __syncthreads();
-                        }
-
-                        // result
-                        if(ii < sz && tidb == 0)
-                            vecs[i + eid * n] = temp / nrm;
-                        __syncthreads();
-                    }
-                }
+                // result
+                if(ii < sz && tidb == 0)
+                    vecs[i + eid * n] = temp / nrm;
+                __syncthreads();
             }
         }
     }
@@ -2204,7 +2155,7 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             // c. find merged eigenvectors
             ROCSOLVER_LAUNCH_KERNEL(
                 (stedc_mergeVectors_kernel<STEDC_EXTERNAL_GEMM, S>),
-                dim3(numgrps3, batch_count), dim3(STEDC_BDIM), 0, stream, 
+                dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
                 levs, blks, k, n, D + shiftD, strideD, E + shiftE, strideE, V, 0, ldv, strideV, 
                 tmpz, tempgemm, splits);
 

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -81,6 +81,28 @@ __host__ __device__ inline rocblas_int get_splits_size(const rocblas_int n)
     return 17 * n;
 }
 
+__host__ __device__ inline rocblas_int get_tmpz_size(const rocblas_int n)
+{
+    // tmpz layout:
+    // struct {
+    // 0    S z[n];       // the rank-1 modification vectors in the merges
+    // 1    S evs[n];     // roots of secular equations
+    // 2    S cc[n];
+    // 3    S ss[n];
+    // 4    S tolsD[n];
+    // 5    S tolsZ[n];
+    // 6    S md[n];
+    return 7 * n;
+}
+
+template <typename S> __device__ inline S* ptr_z    (rocblas_int n, S* tmpz) { return tmpz + 0 * n; }
+template <typename S> __device__ inline S* ptr_evs  (rocblas_int n, S* tmpz) { return tmpz + 1 * n; }
+template <typename S> __device__ inline S* ptr_cc   (rocblas_int n, S* tmpz) { return tmpz + 2 * n; }
+template <typename S> __device__ inline S* ptr_ss   (rocblas_int n, S* tmpz) { return tmpz + 3 * n; }
+template <typename S> __device__ inline S* ptr_tolsD(rocblas_int n, S* tmpz) { return tmpz + 4 * n; }
+template <typename S> __device__ inline S* ptr_tolsZ(rocblas_int n, S* tmpz) { return tmpz + 5 * n; }
+template <typename S> __device__ inline S* ptr_md   (rocblas_int n, S* tmpz) { return tmpz + 6 * n; }
+
 
 /*************** Main kernels *********************************************************/
 /**************************************************************************************/
@@ -184,9 +206,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_solve_kernel(const roc
     rocblas_int tidb_inc = hipBlockDim_x;
 
     // select batch instance to work with
-    S* C;
-    if(CC)
-        C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
+    S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
     S* D = DD + bid * strideD;
     S* E = EE + bid * strideE;
     rocblas_int* info = iinfo + bid;
@@ -198,7 +218,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_solve_kernel(const roc
     // the sub-blocks initial positions
     rocblas_int* ps = ns + n;
     // workspace for solvers
-    S* W = WA + bid * (2 * n);
+    S* W = WA + bid * get_tmpz_size(n);
 
     // Solve the blks sub-blocks in parallel (using classic QR iteration).
     if(sid < blks)
@@ -232,7 +252,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                                           const rocblas_int ldc,
                                           const rocblas_stride strideC,
                                           S* tmpzA,
-                                          S* vecsA,
                                           rocblas_int* splitsA,
                                           const S eps)
 {
@@ -267,14 +286,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // degrees of secular equation
     rocblas_int* dds = szs + n;
     // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // temp for tolerance values used in deflation
-    // IMPORTANT: tols maps to the same memory as evs
-    S* tols = z + n;
-    // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* z     = ptr_z(n, tmpz);
+    S* tolsD = ptr_tolsD(n, tmpz);
+    S* tolsZ = ptr_tolsD(n, tmpz);
 
     // temporary arrays in shared memory
     // used to store temp values during the different reductions
@@ -368,7 +383,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         for(int i = 1; i < bdm; ++i)
             sz += ns[in + i];
         szs[in] = sz;
-        tols[in] = tol;
+        tolsD[in] = tol;
+        tolsZ[in] = tol;
         in = ps[in];
 
         // first deflate zero components
@@ -398,7 +414,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                                    const rocblas_int k,
                                    const rocblas_int n,
                                    S* tmpzA,
-                                   S* vecsA,
                                    rocblas_int* splitsA)
 {
     // threads and groups indices
@@ -424,19 +439,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // degrees of secular equation
     rocblas_int* dds = szs + n;
     // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // temp for tolerance values used in deflation
-    // IMPORTANT: tols maps to the same memory as evs
-    S* tols = z + n;
-    // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
-
-    S* cc    = vecs + 2 * n;
-    S* ss    = vecs + 3 * n;
-    S* mtols = vecs + 4 * n;
-    S* md    = vecs + 5 * n;
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* tolsD = ptr_tolsD(n, tmpz);
+    S* tolsZ = ptr_tolsZ(n, tmpz);
 
     rocblas_int* map    = splits +  8 * n;
     rocblas_int* dcount = splits +  9 * n;
@@ -448,13 +453,14 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int in = sid << (k + 1);
     rocblas_int sz = szs[in];
     rocblas_int p  = ps[in];
-    S tol = tols[in];
+    S tol = tolsD[in];
 
     for (int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x) {
         int id = p + i;
         mns[id] = sz;
         mps[id] = p;
-        mtols[id] = tol;
+        tolsD[id] = tol;
+        tolsZ[id] = tol;
         dcount[id] = 0;
         map[id] = 0;
     }
@@ -472,7 +478,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                                     S* DD,
                                     const rocblas_stride strideD,
                                     S* tmpzA,
-                                    S* vecsA,
                                     rocblas_int* splitsA)
 {
     // threads and groups indices
@@ -501,19 +506,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // degrees of secular equation
     rocblas_int* dds = szs + n;
     // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // temp for tolerance values used in deflation
-    // IMPORTANT: tols maps to the same memory as evs
-    S* tols = z + n;
-    // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
-
-    S* cc    = vecs + 2 * n;
-    S* ss    = vecs + 3 * n;
-    S* mtols = vecs + 4 * n;
-    S* md    = vecs + 5 * n;
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* md    = ptr_md(n, tmpz);
+    S* tolsD = ptr_tolsD(n, tmpz);
 
     rocblas_int* map    = splits +  8 * n;
     rocblas_int* dcount = splits +  9 * n;
@@ -611,7 +606,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                                            S* DD,
                                            const rocblas_stride strideD,
                                            S* tmpzA,
-                                           S* vecsA,
                                            rocblas_int* splitsA)
 {
     // threads and groups indices
@@ -623,16 +617,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    S* z = tmpzA + bid * (2 * n);
-    // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
-
-    S* cc    = vecs + 2 * n;
-    S* ss    = vecs + 3 * n;
-    S* mtols = vecs + 4 * n;
-    S* md    = vecs + 5 * n;
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* md    = ptr_md(n, tmpz);
+    S* tolsD = ptr_tolsD(n, tmpz);
 
     rocblas_int* map    = splits +  8 * n;
     rocblas_int* dcount = splits +  9 * n;
@@ -650,7 +637,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     {
         int next = (i + 1) < n ? (i + 1) : i;
         int prev = (i > 0) ? (i - 1) : 0;
-        S tol = mtols[i];
+        S tol = tolsD[i];
         S d   = md[i];
         S dn  = md[next];
         S dp  = md[prev];
@@ -687,7 +674,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                                            S* DD,
                                            const rocblas_stride strideD,
                                            S* tmpzA,
-                                           S* vecsA,
                                            rocblas_int* splitsA)
 {
     // threads and groups indices
@@ -706,16 +692,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // if idd[i] = 0, the value in position i has been deflated
     rocblas_int* idd = ps + n;
     // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
-
-    S* cc    = vecs + 2 * n;
-    S* ss    = vecs + 3 * n;
-    S* mtols = vecs + 4 * n;
-    S* md    = vecs + 5 * n;
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* md    = ptr_md(n, tmpz);
+    S* tolsD = ptr_tolsD(n, tmpz);
 
     rocblas_int* map    = splits +  8 * n;
     rocblas_int* dcount = splits +  9 * n;
@@ -736,7 +715,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     int candp = (prev < n) ? cand[prev] : 0;
     int candb = (base < n) ? cand[base] : 0;
     S bval = (base < n) ? md[base] : 0;
-    S tol  = (base < n) ? mtols[base] : 0;
+    S tol  = (base < n) ? tolsD[base] : 0;
 
     // cache max_len values of D[] and cand[]
     for(int i = hipThreadIdx_x; i < max_len; i += hipBlockDim_x)
@@ -791,7 +770,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                                            S* DD,
                                            const rocblas_stride strideD,
                                            S* tmpzA,
-                                           S* vecsA,
                                            rocblas_int* splitsA)
 {
     // threads and groups indices
@@ -809,17 +787,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* ps = ns + n;
     // if idd[i] = 0, the value in position i has been deflated
     rocblas_int* idd = ps + n;
-    // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
-
-    S* cc    = vecs + 2 * n;
-    S* ss    = vecs + 3 * n;
-    S* mtols = vecs + 4 * n;
-    S* md    = vecs + 5 * n;
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* z  = ptr_z(n, tmpz);
+    S* cc = ptr_cc(n, tmpz);
+    S* ss = ptr_ss(n, tmpz);
 
     rocblas_int* map    = splits +  8 * n;
     rocblas_int* dcount = splits +  9 * n;
@@ -889,28 +860,21 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                              const rocblas_int ldc,
                              const rocblas_stride strideC,
                              S* tmpzA,
-                             S* vecsA,
                              rocblas_int* splitsA)
 {
     // threads and groups indices
     // batch instance id
     rocblas_int bid = hipBlockIdx_y;
 
-    // temporary arrays in global memory
-    rocblas_int* splits = splitsA + bid * get_splits_size(n);
-
-    // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
-
     S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
-
-
+    
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
     rocblas_int* map     = splits + 8 * n;         
     rocblas_int* dcounts = splits + 9 * n; 
-    S* cc = vecs + 2 * n;
-    S* ss = vecs + 3 * n; 
+
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* cc = ptr_cc(n, tmpz);
+    S* ss = ptr_ss(n, tmpz);
 
     constexpr int regs = 16;
     const int chunk_width = regs * hipBlockDim_x;
@@ -1024,10 +988,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // degrees of secular equation
     rocblas_int* dds = szs + n;
     // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // temp for tolerance values used in deflation
-    // IMPORTANT: tols maps to the same memory as evs
-    S* tols = z + n;
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* z     = ptr_z(n, tmpz);
+    S* tolsD = ptr_tolsD(n, tmpz);
     // updated eigenvectors after merges
     S* vecs = vecsA + bid * 2 * (n * n);
     // temp values during the merges
@@ -1110,58 +1073,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     }
 }
 
-
-template <typename S>
-void __device__ inline sort_tmpd_zz(const rocblas_int dd,
-                                    const rocblas_int iam,
-                                    const rocblas_int bdm,
-                                    S* tmpd,
-                                    S* zz,
-                                    rocblas_int* per)
-{
-    // Order the elements in tmpd and zz using a simple parallel selection/bubble sort.
-    // This will allow us to find initial intervals for eigenvalue guesses
-    for(int i = 0; i < dd; i++)
-    {
-        for(int j = 2 * iam + i % 2; j < dd - 1; j += 2 * bdm)
-        {
-            if(tmpd[j] > tmpd[j + 1])
-            {
-                swap(tmpd[j], tmpd[j + 1]);
-                swap(zz[j], zz[j + 1]);
-                swap(per[j], per[j + 1]);
-            }
-        }
-        __syncthreads();
-    }
-}
-
-template <typename S>
-void __device__ inline copy_d_ev(const rocblas_int dd,
-                                 const rocblas_int iam,
-                                 const rocblas_int bdm,
-                                 const rocblas_int sz,
-                                 const rocblas_int n,
-                                 S* tmpd,
-                                 S* ev,
-                                 S* diag)
-{
-    // make dd copies of the non-deflated ordered diagonal elements
-    // (i.e. the poles of the secular eqn) so that the distances to the
-    // eigenvalues (D - lambda_i) are updated while computing each eigenvalue.
-    // This will prevent collapses and division by zero when an eigenvalue
-    // is too close to a pole.
-    for(int i = iam; i < dd; i += bdm)
-    {
-        for(int j = i + n; j < i + sz * n; j += n)
-            tmpd[j] = tmpd[i];
-    }
-
-    // finally copy over all diagonal elements in ev. ev will be overwritten
-    // by the new computed eigenvalues of the merged block
-    for(int i = iam; i < sz; i += bdm)
-        ev[i] = diag[i];
-}
 
 template <typename S>
 void __device__ inline solve_seq_eqns(const rocblas_int dd,
@@ -1267,141 +1178,6 @@ void __device__ inline rescale_z(const rocblas_int dd,
           of sub-blocks. Groups are size STEDC_BDIM **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeValues_kernel(const rocblas_int levs,
-                             const rocblas_int blks,
-                             const rocblas_int k,
-                             const rocblas_int n,
-                             S* DD,
-                             const rocblas_stride strideD,
-                             S* EE,
-                             const rocblas_stride strideE,
-                             S* tmpzA,
-                             S* vecsA,
-                             rocblas_int* splitsA,
-                             const S eps,
-                             const S ssfmin,
-                             const S ssfmax)
-{
-    // threads and groups indices
-    // batch instance id
-    rocblas_int bid = hipBlockIdx_y;
-    // merge sub-block id
-    rocblas_int sid = hipBlockIdx_x;
-    // thread id
-    rocblas_int tidb = hipThreadIdx_x;
-    rocblas_int tid;
-
-    // select batch instance to work with
-    S* D = DD + bid * strideD;
-    S* E = EE + bid * strideE;
-
-    // temporary arrays in global memory
-    rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
-    // container of permutations when solving the secular eqns
-    rocblas_int* pers = idd + n;
-    // sizes of the first sub-block in a merge
-    rocblas_int* szfs = pers + n;
-    // sizes of both sub-blocks in a merge
-    rocblas_int* szs = szfs + n;
-    // degrees of secular equation
-    rocblas_int* dds = szs + n;
-    // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // roots of secular equations
-    S* evs = z + n;
-    // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
-
-    // tn is the number of thread-groups needed in level k of the merge
-    rocblas_int bd = 1 << k;
-    rocblas_int bdm = bd << 1;
-    rocblas_int tn = blks / bdm;
-
-    // Work with merges on level k. A thread-group works with two leaves in the merge tree;
-    // all threads work together to solve the secular equation.
-    if(sid < tn)
-    {
-        rocblas_int iam, sz, dim, p2;
-        S valf, valg;
-
-        // tid indexes the sub-blocks in the entire split block
-        // iam indexes the sub-blocks in the context of the merge
-        // (according to its level in the merge tree)
-        dim = hipBlockDim_x / 2;
-        iam = tidb / dim;
-        tid = sid * bdm + iam * bd;
-        p2 = ps[tid];
-
-        // Find off-diagonal element of the merge
-        // Threads with iam = 0 work with components below the merge point;
-        // threads with iam = 1 work above the merge point
-        //sz = ns[tid];
-        //for(int j = 1; j < bd; ++j)
-        //    sz += ns[tid + j];
-        sz = szfs[tid];
-        // with this, all threads involved in a merge
-        // will point to the same row of C and the same off-diag element
-        S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
-
-        // determine boundaries of what would be the new merged sub-block
-        // 'in' will be its initial position.
-        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        rocblas_int in = tid - iam * bd;
-        //sz = ns[in];
-        //for(int i = 1; i < bdm; ++i)
-        //    sz += ns[in + i];
-        sz = szs[in];
-        in = ps[in];
-
-
-        // 1. Organize data with non-deflated values to prepare secular equation
-        // ----------------------------------------------------------------- 
-        // All threads of the group participating in the merge will work together
-        // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
-        iam = tidb;
-        bdm = hipBlockDim_x;
-
-        // define shifted arrays
-        S* tmpd = temps + in * n;
-        S* ev = evs + in;
-        S* diag = D + in;
-        rocblas_int* mask = idd + in;
-        S* zz = z + in;
-        rocblas_int* per = pers + in;
-
-        // find degree of secular equation
-        rocblas_int dd = dds[in];
-        //rocblas_int dd = 0;
-        //for(int i = 0; i < sz; ++i)
-        //{
-        //    if(mask[i] == 1)
-        //        dd++;
-        //}
-
-        sort_tmpd_zz(dd, iam, bdm, tmpd, zz, per);
-        copy_d_ev(dd, iam, bdm, sz, n, tmpd, ev, diag);
-
-        __syncthreads();
-
-
-        solve_seq_eqns(dd, iam, bdm, sz, n, p, eps, ssfmin, ssfmax, mask, tmpd, ev, zz);
-
-        __syncthreads();
-
-        rescale_z(dd, iam, bdm, sz, n, per, mask, tmpd, diag, zz);
-    }
-}
-
-template <typename S>
-ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     stedc_mergeValues_Sort_kernel(const rocblas_int levs,
                                   const rocblas_int blks,
                                   const rocblas_int k,
@@ -1447,9 +1223,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // degrees of secular equation
     rocblas_int* dds = szs + n;
     // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // roots of secular equations
-    S* evs = z + n;
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* z   = ptr_z(n, tmpz);
+    S* evs = ptr_evs(n, tmpz);
     // updated eigenvectors after merges
     S* vecs = vecsA + bid * 2 * (n * n);
     // temp values during the merges
@@ -1521,8 +1297,37 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         //        dd++;
         //}
 
-        sort_tmpd_zz(dd, iam, bdm, tmpd, zz, per);
-        copy_d_ev(dd, iam, bdm, sz, n, tmpd, ev, diag);
+        // Order the elements in tmpd and zz using a simple parallel selection/bubble sort.
+        // This will allow us to find initial intervals for eigenvalue guesses
+        for(int i = 0; i < dd; i++)
+        {
+            for(int j = 2 * iam + i % 2; j < dd - 1; j += 2 * bdm)
+            {
+                if(tmpd[j] > tmpd[j + 1])
+                {
+                    swap(tmpd[j], tmpd[j + 1]);
+                    swap(zz[j], zz[j + 1]);
+                    swap(per[j], per[j + 1]);
+                }
+            }
+            __syncthreads();
+        }
+        
+        // make dd copies of the non-deflated ordered diagonal elements
+        // (i.e. the poles of the secular eqn) so that the distances to the
+        // eigenvalues (D - lambda_i) are updated while computing each eigenvalue.
+        // This will prevent collapses and division by zero when an eigenvalue
+        // is too close to a pole.
+        for(int i = iam; i < dd; i += bdm)
+        {
+            for(int j = i + n; j < i + sz * n; j += n)
+                tmpd[j] = tmpd[i];
+        }
+
+        // finally copy over all diagonal elements in ev. ev will be overwritten
+        // by the new computed eigenvalues of the merged block
+        for(int i = iam; i < sz; i += bdm)
+            ev[i] = diag[i];
     }
 }
 
@@ -1575,9 +1380,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // degrees of secular equation
     rocblas_int* dds = szs + n;
     // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // roots of secular equations
-    S* evs = z + n;
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* z   = ptr_z(n, tmpz);
+    S* evs = ptr_evs(n, tmpz);
     // updated eigenvectors after merges
     S* vecs = vecsA + bid * 2 * (n * n);
     // temp values during the merges
@@ -1699,9 +1504,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // degrees of secular equation
     rocblas_int* dds = szs + n;
     // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // roots of secular equations
-    S* evs = z + n;
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* z   = ptr_z(n, tmpz);
+    S* evs = ptr_evs(n, tmpz);
     // updated eigenvectors after merges
     S* vecs = vecsA + bid * 2 * (n * n);
     // temp values during the merges
@@ -1814,9 +1619,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int tid, vidb;
 
     // select batch instance to work with
-    S* C;
-    if(CC)
-        C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
+    S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
     S* D = DD + bid * strideD;
     S* E = EE + bid * strideE;
 
@@ -1837,9 +1640,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // degrees of secular equation
     rocblas_int* dds = szs + n;
     // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // roots of secular equations
-    S* evs = z + n;
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* z   = ptr_z(n, tmpz);
     // updated eigenvectors after merges
     S* vecs = vecsA + bid * 2 * (n * n);
     // temp values during the merges
@@ -1882,7 +1684,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
         // define shifted arrays
         S* tmpd = temps + in * n;
-        S* ev = evs + in;
         S* diag = D + in;
         rocblas_int* mask = idd + in;
         S* zz = z + in;
@@ -2032,9 +1833,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int tid, vidb;
 
     // select batch instance to work with
-    S* C;
-    if(CC)
-        C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
+    S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
     S* D = DD + bid * strideD;
 
     // temporary arrays in global memory
@@ -2045,10 +1844,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* ps = ns + n;
     // if idd[i] = 0, the value in position i has been deflated
     rocblas_int* idd = ps + n;
-    // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // roots of secular equations
-    S* evs = z + n;
+    
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* evs = ptr_evs(n, tmpz);
     // updated eigenvectors after merges
     S* vecs = vecsA + bid * 2 * (n * n);
 
@@ -2378,7 +2176,7 @@ void rocsolver_stedc_getMemorySize(const rocblas_evect evect,
         *size_splits_map = sizeof(rocblas_int) * get_splits_size(n) * batch_count;
 
         // size for temporary diagonal and rank-1 modif vector
-        *size_tmpz = sizeof(S) * (2 * n) * batch_count;
+        *size_tmpz = sizeof(S) * get_tmpz_size(n) * batch_count;
     }
 }
 
@@ -2552,32 +2350,31 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_DeflateZero_kernel<S>),
                                     dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream, 
                                     levs, blks, k, n, D + shiftD, strideD,
-                                    E + shiftE, strideE, V, 0, ldv, strideV, tmpz, tempgemm, splits,
+                                    E + shiftE, strideE, V, 0, ldv, strideV, tmpz, splits,
                                     eps);
 
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_Fill_kernel<S>),
                                     dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream,
-                                    levs, blks, k, n,
-                                    tmpz, tempgemm, splits);
+                                    levs, blks, k, n, tmpz, splits);
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_SortD_kernel<S>),
                                     dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream,
                                     levs, blks, k, n, D + shiftD, strideD,
-                                    tmpz, tempgemm, splits);
+                                    tmpz, splits);
             rocblas_int numgrps_deflate = (n - 1) / STEDC_BDIM + 1;
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_SetCandFlags_kernel<S>),
                                     dim3(numgrps_deflate, batch_count), dim3(STEDC_BDIM), 0, stream, levs,
-                                    blks, k, n, D + shiftD, strideD, tmpz, tempgemm, splits);
+                                    blks, k, n, D + shiftD, strideD, tmpz, splits);
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_DeflateCount_kernel<S>),
                                     dim3(numgrps_deflate, batch_count), dim3(STEDC_BDIM), 0, stream, levs,
-                                    blks, k, n, D + shiftD, strideD, tmpz, tempgemm, splits);
+                                    blks, k, n, D + shiftD, strideD, tmpz, splits);
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_DeflateApply_kernel<S>),
                                     dim3(numgrps_deflate, batch_count), dim3(STEDC_BDIM), 0, stream,
                                     levs, blks, k, n, D + shiftD, strideD,
-                                    tmpz, tempgemm, splits);
+                                    tmpz, splits);
                 
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeRotate_kernel<S>), dim3(n, batch_count),
                                     dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, V, 0, ldv,
-                                    strideV, tmpz, tempgemm, splits);
+                                    strideV, tmpz, splits);
 
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_Organize_kernel<S>),
                                     dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream, 
@@ -2586,34 +2383,22 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     eps);
 
             // b. solve secular eq to find merged eigenvalues
-            rocblas_int max_n_per_merge = (n + numgrps2 - 1) / numgrps2;
-            
-            if(max_n_per_merge > STEDC_BDIM)
-            {
-                // split mergeValues into stages to run seqular eqns solver using more groups
-                ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Sort_kernel<S>), dim3(numgrps2, batch_count),
-                                        dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
-                                        strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
-                                        ssfmin, ssfmax);
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Sort_kernel<S>), dim3(numgrps2, batch_count),
+                                    dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
+                                    strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
+                                    ssfmin, ssfmax);
 
-                rocblas_int groups_per_merge = (max_n_per_merge + STEDC_BDIM - 1) / STEDC_BDIM;
-                ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Solve_kernel<S>),
-                                        dim3(numgrps2 * groups_per_merge, batch_count),
-                                        dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
-                                        strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
-                                        ssfmin, ssfmax, groups_per_merge);
-                ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Rescale_kernel<S>), dim3(numgrps2, batch_count),
-                                        dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
-                                        strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
-                                        ssfmin, ssfmax);
-            }
-            else {
-                // compute in one dispatch for small merges
-                ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_kernel<S>), dim3(numgrps2, batch_count),
-                                        dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
-                                        strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
-                                        ssfmin, ssfmax);
-            }
+            rocblas_int max_n_per_merge  = (n + numgrps2 - 1) / numgrps2;
+            rocblas_int groups_per_merge = (max_n_per_merge + STEDC_BDIM - 1) / STEDC_BDIM;
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Solve_kernel<S>),
+                                    dim3(numgrps2 * groups_per_merge, batch_count),
+                                    dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
+                                    strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
+                                    ssfmin, ssfmax, groups_per_merge);
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Rescale_kernel<S>), dim3(numgrps2, batch_count),
+                                    dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
+                                    strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
+                                    ssfmin, ssfmax);
 
             // c. find merged eigenvectors
             ROCSOLVER_LAUNCH_KERNEL(

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1152,6 +1152,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // TODO: check if that should be dd or sz
         // for (int j = 0; j < dd; j++) {
         for (int j = 0; j < sz; j++) {
+            __syncthreads();
             for(int i = 0; i < regs; i++) {
                 int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
                 if(x < dd) {
@@ -1300,65 +1301,68 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // threads and groups indices
     // batch instance id
     rocblas_int bid = hipBlockIdx_y;
-    // merge sub-block id
-    rocblas_int sid = hipBlockIdx_x;
+    // value id
+    rocblas_int eid = hipBlockIdx_x;
 
     // select batch instance to work with
     S* D = DD + bid * strideD;
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    rocblas_int* em   = ptr_em(n, splits);
     rocblas_int* mps  = ptr_mps(n, splits);
     rocblas_int* idd  = ptr_idd(n, splits);
     rocblas_int* pers = ptr_map(n, splits);
     rocblas_int* msz  = ptr_msz(n, splits);
     rocblas_int* dds  = ptr_dds(n, splits);
-    
+
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
-    S* z   = ptr_cz(n, tmpz);
+    S* z = ptr_cz(n, tmpz);
     // updated eigenvectors after merges
     S* vecs = vecsA + bid * 2 * (n * n);
     // temp values during the merges
     S* temps = vecs + (n * n);
+    S* etmpd = temps;
 
-    // Work with merges on level k. A thread-group works with two leaves in the merge tree;
-    // all threads work together to solve the secular equation.
+    rocblas_int sid = em[eid];
+    rocblas_int sz = msz[sid];
+    rocblas_int p1 = mps[sid];
+    rocblas_int dd = dds[sid];
+
+    // Re-scale vector Z to avoid bad numerics when an eigenvalue
+    // is too close to a pole
+    rocblas_int i = eid - p1;
+    if(i < dd)
     {
-        // determine boundaries of what would be the new merged sub-block
-        // 'p1' will be its initial position.
-        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        rocblas_int sz = msz[sid];
-        rocblas_int p1 = mps[sid];
-
-
-        // 1. Organize data with non-deflated values to prepare secular equation
-        // ----------------------------------------------------------------- 
-        // All threads of the group participating in the merge will work together
-        // to solve the correspondinbg secular eqn.
-
-        // define shifted arrays
-        S* etmpd = temps;
-        rocblas_int* mask = idd + p1;
-        rocblas_int* per = pers + p1;
-
-        // find degree of secular equation
-        rocblas_int dd = dds[sid];
-
-        // Re-scale vector Z to avoid bad numerics when an eigenvalue
-        // is too close to a pole
-        for(int i = hipThreadIdx_x; i < dd; i += hipBlockDim_x)
+        S valf = 1;
+        for(int j = hipThreadIdx_x; j < sz; j += hipBlockDim_x)
         {
-            S valf = 1;
-            for(int j = 0; j < sz; ++j)
+            if(idd[p1 + j] == 1)
             {
-                if(mask[j] == 1)
-                {
-                    S valg = etmpd[(p1 + j) * n + i];
-                    valf *= (per[i] == j) ? valg : valg / (D[p1 + per[i]] - D[p1 + j]);
-                }
+                S valg = etmpd[(p1 + j) * n + i];
+                valf *= (pers[p1 + i] == j) ? valg : valg / (D[p1 + pers[p1 + i]] - D[p1 + j]);
             }
+        }
+        __shared__ S lds[STEDC_BDIM];
+        rocblas_int dim2 = hipBlockDim_x / 2;
+
+        lds[hipThreadIdx_x] = valf;
+        __syncthreads();
+        while(dim2 > 0)
+        {
+            if(hipThreadIdx_x < dim2)
+            {
+                valf *= lds[hipThreadIdx_x + dim2];
+                lds[hipThreadIdx_x] = valf;
+            }
+            dim2 /= 2;
+            __syncthreads();
+        }
+
+        if(hipThreadIdx_x == 0)
+        {
             valf = sqrt(std::abs(valf));
-            z[p1 + i] = z[p1 + i] < 0 ? -valf : valf;
+            z[eid] = z[eid] < 0 ? -valf : valf;
         }
     }
 }
@@ -2114,7 +2118,6 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         // 3. merge phase
         //----------------
         size_t lmemsize3 = sizeof(S) * STEDC_BDIM;
-        rocblas_int numgrps3 = ((n - 1) / blks + 1) * blks;
 
         // launch merge for level k
         for(rocblas_int k = 0; k < levs; ++k)
@@ -2192,13 +2195,14 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
                                     strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
                                     ssfmin, ssfmax);
+
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Rescale_kernel<S>),
-                                    dim3(n_merges, batch_count),
-                                    dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
-                                    strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
-                                    ssfmin, ssfmax);
+                                    dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream,
+                                    levs, blks, k, n, D + shiftD, strideD, E + shiftE, strideE,
+                                    tmpz, tempgemm, splits, eps, ssfmin, ssfmax);
 
             // c. find merged eigenvectors
+            rocblas_int numgrps3 = ((n - 1) / blks + 1) * blks;
             ROCSOLVER_LAUNCH_KERNEL(
                 (stedc_mergeVectors_kernel<STEDC_EXTERNAL_GEMM, S>),
                 dim3(numgrps3, batch_count), dim3(STEDC_BDIM), lmemsize3, stream, 

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -118,7 +118,10 @@ __host__ __device__ inline rocblas_int get_tmpz_size(const rocblas_int n)
     // 4    S tolsD[n];   // tollerance for deflation of repeaded values in D
     // 5    S tolsZ[n];   // tollerance for deflation of zero values in z
     // 6    S md[n];      // sorted d values
-    return 7 * n;
+    // 7    S cd[n];      // sorted and compacted d values
+    // 8    S cz[n];      // sorted and compacted z values
+    // 9    S sdbg[n];    //
+    return 10 * n;
 }
 
 template <typename S> __host__ __device__ inline S* ptr_z    (rocblas_int n, S* tmpz) { return tmpz + 0 * n; }
@@ -128,6 +131,9 @@ template <typename S> __host__ __device__ inline S* ptr_ss   (rocblas_int n, S* 
 template <typename S> __host__ __device__ inline S* ptr_tolsD(rocblas_int n, S* tmpz) { return tmpz + 4 * n; }
 template <typename S> __host__ __device__ inline S* ptr_tolsZ(rocblas_int n, S* tmpz) { return tmpz + 5 * n; }
 template <typename S> __host__ __device__ inline S* ptr_md   (rocblas_int n, S* tmpz) { return tmpz + 6 * n; }
+template <typename S> __host__ __device__ inline S* ptr_cd   (rocblas_int n, S* tmpz) { return tmpz + 7 * n; }
+template <typename S> __host__ __device__ inline S* ptr_cz   (rocblas_int n, S* tmpz) { return tmpz + 8 * n; }
+template <typename S> __host__ __device__ inline S* ptr_sdbg (rocblas_int n, S* tmpz) { return tmpz + 9 * n; }
 
 
 /*************** Main kernels *********************************************************/
@@ -508,24 +514,22 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* map    = ptr_map(n, splits);
     rocblas_int* esz    = ptr_esz (n, splits);
     rocblas_int* eps    = ptr_eps (n, splits); 
-    rocblas_int* cand   = ptr_cand(n, splits); 
     rocblas_int* sidd   = ptr_sidd(n, splits);
     
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* md    = ptr_md(n, tmpz);
-    S* tolsD = ptr_tolsD(n, tmpz);
 
 
     S d = D[sid];
     rocblas_int sz = esz[sid];
     rocblas_int p  = eps[sid];
-    rocblas_int dz = idd[sid];
+    rocblas_int def = idd[sid];
 
     constexpr int regs = 8;
     const int chunk_width = regs * hipBlockDim_x;
     const int n_chunks = (sz - 1) / chunk_width + 1;
     S bval[regs];
-    int dzs[regs];
+    int iddval[regs];
 
 
     int nan = 0;
@@ -540,7 +544,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             if(x < sz)
             {
                 bval[i] = D[p + x];
-                dzs[i]  = idd[p + x];
+                iddval[i]  = idd[p + x];
             }
         }
         for(int i = 0; i < regs; i++)
@@ -553,9 +557,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 // eq - how many values are equal to the current
                 // all zero deflated values have to be grouped at the end
                 // so we order any deflated value > any non-deflated value
-                // dz == 0 - current is deflated, dz[i] == 1 - other value is not deflated
-                lt += (dz < dzs[i]) || (dz == dzs[i] && bval[i] < d);
-                eq += (dz == dzs[i]) && (bval[i] == d && (p + x) < sid);
+                // def == 0 - current is deflated, def[i] == 1 - other value is not deflated
+                lt += (def < iddval[i]) || (def == iddval[i] && bval[i] < d);
+                eq += (def == iddval[i]) && (bval[i] == d && (p + x) < sid);
             }
         }
     }
@@ -579,7 +583,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     if (hipThreadIdx_x == 0) {
         map [pos+p] = sid;
         md  [pos+p] = d;
-        sidd[pos+p] = dz;
+        sidd[pos+p] = def;
     }
 
     __syncthreads();
@@ -958,6 +962,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z     = ptr_z(n, tmpz);
+    S* sdbg  = ptr_sdbg(n, tmpz);
     // updated eigenvectors after merges
     S* vecs = vecsA + bid * 2 * (n * n);
     // temp values during the merges
@@ -1052,6 +1057,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z   = ptr_z(n, tmpz);
     S* evs = ptr_evs(n, tmpz);
+    S* sdbg = ptr_sdbg(n, tmpz);
     // updated eigenvectors after merges
     S* vecs = vecsA + bid * 2 * (n * n);
     // temp values during the merges
@@ -1112,6 +1118,118 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // by the new computed eigenvalues of the merged block
         for(int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x)
             evs[p1 + i] = D[p1 + i];
+    }
+}
+
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+    stedc_mergePrepare_SortDZ_kernel(const rocblas_int levs,
+                                     const rocblas_int blks,
+                                     const rocblas_int k,
+                                     const rocblas_int n,
+                                     S* DD,
+                                     const rocblas_stride strideD,
+                                     S* tmpzA,
+                                     rocblas_int* splitsA)
+{
+    // threads and groups indices
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+    // merge sub-block id
+    rocblas_int sid = hipBlockIdx_x;
+
+    // select batch instance to work with
+    S* D = DD + bid * strideD;
+
+    // temporary arrays in global memory
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    rocblas_int* idd    = ptr_idd(n, splits);
+    rocblas_int* map    = ptr_map(n, splits);
+    rocblas_int* esz    = ptr_esz (n, splits);
+    rocblas_int* eps    = ptr_eps (n, splits); 
+    rocblas_int* sidd   = ptr_sidd(n, splits);
+    
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* z     = ptr_z(n, tmpz);
+    S* cd    = ptr_cd(n, tmpz);
+    S* cz    = ptr_cz(n, tmpz);
+
+
+    S d_ = D[sid];
+    S z_ = z[sid];
+    rocblas_int sz = esz[sid];
+    rocblas_int p1 = eps[sid];
+    rocblas_int def = idd[sid];
+
+    constexpr int regs = 8;
+    const int chunk_width = regs * hipBlockDim_x;
+    const int n_chunks = (sz - 1) / chunk_width + 1;
+    S bval[regs];
+    int iddval[regs];
+
+
+    int nan = 0;
+    int lt = 0;
+    int eq = 0;
+
+    for(int chunk = 0; chunk < n_chunks; chunk++)
+    {
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < sz)
+            {
+                bval[i] = D[p1 + x];
+                iddval[i]  = idd[p1 + x];
+            }
+        }
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < sz)
+            {
+                nan += (bval[i] != bval[i]);
+                // lt - how many values are less then the current
+                // eq - how many values are equal to the current
+                // all zero deflated values have to be grouped at the end
+                // so we order any deflated value > any non-deflated value
+                // def == 0 - current is deflated, def[i] == 1 - other value is not deflated
+                lt += (def < iddval[i]) || (def == iddval[i] && bval[i] < d_);
+                eq += (def == iddval[i]) && (bval[i] == d_ && (p1 + x) < sid);
+            }
+        }
+    }
+
+    int pos = lt + eq;
+    __shared__ int lds[STEDC_BDIM];
+    // Reduction (sum of pos across all lanes in a workgroup)
+    // on each iteration reduction is done within a subgroup of size of 2*bit
+    // by xoring corresponding bit of an address.
+    // The faster implementation should use dpp + a single trip through lds
+    // but keeping code simple for now.
+    int bit = 1;
+    while (bit < STEDC_BDIM) {
+        lds[hipThreadIdx_x ^ bit] = pos;
+        __syncthreads();
+        pos += lds[hipThreadIdx_x];
+        __syncthreads();
+        bit *= 2;
+    }
+
+    if (hipThreadIdx_x == 0) {
+        map [pos+p1] = sid - p1;
+        cd  [pos+p1] = d_;
+        cz  [pos+p1] = z_;
+        sidd[pos+p1] = def;
+    }
+
+    __syncthreads();
+    // The NAN fp value is unordered, so it is possible that with computed
+    // new positions it would be silently overwriten with non NAN value.
+    // Make sure we propagate NAN. It is likely to have more NANs in the output
+    // than in the input, but the following computations are doomed anyway.
+    if (nan) {
+        cd[sid] = NAN;
     }
 }
 
@@ -1264,7 +1382,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z   = ptr_z(n, tmpz);
-    S* evs = ptr_evs(n, tmpz);
     // updated eigenvectors after merges
     S* vecs = vecsA + bid * 2 * (n * n);
     // temp values during the merges
@@ -1738,9 +1855,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int
                 nan += (bval[i] != bval[i]);
                 // lt - how many values are less then the current
                 // eq - how many values are equal to the current
-                // all zero deflated values have to be grouped at the end
-                // so we order any deflated value > any non-deflated value
-                // dz == 0 - current is deflated, dz[i] == 1 - other value is not deflated
                 lt += (bval[i] < d);
                 eq += (bval[i] == d && x < gid);
             }
@@ -2082,24 +2196,6 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     levs, blks, k, n, D + shiftD, strideD,
                                     E + shiftE, strideE, V, 0, ldv, strideV, tmpz, splits,
                                     eps);
-#if DEBUG_OUTPUT
-            //hipError_t status = hipStreamSynchronize(stream);
-            if (env_levs && global_cnt == 1) {
-                std::cout << "\nk=" << k << std::endl;
-                //print_device_matrix(std::cout, "ns", 1, 1 << levs, ptr_ns(n, splits), 1);
-                //print_device_matrix(std::cout, "ps", 1, 1 << levs, ptr_ps(n, splits), 1);
-                print_device_matrix(std::cout, "msz", 1, n_merges, ptr_msz(n, splits), 1);
-                print_device_matrix(std::cout, "mps", 1, n_merges, ptr_mps(n, splits), 1);
-                print_device_matrix(std::cout, "em",  1, n, ptr_em(n, splits), 1);
-                print_device_matrix(std::cout, "esz", 1, n, ptr_esz(n, splits), 1);
-                print_device_matrix(std::cout, "eps", 1, n, ptr_eps(n, splits), 1);
-                print_device_matrix(std::cout, "dbg", 1, n, ptr_dbg(n, splits), 1);
-
-                //print_device_matrix(std::cout, "D", 1, n, D, 1);
-                //print_device_matrix(std::cout, "mtols", 1, n, tempgemm + n * 4, 1);
-                //print_device_matrix(std::cout, "mD", 1, n, tempgemm + n * 5, 1);
-            }
-#endif
 
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_SortD_kernel<S>),
                                     dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream,
@@ -2132,6 +2228,36 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
                                     strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
                                     ssfmin, ssfmax);
+
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_SortDZ_kernel<S>), dim3(n, batch_count),
+                                    dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
+                                    strideD, tmpz, splits);
+
+#if DEBUG_OUTPUT
+            //hipError_t status = hipStreamSynchronize(stream);
+            if(env_levs && global_cnt == 1)
+            {
+                std::cout << "\nk=" << k << std::endl;
+                //print_device_matrix(std::cout, "ns", 1, 1 << levs, ptr_ns(n, splits), 1);
+                //print_device_matrix(std::cout, "ps", 1, 1 << levs, ptr_ps(n, splits), 1);
+                print_device_matrix(std::cout, "msz", 1, n_merges, ptr_msz(n, splits), 1);
+                print_device_matrix(std::cout, "mps", 1, n_merges, ptr_mps(n, splits), 1);
+                print_device_matrix(std::cout, "em", 1, n, ptr_em(n, splits), 1);
+                print_device_matrix(std::cout, "idd", 1, n, ptr_idd(n, splits), 1);
+                print_device_matrix(std::cout, "sidd", 1, n, ptr_sidd(n, splits), 1);
+                print_device_matrix(std::cout, "map", 1, n, ptr_map(n, splits), 1);
+                print_device_matrix(std::cout, "pers", 1, n, ptr_pers(n, splits), 1);
+                print_device_matrix(std::cout, "dds", 1, n, ptr_dds(n, splits), 1);
+                print_device_matrix(std::cout, "D", 1, n, D, 1);
+                print_device_matrix(std::cout, "cd", 1, n, ptr_cd(n, tmpz), 1);
+                
+                //print_device_matrix(std::cout, "dbg", 1, n, ptr_dbg(n, splits), 1);
+
+                //print_device_matrix(std::cout, "D", 1, n, D, 1);
+                //print_device_matrix(std::cout, "mtols", 1, n, tempgemm + n * 4, 1);
+                //print_device_matrix(std::cout, "mD", 1, n, tempgemm + n * 5, 1);
+            }
+#endif
 
             rocblas_int numgrps_solve = (n - 1) / STEDC_BDIM + 1;
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Solve_kernel<S>),

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -48,12 +48,13 @@ ROCSOLVER_BEGIN_NAMESPACE
 // bit indicating base deflation candidate
 #define L_F_BCAND_BIT 0
 // bit indicating top deflation candidate
-#define L_F_TCAND_BIT 1
+#define L_F_TCAND_BIT 1 
 
 // TODO: using macro STEDC_EXTERNAL_GEMM = true for now. In the future we can pass
 // STEDC_EXTERNAL_GEMM at run time to switch between internal vector updates and
 // external gemm-based updates.
 #define STEDC_EXTERNAL_GEMM true
+
 
 __host__ __device__ inline rocblas_int get_splits_size(const rocblas_int n)
 {
@@ -67,7 +68,7 @@ __host__ __device__ inline rocblas_int get_splits_size(const rocblas_int n)
     // 5     rocblas_int szfs[n];     // sizes of the first sub-block in a merge
     // 6     rocblas_int szs[n];      // sizes of both sub-blocks in a merge
     // 7     rocblas_int dds[n];      // degrees of secular equation
-    // 8     rocblas_int map[n];      //
+    // 8     rocblas_int map[n];      // 
     // 9     rocblas_int dcount[n];   // number of deflations
     // 10    rocblas_int mns[n];      // merge sizes
     // 11    rocblas_int mps[n];      // merge initial positions
@@ -80,6 +81,7 @@ __host__ __device__ inline rocblas_int get_splits_size(const rocblas_int n)
     return 17 * n;
 }
 
+
 /*************** Main kernels *********************************************************/
 /**************************************************************************************/
 
@@ -87,19 +89,18 @@ __host__ __device__ inline rocblas_int get_splits_size(const rocblas_int n)
 /** STEDC_DIVIDE_KERNEL implements the divide phase of the DC algorithm. It
     divides the input matrix into a 'blks' sub-blocks.
         - This kernel is to be called with as many groups in x as needed to cover all
-        the batch_count problems. Each thread will work with a matrix in the batch.
+        the batch_count problems. Each thread will work with a matrix in the batch. 
         - Size of groups is set to STEDC_BDIM. **/
 template <typename S>
-ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_divide_kernel(const rocblas_int levs,
-                        const rocblas_int blks,
-                        const rocblas_int n,
-                        S* DD,
-                        const rocblas_stride strideD,
-                        S* EE,
-                        const rocblas_stride strideE,
-                        const rocblas_int batch_count,
-                        rocblas_int* splitsA)
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_divide_kernel(const rocblas_int levs,
+                                                                        const rocblas_int blks,
+                                                                        const rocblas_int n,
+                                                                        S* DD,
+                                                                        const rocblas_stride strideD,
+                                                                        S* EE,
+                                                                        const rocblas_stride strideE,
+                                                                        const rocblas_int batch_count,
+                                                                        rocblas_int* splitsA)
 {
     // threads and groups indices
     rocblas_int bid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
@@ -148,10 +149,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     }
 }
 
+
 //--------------------------------------------------------------------------------------//
 /** STEDC_SOLVE_KERNEL implements the solver phase of the DC algorithm to
    compute the eigenvalues/eigenvectors of the 'blks' different sub-blocks of a matrix.
-        - Call this kernel with batch_count groups in y, and 'blks' groups in x.
+        - Call this kernel with batch_count groups in y, and 'blks' groups in x. 
           Groups are single-thread **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_solve_kernel(const rocblas_int levs,
@@ -201,17 +203,18 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_solve_kernel(const roc
     // Solve the blks sub-blocks in parallel (using classic QR iteration).
     if(sid < blks)
     {
-        rocblas_int sbs = ns[sid]; // size of sub-block
-        rocblas_int p2 = ps[sid]; // start position of sub-block
+        rocblas_int sbs = ns[sid];  // size of sub-block
+        rocblas_int p2 = ps[sid];   // start position of sub-block
 
         run_steqr(tidb, tidb_inc, sbs, D + p2, E + p2, C + p2 + p2 * ldc, ldc, info, W + p2 * 2,
                   30 * sbs, eps, ssfmin, ssfmax, false);
     }
 }
 
+
 //--------------------------------------------------------------------------------------//
 /** STEDC_MERGEPREPARE_DEFLATEZERO_KERNEL performs deflation of zero values
-        - Call this kernel with batch_count groups in y, and as many groups as half of the
+        - Call this kernel with batch_count groups in y, and as many groups as half of the 
           unmerged sub-blocks in current level in x. Each group works with a merge of a pair
           of sub-blocks. Groups are size STEDC_BDIM **/
 template <typename S>
@@ -314,6 +317,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         for(int j = tx; j < sz; j += dim)
             z[p2 + j] = ptz[(p2 + j) * ldc] / sqrt(2);
 
+
         // 2. calculate deflation tolerance
         // ----------------------------------------------------------------
         // compute maximum of diagonal and z in each merge block
@@ -353,6 +357,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         maxd = maxz > maxd ? maxz : maxd;
         S tol = 8 * eps * maxd;
 
+
         // 3. deflate eigenvalues
         // ----------------------------------------------------------------
         // determine boundaries of what would be the new merged sub-block
@@ -380,9 +385,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     }
 }
 
+
 //--------------------------------------------------------------------------------------//
 /** STEDC_MERGEPREPARE_FILL_KERNEL fills different arrays in splits struct
-        - Call this kernel with batch_count groups in y, and as many groups as half of the
+        - Call this kernel with batch_count groups in y, and as many groups as half of the 
           unmerged sub-blocks in current level in x. Each group works with a merge of a pair
           of sub-blocks. Groups are size STEDC_BDIM **/
 template <typename S>
@@ -427,25 +433,24 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // temp values during the merges
     S* temps = vecs + (n * n);
 
-    S* cc = vecs + 2 * n;
-    S* ss = vecs + 3 * n;
+    S* cc    = vecs + 2 * n;
+    S* ss    = vecs + 3 * n;
     S* mtols = vecs + 4 * n;
-    S* md = vecs + 5 * n;
+    S* md    = vecs + 5 * n;
 
-    rocblas_int* map = splits + 8 * n;
-    rocblas_int* dcount = splits + 9 * n;
-    rocblas_int* mns = splits + 10 * n;
-    rocblas_int* mps = splits + 11 * n;
-    rocblas_int* cand = splits + 12 * n;
-    rocblas_int* midd = splits + 13 * n;
+    rocblas_int* map    = splits +  8 * n;
+    rocblas_int* dcount = splits +  9 * n;
+    rocblas_int* mns    = splits + 10 * n;
+    rocblas_int* mps    = splits + 11 * n; 
+    rocblas_int* cand   = splits + 12 * n; 
+    rocblas_int* midd   = splits + 13 * n;
 
     rocblas_int in = sid << (k + 1);
     rocblas_int sz = szs[in];
-    rocblas_int p = ps[in];
+    rocblas_int p  = ps[in];
     S tol = tols[in];
 
-    for(int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x)
-    {
+    for (int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x) {
         int id = p + i;
         mns[id] = sz;
         mps[id] = p;
@@ -505,21 +510,21 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // temp values during the merges
     S* temps = vecs + (n * n);
 
-    S* cc = vecs + 2 * n;
-    S* ss = vecs + 3 * n;
+    S* cc    = vecs + 2 * n;
+    S* ss    = vecs + 3 * n;
     S* mtols = vecs + 4 * n;
-    S* md = vecs + 5 * n;
+    S* md    = vecs + 5 * n;
 
-    rocblas_int* map = splits + 8 * n;
-    rocblas_int* dcount = splits + 9 * n;
-    rocblas_int* mns = splits + 10 * n;
-    rocblas_int* mps = splits + 11 * n;
-    rocblas_int* cand = splits + 12 * n;
-    rocblas_int* midd = splits + 13 * n;
+    rocblas_int* map    = splits +  8 * n;
+    rocblas_int* dcount = splits +  9 * n;
+    rocblas_int* mns    = splits + 10 * n;
+    rocblas_int* mps    = splits + 11 * n; 
+    rocblas_int* cand   = splits + 12 * n; 
+    rocblas_int* midd   = splits + 13 * n;
 
     S d = D[sid];
     rocblas_int sz = mns[sid];
-    rocblas_int p = mps[sid];
+    rocblas_int p  = mps[sid];
     rocblas_int dz = idd[sid];
 
     constexpr int regs = 8;
@@ -527,6 +532,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     const int n_chunks = (sz - 1) / chunk_width + 1;
     S bval[regs];
     int dzs[regs];
+
 
     int nan = 0;
     int lt = 0;
@@ -540,7 +546,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             if(x < sz)
             {
                 bval[i] = D[p + x];
-                dzs[i] = idd[p + x];
+                dzs[i]  = idd[p + x];
             }
         }
         for(int i = 0; i < regs; i++)
@@ -568,8 +574,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // The faster implementation should use dpp + a single trip through lds
     // but keeping code simple for now.
     int bit = 1;
-    while(bit < STEDC_BDIM)
-    {
+    while (bit < STEDC_BDIM) {
         lds[hipThreadIdx_x ^ bit] = pos;
         __syncthreads();
         pos += lds[hipThreadIdx_x];
@@ -577,11 +582,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         bit *= 2;
     }
 
-    if(hipThreadIdx_x == 0)
-    {
-        map[pos + p] = sid;
-        md[pos + p] = d;
-        midd[pos + p] = dz;
+    if (hipThreadIdx_x == 0) {
+        map [pos+p] = sid;
+        md  [pos+p] = d;
+        midd[pos+p] = dz;
     }
 
     __syncthreads();
@@ -589,8 +593,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // new positions it would be silently overwriten with non NAN value.
     // Make sure we propagate NAN. It is likely to have more NANs in the output
     // than in the input, but the following computations are doomed anyway.
-    if(nan)
-    {
+    if (nan) {
         md[sid] = NAN;
     }
 }
@@ -626,44 +629,46 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // temp values during the merges
     S* temps = vecs + (n * n);
 
-    S* cc = vecs + 2 * n;
-    S* ss = vecs + 3 * n;
+    S* cc    = vecs + 2 * n;
+    S* ss    = vecs + 3 * n;
     S* mtols = vecs + 4 * n;
-    S* md = vecs + 5 * n;
+    S* md    = vecs + 5 * n;
 
-    rocblas_int* map = splits + 8 * n;
-    rocblas_int* dcount = splits + 9 * n;
-    rocblas_int* mns = splits + 10 * n;
-    rocblas_int* mps = splits + 11 * n;
-    rocblas_int* cand = splits + 12 * n;
-    rocblas_int* midd = splits + 13 * n;
+    rocblas_int* map    = splits +  8 * n;
+    rocblas_int* dcount = splits +  9 * n;
+    rocblas_int* mns    = splits + 10 * n;
+    rocblas_int* mps    = splits + 11 * n; 
+    rocblas_int* cand   = splits + 12 * n; 
+    rocblas_int* midd   = splits + 13 * n;
 
     constexpr int F_BCAND = 1 << L_F_BCAND_BIT;
     constexpr int F_TCAND = 1 << L_F_TCAND_BIT;
 
     // find deflate candidates
     int i = hipThreadIdx_x + hipBlockDim_x * hipBlockIdx_x;
-    if(i < n)
+    if (i < n)
     {
         int next = (i + 1) < n ? (i + 1) : i;
         int prev = (i > 0) ? (i - 1) : 0;
         S tol = mtols[i];
-        S d = md[i];
-        S dn = md[next];
-        S dp = md[prev];
-        rocblas_int p = mps[i];
+        S d   = md[i];
+        S dn  = md[next];
+        S dp  = md[prev];
+        rocblas_int p  = mps[i];
         rocblas_int pn = mps[next];
         rocblas_int pp = mps[prev];
 
-        int bcandidate = midd[i] && midd[next] // not yet deflated
-            && p == pn // in the same merge block
-            && std::abs(d - dn) <= tol // within tolerance
-            && i != (n - 1) // isn't last
+        int bcandidate =
+            midd[i] && midd[next]       // not yet deflated
+            && p == pn                  // in the same merge block
+            && std::abs(d - dn) <= tol  // within tolerance
+            && i != (n-1)               // isn't last 
             ;
-        int tcandidate = midd[i] && midd[prev] // not yet deflated
-            && p == pp // in the same merge block
-            && std::abs(d - dp) <= tol // within tolerance
-            && i > 0 // isn't first
+        int tcandidate =
+            midd[i] && midd[prev]       // not yet deflated
+            && p == pp                  // in the same merge block
+            && std::abs(d - dp) <= tol  // within tolerance
+            && i > 0                    // isn't first
             ;
         cand[i] = (bcandidate << L_F_BCAND_BIT) + (tcandidate << L_F_TCAND_BIT);
     }
@@ -707,53 +712,54 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // temp values during the merges
     S* temps = vecs + (n * n);
 
-    S* cc = vecs + 2 * n;
-    S* ss = vecs + 3 * n;
+    S* cc    = vecs + 2 * n;
+    S* ss    = vecs + 3 * n;
     S* mtols = vecs + 4 * n;
-    S* md = vecs + 5 * n;
+    S* md    = vecs + 5 * n;
 
-    rocblas_int* map = splits + 8 * n;
-    rocblas_int* dcount = splits + 9 * n;
-    rocblas_int* mns = splits + 10 * n;
-    rocblas_int* mps = splits + 11 * n;
-    rocblas_int* cand = splits + 12 * n;
-    rocblas_int* midd = splits + 13 * n;
+    rocblas_int* map    = splits +  8 * n;
+    rocblas_int* dcount = splits +  9 * n;
+    rocblas_int* mns    = splits + 10 * n;
+    rocblas_int* mps    = splits + 11 * n; 
+    rocblas_int* cand   = splits + 12 * n; 
+    rocblas_int* midd   = splits + 13 * n;
 
     constexpr rocblas_int max_len = 4096;
-    __shared__ S ldsD[max_len];
+    __shared__ S   ldsD[max_len];
     __shared__ int lcand[max_len];
     constexpr int F_BCAND = 1 << L_F_BCAND_BIT;
     constexpr int F_TCAND = 1 << L_F_TCAND_BIT;
 
     int start = hipBlockDim_x * hipBlockIdx_x;
-    int base = start + hipThreadIdx_x;
-    int prev = (base > 0) ? (base - 1) : 0;
+    int base  = start + hipThreadIdx_x;
+    int prev  = (base > 0) ? (base - 1) : 0;
     int candp = (prev < n) ? cand[prev] : 0;
     int candb = (base < n) ? cand[base] : 0;
     S bval = (base < n) ? md[base] : 0;
-    S tol = (base < n) ? mtols[base] : 0;
+    S tol  = (base < n) ? mtols[base] : 0;
 
     // cache max_len values of D[] and cand[]
     for(int i = hipThreadIdx_x; i < max_len; i += hipBlockDim_x)
     {
         int x = start + i;
-        ldsD[i] = (x < n) ? md[x] : 0;
+        ldsD[i]  = (x < n) ? md[x]   : 0;
         lcand[i] = (x < n) ? cand[x] : 0;
     }
     __syncthreads();
-
-    if((candb & F_BCAND) && (base == 0 || !(candp & F_BCAND)))
-    {
+    
+    if ((candb & F_BCAND) && (base == 0 || !(candp & F_BCAND))) {
         int top = base + 2;
         int candt = lcand[top - start];
-        while(top < n && (candt & F_TCAND))
+        while (top < n && (candt & F_TCAND))
         {
             // first max_len values are prefetched into lds,
             // access global memory only if need to go beyond that
             // which is very unlikely
-            S tval = (top - start) < max_len ? ldsD[top - start] : md[top];
+            S tval = (top - start) < max_len
+                   ? ldsD[top-start]
+                   : md[top];
 
-            if((tval - bval) > tol)
+            if ((tval - bval) > tol)
             {
                 dcount[base] = top - base - 1;
                 base = top;
@@ -764,7 +770,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             // first max_len values are prefetched into lds,
             // access global memory only if need to go beyond that
             // which is very unlikely
-            candt = (top - start) < max_len ? lcand[top - start] : cand[top];
+            candt = (top - start) < max_len
+                ? lcand[top-start]
+                : cand[top];
         }
         dcount[base] = top - base - 1;
     }
@@ -808,47 +816,48 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // temp values during the merges
     S* temps = vecs + (n * n);
 
-    S* cc = vecs + 2 * n;
-    S* ss = vecs + 3 * n;
+    S* cc    = vecs + 2 * n;
+    S* ss    = vecs + 3 * n;
     S* mtols = vecs + 4 * n;
-    S* md = vecs + 5 * n;
+    S* md    = vecs + 5 * n;
 
-    rocblas_int* map = splits + 8 * n;
-    rocblas_int* dcount = splits + 9 * n;
-    rocblas_int* mns = splits + 10 * n;
-    rocblas_int* mps = splits + 11 * n;
-    rocblas_int* cand = splits + 12 * n;
-    rocblas_int* midd = splits + 13 * n;
+    rocblas_int* map    = splits +  8 * n;
+    rocblas_int* dcount = splits +  9 * n;
+    rocblas_int* mns    = splits + 10 * n;
+    rocblas_int* mps    = splits + 11 * n; 
+    rocblas_int* cand   = splits + 12 * n; 
+    rocblas_int* midd   = splits + 13 * n;
 
     constexpr rocblas_int max_len = 4096;
-    __shared__ S lz[max_len];
+    __shared__ S   lz[max_len];
     __shared__ int lmap[max_len];
 
-    int start = hipBlockDim_x * hipBlockIdx_x;
-    int base = start + hipThreadIdx_x;
-    int cnt = (base < n) ? dcount[base] : 0;
+    int start   = hipBlockDim_x * hipBlockIdx_x;
+    int base    = start + hipThreadIdx_x;
+    int cnt     = (base < n) ? dcount[base] : 0;
 
     // cache max_len values of map[] and appropriate z[]
-    for(int i = hipThreadIdx_x; i < max_len; i += hipBlockDim_x)
-    {
-        int x = start + i;
-        lmap[i] = (x < n) ? map[x] : 0;
-        lz[i] = (x < n) ? z[map[x]] : 0;
+    for (int i = hipThreadIdx_x; i < max_len; i += hipBlockDim_x) {
+        int x   = start + i;
+        lmap[i] = (x < n) ? map[x]    : 0;
+        lz[i]   = (x < n) ? z[map[x]] : 0;
     }
     __syncthreads();
 
-    if(cnt)
-    {
+    if (cnt) {
         S baseval = lz[hipThreadIdx_x];
-        for(int j = 0; j < cnt; j++)
-        {
+        for (int j = 0; j < cnt; j++) {
             int top = base + j + 1;
 
             // first max_len values are prefetched into lds,
             // access global memory only if need to go beyond that
             // which is very unlikely
-            int idx = (top - start) < max_len ? lmap[top - start] : map[top];
-            S g = (top - start) < max_len ? lz[top - start] : z[idx];
+            int idx = (top - start) < max_len
+                    ? lmap[top - start]
+                    : map[top];
+            S g     = (top - start) < max_len
+                    ? lz[top - start]
+                    : z[idx];
 
             S f = baseval;
             S c, s, rr;
@@ -856,9 +865,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             baseval = rr;
 
             idd[idx] = 0;
-            z[idx] = 0;
-            cc[idx] = c;
-            ss[idx] = s;
+            z[idx]   = 0;
+            cc[idx]  = c;
+            ss[idx]  = s;
         }
         z[lmap[hipThreadIdx_x]] = baseval;
     }
@@ -897,75 +906,67 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
 
-    rocblas_int* map = splits + 8 * n;
-    rocblas_int* dcounts = splits + 9 * n;
+
+    rocblas_int* map     = splits + 8 * n;         
+    rocblas_int* dcounts = splits + 9 * n; 
     S* cc = vecs + 2 * n;
-    S* ss = vecs + 3 * n;
+    S* ss = vecs + 3 * n; 
 
     constexpr int regs = 16;
     const int chunk_width = regs * hipBlockDim_x;
-    const int n_chunks = (n - 1) / chunk_width + 1;
+    const int n_chunks    = (n - 1) / chunk_width + 1;
     S bval[regs];
     S tval[regs];
 
+
     rocblas_int dgs = hipBlockIdx_x;
     rocblas_int dcnt = dcounts[dgs];
-    if(dcnt)
+    if (dcnt)
     {
         rocblas_int base = map[dgs];
         S* Cbase = C + base * ldc;
 
-        for(int chunk = 0; chunk < n_chunks; chunk++)
-        {
-            for(int i = 0; i < regs; i++)
-            {
+        for (int chunk = 0; chunk < n_chunks; chunk++) {
+
+            for(int i = 0; i < regs; i++) {
                 int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
-                if(x < n)
-                {
+                if (x < n) {
                     bval[i] = Cbase[x];
                 }
             }
 
-            for(int dn = 0; dn < dcnt; dn++)
-            {
+            for (int dn = 0; dn < dcnt; dn++) {
                 rocblas_int top = map[dgs + dn + 1];
                 S c = cc[top];
                 S s = ss[top];
                 S* Ctop = C + top * ldc;
 
-                for(int i = 0; i < regs; i++)
-                {
+                for(int i = 0; i < regs; i++) {
                     int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
-                    if(x < n)
-                    {
+                    if(x < n){
                         tval[i] = Ctop[x];
                     }
                 }
 
-                for(int i = 0; i < regs; i++)
-                {
+                for (int i = 0; i < regs; i++) {
                     S valf = bval[i];
                     S valg = tval[i];
                     bval[i] = valf * c - valg * s;
-                    tval[i] = valf * s + valg * c;
+                    tval[i] = valf * s + valg * c; 
                 }
 
-                for(int i = 0; i < regs; i++)
-                {
+                for(int i = 0; i < regs; i++) {
                     int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
-                    if(x < n)
-                    {
+                    if(x < n){
                         Ctop[x] = tval[i];
                     }
                 }
                 __syncthreads();
             }
 
-            for(int i = 0; i < regs; i++)
-            {
+            for(int i = 0; i < regs; i++) {
                 int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
-                if(x < n)
-                {
+                if (x < n) {
                     Cbase[x] = bval[i];
                 }
             }
@@ -1064,6 +1065,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         S* ptz = (iam == 0) ? C + p2 - 1 + sz : C + p2;
         S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
 
+
         // 3. deflate eigenvalues
         // ----------------------------------------------------------------
         // determine boundaries of what would be the new merged sub-block
@@ -1077,7 +1079,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         in = ps[in];
 
         // 4. Organize data with non-deflated values to prepare secular equation
-        // ------------------------------------------------------------------------
+        // ------------------------------------------------------------------------ 
         // define shifted arrays
         S* tmpd = temps + in * n;
         S* diag = D + in;
@@ -1107,6 +1109,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         dds[in] = dd;
     }
 }
+
 
 template <typename S>
 void __device__ inline sort_tmpd_zz(const rocblas_int dd,
@@ -1171,9 +1174,9 @@ void __device__ inline solve_seq_eqns(const rocblas_int dd,
                                       const S ssfmin,
                                       const S ssfmax,
                                       const rocblas_int* mask,
-                                      S* tmpd,
-                                      S* ev,
-                                      S* zz)
+                                            S* tmpd,
+                                            S* ev,
+                                            S* zz)
 {
     /* ----------------------------------------------------------------- */
 
@@ -1224,6 +1227,7 @@ void __device__ inline solve_seq_eqns(const rocblas_int dd,
     }
 }
 
+
 template <typename S>
 void __device__ inline rescale_z(const rocblas_int dd,
                                  const rocblas_int iam,
@@ -1234,7 +1238,7 @@ void __device__ inline rescale_z(const rocblas_int dd,
                                  const rocblas_int* mask,
                                  const S* tmpd,
                                  const S* diag,
-                                 S* zz)
+                                       S* zz)
 {
     // Re-scale vector Z to avoid bad numerics when an eigenvalue
     // is too close to a pole
@@ -1254,10 +1258,11 @@ void __device__ inline rescale_z(const rocblas_int dd,
     }
 }
 
+
 //--------------------------------------------------------------------------------------//
-/** STEDC_MERGEVALUES_KERNEL solves the secular equation for every pair of sub-blocks
-    that need to be merged.
-        - Call this kernel with batch_count groups in y, and as many groups as half of the
+/** STEDC_MERGEVALUES_KERNEL solves the secular equation for every pair of sub-blocks 
+    that need to be merged. 
+        - Call this kernel with batch_count groups in y, and as many groups as half of the 
           unmerged sub-blocks in current level in x. Each group works with a merge of a pair
           of sub-blocks. Groups are size STEDC_BDIM **/
 template <typename S>
@@ -1356,8 +1361,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         sz = szs[in];
         in = ps[in];
 
+
         // 1. Organize data with non-deflated values to prepare secular equation
-        // -----------------------------------------------------------------
+        // ----------------------------------------------------------------- 
         // All threads of the group participating in the merge will work together
         // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
         iam = tidb;
@@ -1384,6 +1390,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         copy_d_ev(dd, iam, bdm, sz, n, tmpd, ev, diag);
 
         __syncthreads();
+
 
         solve_seq_eqns(dd, iam, bdm, sz, n, p, eps, ssfmin, ssfmax, mask, tmpd, ev, zz);
 
@@ -1489,8 +1496,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         sz = szs[in];
         in = ps[in];
 
+
         // 1. Organize data with non-deflated values to prepare secular equation
-        // -----------------------------------------------------------------
+        // ----------------------------------------------------------------- 
         // All threads of the group participating in the merge will work together
         // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
         iam = tidb;
@@ -1740,8 +1748,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         sz = szs[in];
         in = ps[in];
 
+
         // 1. Organize data with non-deflated values to prepare secular equation
-        // -----------------------------------------------------------------
+        // ----------------------------------------------------------------- 
         // All threads of the group participating in the merge will work together
         // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
         iam = tidb;
@@ -1768,10 +1777,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     }
 }
 
+
 //--------------------------------------------------------------------------------------//
 /** STEDC_MERGEVECTORS_KERNEL prepares vectors from the secular equation for
     every pair of sub-blocks that need to be merged.
-        - Call this kernel with batch_count groups in y, and as many groups as columns would
+        - Call this kernel with batch_count groups in y, and as many groups as columns would 
           be in the matrix if its size is exact multiple of the number of sub-blocks 'blks'.
           Each group works with a column. Groups are size STEDC_BDIM.
         - If a group has an id larger than the actual number of columns it will do nothing. **/
@@ -1887,6 +1897,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         }
         __syncthreads();
 
+
         // Prepare vectors corresponding to non-deflated values
         S temp, nrm;
         rocblas_int j = vidb;
@@ -1987,9 +1998,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     }
 }
 
+
 //--------------------------------------------------------------------------------------//
-/** STEDC_MERGEUPDATE_KERNEL updates vectors and values after a merge is done.
-        - Call this kernel with batch_count groups in y, and as many groups as columns would
+/** STEDC_MERGEUPDATE_KERNEL updates vectors and values after a merge is done. 
+        - Call this kernel with batch_count groups in y, and as many groups as columns would 
           be in the matrix if its size is exact multiple of the number of sub-blocks 'blks'.
           Each group works with a column. Groups are size STEDC_BDIM.
         - If a group has an id larger than the actual number of columns it will do nothing. **/
@@ -2083,6 +2095,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     }
 }
 
+
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_copyD(const rocblas_int n,
                                                                 S* DDin,
@@ -2093,7 +2106,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_copyD(const rocblas_in
     // batch instance id
     rocblas_int bid = hipBlockIdx_y;
 
-    S* Din = DDin + bid * strideDin;
+    S* Din  = DDin  + bid * strideDin;
     S* Dout = DDout + bid * strideDout;
 
     int tid = hipThreadIdx_x;
@@ -2103,16 +2116,13 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_copyD(const rocblas_in
     const int n_chunks = (n - 1) / chunk_width + 1;
     S bval[regs];
 
-    for(int chunk = 0; chunk < n_chunks; chunk++)
-    {
-        for(int i = 0; i < regs; i++)
-        {
+    for(int chunk = 0; chunk < n_chunks; chunk++) {
+        for(int i = 0; i < regs; i++) {
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < n)
                 bval[i] = Din[x];
         }
-        for(int i = 0; i < regs; i++)
-        {
+        for(int i = 0; i < regs; i++) {
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < n)
                 Dout[x] = bval[i];
@@ -2120,13 +2130,13 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_copyD(const rocblas_in
     }
 }
 
-template <typename T, typename U1, typename U2>
+template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_copyC(const rocblas_int n,
-                                                                U1 CCin,
+                                                                S* CCin,
                                                                 const rocblas_int shiftCin,
                                                                 const rocblas_int ldcin,
                                                                 const rocblas_stride strideCin,
-                                                                U2 CCout,
+                                                                S* CCout,
                                                                 const rocblas_int shiftCout,
                                                                 const rocblas_int ldcout,
                                                                 const rocblas_stride strideCout)
@@ -2136,27 +2146,24 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_copyC(const rocblas_in
     // group id
     rocblas_int gid = hipBlockIdx_x;
 
-    T* Cin = load_ptr_batch<T>(CCin, bid, shiftCin, strideCin);
-    T* Cout = load_ptr_batch<T>(CCout, bid, shiftCout, strideCout);
+    S* Cin  = load_ptr_batch<S>(CCin,  bid, shiftCin,  strideCin);
+    S* Cout = load_ptr_batch<S>(CCout, bid, shiftCout, strideCout);
 
-    T* src = Cin + ldcin * gid;
-    T* dst = Cout + ldcout * gid;
-
+    S* src =  Cin + ldcin  * gid;
+    S* dst = Cout + ldcout * gid;
+    
     constexpr int regs = 16;
     const int chunk_width = regs * hipBlockDim_x;
     const int n_chunks = (n - 1) / chunk_width + 1;
-    T bval[regs];
-
-    for(int chunk = 0; chunk < n_chunks; chunk++)
-    {
-        for(int i = 0; i < regs; i++)
-        {
+    S bval[regs];
+    
+    for(int chunk = 0; chunk < n_chunks; chunk++) {
+        for(int i = 0; i < regs; i++) {
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < n)
                 bval[i] = src[x];
         }
-        for(int i = 0; i < regs; i++)
-        {
+        for(int i = 0; i < regs; i++) {
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < n)
                 dst[x] = bval[i];
@@ -2165,21 +2172,21 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_copyC(const rocblas_in
 }
 
 /** STEDC_SORT sorts computed eigenvalues and eigenvectors in increasing order **/
-template <typename T, typename S, typename U1, typename U2>
+template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int n,
-                                                               S* DDin,
-                                                               const rocblas_stride strideDin,
-                                                               S* DDout,
-                                                               const rocblas_stride strideDout,
-                                                               U1 CCin,
-                                                               const rocblas_int shiftCin,
-                                                               const rocblas_int ldcin,
-                                                               const rocblas_stride strideCin,
-                                                               U2 CCout,
-                                                               const rocblas_int shiftCout,
-                                                               const rocblas_int ldcout,
-                                                               const rocblas_stride strideCout
-
+                                                              S* DDin,
+                                                              const rocblas_stride strideDin,
+                                                              S* DDout,
+                                                              const rocblas_stride strideDout,
+                                                              S* CCin,
+                                                              const rocblas_int shiftCin,
+                                                              const rocblas_int ldcin,
+                                                              const rocblas_stride strideCin,
+                                                              S* CCout,
+                                                              const rocblas_int shiftCout,
+                                                              const rocblas_int ldcout,
+                                                              const rocblas_stride strideCout
+                                                              
 )
 {
     // batch instance id
@@ -2187,7 +2194,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int
     // group id
     rocblas_int gid = hipBlockIdx_x;
 
-    S* Din = DDin + bid * strideDin;
+
+    S* Din  = DDin  + bid * strideDin;
     S* Dout = DDout + bid * strideDout;
 
     int tid = hipThreadIdx_x;
@@ -2197,8 +2205,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int
     constexpr int regs = 16;
     const int chunk_width = regs * hipBlockDim_x;
     const int n_chunks = (n - 1) / chunk_width + 1;
-    T bvalT[regs];
-    S* bvalS = reinterpret_cast<S*>(bvalT);
+    S bval[regs];
 
     int nan = 0;
     int lt = 0;
@@ -2206,27 +2213,25 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int
 
     for(int chunk = 0; chunk < n_chunks; chunk++)
     {
-        for(int i = 0; i < regs; i++)
-        {
+        for(int i = 0; i < regs; i++) {
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < n)
             {
-                bvalS[i] = Din[x];
+                bval[i] = Din[x];
             }
         }
-        for(int i = 0; i < regs; i++)
-        {
+        for(int i = 0; i < regs; i++) {
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < n)
             {
-                nan += (bvalS[i] != bvalS[i]);
+                nan += (bval[i] != bval[i]);
                 // lt - how many values are less then the current
                 // eq - how many values are equal to the current
                 // all zero deflated values have to be grouped at the end
                 // so we order any deflated value > any non-deflated value
                 // dz == 0 - current is deflated, dz[i] == 1 - other value is not deflated
-                lt += (bvalS[i] < d);
-                eq += (bvalS[i] == d && x < gid);
+                lt += (bval[i] < d);
+                eq += (bval[i] == d && x < gid);
             }
         }
     }
@@ -2239,8 +2244,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int
     // The faster implementation should use dpp + a single trip through lds
     // but keeping code simple for now.
     int bit = 1;
-    while(bit < STEDC_BDIM)
-    {
+    while(bit < STEDC_BDIM) {
         lds[hipThreadIdx_x ^ bit] = pos;
         __syncthreads();
         pos += lds[hipThreadIdx_x];
@@ -2248,8 +2252,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int
         bit *= 2;
     }
 
-    if(hipThreadIdx_x == 0)
-    {
+    if (hipThreadIdx_x == 0) {
         Dout[pos] = d;
     }
 
@@ -2258,40 +2261,38 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int
     // new positions it would be silently overwriten with non NAN value.
     // Make sure we propagate NAN. It is likely to have more NANs in the output
     // than in the input, but the following computations are doomed anyway.
-    if(nan)
-    {
+    if (nan) {
         Dout[gid] = NAN;
     }
 
-    T* Cin = load_ptr_batch<T>(CCin, bid, shiftCin, strideCin);
-    T* Cout = load_ptr_batch<T>(CCout, bid, shiftCout, strideCout);
+    
+    S* Cin  = load_ptr_batch<S>(CCin,  bid, shiftCin,  strideCin);
+    S* Cout = load_ptr_batch<S>(CCout, bid, shiftCout, strideCout);
 
-    T* src = Cin + ldcin * gid;
-    T* dst = Cout + ldcout * pos;
-
-    for(int chunk = 0; chunk < n_chunks; chunk++)
-    {
-        for(int i = 0; i < regs; i++)
-        {
+    S* src =  Cin + ldcin  * gid;
+    S* dst = Cout + ldcout * pos;
+    
+    for(int chunk = 0; chunk < n_chunks; chunk++) {
+        for(int i = 0; i < regs; i++) {
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < n)
-                bvalT[i] = src[x];
+                bval[i] = src[x];
         }
-        for(int i = 0; i < regs; i++)
-        {
+        for(int i = 0; i < regs; i++) {
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < n)
-                dst[x] = bvalT[i];
+                dst[x] = bval[i];
         }
     }
 }
+
 
 /******************* Host functions *********************************************/
 /*******************************************************************************/
 
 //--------------------------------------------------------------------------------------//
 /** STEDC_NUM_LEVELS returns the ideal number of times/levels in which a matrix
-    will be divided during the divide phase of divide & conquer algorithm
+    will be divided during the divide phase of divide & conquer algorithm 
     i.e. number of sub-blocks = 2^levels **/
 inline rocblas_int stedc_num_levels(const rocblas_int n)
 {
@@ -2503,7 +2504,7 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         ssfmin = sqrt(ssfmin) / (eps * eps);
         ssfmax = sqrt(ssfmax) / S(3.0);
 
-        // find number of sub-blocks
+        // find number of sub-blocks 
         rocblas_int levs = stedc_num_levels(n);
         rocblas_int blks = 1 << levs;
 
@@ -2526,15 +2527,17 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         // 1. divide phase
         //-----------------------------
         rocblas_int groups = (batch_count - 1) / STEDC_BDIM + 1;
-        ROCSOLVER_LAUNCH_KERNEL((stedc_divide_kernel<S>), dim3(groups), dim3(STEDC_BDIM), 0, stream,
-                                levs, blks, n, D + shiftD, strideD, E + shiftE, strideE,
-                                batch_count, splits);
+        ROCSOLVER_LAUNCH_KERNEL((stedc_divide_kernel<S>),
+                                dim3(groups), dim3(STEDC_BDIM), 0, stream, levs, blks, n, D + shiftD,
+                                strideD, E + shiftE, strideE, batch_count, splits);
 
         // 2. solve phase
         //-----------------------------
-        ROCSOLVER_LAUNCH_KERNEL((stedc_solve_kernel<S>), dim3(blks, batch_count), dim3(64), 0,
-                                stream, levs, blks, n, D + shiftD, strideD, E + shiftE, strideE, V,
-                                0, ldv, strideV, info, (S*)work_stack, splits, eps, ssfmin, ssfmax);
+        ROCSOLVER_LAUNCH_KERNEL((stedc_solve_kernel<S>),
+                                dim3(blks, batch_count), dim3(64), 0, stream, levs, blks, 
+                                n, D + shiftD, strideD, E + shiftE, strideE, 
+                                V, 0, ldv, strideV, info, (S*)work_stack, splits, 
+                                eps, ssfmin, ssfmax);
 
         // 3. merge phase
         //----------------
@@ -2547,46 +2550,51 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             // a. prepare secular equations
             rocblas_int numgrps2 = 1 << (levs - 1 - k);
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_DeflateZero_kernel<S>),
-                                    dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream, levs,
-                                    blks, k, n, D + shiftD, strideD, E + shiftE, strideE, V, 0, ldv,
-                                    strideV, tmpz, tempgemm, splits, eps);
+                                    dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream, 
+                                    levs, blks, k, n, D + shiftD, strideD,
+                                    E + shiftE, strideE, V, 0, ldv, strideV, tmpz, tempgemm, splits,
+                                    eps);
 
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_Fill_kernel<S>),
-                                    dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream, levs,
-                                    blks, k, n, tmpz, tempgemm, splits);
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_SortD_kernel<S>), dim3(n, batch_count),
-                                    dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
-                                    strideD, tmpz, tempgemm, splits);
+                                    dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream,
+                                    levs, blks, k, n,
+                                    tmpz, tempgemm, splits);
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_SortD_kernel<S>),
+                                    dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream,
+                                    levs, blks, k, n, D + shiftD, strideD,
+                                    tmpz, tempgemm, splits);
             rocblas_int numgrps_deflate = (n - 1) / STEDC_BDIM + 1;
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_SetCandFlags_kernel<S>),
-                                    dim3(numgrps_deflate, batch_count), dim3(STEDC_BDIM), 0, stream,
-                                    levs, blks, k, n, D + shiftD, strideD, tmpz, tempgemm, splits);
+                                    dim3(numgrps_deflate, batch_count), dim3(STEDC_BDIM), 0, stream, levs,
+                                    blks, k, n, D + shiftD, strideD, tmpz, tempgemm, splits);
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_DeflateCount_kernel<S>),
-                                    dim3(numgrps_deflate, batch_count), dim3(STEDC_BDIM), 0, stream,
-                                    levs, blks, k, n, D + shiftD, strideD, tmpz, tempgemm, splits);
+                                    dim3(numgrps_deflate, batch_count), dim3(STEDC_BDIM), 0, stream, levs,
+                                    blks, k, n, D + shiftD, strideD, tmpz, tempgemm, splits);
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_DeflateApply_kernel<S>),
                                     dim3(numgrps_deflate, batch_count), dim3(STEDC_BDIM), 0, stream,
-                                    levs, blks, k, n, D + shiftD, strideD, tmpz, tempgemm, splits);
-
+                                    levs, blks, k, n, D + shiftD, strideD,
+                                    tmpz, tempgemm, splits);
+                
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeRotate_kernel<S>), dim3(n, batch_count),
                                     dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, V, 0, ldv,
                                     strideV, tmpz, tempgemm, splits);
 
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_Organize_kernel<S>),
-                                    dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream, levs,
-                                    blks, k, n, D + shiftD, strideD, E + shiftE, strideE, V, 0, ldv,
-                                    strideV, tmpz, tempgemm, splits, eps);
+                                    dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream, 
+                                    levs, blks, k, n, D + shiftD, strideD,
+                                    E + shiftE, strideE, V, 0, ldv, strideV, tmpz, tempgemm, splits,
+                                    eps);
 
             // b. solve secular eq to find merged eigenvalues
             rocblas_int max_n_per_merge = (n + numgrps2 - 1) / numgrps2;
-
+            
             if(max_n_per_merge > STEDC_BDIM)
             {
                 // split mergeValues into stages to run seqular eqns solver using more groups
-                ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Sort_kernel<S>),
-                                        dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream,
-                                        levs, blks, k, n, D + shiftD, strideD, E + shiftE, strideE,
-                                        tmpz, tempgemm, splits, eps, ssfmin, ssfmax);
+                ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Sort_kernel<S>), dim3(numgrps2, batch_count),
+                                        dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
+                                        strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
+                                        ssfmin, ssfmax);
 
                 rocblas_int groups_per_merge = (max_n_per_merge + STEDC_BDIM - 1) / STEDC_BDIM;
                 ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Solve_kernel<S>),
@@ -2594,13 +2602,12 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                         dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
                                         strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
                                         ssfmin, ssfmax, groups_per_merge);
-                ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Rescale_kernel<S>),
-                                        dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream,
-                                        levs, blks, k, n, D + shiftD, strideD, E + shiftE, strideE,
-                                        tmpz, tempgemm, splits, eps, ssfmin, ssfmax);
+                ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Rescale_kernel<S>), dim3(numgrps2, batch_count),
+                                        dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
+                                        strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
+                                        ssfmin, ssfmax);
             }
-            else
-            {
+            else {
                 // compute in one dispatch for small merges
                 ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_kernel<S>), dim3(numgrps2, batch_count),
                                         dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
@@ -2609,10 +2616,11 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             }
 
             // c. find merged eigenvectors
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeVectors_kernel<STEDC_EXTERNAL_GEMM, S>),
-                                    dim3(numgrps3, batch_count), dim3(STEDC_BDIM), lmemsize3,
-                                    stream, levs, blks, k, n, D + shiftD, strideD, E + shiftE,
-                                    strideE, V, 0, ldv, strideV, tmpz, tempgemm, splits);
+            ROCSOLVER_LAUNCH_KERNEL(
+                (stedc_mergeVectors_kernel<STEDC_EXTERNAL_GEMM, S>),
+                dim3(numgrps3, batch_count), dim3(STEDC_BDIM), lmemsize3, stream, 
+                levs, blks, k, n, D + shiftD, strideD, E + shiftE, strideE, V, 0, ldv, strideV, 
+                tmpz, tempgemm, splits);
 
             if(STEDC_EXTERNAL_GEMM)
             {
@@ -2627,9 +2635,10 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             }
 
             // d. update level
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeUpdate_kernel<S>), dim3(numgrps3, batch_count),
-                                    dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
-                                    strideD, V, 0, ldv, strideV, tmpz, tempgemm, splits);
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeUpdate_kernel<S>),
+                                    dim3(numgrps3, batch_count), dim3(STEDC_BDIM), 0, stream, 
+                                    levs, blks, k, n, D + shiftD, strideD,
+                                    V, 0, ldv, strideV, tmpz, tempgemm, splits);
         }
 
         // 4. update and sort
@@ -2661,12 +2670,14 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         ROCSOLVER_LAUNCH_KERNEL(stedc_copyD, dim3(1, batch_count), dim3(STEDC_BDIM), 0, stream, n,
                                 D + shiftD, strideD, tmpz, n);
 
-        ROCSOLVER_LAUNCH_KERNEL(stedc_copyC<T>, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream,
-                                n, C, shiftC, ldc, strideC, (T*)tempgemm, 0, n, n * n);
+        ROCSOLVER_LAUNCH_KERNEL(stedc_copyC, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, n,
+                                (S*)C,    shiftC, ldc, strideC,
+                                tempgemm, 0,      n,   n*n);
 
-        ROCSOLVER_LAUNCH_KERNEL(stedc_sort<T>, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, n,
-                                tmpz, n, D + shiftD, strideD, (T*)tempgemm, 0, n, n * n, C, shiftC,
-                                ldc, strideC);
+        ROCSOLVER_LAUNCH_KERNEL(stedc_sort, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream,
+                                n, tmpz, n, D + shiftD, strideD,
+                                tempgemm, 0,      n,   n*n,
+                                (S*)C,    shiftC, ldc, strideC);
 
         rocblas_set_pointer_mode(handle, old_mode);
     }

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -63,33 +63,35 @@ __host__ __device__ inline rocblas_int get_splits_size(const rocblas_int n)
     // n - number of eigenvalues (matrix size)
     // m - number of merges on a current level
     // struct {
-    // 0     rocblas_int sort_tmp[n];      // temp buffer used for mapping in stedc_sort()
-    // 1     rocblas_int ns[n];            // the sub-blocks sizes
-    // 2     rocblas_int ps[n];            // the sub-blocks initial positions
-    // 3     rocblas_int idd[n];           // if idd[i] = 0, the value in position i has been deflated  (aka mask)
-    // 4     rocblas_int pers[n];          // container of permutations when solving the secular eqns
-    // 5     rocblas_int r1p[m], _[n-m];   // position of a rank-1 modification component p (per each merge)
-    // 6     rocblas_int szs[n];           // sizes of both sub-blocks in a merge
-    // 7     rocblas_int dds[n];           // degrees of secular equation
-    // 8     rocblas_int map[n];           // 
-    // 9     rocblas_int dcount[n];        // number of deflations
-    // 10    rocblas_int esz[n];           // size of a corresponding merge (per each eigenvalue)
-    // 11    rocblas_int eps[n];           // starting position of a corresponding merge (per each eigenvalue)
-    // 12    rocblas_int cand[n];          // deflation candidate flags
-    // 13    rocblas_int sidd[n];          // sorted idd
-    // 14    rocblas_int em[n];            // id of a corresponding merge (per each eigenvalue)
-    // 15    rocblas_int msz[m], _[n-m];   // size of each merge
-    // 16    rocblas_int mps[m], _[n-m];   // starting position of each merge
-    // 17    rocblas_int dbg4[n];          //
+    // 0     rocblas_int sort_tmp[n];         // temp buffer used for mapping in stedc_sort()
+    // 1     rocblas_int ns[n];               // the sub-blocks sizes
+    // 2     rocblas_int ps[n];               // the sub-blocks initial positions
+    // 3     rocblas_int idd[n];              // if idd[i] = 0, the value in position i has been deflated  (aka mask)
+    // 4     rocblas_int pers[n];             // container of permutations when solving the secular eqns
+    // 5     rocblas_int ;      //
+    // 6     rocblas_int szs[n];              // sizes of both sub-blocks in a merge
+    // 7     rocblas_int dds[n];              // degrees of secular equation
+    // 8     rocblas_int map[n];              // 
+    // 9     rocblas_int dcount[n];           // number of deflations
+    // 10    rocblas_int esz[n];              // size of a corresponding merge (per each eigenvalue)
+    // 11    rocblas_int eps[n];              // starting position of a corresponding merge (per each eigenvalue)
+    // 12    rocblas_int cand[n];             // deflation candidate flags
+    // 13    rocblas_int sidd[n];             // sorted idd
+    // 14    rocblas_int em[n];               // id of a corresponding merge (per each eigenvalue)
+    // 15    rocblas_int msz[m], _[n-m];      // size of each merge
+    // 16    rocblas_int mps[m], _[n-m];      // starting position of each merge
+    // 17    rocblas_int bsz[2*m], _[n-2*m];  // size of each block
+    // 18    rocblas_int bps[2*m], _[n-2*m];  // starting position of each block
+    // 19    rocblas_int dbg4[n];             //
     // };
-    return 18 * n;
+    return 20 * n;
 }
 
 template <typename S> __host__ __device__ inline S* ptr_ns    (rocblas_int n, S* splits) { return splits +  1 * n; }
 template <typename S> __host__ __device__ inline S* ptr_ps    (rocblas_int n, S* splits) { return splits +  2 * n; }
 template <typename S> __host__ __device__ inline S* ptr_idd   (rocblas_int n, S* splits) { return splits +  3 * n; }
 template <typename S> __host__ __device__ inline S* ptr_pers  (rocblas_int n, S* splits) { return splits +  4 * n; }
-template <typename S> __host__ __device__ inline S* ptr_r1p   (rocblas_int n, S* splits) { return splits +  5 * n; }
+template <typename S> __host__ __device__ inline S* ptr_      (rocblas_int n, S* splits) { return splits +  5 * n; }
 template <typename S> __host__ __device__ inline S* ptr_szs   (rocblas_int n, S* splits) { return splits +  6 * n; }
 template <typename S> __host__ __device__ inline S* ptr_dds   (rocblas_int n, S* splits) { return splits +  7 * n; }
 template <typename S> __host__ __device__ inline S* ptr_map   (rocblas_int n, S* splits) { return splits +  8 * n; }
@@ -101,7 +103,9 @@ template <typename S> __host__ __device__ inline S* ptr_sidd  (rocblas_int n, S*
 template <typename S> __host__ __device__ inline S* ptr_em    (rocblas_int n, S* splits) { return splits + 14 * n; }
 template <typename S> __host__ __device__ inline S* ptr_msz   (rocblas_int n, S* splits) { return splits + 15 * n; }
 template <typename S> __host__ __device__ inline S* ptr_mps   (rocblas_int n, S* splits) { return splits + 16 * n; }
-template <typename S> __host__ __device__ inline S* ptr_dbg   (rocblas_int n, S* splits) { return splits + 17 * n; }
+template <typename S> __host__ __device__ inline S* ptr_bsz   (rocblas_int n, S* splits) { return splits + 17 * n; }
+template <typename S> __host__ __device__ inline S* ptr_bps   (rocblas_int n, S* splits) { return splits + 18 * n; }
+template <typename S> __host__ __device__ inline S* ptr_dbg   (rocblas_int n, S* splits) { return splits + 19 * n; }
 
 __host__ __device__ inline rocblas_int get_tmpz_size(const rocblas_int n)
 {
@@ -296,21 +300,27 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_update_splits(const ro
     rocblas_int* mps = ptr_mps(n, splits);
     rocblas_int* esz = ptr_esz(n, splits);
     rocblas_int* eps = ptr_eps(n, splits);
-    rocblas_int* r1p = ptr_r1p(n, splits);
+    rocblas_int* bsz = ptr_bsz(n, splits);
+    rocblas_int* bps = ptr_bps(n, splits);
     
 
     rocblas_int n_merges = 1 << (levs - k - 1);
 
+    // previous merges becomes blocks on a current level
+    for (int i = hipThreadIdx_x; i < n_merges * 2; i += hipBlockDim_x)
+    {
+        bsz[i] = msz[i];
+        bps[i] = mps[i];
+    }
+    __syncthreads();
+
     for(int i = hipThreadIdx_x; i < n_merges; i += hipBlockDim_x)
     {
-        rocblas_int sz1 = msz[i * 2 + 0];
-        rocblas_int sz2 = msz[i * 2 + 1];
-        rocblas_int p   = mps[i * 2];
-        rocblas_int sz = sz1 + sz2;
-        __syncthreads();
-        msz[i] = sz;
+        rocblas_int sz1 = bsz[i * 2 + 0];
+        rocblas_int sz2 = bsz[i * 2 + 1];
+        rocblas_int p   = bps[i * 2];
+        msz[i] = sz1 + sz2;
         mps[i] = p;
-        r1p[i] = p + sz1 - 1;
     }
     __syncthreads();
 
@@ -371,8 +381,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* ns   = ptr_ns(n, splits);
     rocblas_int* ps   = ptr_ps(n, splits);
     rocblas_int* idd  = ptr_idd(n, splits);
-    rocblas_int* r1p  = ptr_r1p(n, splits);
     rocblas_int* szs  = ptr_szs(n, splits);
+    rocblas_int* mps = ptr_mps(n, splits);
+    rocblas_int* bsz = ptr_bsz(n, splits);
+
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z     = ptr_z(n, tmpz);
@@ -404,16 +416,16 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // ----------------------------------------------------------------
         // Threads with iam = 0 work with components below the merge point;
         // threads with iam = 1 work above the merge point
-        sz = ns[tid];
-        for(int j = 1; j < bd; ++j)
-            sz += ns[tid + j];
         //r1p[tid] = (iam == 0) ? (p2 - 1 + sz) : (p2 - 1);
         // with this, all threads involved in a merge
         // will point to the same row of C and the same off-diag element
-        S* ptz = C + r1p[sid] + iam;
-        S p = 2 * E[r1p[sid]];
+        // position of a rank-1 modification component
+        rocblas_int r1p = mps[sid] + bsz[sid * 2] - 1;
+        S p = 2 * E[r1p];
+        S* ptz = C + r1p + iam;
 
         // copy elements of z
+        sz = bsz[sid * 2 + iam];
         for(int j = tx; j < sz; j += dim)
             z[p2 + j] = ptz[(p2 + j) * ldc] / sqrt(2);
 
@@ -513,8 +525,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* szs    = ptr_szs(n, splits);
     rocblas_int* map    = ptr_map(n, splits);
     rocblas_int* dcount = ptr_dcount(n, splits);
-    rocblas_int* esz    = ptr_esz(n, splits);
-    rocblas_int* eps    = ptr_eps(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* tolsD = ptr_tolsD(n, tmpz);
@@ -527,8 +537,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     for (int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x) {
         int id = p + i;
-        esz[id] = sz;
-        eps[id] = p;
         tolsD[id] = tol;
         tolsZ[id] = tol;
         dcount[id] = 0;
@@ -1011,9 +1019,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* ps   = ptr_ps(n, splits);
     rocblas_int* idd  = ptr_idd(n, splits);
     rocblas_int* pers = ptr_pers(n, splits);
-    rocblas_int* r1p  = ptr_r1p(n, splits);
     rocblas_int* szs  = ptr_szs(n, splits);
     rocblas_int* dds  = ptr_dds(n, splits);
+    rocblas_int* mps = ptr_mps(n, splits);
+    rocblas_int* bsz = ptr_bsz(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z     = ptr_z(n, tmpz);
@@ -1029,7 +1038,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     {
         // 1. find rank-1 modification component (p) for this merge
         // ----------------------------------------------------------------
-        S p = 2 * E[r1p[sid]];
+        // position of a rank-1 modification component
+        rocblas_int r1p = mps[sid] + bsz[sid * 2] - 1;
+        S p = 2 * E[r1p];
 
         // 3. deflate eigenvalues
         // ----------------------------------------------------------------
@@ -1321,9 +1332,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* ps   = ptr_ps(n, splits);
     rocblas_int* idd  = ptr_idd(n, splits);
     rocblas_int* pers = ptr_pers(n, splits);
-    rocblas_int* r1p  = ptr_r1p(n, splits);
     rocblas_int* szs  = ptr_szs(n, splits);
     rocblas_int* dds  = ptr_dds(n, splits);
+    rocblas_int* mps  = ptr_mps(n, splits);
+    rocblas_int* bsz  = ptr_bsz(n, splits);
     
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z   = ptr_z(n, tmpz);
@@ -1339,7 +1351,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // all threads work together to solve the secular equation.
     {
         // Find off-diagonal element of the merge
-        S p = 2 * E[r1p[sid]];
+        rocblas_int r1p = mps[sid] + bsz[sid * 2] - 1;
+        S p = 2 * E[r1p];
 
         // determine boundaries of what would be the new merged sub-block
         // 'in' will be its initial position.
@@ -2232,7 +2245,6 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                 print_device_matrix(std::cout, "em",  1, n, ptr_em(n, splits), 1);
                 print_device_matrix(std::cout, "esz", 1, n, ptr_esz(n, splits), 1);
                 print_device_matrix(std::cout, "eps", 1, n, ptr_eps(n, splits), 1);
-                print_device_matrix(std::cout, "r1p", 1, n, ptr_r1p(n, splits), 1);
                 print_device_matrix(std::cout, "dbg", 1, n, ptr_dbg(n, splits), 1);
 
                 //print_device_matrix(std::cout, "D", 1, n, D, 1);

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -302,6 +302,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_update_splits(const ro
     rocblas_int* eps = ptr_eps(n, splits);
     rocblas_int* bsz = ptr_bsz(n, splits);
     rocblas_int* bps = ptr_bps(n, splits);
+    rocblas_int* map = ptr_map(n, splits);
+    rocblas_int* dcount = ptr_dcount(n, splits);
     
 
     rocblas_int n_merges = 1 << (levs - k - 1);
@@ -329,6 +331,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_update_splits(const ro
         int m = em[i] / 2;
         esz[i] = msz[m];
         eps[i] = mps[m];
+        map[i] = 0;
+        dcount[i] = 0;
     }
     __syncthreads();
 
@@ -383,6 +387,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* idd  = ptr_idd(n, splits);
     rocblas_int* szs  = ptr_szs(n, splits);
     rocblas_int* mps = ptr_mps(n, splits);
+    rocblas_int* msz = ptr_msz(n, splits);
     rocblas_int* bsz = ptr_bsz(n, splits);
 
 
@@ -416,7 +421,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // ----------------------------------------------------------------
         // Threads with iam = 0 work with components below the merge point;
         // threads with iam = 1 work above the merge point
-        //r1p[tid] = (iam == 0) ? (p2 - 1 + sz) : (p2 - 1);
         // with this, all threads involved in a merge
         // will point to the same row of C and the same off-diag element
         // position of a rank-1 modification component
@@ -480,6 +484,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         for(int i = 1; i < bdm; ++i)
             sz += ns[in + i];
         szs[in] = sz;
+        sz = msz[sid];
         tolsD[in] = tol;
         tolsZ[in] = tol;
         in = ps[in];
@@ -523,8 +528,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
     rocblas_int* ps     = ptr_ps(n, splits);
     rocblas_int* szs    = ptr_szs(n, splits);
-    rocblas_int* map    = ptr_map(n, splits);
-    rocblas_int* dcount = ptr_dcount(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* tolsD = ptr_tolsD(n, tmpz);
@@ -539,8 +542,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         int id = p + i;
         tolsD[id] = tol;
         tolsZ[id] = tol;
-        dcount[id] = 0;
-        map[id] = 0;
     }
 }
 
@@ -1016,10 +1017,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* ps   = ptr_ps(n, splits);
     rocblas_int* idd  = ptr_idd(n, splits);
     rocblas_int* pers = ptr_pers(n, splits);
-    rocblas_int* szs  = ptr_szs(n, splits);
+    rocblas_int* msz  = ptr_msz(n, splits);
     rocblas_int* dds  = ptr_dds(n, splits);
     rocblas_int* mps = ptr_mps(n, splits);
     rocblas_int* bsz = ptr_bsz(n, splits);
@@ -1047,8 +1047,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // determine boundaries of what would be the new merged sub-block
         // 'in' will be its initial position.
         // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        rocblas_int sz = szs[sid * bdm];
-        rocblas_int in = ps[sid * bdm];
+        rocblas_int sz = msz[sid];
+        rocblas_int in = mps[sid];
 
         // 4. Organize data with non-deflated values to prepare secular equation
         // ------------------------------------------------------------------------ 
@@ -1217,10 +1217,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* ps   = ptr_ps(n, splits);
+    rocblas_int* mps  = ptr_mps(n, splits);
     rocblas_int* idd  = ptr_idd(n, splits);
     rocblas_int* pers = ptr_pers(n, splits);
-    rocblas_int* szs  = ptr_szs(n, splits);
+    rocblas_int* msz  = ptr_msz(n, splits);
     rocblas_int* dds  = ptr_dds(n, splits);
     
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
@@ -1239,8 +1239,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // determine boundaries of what would be the new merged sub-block
         // 'in' will be its initial position.
         // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        rocblas_int sz = szs[sid * bdm];
-        rocblas_int in = ps[sid * bdm];
+        rocblas_int sz = msz[sid];
+        rocblas_int in = mps[sid];
 
 
         // 1. Organize data with non-deflated values to prepare secular equation
@@ -1329,10 +1329,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* ps   = ptr_ps(n, splits);
     rocblas_int* idd  = ptr_idd(n, splits);
     rocblas_int* pers = ptr_pers(n, splits);
-    rocblas_int* szs  = ptr_szs(n, splits);
+    rocblas_int* msz  = ptr_msz(n, splits);
     rocblas_int* dds  = ptr_dds(n, splits);
     rocblas_int* mps  = ptr_mps(n, splits);
     rocblas_int* bsz  = ptr_bsz(n, splits);
@@ -1345,8 +1344,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // temp values during the merges
     S* temps = vecs + (n * n);
 
-    rocblas_int bdm = 1 << (k + 1);
-
     // Work with merges on level k. A thread-group works with two leaves in the merge tree;
     // all threads work together to solve the secular equation.
     {
@@ -1357,15 +1354,15 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // determine boundaries of what would be the new merged sub-block
         // 'in' will be its initial position.
         // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        rocblas_int sz = szs[sid * bdm];
-        rocblas_int in = ps[sid * bdm];
+        rocblas_int sz = msz[sid];
+        rocblas_int in = mps[sid];
 
         // 1. Organize data with non-deflated values to prepare secular equation
         // -----------------------------------------------------------------
         // All threads of the group participating in the merge will work together
         // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
         rocblas_int iam = tidb;
-        bdm = hipBlockDim_x * groups_per_merge;
+        rocblas_int bdm = hipBlockDim_x * groups_per_merge;
 
         // define shifted arrays
         S* tmpd = temps + in * n;
@@ -1414,10 +1411,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* ps   = ptr_ps(n, splits);
+    rocblas_int* mps  = ptr_mps(n, splits);
     rocblas_int* idd  = ptr_idd(n, splits);
     rocblas_int* pers = ptr_pers(n, splits);
-    rocblas_int* szs  = ptr_szs(n, splits);
+    rocblas_int* msz  = ptr_msz(n, splits);
     rocblas_int* dds  = ptr_dds(n, splits);
     
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
@@ -1428,16 +1425,14 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // temp values during the merges
     S* temps = vecs + (n * n);
 
-    rocblas_int bdm = 1 << (k + 1);
-
     // Work with merges on level k. A thread-group works with two leaves in the merge tree;
     // all threads work together to solve the secular equation.
     {
         // determine boundaries of what would be the new merged sub-block
         // 'in' will be its initial position.
         // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        rocblas_int sz = szs[sid * bdm];
-        rocblas_int in = ps[sid * bdm];
+        rocblas_int sz = msz[sid];
+        rocblas_int in = mps[sid];
 
 
         // 1. Organize data with non-deflated values to prepare secular equation
@@ -1445,7 +1440,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // All threads of the group participating in the merge will work together
         // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
         rocblas_int iam = tidb;
-        bdm = hipBlockDim_x;
+        rocblas_int bdm = hipBlockDim_x;
 
         // define shifted arrays
         S* tmpd = temps + in * n;

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1136,17 +1136,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                                    rocblas_int* splitsA,
                                    const S eps,
                                    const S ssfmin,
-                                   const S ssfmax,
-                                   const rocblas_int groups_per_merge)
+                                   const S ssfmax)
 {
     // threads and groups indices
     // batch instance id
     rocblas_int bid = hipBlockIdx_y;
-    // merge sub-block id
-    rocblas_int sid = hipBlockIdx_x / groups_per_merge;
-    // thread id
-    rocblas_int group_in_subblock = hipBlockIdx_x % groups_per_merge;
-    rocblas_int tidb = hipThreadIdx_x + group_in_subblock * hipBlockDim_x;
 
     // select batch instance to work with
     S* D = DD + bid * strideD;
@@ -1159,6 +1153,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* dds = ptr_dds(n, splits);
     rocblas_int* mps = ptr_mps(n, splits);
     rocblas_int* bps = ptr_bps(n, splits);
+    rocblas_int* em  = ptr_em(n, splits);
     
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z   = ptr_z(n, tmpz);
@@ -1168,9 +1163,12 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // temp values during the merges
     S* temps = vecs + (n * n);
 
-    // Work with merges on level k. A thread-group works with two leaves in the merge tree;
-    // all threads work together to solve the secular equation.
+    int i = hipThreadIdx_x + hipBlockDim_x * hipBlockIdx_x;
+    if(i < n)
     {
+        // merge block id
+        rocblas_int sid = em[i];
+
         // Find off-diagonal element of the merge
         // rank-1 modification component p correspond to the last element in the first sub-block
         rocblas_int p2 = bps[sid * 2 + 1];
@@ -1182,17 +1180,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         rocblas_int sz = msz[sid];
         rocblas_int p1 = mps[sid];
 
-        // 1. Organize data with non-deflated values to prepare secular equation
-        // -----------------------------------------------------------------
-        // All threads of the group participating p1 the merge will work together
-        // to solve the correspondinbg secular eqn.
-        rocblas_int bdm = hipBlockDim_x * groups_per_merge;
-
         // define shifted arrays
         S* tmpd = temps + p1 * n;
-        S* ev = evs + p1;
-        S* diag = D + p1;
-        rocblas_int* mask = idd + p1;
         S* zz = z + p1;
 
         // find degree of secular equation
@@ -1205,45 +1194,43 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         /* ----------------------------------------------------------------- */
         // each thread will find a different zero in parallel
         S a, b;
-        for(int j = tidb; j < sz; j += bdm)
+        int j = i - p1;
+        if(idd[i] == 1)
         {
-            if(mask[j] == 1)
+            // find position in the ordered array
+            S valf = p < 0 ? -evs[i] : evs[i];
+            int count = dd, cc = 0;
+            while(count > 0)
             {
-                // find position in the ordered array
-                S valf = p < 0 ? -ev[j] : ev[j];
-                int count = dd, cc = 0;
-                while(count > 0)
+                auto step = count / 2;
+                auto it = cc + step;
+                if(tmpd[it + j * n] < valf)
                 {
-                    auto step = count / 2;
-                    auto it = cc + step;
-                    if(tmpd[it + j * n] < valf)
-                    {
-                        cc = ++it;
-                        count -= step + 1;
-                    }
-                    else
-                        count = step;
+                    cc = ++it;
+                    count -= step + 1;
                 }
+                else
+                    count = step;
+            }
 
-                // computed zero will overwrite 'ev' at the corresponding position.
-                // 'tmpd' will be updated with the distances D - lambda_i.
-                // deflated values are not changed.
-                rocblas_int linfo;
+            // computed zero will overwrite 'ev' at the corresponding position.
+            // 'tmpd' will be updated with the distances D - lambda_i.
+            // deflated values are not changed.
+            rocblas_int linfo;
 
 #if defined(ROCSOLVER_USE_REFERENCE_SECULAR_EQUATIONS_SOLVER)
-                linfo = slaed4(dd, cc, tmpd + j * n, zz, std::abs(p), ev[j]);
+            linfo = slaed4(dd, cc, tmpd + j * n, zz, std::abs(p), evs[i]);
 #else
-                if(cc == dd - 1)
-                    linfo = seq_solve_ext(dd, tmpd + j * n, zz, (p < 0 ? -p : p), ev + j, eps,
-                                          ssfmin, ssfmax);
-                else
-                    linfo = seq_solve(dd, tmpd + j * n, zz, (p < 0 ? -p : p), cc, ev + j, eps,
-                                      ssfmin, ssfmax);
+            if(cc == dd - 1)
+                linfo = seq_solve_ext(dd, tmpd + j * n, zz, (p < 0 ? -p : p), evs + i, eps,
+                                        ssfmin, ssfmax);
+            else
+                linfo = seq_solve(dd, tmpd + j * n, zz, (p < 0 ? -p : p), cc, evs + i, eps,
+                                    ssfmin, ssfmax);
 #endif
 
-                if(p < 0)
-                    ev[j] *= -1;
-            }
+            if(p < 0)
+                evs[i] *= -1;
         }
     }
 }
@@ -2158,13 +2145,12 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
                                     ssfmin, ssfmax);
 
-            rocblas_int max_n_per_merge  = (n + n_merges - 1) / n_merges;
-            rocblas_int groups_per_merge = (max_n_per_merge + STEDC_BDIM - 1) / STEDC_BDIM;
+            rocblas_int numgrps_solve = (n - 1) / STEDC_BDIM + 1;
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Solve_kernel<S>),
-                                    dim3(n_merges * groups_per_merge, batch_count),
+                                    dim3(numgrps_solve, batch_count),
                                     dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
                                     strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
-                                    ssfmin, ssfmax, groups_per_merge);
+                                    ssfmin, ssfmax);
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Rescale_kernel<S>),
                                     dim3(n_merges, batch_count),
                                     dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -180,15 +180,13 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_divide_kernel(const ro
 
         // find sizes of sub-blocks
         msz[0] = n;
-        rocblas_int t, t2;
         for(int i = 0; i < levs; ++i)
         {
             for(int j = (1 << i); j > 0; --j)
             {
-                t = msz[j - 1];
-                t2 = t / 2;
-                msz[j * 2 - 1] = (2 * t2 < t) ? t2 + 1 : t2;
-                msz[j * 2 - 2] = t2;
+                rocblas_int t = msz[j - 1];
+                msz[j * 2 - 1] = t / 2 + (t & 1);
+                msz[j * 2 - 2] = t / 2;
             }
         }
 
@@ -1764,10 +1762,9 @@ void rocsolver_stedc_getMemorySize(const rocblas_evect evect,
         else
             *size_tempvect = 0;
         *size_tempgemm = sizeof(S) * get_tempgemm_size(n) * batch_count;
-        if(BATCHED && !COMPLEX)
-            *size_workArr = sizeof(S*) * batch_count;
-        else
-            *size_workArr = 0;
+        // blocks for batched GEMM are at least 8 x 8
+        auto max_n_merges = 1 << (stedc_num_levels(n) - 1);
+        *size_workArr = sizeof(S*) * std::max(max_n_merges * 3, batch_count);
 
         // size for split blocks and sub-blocks positions
         *size_splits_map = sizeof(rocblas_int) * get_splits_size(n) * batch_count;
@@ -1913,6 +1910,11 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
     static int global_cnt = 0;
     global_cnt++;
     char* env_levs = std::getenv("LEVS");
+    char* env_gemm = std::getenv("OLD_GEMM");
+    bool old_gemm = false;
+    if (env_gemm) {
+        old_gemm = env_gemm[0] == '1';
+    }
 #endif
 
     // quick return
@@ -2112,10 +2114,68 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                 // TODO: using macro STEDC_EXTERNAL_GEMM = true for now. In the future we can pass
                 // STEDC_EXTERNAL_GEMM at run time to switch between internal vector updates and
                 // external gemm based updates.
-                rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, n, n, n,
-                               &one, V, 0, ldv, strideV,
-                               ptr_etmpd(n, tempgemm), 0, n, get_tempgemm_size(n), &zero,
-                               ptr_vecs(n, tempgemm),  0, n, get_tempgemm_size(n), batch_count, workArr);
+                if(old_gemm || n <= 1024 || batch_count > 1)
+                {
+                    rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, n, n, n,
+                                   &one, V, 0, ldv, strideV,
+                                   ptr_etmpd(n, tempgemm), 0, n, get_tempgemm_size(n), &zero,
+                                   ptr_vecs(n, tempgemm),  0, n, get_tempgemm_size(n), batch_count, workArr);
+                }
+                else {
+                    HIP_CHECK(hipMemsetAsync((void*)tempgemm, 0, n * n * sizeof(S), stream));
+
+                    if(n % n_merges == 0)
+                    {
+                        int sz = n / n_merges;
+                        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none,
+                                       sz, sz, sz, &one,
+                                       V,                      0, ldv, sz * ldv + sz,
+                                       ptr_etmpd(n, tempgemm), 0,   n, sz * n + sz, &zero,
+                                       ptr_vecs(n, tempgemm),  0,   n, sz * n + sz, n_merges,
+                                       workArr);
+                    }
+                    else
+                    {
+                        rocblas_int lvl = levs - k - 1;
+                        std::vector<rocblas_int> ns(n_merges);
+                        ns[0] = n;
+                        for(int i = 0; i < lvl; ++i)
+                        {
+                            for(int j = (1 << i); j > 0; --j)
+                            {
+                                auto t = ns[j - 1];
+                                ns[j * 2 - 1] = t / 2 + (t & 1);
+                                ns[j * 2 - 2] = t / 2;
+                            }
+                        }
+                        // there can only be 2 block sizes: ns[0] and ns[0]+1
+                        std::array<std::vector<rocblas_int>, 2> uniform_batch;
+                        uniform_batch[0].reserve(n_merges);
+                        uniform_batch[1].reserve(n_merges);
+                        for(rocblas_int i = 0, ps = 0; i < n_merges; ps += ns[i++])
+                            uniform_batch[ns[i] != ns[0]].push_back(ps);
+                        for(rocblas_int i = 0, nsb = ns[0]; i < 2; ++i, ++nsb)
+                        {
+                            auto& b = uniform_batch[i];
+                            auto nbb = b.size();
+                            std::vector<S*> hABC(nbb * 3);
+                            for(size_t j = 0; j < nbb; ++j)
+                            {
+                                auto ps = b[j];
+                                hABC[j + 0 * nbb] = ps + ps * ldv + V;
+                                hABC[j + 1 * nbb] = ps + ps * n + ptr_etmpd(n, tempgemm);
+                                hABC[j + 2 * nbb] = ps + ps * n + ptr_vecs(n, tempgemm);
+                            }
+                            HIP_CHECK(hipMemcpy(workArr, hABC.data(), 3 * nbb * sizeof(S*),
+                                                hipMemcpyHostToDevice));
+                            rocsolver_gemm<S, rocblas_int, S* const*, S* const*, S* const*>(
+                                handle, rocblas_operation_none, rocblas_operation_none, nsb, nsb,
+                                nsb, &one, workArr, 0, ldv, 0, workArr + nbb, 0, n, 0, &zero,
+                                workArr + 2 * nbb, 0, n, 0, nbb, nullptr);
+                        }
+                    }
+                }
+
             }
 
             // d. update level

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -379,8 +379,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* ns   = ptr_ns(n, splits);
-    rocblas_int* ps   = ptr_ps(n, splits);
     rocblas_int* idd = ptr_idd(n, splits);
     rocblas_int* mps = ptr_mps(n, splits);
     rocblas_int* msz = ptr_msz(n, splits);
@@ -943,8 +941,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int bid = hipBlockIdx_y;
     // merge sub-block id
     rocblas_int sid = hipBlockIdx_x;
-    // thread id
-    rocblas_int tidb = hipThreadIdx_x;
 
     // select batch instance to work with
     S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
@@ -958,18 +954,14 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* msz  = ptr_msz(n, splits);
     rocblas_int* dds  = ptr_dds(n, splits);
     rocblas_int* mps = ptr_mps(n, splits);
-    rocblas_int* bsz = ptr_bsz(n, splits);
     rocblas_int* bps = ptr_bps(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z     = ptr_z(n, tmpz);
-    S* tolsD = ptr_tolsD(n, tmpz);
     // updated eigenvectors after merges
     S* vecs = vecsA + bid * 2 * (n * n);
     // temp values during the merges
     S* temps = vecs + (n * n);
-
-    rocblas_int bdm = 1 << (k + 1);
 
     // Work with merges on level k. A thread-group works with two leaves in the merge tree.
     {
@@ -982,19 +974,19 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // 3. deflate eigenvalues
         // ----------------------------------------------------------------
         // determine boundaries of what would be the new merged sub-block
-        // 'in' will be its initial position.
+        // 'p1' will be its initial position.
         // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
         rocblas_int sz = msz[sid];
-        rocblas_int in = mps[sid];
+        rocblas_int p1 = mps[sid];
 
         // 4. Organize data with non-deflated values to prepare secular equation
         // ------------------------------------------------------------------------ 
         // define shifted arrays
-        S* tmpd = temps + in * n;
-        S* diag = D + in;
-        rocblas_int* mask = idd + in;
-        S* zz = z + in;
-        rocblas_int* per = pers + in;
+        S* tmpd = temps + p1 * n;
+        S* diag = D + p1;
+        rocblas_int* mask = idd + p1;
+        S* zz = z + p1;
+        rocblas_int* per = pers + p1;
 
         // find degree and components of secular equation
         // tmpd contains the non-deflated diagonal elements (ie. poles of the
@@ -1005,7 +997,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         {
             if(mask[i] == 1)
             {
-                if(tidb == 0)
+                if(hipThreadIdx_x == 0)
                 {
                     per[dd] = i;
                     tmpd[dd] = p < 0 ? -diag[i] : diag[i];
@@ -1015,103 +1007,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 dd++;
             }
         }
-        dds[in] = dd;
-    }
-}
-
-
-template <typename S>
-void __device__ inline solve_seq_eqns(const rocblas_int dd,
-                                      const rocblas_int iam,
-                                      const rocblas_int bdm,
-                                      const rocblas_int sz,
-                                      const rocblas_int n,
-                                      const S p,
-                                      const S eps,
-                                      const S ssfmin,
-                                      const S ssfmax,
-                                      const rocblas_int* mask,
-                                            S* tmpd,
-                                            S* ev,
-                                            S* zz)
-{
-    /* ----------------------------------------------------------------- */
-
-    // 2. Solve secular eqns, i.e. find the dd zeros
-    // corresponding to non-deflated new eigenvalues of the merged block
-    /* ----------------------------------------------------------------- */
-    // each thread will find a different zero in parallel
-    S a, b;
-    for(int j = iam; j < sz; j += bdm)
-    {
-        if(mask[j] == 1)
-        {
-            // find position in the ordered array
-            S valf = p < 0 ? -ev[j] : ev[j];
-            int count = dd, cc = 0;
-            while(count > 0)
-            {
-                auto step = count / 2;
-                auto it = cc + step;
-                if(tmpd[it + j * n] < valf)
-                {
-                    cc = ++it;
-                    count -= step + 1;
-                }
-                else
-                    count = step;
-            }
-
-            // computed zero will overwrite 'ev' at the corresponding position.
-            // 'tmpd' will be updated with the distances D - lambda_i.
-            // deflated values are not changed.
-            rocblas_int linfo;
-
-#if defined(ROCSOLVER_USE_REFERENCE_SECULAR_EQUATIONS_SOLVER)
-            linfo = slaed4(dd, cc, tmpd + j * n, zz, std::abs(p), ev[j]);
-#else
-            if(cc == dd - 1)
-                linfo = seq_solve_ext(dd, tmpd + j * n, zz, (p < 0 ? -p : p), ev + j, eps, ssfmin,
-                                      ssfmax);
-            else
-                linfo = seq_solve(dd, tmpd + j * n, zz, (p < 0 ? -p : p), cc, ev + j, eps, ssfmin,
-                                  ssfmax);
-#endif
-
-            if(p < 0)
-                ev[j] *= -1;
-        }
-    }
-}
-
-
-template <typename S>
-void __device__ inline rescale_z(const rocblas_int dd,
-                                 const rocblas_int iam,
-                                 const rocblas_int bdm,
-                                 const rocblas_int sz,
-                                 const rocblas_int n,
-                                 const rocblas_int* per,
-                                 const rocblas_int* mask,
-                                 const S* tmpd,
-                                 const S* diag,
-                                       S* zz)
-{
-    // Re-scale vector Z to avoid bad numerics when an eigenvalue
-    // is too close to a pole
-    for(int i = iam; i < dd; i += bdm)
-    {
-        S valf = 1;
-        for(int j = 0; j < sz; ++j)
-        {
-            if(mask[j] == 1)
-            {
-                S valg = tmpd[i + j * n];
-                valf *= (per[i] == j) ? valg : valg / (diag[per[i]] - diag[j]);
-            }
-        }
-        valf = sqrt(std::abs(valf));
-        zz[i] = zz[i] < 0 ? -valf : valf;
+        dds[p1] = dd;
     }
 }
 
@@ -1144,9 +1040,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int bid = hipBlockIdx_y;
     // merge sub-block id
     rocblas_int sid = hipBlockIdx_x;
-    // thread id
-    rocblas_int tidb = hipThreadIdx_x;
-    rocblas_int tid;
 
     // select batch instance to work with
     S* D = DD + bid * strideD;
@@ -1168,41 +1061,37 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // temp values during the merges
     S* temps = vecs + (n * n);
 
-    rocblas_int bdm = 1 << (k + 1);
-
     // Work with merges on level k. A thread-group works with two leaves in the merge tree;
     // all threads work together to solve the secular equation.
     {
         // determine boundaries of what would be the new merged sub-block
-        // 'in' will be its initial position.
+        // 'p1' will be its initial position.
         // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
         rocblas_int sz = msz[sid];
-        rocblas_int in = mps[sid];
+        rocblas_int p1 = mps[sid];
 
 
         // 1. Organize data with non-deflated values to prepare secular equation
         // ----------------------------------------------------------------- 
         // All threads of the group participating in the merge will work together
         // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
-        rocblas_int iam = tidb;
-        bdm = hipBlockDim_x;
 
         // define shifted arrays
-        S* tmpd = temps + in * n;
-        S* ev = evs + in;
-        S* diag = D + in;
-        rocblas_int* mask = idd + in;
-        S* zz = z + in;
-        rocblas_int* per = pers + in;
+        S* tmpd = temps + p1 * n;
+        S* ev = evs + p1;
+        S* diag = D + p1;
+        rocblas_int* mask = idd + p1;
+        S* zz = z + p1;
+        rocblas_int* per = pers + p1;
 
         // find degree of secular equation
-        rocblas_int dd = dds[in];
+        rocblas_int dd = dds[p1];
 
         // Order the elements in tmpd and zz using a simple parallel selection/bubble sort.
         // This will allow us to find initial intervals for eigenvalue guesses
         for(int i = 0; i < dd; i++)
         {
-            for(int j = 2 * iam + i % 2; j < dd - 1; j += 2 * bdm)
+            for(int j = 2 * hipThreadIdx_x + i % 2; j < dd - 1; j += 2 * hipBlockDim_x)
             {
                 if(tmpd[j] > tmpd[j + 1])
                 {
@@ -1219,7 +1108,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // eigenvalues (D - lambda_i) are updated while computing each eigenvalue.
         // This will prevent collapses and division by zero when an eigenvalue
         // is too close to a pole.
-        for(int i = iam; i < dd; i += bdm)
+        for(int i = hipThreadIdx_x; i < dd; i += hipBlockDim_x)
         {
             for(int j = i + n; j < i + sz * n; j += n)
                 tmpd[j] = tmpd[i];
@@ -1227,7 +1116,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
         // finally copy over all diagonal elements in ev. ev will be overwritten
         // by the new computed eigenvalues of the merged block
-        for(int i = iam; i < sz; i += bdm)
+        for(int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x)
             ev[i] = diag[i];
     }
 }
@@ -1258,7 +1147,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // thread id
     rocblas_int group_in_subblock = hipBlockIdx_x % groups_per_merge;
     rocblas_int tidb = hipThreadIdx_x + group_in_subblock * hipBlockDim_x;
-    rocblas_int tid;
 
     // select batch instance to work with
     S* D = DD + bid * strideD;
@@ -1266,12 +1154,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* idd  = ptr_idd(n, splits);
-    rocblas_int* pers = ptr_pers(n, splits);
-    rocblas_int* msz  = ptr_msz(n, splits);
-    rocblas_int* dds  = ptr_dds(n, splits);
-    rocblas_int* mps  = ptr_mps(n, splits);
-    rocblas_int* bsz  = ptr_bsz(n, splits);
+    rocblas_int* idd = ptr_idd(n, splits);
+    rocblas_int* msz = ptr_msz(n, splits);
+    rocblas_int* dds = ptr_dds(n, splits);
+    rocblas_int* mps = ptr_mps(n, splits);
     rocblas_int* bps = ptr_bps(n, splits);
     
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
@@ -1291,30 +1177,74 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         S p = 2 * E[p2 - 1];
 
         // determine boundaries of what would be the new merged sub-block
-        // 'in' will be its initial position.
+        // 'p1' will be its initial position.
         // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
         rocblas_int sz = msz[sid];
-        rocblas_int in = mps[sid];
+        rocblas_int p1 = mps[sid];
 
         // 1. Organize data with non-deflated values to prepare secular equation
         // -----------------------------------------------------------------
-        // All threads of the group participating in the merge will work together
-        // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
-        rocblas_int iam = tidb;
+        // All threads of the group participating p1 the merge will work together
+        // to solve the correspondinbg secular eqn.
         rocblas_int bdm = hipBlockDim_x * groups_per_merge;
 
         // define shifted arrays
-        S* tmpd = temps + in * n;
-        S* ev = evs + in;
-        S* diag = D + in;
-        rocblas_int* mask = idd + in;
-        S* zz = z + in;
-        rocblas_int* per = pers + in;
+        S* tmpd = temps + p1 * n;
+        S* ev = evs + p1;
+        S* diag = D + p1;
+        rocblas_int* mask = idd + p1;
+        S* zz = z + p1;
 
         // find degree of secular equation
-        rocblas_int dd = dds[in];
+        rocblas_int dd = dds[p1];
 
-        solve_seq_eqns(dd, iam, bdm, sz, n, p, eps, ssfmin, ssfmax, mask, tmpd, ev, zz);
+        /* ----------------------------------------------------------------- */
+
+        // 2. Solve secular eqns, i.e. find the dd zeros
+        // corresponding to non-deflated new eigenvalues of the merged block
+        /* ----------------------------------------------------------------- */
+        // each thread will find a different zero in parallel
+        S a, b;
+        for(int j = tidb; j < sz; j += bdm)
+        {
+            if(mask[j] == 1)
+            {
+                // find position in the ordered array
+                S valf = p < 0 ? -ev[j] : ev[j];
+                int count = dd, cc = 0;
+                while(count > 0)
+                {
+                    auto step = count / 2;
+                    auto it = cc + step;
+                    if(tmpd[it + j * n] < valf)
+                    {
+                        cc = ++it;
+                        count -= step + 1;
+                    }
+                    else
+                        count = step;
+                }
+
+                // computed zero will overwrite 'ev' at the corresponding position.
+                // 'tmpd' will be updated with the distances D - lambda_i.
+                // deflated values are not changed.
+                rocblas_int linfo;
+
+#if defined(ROCSOLVER_USE_REFERENCE_SECULAR_EQUATIONS_SOLVER)
+                linfo = slaed4(dd, cc, tmpd + j * n, zz, std::abs(p), ev[j]);
+#else
+                if(cc == dd - 1)
+                    linfo = seq_solve_ext(dd, tmpd + j * n, zz, (p < 0 ? -p : p), ev + j, eps,
+                                          ssfmin, ssfmax);
+                else
+                    linfo = seq_solve(dd, tmpd + j * n, zz, (p < 0 ? -p : p), cc, ev + j, eps,
+                                      ssfmin, ssfmax);
+#endif
+
+                if(p < 0)
+                    ev[j] *= -1;
+            }
+        }
     }
 }
 
@@ -1340,9 +1270,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int bid = hipBlockIdx_y;
     // merge sub-block id
     rocblas_int sid = hipBlockIdx_x;
-    // thread id
-    rocblas_int tidb = hipThreadIdx_x;
-    rocblas_int tid;
 
     // select batch instance to work with
     S* D = DD + bid * strideD;
@@ -1368,31 +1295,44 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // all threads work together to solve the secular equation.
     {
         // determine boundaries of what would be the new merged sub-block
-        // 'in' will be its initial position.
+        // 'p1' will be its initial position.
         // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
         rocblas_int sz = msz[sid];
-        rocblas_int in = mps[sid];
+        rocblas_int p1 = mps[sid];
 
 
         // 1. Organize data with non-deflated values to prepare secular equation
         // ----------------------------------------------------------------- 
         // All threads of the group participating in the merge will work together
-        // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
-        rocblas_int iam = tidb;
-        rocblas_int bdm = hipBlockDim_x;
+        // to solve the correspondinbg secular eqn.
 
         // define shifted arrays
-        S* tmpd = temps + in * n;
-        S* ev = evs + in;
-        S* diag = D + in;
-        rocblas_int* mask = idd + in;
-        S* zz = z + in;
-        rocblas_int* per = pers + in;
+        S* tmpd = temps + p1 * n;
+        S* ev = evs + p1;
+        S* diag = D + p1;
+        rocblas_int* mask = idd + p1;
+        S* zz = z + p1;
+        rocblas_int* per = pers + p1;
 
         // find degree of secular equation
-        rocblas_int dd = dds[in];
+        rocblas_int dd = dds[p1];
 
-        rescale_z(dd, iam, bdm, sz, n, per, mask, tmpd, diag, zz);
+        // Re-scale vector Z to avoid bad numerics when an eigenvalue
+        // is too close to a pole
+        for(int i = hipThreadIdx_x; i < dd; i += hipBlockDim_x)
+        {
+            S valf = 1;
+            for(int j = 0; j < sz; ++j)
+            {
+                if(mask[j] == 1)
+                {
+                    S valg = tmpd[i + j * n];
+                    valf *= (per[i] == j) ? valg : valg / (diag[per[i]] - diag[j]);
+                }
+            }
+            valf = sqrt(std::abs(valf));
+            zz[i] = zz[i] < 0 ? -valf : valf;
+        }
     }
 }
 

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -508,8 +508,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // threads and groups indices
     // batch instance id
     rocblas_int bid = hipBlockIdx_y;
-    // merge sub-block id
-    rocblas_int sid = hipBlockIdx_x;
+    // group id
+    rocblas_int gid = hipBlockIdx_x;
 
     // select batch instance to work with
     S* D = DD + bid * strideD;
@@ -526,10 +526,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* md    = ptr_md(n, tmpz);
 
 
-    S d = D[sid];
-    rocblas_int sz = esz[sid];
-    rocblas_int p1 = eps[sid];
-    rocblas_int def = idd[sid];
+    S d = D[gid];
+    rocblas_int sz = esz[gid];
+    rocblas_int p1 = eps[gid];
+    rocblas_int def = idd[gid];
 
     constexpr int regs = 8;
     const int chunk_width = regs * hipBlockDim_x;
@@ -565,7 +565,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 // so we order any deflated value > any non-deflated value
                 // def == 0 - current is deflated, def[i] == 1 - other value is not deflated
                 lt += (def < iddval[i]) || (def == iddval[i] && bval[i] < d);
-                eq += (def == iddval[i]) && (bval[i] == d && (p1 + x) < sid);
+                eq += (def == iddval[i]) && (bval[i] == d && (p1 + x) < gid);
             }
         }
     }
@@ -587,7 +587,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     }
 
     if (hipThreadIdx_x == 0) {
-        map [pos+p1] = sid;
+        map [pos+p1] = gid;
         md  [pos+p1] = d;
         sidd[pos+p1] = def;
     }
@@ -598,7 +598,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // Make sure we propagate NAN. It is likely to have more NANs in the output
     // than in the input, but the following computations are doomed anyway.
     if (nan) {
-        md[sid] = NAN;
+        md[gid] = NAN;
     }
 }
 
@@ -1138,8 +1138,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // threads and groups indices
     // batch instance id
     rocblas_int bid = hipBlockIdx_y;
-    // merge sub-block id
-    rocblas_int sid = hipBlockIdx_x;
+    // group id
+    rocblas_int gid = hipBlockIdx_x;
 
     // select batch instance to work with
     S* D = DD + bid * strideD;
@@ -1158,11 +1158,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* cz    = ptr_cz(n, tmpz);
 
 
-    S d_ = D[sid];
-    S z_ = z[sid];
-    rocblas_int sz = esz[sid];
-    rocblas_int p1 = eps[sid];
-    rocblas_int def = idd[sid];
+    S d_ = D[gid];
+    S z_ = z[gid];
+    rocblas_int sz = esz[gid];
+    rocblas_int p1 = eps[gid];
+    rocblas_int def = idd[gid];
 
     constexpr int regs = 8;
     const int chunk_width = regs * hipBlockDim_x;
@@ -1198,7 +1198,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 // so we order any deflated value > any non-deflated value
                 // def == 0 - current is deflated, def[i] == 1 - other value is not deflated
                 lt += (def < iddval[i]) || (def == iddval[i] && bval[i] < d_);
-                eq += (def == iddval[i]) && (bval[i] == d_ && (p1 + x) < sid);
+                eq += (def == iddval[i]) && (bval[i] == d_ && (p1 + x) < gid);
             }
         }
     }
@@ -1220,7 +1220,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     }
 
     if (hipThreadIdx_x == 0) {
-        map [pos+p1] = sid - p1;
+        map [pos+p1] = gid - p1;
         cd  [pos+p1] = d_;
         cz  [pos+p1] = z_;
         sidd[pos+p1] = def;
@@ -1232,7 +1232,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // Make sure we propagate NAN. It is likely to have more NANs in the output
     // than in the input, but the following computations are doomed anyway.
     if (nan) {
-        cd[sid] = NAN;
+        cd[gid] = NAN;
     }
 }
 

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -84,7 +84,7 @@ __host__ __device__ inline rocblas_int get_splits_size(const rocblas_int n)
     // 18    rocblas_int bps[2*m], _[n-2*m];  // starting position of each block
     // 19    rocblas_int dbg4[n];             //
     // };
-    return 20 * n;
+    return 20 * n + 64*64;
 }
 
 template <typename S> __host__ __device__ inline S* ptr_ns    (rocblas_int n, S* splits) { return splits +  1 * n; }
@@ -105,7 +105,27 @@ template <typename S> __host__ __device__ inline S* ptr_msz   (rocblas_int n, S*
 template <typename S> __host__ __device__ inline S* ptr_mps   (rocblas_int n, S* splits) { return splits + 16 * n; }
 template <typename S> __host__ __device__ inline S* ptr_bsz   (rocblas_int n, S* splits) { return splits + 17 * n; }
 template <typename S> __host__ __device__ inline S* ptr_bps   (rocblas_int n, S* splits) { return splits + 18 * n; }
-template <typename S> __host__ __device__ inline S* ptr_dbg   (rocblas_int n, S* splits) { return splits + 19 * n; }
+template <typename S> __host__ __device__ inline S* ptr_dbg   (rocblas_int n, S* splits) { return splits + 19 * n + 64 * 0; }
+template <typename S> __host__ __device__ inline S* ptr_dbg1  (rocblas_int n, S* splits) { return splits + 19 * n + 64 * 1; }
+template <typename S> __host__ __device__ inline S* ptr_dbg2  (rocblas_int n, S* splits) { return splits + 19 * n + 64 * 2; }
+template <typename S> __host__ __device__ inline S* ptr_dbg3  (rocblas_int n, S* splits) { return splits + 19 * n + 64 * 3; }
+template <typename S> __host__ __device__ inline S* ptr_dbg4  (rocblas_int n, S* splits) { return splits + 19 * n + 64 * 4; }
+template <typename S> __host__ __device__ inline S* ptr_dbg5  (rocblas_int n, S* splits) { return splits + 19 * n + 64 * 5; }
+template <typename S> __host__ __device__ inline S* ptr_dbg6  (rocblas_int n, S* splits) { return splits + 19 * n + 64 * 6; }
+template <typename S> __host__ __device__ inline S* ptr_dbg7  (rocblas_int n, S* splits) { return splits + 19 * n + 64 * 7; }
+template <typename S> __host__ __device__ inline S* ptr_dbg8  (rocblas_int n, S* splits) { return splits + 19 * n + 64 * 8; }
+template <typename S> __host__ __device__ inline S* ptr_dbg9  (rocblas_int n, S* splits) { return splits + 19 * n + 64 * 9; }
+template <typename S> __host__ __device__ inline S* ptr_dbg10 (rocblas_int n, S* splits) { return splits + 19 * n + 64 *10; }
+template <typename S> __host__ __device__ inline S* ptr_dbg11 (rocblas_int n, S* splits) { return splits + 19 * n + 64 *11; }
+template <typename S> __host__ __device__ inline S* ptr_dbg12 (rocblas_int n, S* splits) { return splits + 19 * n + 64 *12; }
+template <typename S> __host__ __device__ inline S* ptr_dbg13 (rocblas_int n, S* splits) { return splits + 19 * n + 64 *13; }
+template <typename S> __host__ __device__ inline S* ptr_dbg14 (rocblas_int n, S* splits) { return splits + 19 * n + 64 *14; }
+template <typename S> __host__ __device__ inline S* ptr_dbg15 (rocblas_int n, S* splits) { return splits + 19 * n + 64 *15; }
+template <typename S> __host__ __device__ inline S* ptr_dbg16 (rocblas_int n, S* splits) { return splits + 19 * n + 64 *16; }
+template <typename S> __host__ __device__ inline S* ptr_dbg17 (rocblas_int n, S* splits) { return splits + 19 * n + 64 *17; }
+template <typename S> __host__ __device__ inline S* ptr_dbg18 (rocblas_int n, S* splits) { return splits + 19 * n + 64 *18; }
+template <typename S> __host__ __device__ inline S* ptr_dbg19 (rocblas_int n, S* splits) { return splits + 19 * n + 64 *19; }
+template <typename S> __host__ __device__ inline S* ptr_dbg20 (rocblas_int n, S* splits) { return splits + 19 * n + 64 *20; }
 
 __host__ __device__ inline rocblas_int get_tmpz_size(const rocblas_int n)
 {
@@ -1401,7 +1421,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // thread id
     rocblas_int tidb = hipThreadIdx_x;
     rocblas_int dim = hipBlockDim_x;
-    rocblas_int tid, vidb;
 
     // select batch instance to work with
     S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
@@ -1412,10 +1431,35 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* ns   = ptr_ns(n, splits);
     rocblas_int* ps   = ptr_ps(n, splits);
     rocblas_int* idd  = ptr_idd(n, splits);
+    rocblas_int* msz  = ptr_msz(n, splits);
+    rocblas_int* mps  = ptr_mps(n, splits);
+    rocblas_int* dds  = ptr_dds(n, splits);
     rocblas_int* pers = ptr_map(n, splits);
 
+    rocblas_int* dbg  = ptr_dbg(n, splits);
+    rocblas_int* dbg1  = ptr_dbg1(n, splits);
+    rocblas_int* dbg2  = ptr_dbg2(n, splits);
+    rocblas_int* dbg3  = ptr_dbg3(n, splits);
+    rocblas_int* dbg4  = ptr_dbg4(n, splits);
+    rocblas_int* dbg5  = ptr_dbg5(n, splits);
+    rocblas_int* dbg6  = ptr_dbg6(n, splits);
+    rocblas_int* dbg7  = ptr_dbg7(n, splits);
+    rocblas_int* dbg8  = ptr_dbg8(n, splits);
+    rocblas_int* dbg9  = ptr_dbg9(n, splits);
+    rocblas_int* dbg10 = ptr_dbg10(n, splits);
+    rocblas_int* dbg11 = ptr_dbg11(n, splits);
+    rocblas_int* dbg12 = ptr_dbg12(n, splits);
+    rocblas_int* dbg13 = ptr_dbg13(n, splits);
+    rocblas_int* dbg14 = ptr_dbg14(n, splits);
+    rocblas_int* dbg15 = ptr_dbg15(n, splits);
+    rocblas_int* dbg16 = ptr_dbg16(n, splits);
+    rocblas_int* dbg17 = ptr_dbg17(n, splits);
+    rocblas_int* dbg18 = ptr_dbg18(n, splits);
+    rocblas_int* dbg19 = ptr_dbg19(n, splits);
+    rocblas_int* dbg20 = ptr_dbg20(n, splits);
+
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
-    S* z   = ptr_cz(n, tmpz);
+    S* z    = ptr_cz(n, tmpz);
     // updated eigenvectors after merges
     S* vecs = vecsA + bid * 2 * (n * n);
     // temp values during the merges
@@ -1423,71 +1467,54 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in shared memory
     // used to store temp values during the different reductions
-    extern __shared__ rocblas_int lsmem[];
-    S* inrms = reinterpret_cast<S*>(lsmem);
+    __shared__ S inrms[STEDC_BDIM];
 
     // tn is max number of vectors in each sub-block
     rocblas_int bdm = 1 << (k + 1);
     rocblas_int tn = (n - 1) / blks + 1;
 
     // Work with merges on level k. Each thread-group works with one vector.
-    if(sid < tn * blks)
+    //if(sid < tn * blks)
     {
-        rocblas_int iam, sz, p2;
-        S valf, valg;
-
         // tid indexes the sub-blocks in the entire split block
-        tid = sid / tn;
-        p2 = ps[tid];
+        rocblas_int tid = sid / tn;
+        rocblas_int p2 = ps[tid];
         // vidb indexes the vectors associated with each sub-block
-        vidb = sid % tn;
-        // iam indexes the sub-blocks in the context of the merge
-        // (according to its level in the merge tree)
-        iam = tid % bdm;
+        rocblas_int vidb = sid % tn;
+
+        rocblas_int merge_id = tid / bdm;
+        rocblas_int eid = vidb + p2;
 
         // determine boundaries of what would be the new merged sub-block
-        // 'in' will be its initial position
-        rocblas_int in = ps[tid - iam];
-        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        sz = ns[tid];
-        for(int i = iam; i > 0; --i)
-            sz += ns[tid - i];
-        for(int i = bdm - 1 - iam; i > 0; --i)
-            sz += ns[tid + i];
+        rocblas_int p1 = mps[merge_id];
+        rocblas_int sz = msz[merge_id];
+        rocblas_int dd = dds[merge_id];
 
         // define shifted arrays
-        S* diag = D + in;
-        rocblas_int* mask = idd + in;
-        S* zz = z + in;
-        rocblas_int* per = pers + in;
+        S* diag = D + p1;
+        rocblas_int* mask = idd + p1;
+        S* zz = z + p1;
+        rocblas_int* per = pers + p1;
 
-        // find degree of secular equation
-        rocblas_int dd = 0;
-        for(int i = 0; i < sz; ++i)
-        {
-            if(mask[i] == 1)
-                dd++;
-        }
         __syncthreads();
 
 
         // Prepare vectors corresponding to non-deflated values
         S temp, nrm;
-        rocblas_int j = vidb;
-        bool go = (j < ns[tid]);
+        bool go = (vidb < ns[tid]);
         S* putvec = USEGEMM ? vecs : temps;
 
         if(go)
         {
-            if(idd[p2 + j] == 1)
+            if(idd[eid] == 1)
             {
                 // compute vectors of rank-1 perturbed system and their norms
                 nrm = 0;
                 for(int i = tidb; i < dd; i += dim)
                 {
-                    valf = zz[i] / temps[i + (p2 + j) * n];
+                    S valf = zz[i] / temps[i + eid*n];
                     nrm += valf * valf;
-                    putvec[i + (p2 + j) * n] = valf;
+                    putvec[i + eid*n] = valf;
                 }
                 inrms[tidb] = nrm;
                 __syncthreads();
@@ -1510,21 +1537,21 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 // when using external gemms for the update, we need to
                 // put vectors in padded matrix 'temps'
                 // (this is to compute 'vecs = C * temps' using external gemm call)
-                for(int i = tidb; i < in + sz; i += dim)
+                for(int i = tidb; i < p1 + sz; i += dim)
                 {
-                    if(i >= in && idd[p2 + j] == 1 && idd[i] == 1)
+                    if(i >= p1 && idd[eid] == 1 && idd[i] == 1)
                     {
                         dd = 0;
-                        for(int k = in; k < i; ++k)
+                        for(int k = p1; k < i; ++k)
                         {
                             if(idd[k] == 0)
                                 dd++;
                         }
-                        temps[pers[i - dd] + in + (p2 + j) * n]
-                            = vecs[i - dd - in + (p2 + j) * n] / nrm;
+                        temps[pers[i - dd] + p1 + eid * n]
+                            = vecs[i - dd - p1 + eid * n] / nrm;
                     }
                     else
-                        temps[i + (p2 + j) * n] = 0;
+                        temps[i + eid * n] = 0;
                 }
             }
             else
@@ -1533,18 +1560,18 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 // multiply by C (row by row)
                 rocblas_int tsz = 1 << (levs - 1 - k);
                 tsz = (n - 1) / tsz + 1;
-                if(idd[p2 + j] == 1)
+                if(idd[eid] == 1)
                 {
                     for(int ii = 0; ii < tsz; ++ii)
                     {
-                        rocblas_int i = in + ii;
+                        rocblas_int i = p1 + ii;
 
                         // inner products
                         temp = 0;
                         if(ii < sz)
                         {
                             for(int kk = tidb; kk < dd; kk += dim)
-                                temp += C[i + (per[kk] + in) * ldc] * temps[kk + (p2 + j) * n];
+                                temp += C[i + (per[kk] + p1) * ldc] * temps[kk + eid * n];
                         }
                         inrms[tidb] = temp;
                         __syncthreads();
@@ -1562,7 +1589,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
                         // result
                         if(ii < sz && tidb == 0)
-                            vecs[i + (p2 + j) * n] = temp / nrm;
+                            vecs[i + eid * n] = temp / nrm;
                         __syncthreads();
                     }
                 }
@@ -2117,8 +2144,6 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
 
         // 3. merge phase
         //----------------
-        size_t lmemsize3 = sizeof(S) * STEDC_BDIM;
-
         // launch merge for level k
         for(rocblas_int k = 0; k < levs; ++k)
         {
@@ -2162,32 +2187,6 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
                                     strideD, tmpz, tempgemm, splits);//*/
 
-#if DEBUG_OUTPUT
-            //hipError_t status = hipStreamSynchronize(stream);
-            if(env_levs && global_cnt == 1)
-            {
-                //std::cout << "\nk=" << k << std::endl;
-                print_device_matrix(std::cout, "msz", 1, n_merges, ptr_msz(n, splits), 1);
-                print_device_matrix(std::cout, "mps", 1, n_merges, ptr_mps(n, splits), 1);
-                print_device_matrix(std::cout, "dds", 1, n_merges, ptr_dds(n, splits), 1);
-                print_device_matrix(std::cout, "em", 1, n, ptr_em(n, splits), 1);
-                print_device_matrix(std::cout, "idd", 1, n, ptr_idd(n, splits), 1);
-                print_device_matrix(std::cout, "sidd", 1, n, ptr_sidd(n, splits), 1);
-                print_device_matrix(std::cout, "map", 1, n, ptr_map(n, splits), 1);
-                print_device_matrix(std::cout, "pers", 1, n, ptr_pers(n, splits), 1);
-                print_device_matrix(std::cout, "D", 1, n, D, 1);
-                print_device_matrix(std::cout, "cd", 1, n, ptr_cd(n, tmpz), 1);
-                print_device_matrix(std::cout, "etmpd", n, n, tempgemm +n*n, n);
-                
-                //print_device_matrix(std::cout, "dbg", 1, n, ptr_dbg(n, splits), 1);
-
-                //print_device_matrix(std::cout, "D", 1, n, D, 1);
-                //print_device_matrix(std::cout, "mtols", 1, n, tempgemm + n * 4, 1);
-                //print_device_matrix(std::cout, "mD", 1, n, tempgemm + n * 5, 1);
-
-                //std::exit(0);
-            }
-#endif
 
             rocblas_int numgrps_solve = (n - 1) / STEDC_BDIM + 1;
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Solve_kernel<S>),
@@ -2201,14 +2200,50 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     levs, blks, k, n, D + shiftD, strideD, E + shiftE, strideE,
                                     tmpz, tempgemm, splits, eps, ssfmin, ssfmax);
 
-            // c. find merged eigenvectors
             rocblas_int numgrps3 = ((n - 1) / blks + 1) * blks;
+            // c. find merged eigenvectors
             ROCSOLVER_LAUNCH_KERNEL(
                 (stedc_mergeVectors_kernel<STEDC_EXTERNAL_GEMM, S>),
-                dim3(numgrps3, batch_count), dim3(STEDC_BDIM), lmemsize3, stream, 
+                dim3(numgrps3, batch_count), dim3(STEDC_BDIM), 0, stream, 
                 levs, blks, k, n, D + shiftD, strideD, E + shiftE, strideE, V, 0, ldv, strideV, 
                 tmpz, tempgemm, splits);
 
+#if DEBUG_OUTPUT
+            //hipError_t status = hipStreamSynchronize(stream);
+            if(env_levs && global_cnt == 1)
+            {
+                std::cout << "\nk=" << k << std::endl;
+                std::cout << "numgrps3=" << numgrps3 << "\tblks=" << blks << std::endl;
+                print_device_matrix(std::cout, "msz", 1, n_merges, ptr_msz(n, splits), 1);
+                print_device_matrix(std::cout, "mps", 1, n_merges, ptr_mps(n, splits), 1);
+                print_device_matrix(std::cout, "esz", 1, n, ptr_esz(n, splits), 1);
+                print_device_matrix(std::cout, "eps", 1, n, ptr_eps(n, splits), 1);
+                //print_device_matrix(std::cout, "dds", 1, n_merges, ptr_dds(n, splits), 1);
+                print_device_matrix(std::cout, "ns", 1, blks, ptr_ns(n, splits), 1);
+                print_device_matrix(std::cout, "ps", 1, blks, ptr_ps(n, splits), 1);
+                print_device_matrix(std::cout, "sid          ", 1, numgrps3, ptr_dbg(n, splits), 1);
+                print_device_matrix(std::cout, "tid", 1, numgrps3, ptr_dbg1(n, splits), 1);
+                print_device_matrix(std::cout, "iam", 1, numgrps3, ptr_dbg2(n, splits), 1);
+                print_device_matrix(std::cout, "tid - iam", 1, numgrps3, ptr_dbg3(n, splits), 1);
+                print_device_matrix(std::cout, "merge_id", 1, numgrps3, ptr_dbg4(n, splits), 1);
+                print_device_matrix(std::cout, "mps[merge_id]", 1, numgrps3, ptr_dbg5(n, splits), 1);
+                print_device_matrix(std::cout, "ps[tid-iam]", 1, numgrps3, ptr_dbg6(n, splits), 1);
+                //print_device_matrix(std::cout, "em", 1, n, ptr_em(n, splits), 1);
+                //print_device_matrix(std::cout, "idd", 1, n, ptr_idd(n, splits), 1);
+                //print_device_matrix(std::cout, "sidd", 1, n, ptr_sidd(n, splits), 1);
+                //print_device_matrix(std::cout, "map", 1, n, ptr_map(n, splits), 1);
+                //print_device_matrix(std::cout, "pers", 1, n, ptr_pers(n, splits), 1);
+                //print_device_matrix(std::cout, "D", 1, n, D, 1);
+                //print_device_matrix(std::cout, "cd", 1, n, ptr_cd(n, tmpz), 1);
+                //print_device_matrix(std::cout, "etmpd", n, n, tempgemm +n*n, n);
+                
+                //print_device_matrix(std::cout, "dbg", 1, n, ptr_dbg(n, splits), 1);
+
+                //print_device_matrix(std::cout, "D", 1, n, D, 1);
+
+                //std::exit(0);
+            }
+#endif
             if(STEDC_EXTERNAL_GEMM)
             {
                 // using external gemms with padded matrices to do the vector update

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -44,8 +44,6 @@
 
 ROCSOLVER_BEGIN_NAMESPACE
 
-#define DEBUG_OUTPUT 1
-
 #define STEDC_BDIM 512 // Number of threads per thread-block used in main stedc kernels
 #define STEDC_SOLVE_BDIM 4 // Number of threads per thread-block used in solver kernel
 
@@ -1787,14 +1785,6 @@ inline rocblas_int stedc_num_levels(const rocblas_int n)
     else
         levels = std::ceil(std::log2(n)) - 4;
 
-#if DEBUG_OUTPUT
-    char* env_levs = std::getenv("LEVS");
-    if(env_levs)
-    {
-        levels = std::atoi(env_levs);
-    }
-#endif
-
     return levels;
 }
 
@@ -1907,91 +1897,6 @@ rocblas_status rocsolver_stedc_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
-#if DEBUG_OUTPUT
-template <typename S, typename I>
-void print_block_map(const char* tag,
-                     bool show_pres,
-                     bool show_cnt,
-                     int n,
-                     int n_merges,
-                     I* bsz,
-                     I* bps,
-                     S* matr)
-{
-    int n_blocks = n_merges * 2;
-    std::vector<I> sz(n_blocks);
-    std::vector<I> ps(n_blocks);
-    std::vector<S> m(n * n);
-    std::vector<I> cnt(n_blocks * n_blocks);
-
-    THROW_IF_HIP_ERROR(hipMemcpy(sz.data(), bsz, sizeof(I) * sz.size(), hipMemcpyDeviceToHost));
-    THROW_IF_HIP_ERROR(hipMemcpy(ps.data(), bps, sizeof(I) * ps.size(), hipMemcpyDeviceToHost));
-    THROW_IF_HIP_ERROR(hipMemcpy(m.data(), matr, sizeof(S) * m.size(), hipMemcpyDeviceToHost));
-
-    int s = 0;
-    for(int i = 0; i < n_blocks; i++)
-    {
-        s += sz[i];
-    }
-    if(s != n)
-    {
-        std::cout << "ERROR: n(" << n << ") != s(" << s << ")\n";
-        std::exit(0);
-    }
-
-    bool is_blk_diag = true;
-    for(int jb = 0; jb < n_blocks; jb++)
-    {
-        for(int jp = 0; jp < sz[jb]; jp++)
-        {
-            for(int ib = 0; ib < n_blocks; ib++)
-            {
-                for(int ip = 0; ip < sz[ib]; ip++)
-                {
-                    {
-                        int j = ps[jb] + jp;
-                        int i = ps[ib] + ip;
-                        bool non_zero = m[j * n + i] != 0;
-                        cnt[jb * n_blocks + ib] += non_zero;
-                        if((jb / 2 != ib / 2) && non_zero)
-                            is_blk_diag = false;
-                    }
-                }
-            }
-        }
-    }
-
-    std::cout << (is_blk_diag ? "block diag matrix (" : "matrix has off-blockdiag non-zeros (")
-              << tag << ")\n";
-
-    if(show_pres)
-    {
-        std::cout << tag << " present map " << n_blocks << "x" << n_blocks << ":\n";
-        for(int j = 0; j < n_blocks; j++)
-        {
-            for(int i = 0; i < n_blocks; i++)
-            {
-                std::cout << (cnt[j * n_blocks + i] ? " X" : " .");
-            }
-            std::cout << "\n";
-        }
-    }
-
-    if(show_cnt)
-    {
-        std::cout << tag << " cnt map " << n_blocks << "x" << n_blocks << ":\n";
-        for(int j = 0; j < n_blocks; j++)
-        {
-            for(int i = 0; i < n_blocks; i++)
-            {
-                std::cout << "\t" << cnt[j * n_blocks + i];
-            }
-            std::cout << "\n";
-        }
-    }
-}
-#endif
-
 //--------------------------------------------------------------------------------------//
 /** STEDC templated function **/
 template <bool BATCHED, bool STRIDED, typename T, typename S, typename U>
@@ -2019,18 +1924,6 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
 {
     ROCSOLVER_ENTER("stedc", "evect:", evect, "n:", n, "shiftD:", shiftD, "shiftE:", shiftE,
                     "shiftC:", shiftC, "ldc:", ldc, "bc:", batch_count);
-
-#if DEBUG_OUTPUT
-    static int global_cnt = 0;
-    global_cnt++;
-    char* env_levs = std::getenv("LEVS");
-    char* env_gemm = std::getenv("OLD_GEMM");
-    bool old_gemm = false;
-    if(env_gemm)
-    {
-        old_gemm = env_gemm[0] == '1';
-    }
-#endif
 
     // quick return
     if(batch_count == 0)
@@ -2193,7 +2086,7 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                 // TODO: using macro STEDC_EXTERNAL_GEMM = true for now. In the future we can pass
                 // STEDC_EXTERNAL_GEMM at run time to switch between internal vector updates and
                 // external gemm based updates.
-                if(old_gemm || n <= 1024 || batch_count > 1)
+                if(n <= 1024 || batch_count > 1)
                 {
                     rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, n, n, n,
                                    &one, V, 0, ldv, strideV, ptr_etmpd(n, tempgemm), 0, n,
@@ -2244,8 +2137,8 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                 hABC[j + 1 * nbb] = ps + ps * n + ptr_etmpd(n, tempgemm);
                                 hABC[j + 2 * nbb] = ps + ps * n + ptr_vecs(n, tempgemm);
                             }
-                            HIP_CHECK(hipMemcpy(workArr, hABC.data(), 3 * nbb * sizeof(S*),
-                                                hipMemcpyHostToDevice));
+                            HIP_CHECK(hipMemcpyAsync(workArr, hABC.data(), 3 * nbb * sizeof(S*),
+                                                     hipMemcpyHostToDevice, stream));
                             rocsolver_gemm<S, rocblas_int, S* const*, S* const*, S* const*>(
                                 handle, rocblas_operation_none, rocblas_operation_none, nsb, nsb,
                                 nsb, &one, workArr, 0, ldv, 0, workArr + nbb, 0, n, 0, &zero,

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -281,11 +281,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_init_splits(const rocb
     for(int i = hipThreadIdx_x; i < n_blocks; i+=hipBlockDim_x)
     {
         rocblas_int sz = ns[i];
-        rocblas_int p = ps[i];
+        rocblas_int p1 = ps[i];
         msz[i] = sz;
-        mps[i] = p;
+        mps[i] = p1;
         for (int j = 0; j < sz; j++) {
-            em[p + j] = i;
+            em[p1 + j] = i;
         }
     }
 }
@@ -326,9 +326,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_update_splits(const ro
     {
         rocblas_int sz1 = bsz[i * 2 + 0];
         rocblas_int sz2 = bsz[i * 2 + 1];
-        rocblas_int p   = bps[i * 2];
+        rocblas_int p1  = bps[i * 2];
         msz[i] = sz1 + sz2;
-        mps[i] = p;
+        mps[i] = p1;
     }
     __syncthreads();
 
@@ -522,7 +522,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     S d = D[sid];
     rocblas_int sz = esz[sid];
-    rocblas_int p  = eps[sid];
+    rocblas_int p1 = eps[sid];
     rocblas_int def = idd[sid];
 
     constexpr int regs = 8;
@@ -543,8 +543,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < sz)
             {
-                bval[i] = D[p + x];
-                iddval[i]  = idd[p + x];
+                bval[i] = D[p1 + x];
+                iddval[i]  = idd[p1 + x];
             }
         }
         for(int i = 0; i < regs; i++)
@@ -559,7 +559,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 // so we order any deflated value > any non-deflated value
                 // def == 0 - current is deflated, def[i] == 1 - other value is not deflated
                 lt += (def < iddval[i]) || (def == iddval[i] && bval[i] < d);
-                eq += (def == iddval[i]) && (bval[i] == d && (p + x) < sid);
+                eq += (def == iddval[i]) && (bval[i] == d && (p1 + x) < sid);
             }
         }
     }
@@ -581,9 +581,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     }
 
     if (hipThreadIdx_x == 0) {
-        map [pos+p] = sid;
-        md  [pos+p] = d;
-        sidd[pos+p] = def;
+        map [pos+p1] = sid;
+        md  [pos+p1] = d;
+        sidd[pos+p1] = def;
     }
 
     __syncthreads();
@@ -643,19 +643,19 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         S d   = md[i];
         S dn  = md[next];
         S dp  = md[prev];
-        rocblas_int p  = eps[i];
+        rocblas_int p1 = eps[i];
         rocblas_int pn = eps[next];
         rocblas_int pp = eps[prev];
 
         int bcandidate =
             sidd[i] && sidd[next]       // not yet deflated
-            && p == pn                  // in the same merge block
+            && p1 == pn                 // in the same merge block
             && std::abs(d - dn) <= tol  // within tolerance
             && i != (n-1)               // isn't last 
             ;
         int tcandidate =
             sidd[i] && sidd[prev]       // not yet deflated
-            && p == pp                  // in the same merge block
+            && p1 == pp                 // in the same merge block
             && std::abs(d - dp) <= tol  // within tolerance
             && i > 0                    // isn't first
             ;

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -110,30 +110,34 @@ template <typename S> __host__ __device__ inline S* ptr_dbg   (rocblas_int n, S*
 __host__ __device__ inline rocblas_int get_tmpz_size(const rocblas_int n)
 {
     // tmpz layout:
+    // n - number of eigenvalues (matrix size)
+    // m - number of merges on a current level
     // struct {
-    // 0    S z[n];       // the rank-1 modification vectors in the merges
-    // 1    S evs[n];     // roots of secular equations
-    // 2    S cc[n];      // c value of rotation of corresponding deflation
-    // 3    S ss[n];      // s value of rotation of corresponding deflation
-    // 4    S tolsD[n];   // tollerance for deflation of repeaded values in D
-    // 5    S tolsZ[n];   // tollerance for deflation of zero values in z
-    // 6    S md[n];      // sorted d values
-    // 7    S cd[n];      // sorted and compacted d values
-    // 8    S cz[n];      // sorted and compacted z values
-    // 9    S sdbg[n];    //
-    return 10 * n;
+    // 0    S z[n];              // the rank-1 modification vectors in the merges
+    // 1    S evs[n];            // roots of secular equations
+    // 2    S cc[n];             // c value of rotation of corresponding deflation
+    // 3    S ss[n];             // s value of rotation of corresponding deflation
+    // 4    S tolsD[n];          // tollerance for deflation of repeaded values in D
+    // 5    S tolsZ[n];          // tollerance for deflation of zero values in z
+    // 6    S md[n];             // sorted d values
+    // 7    S cd[n];             // sorted and compacted d values
+    // 8    S cz[n];             // sorted and compacted z values
+    // 9    S r1p[m], _[n-m];    // p component of the rank-1 modification
+    // 10   S sdbg[n];           //
+    return 11 * n;
 }
 
-template <typename S> __host__ __device__ inline S* ptr_z    (rocblas_int n, S* tmpz) { return tmpz + 0 * n; }
-template <typename S> __host__ __device__ inline S* ptr_evs  (rocblas_int n, S* tmpz) { return tmpz + 1 * n; }
-template <typename S> __host__ __device__ inline S* ptr_cc   (rocblas_int n, S* tmpz) { return tmpz + 2 * n; }
-template <typename S> __host__ __device__ inline S* ptr_ss   (rocblas_int n, S* tmpz) { return tmpz + 3 * n; }
-template <typename S> __host__ __device__ inline S* ptr_tolsD(rocblas_int n, S* tmpz) { return tmpz + 4 * n; }
-template <typename S> __host__ __device__ inline S* ptr_tolsZ(rocblas_int n, S* tmpz) { return tmpz + 5 * n; }
-template <typename S> __host__ __device__ inline S* ptr_md   (rocblas_int n, S* tmpz) { return tmpz + 6 * n; }
-template <typename S> __host__ __device__ inline S* ptr_cd   (rocblas_int n, S* tmpz) { return tmpz + 7 * n; }
-template <typename S> __host__ __device__ inline S* ptr_cz   (rocblas_int n, S* tmpz) { return tmpz + 8 * n; }
-template <typename S> __host__ __device__ inline S* ptr_sdbg (rocblas_int n, S* tmpz) { return tmpz + 9 * n; }
+template <typename S> __host__ __device__ inline S* ptr_z    (rocblas_int n, S* tmpz) { return tmpz +  0 * n; }
+template <typename S> __host__ __device__ inline S* ptr_evs  (rocblas_int n, S* tmpz) { return tmpz +  1 * n; }
+template <typename S> __host__ __device__ inline S* ptr_cc   (rocblas_int n, S* tmpz) { return tmpz +  2 * n; }
+template <typename S> __host__ __device__ inline S* ptr_ss   (rocblas_int n, S* tmpz) { return tmpz +  3 * n; }
+template <typename S> __host__ __device__ inline S* ptr_tolsD(rocblas_int n, S* tmpz) { return tmpz +  4 * n; }
+template <typename S> __host__ __device__ inline S* ptr_tolsZ(rocblas_int n, S* tmpz) { return tmpz +  5 * n; }
+template <typename S> __host__ __device__ inline S* ptr_md   (rocblas_int n, S* tmpz) { return tmpz +  6 * n; }
+template <typename S> __host__ __device__ inline S* ptr_cd   (rocblas_int n, S* tmpz) { return tmpz +  7 * n; }
+template <typename S> __host__ __device__ inline S* ptr_cz   (rocblas_int n, S* tmpz) { return tmpz +  8 * n; }
+template <typename S> __host__ __device__ inline S* ptr_r1p  (rocblas_int n, S* tmpz) { return tmpz +  9 * n; }
+template <typename S> __host__ __device__ inline S* ptr_sdbg (rocblas_int n, S* tmpz) { return tmpz + 10 * n; }
 
 
 /*************** Main kernels *********************************************************/
@@ -394,8 +398,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z     = ptr_z(n, tmpz);
+    S* r1p   = ptr_r1p(n, tmpz);
     S* tolsD = ptr_tolsD(n, tmpz);
-    S* tolsZ = ptr_tolsD(n, tmpz);
+    S* tolsZ = ptr_tolsZ(n, tmpz);
 
 
     // Work with merges on level k. A thread-group works with two leaves in the merge tree.
@@ -408,6 +413,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         rocblas_int p2  = bps[sid * 2 + 1];
 
         S p = 2 * E[p2 - 1];
+        r1p[sid] = p;
 
         S maxd = 0;
         S maxz = 0;
@@ -468,7 +474,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         for(int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x)
         {
             tolsD[p1 + i] = tolD;
-            tolsZ[p1 + i] = tolD;
+            tolsZ[p1 + i] = tolZ;
         }
 
 
@@ -949,7 +955,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // select batch instance to work with
     S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
     S* D = DD + bid * strideD;
-    S* E = EE + bid * strideE;
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
@@ -958,10 +963,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* msz  = ptr_msz(n, splits);
     rocblas_int* dds  = ptr_dds(n, splits);
     rocblas_int* mps = ptr_mps(n, splits);
-    rocblas_int* bps = ptr_bps(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z     = ptr_z(n, tmpz);
+    S* r1p   = ptr_r1p(n, tmpz);
     S* sdbg  = ptr_sdbg(n, tmpz);
     // updated eigenvectors after merges
     S* vecs = vecsA + bid * 2 * (n * n);
@@ -973,8 +978,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // 1. find rank-1 modification component (p) for this merge
         // ----------------------------------------------------------------
         // rank-1 modification component p correspond to the last element in the first sub-block
-        rocblas_int p2 = bps[sid * 2 + 1];
-        S p = 2 * E[p2 - 1];
+        S p = r1p[sid];
 
         // 3. deflate eigenvalues
         // ----------------------------------------------------------------
@@ -1044,7 +1048,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // select batch instance to work with
     S* D = DD + bid * strideD;
-    S* E = EE + bid * strideE;
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
@@ -1256,7 +1259,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // select batch instance to work with
     S* D = DD + bid * strideD;
-    S* E = EE + bid * strideE;
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
@@ -1264,11 +1266,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* msz = ptr_msz(n, splits);
     rocblas_int* dds = ptr_dds(n, splits);
     rocblas_int* mps = ptr_mps(n, splits);
-    rocblas_int* bps = ptr_bps(n, splits);
     rocblas_int* em  = ptr_em(n, splits);
     
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z   = ptr_z(n, tmpz);
+    S* r1p = ptr_r1p(n, tmpz);
     S* evs = ptr_evs(n, tmpz);
     // updated eigenvectors after merges
     S* vecs = vecsA + bid * 2 * (n * n);
@@ -1283,8 +1285,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
         // Find off-diagonal element of the merge
         // rank-1 modification component p correspond to the last element in the first sub-block
-        rocblas_int p2 = bps[sid * 2 + 1];
-        S p = 2 * E[p2 - 1];
+        S p = r1p[sid];
 
         // determine boundaries of what would be the new merged sub-block
         // 'p1' will be its initial position.
@@ -1370,7 +1371,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // select batch instance to work with
     S* D = DD + bid * strideD;
-    S* E = EE + bid * strideE;
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
@@ -1468,7 +1468,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // select batch instance to work with
     S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
     S* D = DD + bid * strideD;
-    S* E = EE + bid * strideE;
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -982,27 +982,23 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // 4. Organize data with non-deflated values to prepare secular equation
         // ------------------------------------------------------------------------ 
         // define shifted arrays
-        S* tmpd = temps + p1 * n;
-        S* diag = D + p1;
-        rocblas_int* mask = idd + p1;
-        S* zz = z + p1;
-        rocblas_int* per = pers + p1;
+        S* etmpd = temps;
 
         // find degree and components of secular equation
-        // tmpd contains the non-deflated diagonal elements (ie. poles of the
+        // etmpd contains the non-deflated diagonal elements (ie. poles of the
         // secular eqn) zz contains the corresponding non-zero elements of the
         // rank-1 modif vector
         rocblas_int dd = 0;
         for(int i = 0; i < sz; ++i)
         {
-            if(mask[i] == 1)
+            if(idd[p1 + i] == 1)
             {
                 if(hipThreadIdx_x == 0)
                 {
-                    per[dd] = i;
-                    tmpd[dd] = p < 0 ? -diag[i] : diag[i];
+                    pers[p1 + dd] = i;
+                    etmpd[p1 * n + dd] = p < 0 ? -D[p1 + i] : D[p1 + i];
                     if(dd != i)
-                        zz[dd] = zz[i];
+                        z[p1 + dd] = z[p1 + i];
                 }
                 dd++;
             }
@@ -1077,9 +1073,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
 
         // define shifted arrays
-        S* tmpd = temps + p1 * n;
-        S* ev = evs + p1;
-        S* diag = D + p1;
+        S* etmpd = temps;
         rocblas_int* mask = idd + p1;
         S* zz = z + p1;
         rocblas_int* per = pers + p1;
@@ -1087,15 +1081,15 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // find degree of secular equation
         rocblas_int dd = dds[p1];
 
-        // Order the elements in tmpd and zz using a simple parallel selection/bubble sort.
+        // Order the elements in etmpd and zz using a simple parallel selection/bubble sort.
         // This will allow us to find initial intervals for eigenvalue guesses
         for(int i = 0; i < dd; i++)
         {
             for(int j = 2 * hipThreadIdx_x + i % 2; j < dd - 1; j += 2 * hipBlockDim_x)
             {
-                if(tmpd[j] > tmpd[j + 1])
+                if(etmpd[p1 * n + j] > etmpd[p1 * n + j + 1])
                 {
-                    swap(tmpd[j], tmpd[j + 1]);
+                    swap(etmpd[p1 * n + j], etmpd[p1 * n + j + 1]);
                     swap(zz[j], zz[j + 1]);
                     swap(per[j], per[j + 1]);
                 }
@@ -1111,13 +1105,13 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         for(int i = hipThreadIdx_x; i < dd; i += hipBlockDim_x)
         {
             for(int j = i + n; j < i + sz * n; j += n)
-                tmpd[j] = tmpd[i];
+                etmpd[p1 * n + j] = etmpd[p1 * n + i];
         }
 
         // finally copy over all diagonal elements in ev. ev will be overwritten
         // by the new computed eigenvalues of the merged block
         for(int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x)
-            ev[i] = diag[i];
+            evs[p1 + i] = D[p1 + i];
     }
 }
 
@@ -1212,7 +1206,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             }
 
             // computed zero will overwrite 'ev' at the corresponding position.
-            // 'tmpd' will be updated with the distances D - lambda_i.
+            // 'etmpd' will be updated with the distances D - lambda_i.
             // deflated values are not changed.
             rocblas_int linfo;
 
@@ -1292,11 +1286,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // to solve the correspondinbg secular eqn.
 
         // define shifted arrays
-        S* tmpd = temps + p1 * n;
-        S* ev = evs + p1;
-        S* diag = D + p1;
+        S* etmpd = temps;
         rocblas_int* mask = idd + p1;
-        S* zz = z + p1;
         rocblas_int* per = pers + p1;
 
         // find degree of secular equation
@@ -1311,12 +1302,12 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             {
                 if(mask[j] == 1)
                 {
-                    S valg = tmpd[i + j * n];
-                    valf *= (per[i] == j) ? valg : valg / (diag[per[i]] - diag[j]);
+                    S valg = etmpd[(p1 + j) * n + i];
+                    valf *= (per[i] == j) ? valg : valg / (D[p1 + per[i]] - D[p1 + j]);
                 }
             }
             valf = sqrt(std::abs(valf));
-            zz[i] = zz[i] < 0 ? -valf : valf;
+            z[p1 + i] = z[p1 + i] < 0 ? -valf : valf;
         }
     }
 }
@@ -1411,7 +1402,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             sz += ns[tid + i];
 
         // define shifted arrays
-        S* tmpd = temps + in * n;
         S* diag = D + in;
         rocblas_int* mask = idd + in;
         S* zz = z + in;

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -69,7 +69,7 @@ __host__ __device__ inline rocblas_int get_splits_size(const rocblas_int n)
     // 3     rocblas_int idd[n];              // if idd[i] = 0, the value in position i has been deflated  (aka mask)
     // 4     rocblas_int pers[n];             // container of permutations when solving the secular eqns
     // 5     rocblas_int ;      //
-    // 6     rocblas_int szs[n];              // sizes of both sub-blocks in a merge
+    // 6     rocblas_int ;      //
     // 7     rocblas_int dds[n];              // degrees of secular equation
     // 8     rocblas_int map[n];              // 
     // 9     rocblas_int dcount[n];           // number of deflations
@@ -92,7 +92,7 @@ template <typename S> __host__ __device__ inline S* ptr_ps    (rocblas_int n, S*
 template <typename S> __host__ __device__ inline S* ptr_idd   (rocblas_int n, S* splits) { return splits +  3 * n; }
 template <typename S> __host__ __device__ inline S* ptr_pers  (rocblas_int n, S* splits) { return splits +  4 * n; }
 template <typename S> __host__ __device__ inline S* ptr_      (rocblas_int n, S* splits) { return splits +  5 * n; }
-template <typename S> __host__ __device__ inline S* ptr_szs   (rocblas_int n, S* splits) { return splits +  6 * n; }
+template <typename S> __host__ __device__ inline S* ptr__     (rocblas_int n, S* splits) { return splits +  6 * n; }
 template <typename S> __host__ __device__ inline S* ptr_dds   (rocblas_int n, S* splits) { return splits +  7 * n; }
 template <typename S> __host__ __device__ inline S* ptr_map   (rocblas_int n, S* splits) { return splits +  8 * n; }
 template <typename S> __host__ __device__ inline S* ptr_dcount(rocblas_int n, S* splits) { return splits +  9 * n; }
@@ -371,9 +371,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int bid = hipBlockIdx_y;
     // merge sub-block id
     rocblas_int sid = hipBlockIdx_x;
-    // thread id
-    rocblas_int tidb = hipThreadIdx_x;
-    rocblas_int tid, tx;
 
     // select batch instance to work with
     S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
@@ -384,11 +381,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
     rocblas_int* ns   = ptr_ns(n, splits);
     rocblas_int* ps   = ptr_ps(n, splits);
-    rocblas_int* idd  = ptr_idd(n, splits);
-    rocblas_int* szs  = ptr_szs(n, splits);
+    rocblas_int* idd = ptr_idd(n, splits);
     rocblas_int* mps = ptr_mps(n, splits);
     rocblas_int* msz = ptr_msz(n, splits);
     rocblas_int* bsz = ptr_bsz(n, splits);
+    rocblas_int* bps = ptr_bps(n, splits);
 
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
@@ -396,154 +393,93 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* tolsD = ptr_tolsD(n, tmpz);
     S* tolsZ = ptr_tolsD(n, tmpz);
 
-    // temporary arrays in shared memory
-    // used to store temp values during the different reductions
-    __shared__ S inrmsd[STEDC_BDIM];
-    __shared__ S inrmsz[STEDC_BDIM];
-
-    rocblas_int bd = 1 << k;
-    rocblas_int bdm = bd << 1;
 
     // Work with merges on level k. A thread-group works with two leaves in the merge tree.
     {
-        rocblas_int iam, sz, dim, dim2, p2;
-
-        // tid indexes the sub-blocks in the entire matrix
-        // iam indexes the sub-blocks in the context of the merge
-        // (according to its level in the merge tree)
-        dim = hipBlockDim_x / 2;
-        iam = tidb / dim;
-        tx = tidb % dim;
-        tid = sid * bdm + iam * bd;
-        p2 = ps[tid];
-
         // 1. find rank-1 modification components (z and p) for this merge
         // ----------------------------------------------------------------
-        // Threads with iam = 0 work with components below the merge point;
-        // threads with iam = 1 work above the merge point
-        // with this, all threads involved in a merge
-        // will point to the same row of C and the same off-diag element
-        // position of a rank-1 modification component
-        rocblas_int r1p = mps[sid] + bsz[sid * 2] - 1;
-        S p = 2 * E[r1p];
-        S* ptz = C + r1p + iam;
+        rocblas_int sz1 = bsz[sid * 2 + 0];
+        rocblas_int sz2 = bsz[sid * 2 + 1];
+        rocblas_int p1  = bps[sid * 2 + 0];
+        rocblas_int p2  = bps[sid * 2 + 1];
 
-        // copy elements of z
-        sz = bsz[sid * 2 + iam];
-        for(int j = tx; j < sz; j += dim)
-            z[p2 + j] = ptz[(p2 + j) * ldc] / sqrt(2);
+        S p = 2 * E[p2 - 1];
 
+        S maxd = 0;
+        S maxz = 0;
+        // copy z values from first sub-block
+        // copy last line of the first sub-block
+        for (int i = hipThreadIdx_x; i < sz1; i += hipBlockDim_x) {
+            S val = C[p2 - 1 + (p1 + i) * ldc] / sqrt(2);
+            z[p1 + i] = val;
+            maxz = std::max(maxz, std::abs(val));
+        }
+        // copy first line of the second sub-block
+        for (int i = hipThreadIdx_x; i < sz2; i += hipBlockDim_x) {
+            S val = C[p2 - 0 + (p2 + i) * ldc] / sqrt(2);
+            z[p2 + i] = val;
+            maxz = std::max(maxz, std::abs(val));
+        }
 
         // 2. calculate deflation tolerance
         // ----------------------------------------------------------------
         // compute maximum of diagonal and z in each merge block
-        S valf, valg, maxd, maxz;
-        maxd = 0;
-        maxz = 0;
-        for(int i = tx; i < sz; i += dim)
+        rocblas_int sz = sz1 + sz2;
+        for(int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x)
         {
-            valf = std::abs(D[p2 + i]);
-            valg = std::abs(z[p2 + i]);
-            maxd = valf > maxd ? valf : maxd;
-            maxz = valg > maxz ? valg : maxz;
+            maxd = std::max(maxd, abs(D[p1 + i]));
         }
-        inrmsd[tidb] = maxd;
-        inrmsz[tidb] = maxz;
+
+        // temporary arrays in shared memory
+        // used to store temp values during reduction
+        __shared__ S lmaxz[STEDC_BDIM];
+        __shared__ S lmaxd[STEDC_BDIM];
+        lmaxd[hipThreadIdx_x] = maxd;
+        lmaxz[hipThreadIdx_x] = maxz;
         __syncthreads();
 
-        dim2 = dim;
+        rocblas_int dim2 = hipBlockDim_x / 2;
         while(dim2 > 0)
         {
-            if(tidb < dim2)
+            if(hipThreadIdx_x < dim2)
             {
-                valf = inrmsd[tidb + dim2];
-                valg = inrmsz[tidb + dim2];
-                maxd = valf > maxd ? valf : maxd;
-                maxz = valg > maxz ? valg : maxz;
-                inrmsd[tidb] = maxd;
-                inrmsz[tidb] = maxz;
+                S vald = lmaxd[hipThreadIdx_x + dim2];
+                S valz = lmaxz[hipThreadIdx_x + dim2];
+                maxd = std::max(maxd, vald);
+                maxz = std::max(maxz, valz);
+                lmaxd[hipThreadIdx_x] = maxd;
+                lmaxz[hipThreadIdx_x] = maxz;
             }
             dim2 /= 2;
             __syncthreads();
         }
-
+        
         // tol should be  8 * eps * (max diagonal or z element participating in merge)
-        maxd = inrmsd[0];
-        maxz = inrmsz[0];
-        maxd = maxz > maxd ? maxz : maxd;
-        S tol = 8 * eps * maxd;
+        maxd = lmaxd[0];
+        maxz = lmaxz[0];
+        
+        S tolD = 8 * eps * std::max(maxd, maxz);
+        S tolZ = 8 * eps * std::max(maxd, maxz);
+        // store tolerances in global memory
+        for(int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x)
+        {
+            tolsD[p1 + i] = tolD;
+            tolsZ[p1 + i] = tolD;
+        }
 
 
         // 3. deflate eigenvalues
         // ----------------------------------------------------------------
-        // determine boundaries of what would be the new merged sub-block
-        // 'in' will be its initial position.
-        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        rocblas_int in = tid - iam * bd;
-        sz = ns[in];
-        for(int i = 1; i < bdm; ++i)
-            sz += ns[in + i];
-        szs[in] = sz;
-        sz = msz[sid];
-        tolsD[in] = tol;
-        tolsZ[in] = tol;
-        in = ps[in];
-
-        // first deflate zero components
-        for(int i = tidb; i < sz; i += hipBlockDim_x)
+        // deflate zero components
+        for(int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x)
         {
-            tx = in + i;
-            S g = z[tx];
-            if(abs(p * g) <= tol)
-                // deflated ev because component in z is zero
-                idd[tx] = 0;
-            else
-                idd[tx] = 1;
+            S g = z[p1 + i];
+            // deflated ev if component in z is zero
+            idd[p1 + i] = (abs(p * g) <= tolZ) ? 0 : 1;
         }
     }
 }
 
-
-//--------------------------------------------------------------------------------------//
-/** STEDC_MERGEPREPARE_FILL_KERNEL fills different arrays in splits struct
-        - Call this kernel with batch_count groups in y, and as many groups as half of the 
-          unmerged sub-blocks in current level in x. Each group works with a merge of a pair
-          of sub-blocks. Groups are size STEDC_BDIM **/
-template <typename S>
-ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergePrepare_Fill_kernel(const rocblas_int levs,
-                                   const rocblas_int blks,
-                                   const rocblas_int k,
-                                   const rocblas_int n,
-                                   S* tmpzA,
-                                   rocblas_int* splitsA)
-{
-    // threads and groups indices
-    // batch instance id
-    rocblas_int bid = hipBlockIdx_y;
-    // merge sub-block id
-    rocblas_int sid = hipBlockIdx_x;
-
-    // temporary arrays in global memory
-    rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* ps     = ptr_ps(n, splits);
-    rocblas_int* szs    = ptr_szs(n, splits);
-
-    S* tmpz = tmpzA + bid * get_tmpz_size(n);
-    S* tolsD = ptr_tolsD(n, tmpz);
-    S* tolsZ = ptr_tolsZ(n, tmpz);
-
-    rocblas_int in = sid << (k + 1);
-    rocblas_int sz = szs[in];
-    rocblas_int p  = ps[in];
-    S tol = tolsD[in];
-
-    for (int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x) {
-        int id = p + i;
-        tolsD[id] = tol;
-        tolsZ[id] = tol;
-    }
-}
 
 //--------------------------------------------------------------------------------------//
 /** STEDC_MERGEPREPARE_SORTD_KERNEL sorts D array and construct map of original positions
@@ -1023,6 +959,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* dds  = ptr_dds(n, splits);
     rocblas_int* mps = ptr_mps(n, splits);
     rocblas_int* bsz = ptr_bsz(n, splits);
+    rocblas_int* bps = ptr_bps(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z     = ptr_z(n, tmpz);
@@ -1038,9 +975,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     {
         // 1. find rank-1 modification component (p) for this merge
         // ----------------------------------------------------------------
-        // position of a rank-1 modification component
-        rocblas_int r1p = mps[sid] + bsz[sid * 2] - 1;
-        S p = 2 * E[r1p];
+        // rank-1 modification component p correspond to the last element in the first sub-block
+        rocblas_int p2 = bps[sid * 2 + 1];
+        S p = 2 * E[p2 - 1];
 
         // 3. deflate eigenvalues
         // ----------------------------------------------------------------
@@ -1335,6 +1272,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* dds  = ptr_dds(n, splits);
     rocblas_int* mps  = ptr_mps(n, splits);
     rocblas_int* bsz  = ptr_bsz(n, splits);
+    rocblas_int* bps = ptr_bps(n, splits);
     
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z   = ptr_z(n, tmpz);
@@ -1348,8 +1286,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // all threads work together to solve the secular equation.
     {
         // Find off-diagonal element of the merge
-        rocblas_int r1p = mps[sid] + bsz[sid * 2] - 1;
-        S p = 2 * E[r1p];
+        // rank-1 modification component p correspond to the last element in the first sub-block
+        rocblas_int p2 = bps[sid * 2 + 1];
+        S p = 2 * E[p2 - 1];
 
         // determine boundaries of what would be the new merged sub-block
         // 'in' will be its initial position.
@@ -2218,18 +2157,17 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         // launch merge for level k
         for(rocblas_int k = 0; k < levs; ++k)
         {
+            rocblas_int n_merges = 1 << (levs - k - 1);
             ROCSOLVER_LAUNCH_KERNEL(stedc_update_splits, dim3(1, batch_count), dim3(STEDC_BDIM), 0,
                                     stream, levs, k, n, splits);
 
             // a. prepare secular equations
-            rocblas_int numgrps2 = 1 << (levs - 1 - k);
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_DeflateZero_kernel<S>),
-                                    dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream, 
+                                    dim3(n_merges, batch_count), dim3(STEDC_BDIM), 0, stream, 
                                     levs, blks, k, n, D + shiftD, strideD,
                                     E + shiftE, strideE, V, 0, ldv, strideV, tmpz, splits,
                                     eps);
 #if DEBUG_OUTPUT
-            rocblas_int n_merges = 1 << (levs - k - 1);
             //hipError_t status = hipStreamSynchronize(stream);
             if (env_levs && global_cnt == 1) {
                 std::cout << "\nk=" << k << std::endl;
@@ -2248,9 +2186,6 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             }
 #endif
 
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_Fill_kernel<S>),
-                                    dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream,
-                                    levs, blks, k, n, tmpz, splits);
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_SortD_kernel<S>),
                                     dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream,
                                     levs, blks, k, n, D + shiftD, strideD,
@@ -2272,25 +2207,26 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     strideV, tmpz, splits);
 
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_Organize_kernel<S>),
-                                    dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream, 
+                                    dim3(n_merges, batch_count), dim3(STEDC_BDIM), 0, stream, 
                                     levs, blks, k, n, D + shiftD, strideD,
                                     E + shiftE, strideE, V, 0, ldv, strideV, tmpz, tempgemm, splits,
                                     eps);
 
             // b. solve secular eq to find merged eigenvalues
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Sort_kernel<S>), dim3(numgrps2, batch_count),
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Sort_kernel<S>), dim3(n_merges, batch_count),
                                     dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
                                     strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
                                     ssfmin, ssfmax);
 
-            rocblas_int max_n_per_merge  = (n + numgrps2 - 1) / numgrps2;
+            rocblas_int max_n_per_merge  = (n + n_merges - 1) / n_merges;
             rocblas_int groups_per_merge = (max_n_per_merge + STEDC_BDIM - 1) / STEDC_BDIM;
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Solve_kernel<S>),
-                                    dim3(numgrps2 * groups_per_merge, batch_count),
+                                    dim3(n_merges * groups_per_merge, batch_count),
                                     dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
                                     strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
                                     ssfmin, ssfmax, groups_per_merge);
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Rescale_kernel<S>), dim3(numgrps2, batch_count),
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Rescale_kernel<S>),
+                                    dim3(n_merges, batch_count),
                                     dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
                                     strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
                                     ssfmin, ssfmax);

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -47,18 +47,17 @@ ROCSOLVER_BEGIN_NAMESPACE
 #define DEBUG_OUTPUT 1
 
 #define STEDC_BDIM 512 // Number of threads per thread-block used in main stedc kernels
-#define STEDC_SOLVE_BDIM 4  // Number of threads per thread-block used in solver kernel
+#define STEDC_SOLVE_BDIM 4 // Number of threads per thread-block used in solver kernel
 
 // bit indicating base deflation candidate
 #define L_F_BCAND_BIT 0
 // bit indicating top deflation candidate
-#define L_F_TCAND_BIT 1 
+#define L_F_TCAND_BIT 1
 
 // TODO: using macro STEDC_EXTERNAL_GEMM = true for now. In the future we can pass
 // STEDC_EXTERNAL_GEMM at run time to switch between internal vector updates and
 // external gemm-based updates.
 #define STEDC_EXTERNAL_GEMM true
-
 
 __host__ __device__ inline rocblas_int get_splits_size(const rocblas_int n)
 {
@@ -83,19 +82,71 @@ __host__ __device__ inline rocblas_int get_splits_size(const rocblas_int n)
     return 13 * n;
 }
 
-template <typename S> __host__ __device__ inline S* ptr_msz   (rocblas_int n, S* splits) { return splits +  0 * n; }
-template <typename S> __host__ __device__ inline S* ptr_mps   (rocblas_int n, S* splits) { return splits +  1 * n; }
-template <typename S> __host__ __device__ inline S* ptr_bsz   (rocblas_int n, S* splits) { return splits +  2 * n; }
-template <typename S> __host__ __device__ inline S* ptr_bps   (rocblas_int n, S* splits) { return splits +  3 * n; }
-template <typename S> __host__ __device__ inline S* ptr_em    (rocblas_int n, S* splits) { return splits +  4 * n; }
-template <typename S> __host__ __device__ inline S* ptr_nsz   (rocblas_int n, S* splits) { return splits +  5 * n; }
-template <typename S> __host__ __device__ inline S* ptr_nps   (rocblas_int n, S* splits) { return splits +  6 * n; }
-template <typename S> __host__ __device__ inline S* ptr_ndd   (rocblas_int n, S* splits) { return splits +  7 * n; }
-template <typename S> __host__ __device__ inline S* ptr_mask  (rocblas_int n, S* splits) { return splits +  8 * n; }
-template <typename S> __host__ __device__ inline S* ptr_dcount(rocblas_int n, S* splits) { return splits +  9 * n; }
-template <typename S> __host__ __device__ inline S* ptr_map   (rocblas_int n, S* splits) { return splits + 10 * n; }
-template <typename S> __host__ __device__ inline S* ptr_cand  (rocblas_int n, S* splits) { return splits + 11 * n; }
-template <typename S> __host__ __device__ inline S* ptr_dbg   (rocblas_int n, S* splits) { return splits + 12 * n; }
+template <typename S>
+__host__ __device__ inline S* ptr_msz(rocblas_int n, S* splits)
+{
+    return splits + 0 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_mps(rocblas_int n, S* splits)
+{
+    return splits + 1 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_bsz(rocblas_int n, S* splits)
+{
+    return splits + 2 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_bps(rocblas_int n, S* splits)
+{
+    return splits + 3 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_em(rocblas_int n, S* splits)
+{
+    return splits + 4 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_nsz(rocblas_int n, S* splits)
+{
+    return splits + 5 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_nps(rocblas_int n, S* splits)
+{
+    return splits + 6 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_ndd(rocblas_int n, S* splits)
+{
+    return splits + 7 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_mask(rocblas_int n, S* splits)
+{
+    return splits + 8 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_dcount(rocblas_int n, S* splits)
+{
+    return splits + 9 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_map(rocblas_int n, S* splits)
+{
+    return splits + 10 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_cand(rocblas_int n, S* splits)
+{
+    return splits + 11 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_dbg(rocblas_int n, S* splits)
+{
+    return splits + 12 * n;
+}
 
 __host__ __device__ inline rocblas_int get_tmpz_size(const rocblas_int n)
 {
@@ -117,17 +168,56 @@ __host__ __device__ inline rocblas_int get_tmpz_size(const rocblas_int n)
     return 10 * n;
 }
 
-template <typename S> __host__ __device__ inline S* ptr_z    (rocblas_int n, S* tmpz) { return tmpz +  0 * n; }
-template <typename S> __host__ __device__ inline S* ptr_evs  (rocblas_int n, S* tmpz) { return tmpz +  1 * n; }
-template <typename S> __host__ __device__ inline S* ptr_cc   (rocblas_int n, S* tmpz) { return tmpz +  2 * n; }
-template <typename S> __host__ __device__ inline S* ptr_ss   (rocblas_int n, S* tmpz) { return tmpz +  3 * n; }
-template <typename S> __host__ __device__ inline S* ptr_tolsD(rocblas_int n, S* tmpz) { return tmpz +  4 * n; }
-template <typename S> __host__ __device__ inline S* ptr_tolsZ(rocblas_int n, S* tmpz) { return tmpz +  5 * n; }
-template <typename S> __host__ __device__ inline S* ptr_md   (rocblas_int n, S* tmpz) { return tmpz +  6 * n; }
-template <typename S> __host__ __device__ inline S* ptr_cd   (rocblas_int n, S* tmpz) { return tmpz +  7 * n; }
-template <typename S> __host__ __device__ inline S* ptr_cz   (rocblas_int n, S* tmpz) { return tmpz +  8 * n; }
-template <typename S> __host__ __device__ inline S* ptr_r1p  (rocblas_int n, S* tmpz) { return tmpz +  9 * n; }
-
+template <typename S>
+__host__ __device__ inline S* ptr_z(rocblas_int n, S* tmpz)
+{
+    return tmpz + 0 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_evs(rocblas_int n, S* tmpz)
+{
+    return tmpz + 1 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_cc(rocblas_int n, S* tmpz)
+{
+    return tmpz + 2 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_ss(rocblas_int n, S* tmpz)
+{
+    return tmpz + 3 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_tolsD(rocblas_int n, S* tmpz)
+{
+    return tmpz + 4 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_tolsZ(rocblas_int n, S* tmpz)
+{
+    return tmpz + 5 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_md(rocblas_int n, S* tmpz)
+{
+    return tmpz + 6 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_cd(rocblas_int n, S* tmpz)
+{
+    return tmpz + 7 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_cz(rocblas_int n, S* tmpz)
+{
+    return tmpz + 8 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_r1p(rocblas_int n, S* tmpz)
+{
+    return tmpz + 9 * n;
+}
 
 __host__ __device__ inline rocblas_int get_tempgemm_size(const rocblas_int n)
 {
@@ -139,9 +229,16 @@ __host__ __device__ inline rocblas_int get_tempgemm_size(const rocblas_int n)
     return 2 * n * n;
 }
 
-template <typename S> __host__ __device__ inline S* ptr_vecs (rocblas_int n, S* tempgemm) { return tempgemm +  0 * n * n; }
-template <typename S> __host__ __device__ inline S* ptr_etmpd(rocblas_int n, S* tempgemm) { return tempgemm +  1 * n * n; }
-
+template <typename S>
+__host__ __device__ inline S* ptr_vecs(rocblas_int n, S* tempgemm)
+{
+    return tempgemm + 0 * n * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_etmpd(rocblas_int n, S* tempgemm)
+{
+    return tempgemm + 1 * n * n;
+}
 
 /*************** Main kernels *********************************************************/
 /**************************************************************************************/
@@ -150,18 +247,19 @@ template <typename S> __host__ __device__ inline S* ptr_etmpd(rocblas_int n, S* 
 /** STEDC_DIVIDE_KERNEL implements the divide phase of the DC algorithm. It
     divides the input matrix into a 'blks' sub-blocks.
         - This kernel is to be called with as many groups in x as needed to cover all
-        the batch_count problems. Each thread will work with a matrix in the batch. 
+        the batch_count problems. Each thread will work with a matrix in the batch.
         - Size of groups is set to STEDC_BDIM. **/
 template <typename S>
-ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_divide_kernel(const rocblas_int levs,
-                                                                        const rocblas_int blks,
-                                                                        const rocblas_int n,
-                                                                        S* DD,
-                                                                        const rocblas_stride strideD,
-                                                                        S* EE,
-                                                                        const rocblas_stride strideE,
-                                                                        const rocblas_int batch_count,
-                                                                        rocblas_int* splitsA)
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+    stedc_divide_kernel(const rocblas_int levs,
+                        const rocblas_int blks,
+                        const rocblas_int n,
+                        S* DD,
+                        const rocblas_stride strideD,
+                        S* EE,
+                        const rocblas_stride strideE,
+                        const rocblas_int batch_count,
+                        rocblas_int* splitsA)
 {
     // threads and groups indices
     rocblas_int bid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
@@ -206,11 +304,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_divide_kernel(const ro
     }
 }
 
-
 //--------------------------------------------------------------------------------------//
 /** STEDC_SOLVE_KERNEL implements the solver phase of the DC algorithm to
    compute the eigenvalues/eigenvectors of the 'blks' different sub-blocks of a matrix.
-        - Call this kernel with batch_count groups in y, and 'blks' groups in x. 
+        - Call this kernel with batch_count groups in y, and 'blks' groups in x.
           Groups are single-thread **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_solve_kernel(const rocblas_int levs,
@@ -254,19 +351,18 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_solve_kernel(const roc
 
     // Solve the blks sub-blocks in parallel (using classic QR iteration).
     {
-        rocblas_int sz = msz[sid];  // size of sub-block
-        rocblas_int p2 = mps[sid];  // start position of sub-block
+        rocblas_int sz = msz[sid]; // size of sub-block
+        rocblas_int p2 = mps[sid]; // start position of sub-block
 
         run_steqr(tidb, tidb_inc, sz, D + p2, E + p2, C + p2 + p2 * ldc, ldc, info, W + p2 * 2,
                   30 * sz, eps, ssfmin, ssfmax, false);
     }
 }
 
-
 //--------------------------------------------------------------------------------------//
 /** STEDC_UPDATE_SPLITS updates merge block related parts of a splits struct for each
     level of merge.
-        - This kernel is to be called with 1 group in x and batch_count groups in y. 
+        - This kernel is to be called with 1 group in x and batch_count groups in y.
         - Size of groups is set to STEDC_BDIM. **/
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_update_splits(const rocblas_int levs,
                                                                         const rocblas_int k,
@@ -275,7 +371,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_update_splits(const ro
 {
     rocblas_int bid = hipBlockIdx_y;
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* em  = ptr_em(n, splits);
+    rocblas_int* em = ptr_em(n, splits);
     rocblas_int* msz = ptr_msz(n, splits);
     rocblas_int* mps = ptr_mps(n, splits);
     rocblas_int* nsz = ptr_nsz(n, splits);
@@ -284,12 +380,13 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_update_splits(const ro
     rocblas_int* bps = ptr_bps(n, splits);
     rocblas_int* map = ptr_map(n, splits);
     rocblas_int* dcount = ptr_dcount(n, splits);
-    
+
     rocblas_int n_blocks = 1 << levs;
     rocblas_int n_merges = 1 << (levs - k - 1);
 
     // init em array
-    if (k == 0) {
+    if(k == 0)
+    {
         for(int i = hipThreadIdx_x; i < n_blocks; i += hipBlockDim_x)
         {
             rocblas_int sz = msz[i];
@@ -302,7 +399,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_update_splits(const ro
     }
 
     // previous merges becomes blocks on a current level
-    for (int i = hipThreadIdx_x; i < n_merges * 2; i += hipBlockDim_x)
+    for(int i = hipThreadIdx_x; i < n_merges * 2; i += hipBlockDim_x)
     {
         bsz[i] = msz[i];
         bps[i] = mps[i];
@@ -314,12 +411,12 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_update_splits(const ro
     {
         rocblas_int sz1 = bsz[i * 2 + 0];
         rocblas_int sz2 = bsz[i * 2 + 1];
-        rocblas_int p1  = bps[i * 2];
+        rocblas_int p1 = bps[i * 2];
         msz[i] = sz1 + sz2;
         mps[i] = p1;
     }
     __syncthreads();
-    for (int i = hipThreadIdx_x; i < n; i += hipBlockDim_x)
+    for(int i = hipThreadIdx_x; i < n; i += hipBlockDim_x)
     {
         rocblas_int m = em[i] / 2;
         nsz[i] = msz[m];
@@ -335,11 +432,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_update_splits(const ro
     }
 }
 
-
 //--------------------------------------------------------------------------------------//
 /** STEDC_MERGEPREPARE_DEFLATEZERO_KERNEL finds and stores tolerances and performs
     deflation of zero values
-        - Call this kernel with batch_count groups in y, and as many groups as half of the 
+        - Call this kernel with batch_count groups in y, and as many groups as half of the
           unmerged sub-blocks in current level in x. Each group works with a merge of a pair
           of sub-blocks. Groups are size STEDC_BDIM **/
 template <typename S>
@@ -347,7 +443,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     stedc_mergePrepare_DeflateZero_kernel(const rocblas_int k,
                                           const rocblas_int n,
                                           S* DD,
-                                           const rocblas_stride strideD,
+                                          const rocblas_stride strideD,
                                           S* EE,
                                           const rocblas_stride strideE,
                                           S* CC,
@@ -375,13 +471,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* bsz = ptr_bsz(n, splits);
     rocblas_int* bps = ptr_bps(n, splits);
 
-
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
-    S* z     = ptr_z(n, tmpz);
-    S* r1p   = ptr_r1p(n, tmpz);
+    S* z = ptr_z(n, tmpz);
+    S* r1p = ptr_r1p(n, tmpz);
     S* tolsD = ptr_tolsD(n, tmpz);
     S* tolsZ = ptr_tolsZ(n, tmpz);
-
 
     // Work with merges on level k. A thread-group works with two leaves in the merge tree.
     {
@@ -389,13 +483,14 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // ----------------------------------------------------------------
         rocblas_int sz1 = bsz[sid * 2 + 0];
         rocblas_int sz2 = bsz[sid * 2 + 1];
-        rocblas_int p1  = bps[sid * 2 + 0];
-        rocblas_int p2  = bps[sid * 2 + 1];
+        rocblas_int p1 = bps[sid * 2 + 0];
+        rocblas_int p2 = bps[sid * 2 + 1];
 
         // Find off-diagonal element of the merge
         // rank-1 modification component p correspond to the last element in the first sub-block
         S p = 2 * E[p2 - 1];
-        for (int i = hipThreadIdx_x; i < sz1 + sz2; i += hipBlockDim_x) {
+        for(int i = hipThreadIdx_x; i < sz1 + sz2; i += hipBlockDim_x)
+        {
             r1p[p1 + i] = p;
         }
 
@@ -403,13 +498,15 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         S maxz = 0;
         // copy z values from first sub-block
         // copy last line of the first sub-block
-        for (int i = hipThreadIdx_x; i < sz1; i += hipBlockDim_x) {
+        for(int i = hipThreadIdx_x; i < sz1; i += hipBlockDim_x)
+        {
             S val = C[p2 - 1 + (p1 + i) * ldc] / sqrt(2);
             z[p1 + i] = val;
             maxz = std::max(maxz, std::abs(val));
         }
         // copy first line of the second sub-block
-        for (int i = hipThreadIdx_x; i < sz2; i += hipBlockDim_x) {
+        for(int i = hipThreadIdx_x; i < sz2; i += hipBlockDim_x)
+        {
             S val = C[p2 - 0 + (p2 + i) * ldc] / sqrt(2);
             z[p2 + i] = val;
             maxz = std::max(maxz, std::abs(val));
@@ -447,11 +544,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             dim2 /= 2;
             __syncthreads();
         }
-        
+
         // tol should be  8 * eps * (max diagonal or z element participating in merge)
         maxd = lmaxd[0];
         maxz = lmaxz[0];
-        
+
         S tolD = 8 * eps * std::max(maxd, maxz);
         S tolZ = 8 * eps * std::max(maxd, maxz);
         // store tolerances in global memory
@@ -460,7 +557,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             tolsD[p1 + i] = tolD;
             tolsZ[p1 + i] = tolZ;
         }
-
 
         // 3. deflate eigenvalues
         // ----------------------------------------------------------------
@@ -473,7 +569,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         }
     }
 }
-
 
 //--------------------------------------------------------------------------------------//
 /** STEDC_MERGEPREPARE_SORTD_KERNEL sorts D array and construct map of original positions
@@ -499,15 +594,14 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* mask    = ptr_mask(n, splits);
-    rocblas_int* ndd    = ptr_ndd(n, splits);
-    rocblas_int* map    = ptr_map(n, splits);
-    rocblas_int* nsz    = ptr_nsz (n, splits);
-    rocblas_int* nps    = ptr_nps (n, splits); 
-    
-    S* tmpz = tmpzA + bid * get_tmpz_size(n);
-    S* md   = ptr_md(n, tmpz);
+    rocblas_int* mask = ptr_mask(n, splits);
+    rocblas_int* ndd = ptr_ndd(n, splits);
+    rocblas_int* map = ptr_map(n, splits);
+    rocblas_int* nsz = ptr_nsz(n, splits);
+    rocblas_int* nps = ptr_nps(n, splits);
 
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* md = ptr_md(n, tmpz);
 
     S d = D[gid];
     rocblas_int sz = nsz[gid];
@@ -521,7 +615,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S bval[regs];
     int maskval[regs];
 
-
     int nan = 0;
     int lt = 0;
     int eq = 0;
@@ -534,7 +627,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             if(x < sz)
             {
                 bval[i] = D[p1 + x];
-                maskval[i]  = mask[p1 + x];
+                maskval[i] = mask[p1 + x];
             }
         }
         for(int i = 0; i < regs; i++)
@@ -574,10 +667,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         }
     }
 
-    if (hipThreadIdx_x == 0) {
-        ndd [pos+p1]  = dd;
-        map [pos+p1]  = gid;
-        md  [pos+p1]  = d;
+    if(hipThreadIdx_x == 0)
+    {
+        ndd[pos + p1] = dd;
+        map[pos + p1] = gid;
+        md[pos + p1] = d;
     }
 
     __syncthreads();
@@ -585,7 +679,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // new positions it would be silently overwriten with non NAN value.
     // Make sure we propagate NAN. It is likely to have more NANs in the output
     // than in the input, but the following computations are doomed anyway.
-    if (nan) {
+    if(nan)
+    {
         md[gid] = NAN;
     }
 }
@@ -612,45 +707,41 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* nps    = ptr_nps (n, splits); 
-    rocblas_int* ndd    = ptr_ndd (n, splits); 
-    rocblas_int* cand   = ptr_cand(n, splits); 
+    rocblas_int* nps = ptr_nps(n, splits);
+    rocblas_int* ndd = ptr_ndd(n, splits);
+    rocblas_int* cand = ptr_cand(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
-    S* md    = ptr_md(n, tmpz);
+    S* md = ptr_md(n, tmpz);
     S* tolsD = ptr_tolsD(n, tmpz);
-
-    
 
     constexpr int F_BCAND = 1 << L_F_BCAND_BIT;
     constexpr int F_TCAND = 1 << L_F_TCAND_BIT;
 
     // find deflate candidates
     int i = hipThreadIdx_x + hipBlockDim_x * hipBlockIdx_x;
-    if (i < n)
+    if(i < n)
     {
         int next = (i + 1) < n ? (i + 1) : i;
         int prev = (i > 0) ? (i - 1) : 0;
         S tol = tolsD[i];
-        S d   = md[i];
-        S dn  = md[next];
-        S dp  = md[prev];
+        S d = md[i];
+        S dn = md[next];
+        S dp = md[prev];
         rocblas_int dd = ndd[i];
         rocblas_int p1 = nps[i];
         rocblas_int pn = nps[next];
         rocblas_int pp = nps[prev];
 
-        int bcandidate =
-            (i - p1 < dd - 1)           // current and next are not yet deflated
-            && p1 == pn                 // in the same merge block
-            && std::abs(d - dn) <= tol  // within tolerance
-            && i != (n-1)               // isn't last 
+        int bcandidate = (i - p1 < dd - 1) // current and next are not yet deflated
+            && p1 == pn // in the same merge block
+            && std::abs(d - dn) <= tol // within tolerance
+            && i != (n - 1) // isn't last
             ;
-        int tcandidate =
-            (i - p1 < dd)               // current and prev are not yet deflated
-            && p1 == pp                 // in the same merge block
-            && std::abs(d - dp) <= tol  // within tolerance
-            && i > 0                    // isn't first
+        int tcandidate = (i - p1 < dd) // current and prev are not yet deflated
+            && p1 == pp // in the same merge block
+            && std::abs(d - dp) <= tol // within tolerance
+            && i > 0 // isn't first
             ;
         cand[i] = (bcandidate << L_F_BCAND_BIT) + (tcandidate << L_F_TCAND_BIT);
     }
@@ -679,49 +770,47 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
     rocblas_int* dcount = ptr_dcount(n, splits);
-    rocblas_int* cand   = ptr_cand(n, splits);
+    rocblas_int* cand = ptr_cand(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
-    S* md    = ptr_md(n, tmpz);
+    S* md = ptr_md(n, tmpz);
     S* tolsD = ptr_tolsD(n, tmpz);
 
-
     constexpr rocblas_int max_len = 4096;
-    __shared__ S   ldsD[max_len];
+    __shared__ S ldsD[max_len];
     __shared__ int lcand[max_len];
     constexpr int F_BCAND = 1 << L_F_BCAND_BIT;
     constexpr int F_TCAND = 1 << L_F_TCAND_BIT;
 
     int start = hipBlockDim_x * hipBlockIdx_x;
-    int base  = start + hipThreadIdx_x;
-    int prev  = (base > 0) ? (base - 1) : 0;
+    int base = start + hipThreadIdx_x;
+    int prev = (base > 0) ? (base - 1) : 0;
     int candp = (prev < n) ? cand[prev] : 0;
     int candb = (base < n) ? cand[base] : 0;
     S bval = (base < n) ? md[base] : 0;
-    S tol  = (base < n) ? tolsD[base] : 0;
+    S tol = (base < n) ? tolsD[base] : 0;
 
     // cache max_len values of D[] and cand[]
     for(int i = hipThreadIdx_x; i < max_len; i += hipBlockDim_x)
     {
         int x = start + i;
-        ldsD[i]  = (x < n) ? md[x]   : 0;
+        ldsD[i] = (x < n) ? md[x] : 0;
         lcand[i] = (x < n) ? cand[x] : 0;
     }
     __syncthreads();
-    
-    if ((candb & F_BCAND) && (base == 0 || !(candp & F_BCAND))) {
+
+    if((candb & F_BCAND) && (base == 0 || !(candp & F_BCAND)))
+    {
         int top = base + 2;
         int candt = lcand[top - start];
-        while (top < n && (candt & F_TCAND))
+        while(top < n && (candt & F_TCAND))
         {
             // first max_len values are prefetched into lds,
             // access global memory only if need to go beyond that
             // which is very unlikely
-            S tval = (top - start) < max_len
-                   ? ldsD[top-start]
-                   : md[top];
+            S tval = (top - start) < max_len ? ldsD[top - start] : md[top];
 
-            if ((tval - bval) > tol)
+            if((tval - bval) > tol)
             {
                 dcount[base] = top - base - 1;
                 base = top;
@@ -732,9 +821,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             // first max_len values are prefetched into lds,
             // access global memory only if need to go beyond that
             // which is very unlikely
-            candt = (top - start) < max_len
-                ? lcand[top-start]
-                : cand[top];
+            candt = (top - start) < max_len ? lcand[top - start] : cand[top];
         }
         dcount[base] = top - base - 1;
     }
@@ -762,45 +849,44 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* mask    = ptr_mask(n, splits);
-    rocblas_int* map    = ptr_map(n, splits);
+    rocblas_int* mask = ptr_mask(n, splits);
+    rocblas_int* map = ptr_map(n, splits);
     rocblas_int* dcount = ptr_dcount(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
-    S* z  = ptr_z(n, tmpz);
+    S* z = ptr_z(n, tmpz);
     S* cc = ptr_cc(n, tmpz);
     S* ss = ptr_ss(n, tmpz);
 
     constexpr rocblas_int max_len = 4096;
-    __shared__ S   lz[max_len];
+    __shared__ S lz[max_len];
     __shared__ int lmap[max_len];
 
-    int start   = hipBlockDim_x * hipBlockIdx_x;
-    int base    = start + hipThreadIdx_x;
-    int cnt     = (base < n) ? dcount[base] : 0;
+    int start = hipBlockDim_x * hipBlockIdx_x;
+    int base = start + hipThreadIdx_x;
+    int cnt = (base < n) ? dcount[base] : 0;
 
     // cache max_len values of map[] and appropriate z[]
-    for (int i = hipThreadIdx_x; i < max_len; i += hipBlockDim_x) {
-        int x   = start + i;
-        lmap[i] = (x < n) ? map[x]    : 0;
-        lz[i]   = (x < n) ? z[map[x]] : 0;
+    for(int i = hipThreadIdx_x; i < max_len; i += hipBlockDim_x)
+    {
+        int x = start + i;
+        lmap[i] = (x < n) ? map[x] : 0;
+        lz[i] = (x < n) ? z[map[x]] : 0;
     }
     __syncthreads();
 
-    if (cnt) {
+    if(cnt)
+    {
         S baseval = lz[hipThreadIdx_x];
-        for (int j = 0; j < cnt; j++) {
+        for(int j = 0; j < cnt; j++)
+        {
             int top = base + j + 1;
 
             // first max_len values are prefetched into lds,
             // access global memory only if need to go beyond that
             // which is very unlikely
-            int idx = (top - start) < max_len
-                    ? lmap[top - start]
-                    : map[top];
-            S g     = (top - start) < max_len
-                    ? lz[top - start]
-                    : z[idx];
+            int idx = (top - start) < max_len ? lmap[top - start] : map[top];
+            S g = (top - start) < max_len ? lz[top - start] : z[idx];
 
             S f = baseval;
             S c, s, rr;
@@ -808,9 +894,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             baseval = rr;
 
             mask[idx] = 0;
-            z[idx]   = 0;
-            cc[idx]  = c;
-            ss[idx]  = s;
+            z[idx] = 0;
+            cc[idx] = c;
+            ss[idx] = s;
         }
         z[lmap[hipThreadIdx_x]] = baseval;
     }
@@ -837,10 +923,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int bid = hipBlockIdx_y;
 
     S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
-    
+
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* map     = ptr_map(n, splits);         
-    rocblas_int* dcounts = ptr_dcount(n, splits); 
+    rocblas_int* map = ptr_map(n, splits);
+    rocblas_int* dcounts = ptr_dcount(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* cc = ptr_cc(n, tmpz);
@@ -848,66 +934,74 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     constexpr int regs = 16;
     const int chunk_width = regs * hipBlockDim_x;
-    const int n_chunks    = (n - 1) / chunk_width + 1;
+    const int n_chunks = (n - 1) / chunk_width + 1;
     S bval[regs];
     S tval[regs];
 
-
     rocblas_int dgs = hipBlockIdx_x;
     rocblas_int dcnt = dcounts[dgs];
-    if (dcnt)
+    if(dcnt)
     {
         rocblas_int base = map[dgs];
         S* Cbase = C + base * ldc;
 
-        for (int chunk = 0; chunk < n_chunks; chunk++) {
-
-            for(int i = 0; i < regs; i++) {
+        for(int chunk = 0; chunk < n_chunks; chunk++)
+        {
+            for(int i = 0; i < regs; i++)
+            {
                 int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
-                if (x < n) {
+                if(x < n)
+                {
                     bval[i] = Cbase[x];
                 }
             }
 
-            for (int dn = 0; dn < dcnt; dn++) {
+            for(int dn = 0; dn < dcnt; dn++)
+            {
                 rocblas_int top = map[dgs + dn + 1];
                 S c = cc[top];
                 S s = ss[top];
                 S* Ctop = C + top * ldc;
 
-                for(int i = 0; i < regs; i++) {
+                for(int i = 0; i < regs; i++)
+                {
                     int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
-                    if(x < n){
+                    if(x < n)
+                    {
                         tval[i] = Ctop[x];
                     }
                 }
 
-                for (int i = 0; i < regs; i++) {
+                for(int i = 0; i < regs; i++)
+                {
                     S valf = bval[i];
                     S valg = tval[i];
                     bval[i] = valf * c - valg * s;
-                    tval[i] = valf * s + valg * c; 
+                    tval[i] = valf * s + valg * c;
                 }
 
-                for(int i = 0; i < regs; i++) {
+                for(int i = 0; i < regs; i++)
+                {
                     int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
-                    if(x < n){
+                    if(x < n)
+                    {
                         Ctop[x] = tval[i];
                     }
                 }
                 __syncthreads();
             }
 
-            for(int i = 0; i < regs; i++) {
+            for(int i = 0; i < regs; i++)
+            {
                 int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
-                if (x < n) {
+                if(x < n)
+                {
                     Cbase[x] = bval[i];
                 }
             }
         }
     }
 }
-
 
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
@@ -929,26 +1023,25 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* mask    = ptr_mask(n, splits);
-    rocblas_int* map    = ptr_map(n, splits);
-    rocblas_int* nsz    = ptr_nsz (n, splits);
-    rocblas_int* nps    = ptr_nps (n, splits); 
-    rocblas_int* ndd    = ptr_ndd(n, splits);
-    
-    S* tmpz = tmpzA + bid * get_tmpz_size(n);
-    S* z     = ptr_z(n, tmpz);
-    S* cd    = ptr_cd(n, tmpz);
-    S* cz    = ptr_cz(n, tmpz);
-    S* r1p   = ptr_r1p(n, tmpz);
-    S* evs   = ptr_evs(n, tmpz);
+    rocblas_int* mask = ptr_mask(n, splits);
+    rocblas_int* map = ptr_map(n, splits);
+    rocblas_int* nsz = ptr_nsz(n, splits);
+    rocblas_int* nps = ptr_nps(n, splits);
+    rocblas_int* ndd = ptr_ndd(n, splits);
 
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* z = ptr_z(n, tmpz);
+    S* cd = ptr_cd(n, tmpz);
+    S* cz = ptr_cz(n, tmpz);
+    S* r1p = ptr_r1p(n, tmpz);
+    S* evs = ptr_evs(n, tmpz);
 
     S sig = (r1p[gid] < 0) ? -1 : 1;
-    S d_  = D[gid];
+    S d_ = D[gid];
     S sd_ = sig * d_;
-    S z_  = z[gid];
-    rocblas_int sz  = nsz[gid];
-    rocblas_int p1  = nps[gid];
+    S z_ = z[gid];
+    rocblas_int sz = nsz[gid];
+    rocblas_int p1 = nps[gid];
     rocblas_int def = mask[gid];
 
     constexpr int regs = 8;
@@ -956,7 +1049,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     const int n_chunks = (sz - 1) / chunk_width + 1;
     S bval[regs];
     int maskval[regs];
-
 
     int nan = 0;
     int lt = 0;
@@ -972,7 +1064,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             if(x < sz)
             {
                 bval[i] = sig * D[p1 + x];
-                maskval[i]  = mask[p1 + x];
+                maskval[i] = mask[p1 + x];
             }
         }
         for(int i = 0; i < regs; i++)
@@ -1007,7 +1099,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         if(hipThreadIdx_x < dim2)
         {
             pos += lpos[hipThreadIdx_x + dim2];
-            dd  += ldd[hipThreadIdx_x + dim2];
+            dd += ldd[hipThreadIdx_x + dim2];
             lpos[hipThreadIdx_x] = pos;
             ldd[hipThreadIdx_x] = dd;
         }
@@ -1015,14 +1107,15 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         __syncthreads();
     }
 
-    if (hipThreadIdx_x == 0) {
-        ndd [pos+p1] = dd;
-        map [pos+p1] = gid;
-        cd  [pos+p1] = sd_;
-        cz  [pos+p1] = z_;
+    if(hipThreadIdx_x == 0)
+    {
+        ndd[pos + p1] = dd;
+        map[pos + p1] = gid;
+        cd[pos + p1] = sd_;
+        cz[pos + p1] = z_;
         // copy over all diagonal elements in ev. ev will be overwritten
         // by the new computed eigenvalues of the merged block
-        evs [pos+p1] = d_;
+        evs[pos + p1] = d_;
     }
 
     __syncthreads();
@@ -1030,7 +1123,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // new positions it would be silently overwriten with non NAN value.
     // Make sure we propagate NAN. It is likely to have more NANs in the output
     // than in the input, but the following computations are doomed anyway.
-    if (nan) {
+    if(nan)
+    {
         cd[gid] = NAN;
     }
 }
@@ -1059,14 +1153,13 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* evs = ptr_evs(n, tmpz);
-    S* cd  = ptr_cd(n, tmpz);
+    S* cd = ptr_cd(n, tmpz);
 
     S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
     S* etmpd = ptr_etmpd(n, tempgemm);
 
     rocblas_int dd = ndd[eid];
     rocblas_int p1 = nps[eid];
-
 
     // copy sorted values back to D
     int x = hipThreadIdx_x + hipBlockDim_x * hipBlockIdx_x;
@@ -1075,22 +1168,21 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         D[x] = evs[x];
     }
 
-
     // make copies of the non-deflated ordered diagonal elements
     // (i.e. the poles of the secular eqn) so that the distances to the
     // eigenvalues (D - lambda_i) are updated while computing each eigenvalue.
     // This will prevent collapses and division by zero when an eigenvalue
     // is too close to a pole.
-    for (int i = hipThreadIdx_x; i < dd; i += hipBlockDim_x)
+    for(int i = hipThreadIdx_x; i < dd; i += hipBlockDim_x)
     {
         etmpd[eid * n + i] = cd[p1 + i];
     }
 }
 
 //--------------------------------------------------------------------------------------//
-/** STEDC_MERGEVALUES_KERNEL solves the secular equation for every pair of sub-blocks 
-    that need to be merged. 
-        - Call this kernel with batch_count groups in y, and as many groups in x as needed 
+/** STEDC_MERGEVALUES_KERNEL solves the secular equation for every pair of sub-blocks
+    that need to be merged.
+        - Call this kernel with batch_count groups in y, and as many groups in x as needed
           to cover n (i.e. n_groups_x * groups_size_x >= n). Groups are size STEDC_SOLVE_BDIM **/
 
 template <typename S>
@@ -1116,9 +1208,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_SOLVE_BDIM)
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
     rocblas_int* ndd = ptr_ndd(n, splits);
     rocblas_int* nps = ptr_nps(n, splits);
-    
+
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
-    S* z   = ptr_cz(n, tmpz);
+    S* z = ptr_cz(n, tmpz);
     S* r1p = ptr_r1p(n, tmpz);
     S* evs = ptr_evs(n, tmpz);
     // updated eigenvectors after merges
@@ -1138,7 +1230,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_SOLVE_BDIM)
         // corresponding to non-deflated new eigenvalues of the merged block
         /* ----------------------------------------------------------------- */
         // each thread will find a different zero in parallel
-        if((i-p1) < dd)
+        if((i - p1) < dd)
         {
             int cc = i - p1;
 
@@ -1151,11 +1243,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_SOLVE_BDIM)
             linfo = slaed4(dd, cc, etmpd + i * n, z + p1, std::abs(p), evs[i]);
 #else
             if(cc == dd - 1)
-                linfo = seq_solve_ext(dd, etmpd + i * n, z + p1, std::abs(p), evs + i, eps,
-                                        ssfmin, ssfmax);
+                linfo = seq_solve_ext(dd, etmpd + i * n, z + p1, std::abs(p), evs + i, eps, ssfmin,
+                                      ssfmax);
             else
-                linfo = seq_solve(dd, etmpd + i * n, z + p1, std::abs(p), cc, evs + i, eps,
-                                    ssfmin, ssfmax);
+                linfo = seq_solve(dd, etmpd + i * n, z + p1, std::abs(p), cc, evs + i, eps, ssfmin,
+                                  ssfmax);
 #endif
 
             if(p < 0)
@@ -1190,9 +1282,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* nps  = ptr_nps(n, splits);
-    rocblas_int* nsz  = ptr_nsz(n, splits);
-    rocblas_int* ndd  = ptr_ndd(n, splits);
+    rocblas_int* nps = ptr_nps(n, splits);
+    rocblas_int* nsz = ptr_nsz(n, splits);
+    rocblas_int* ndd = ptr_ndd(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z = ptr_cz(n, tmpz);
@@ -1239,7 +1331,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     }
 }
 
-
 //--------------------------------------------------------------------------------------//
 /** STEDC_MERGEVECTORS_KERNEL prepares vectors from the secular equation for
     every pair of sub-blocks that need to be merged.
@@ -1272,15 +1363,15 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* nsz  = ptr_nsz(n, splits);
-    rocblas_int* nps  = ptr_nps(n, splits);
-    rocblas_int* ndd  = ptr_ndd(n, splits);
+    rocblas_int* nsz = ptr_nsz(n, splits);
+    rocblas_int* nps = ptr_nps(n, splits);
+    rocblas_int* ndd = ptr_ndd(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
-    S* z    = ptr_cz(n, tmpz);
+    S* z = ptr_cz(n, tmpz);
     // updated eigenvectors after merges
     S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
-    S* vecs  = ptr_vecs(n, tempgemm);
+    S* vecs = ptr_vecs(n, tempgemm);
     S* etmpd = ptr_etmpd(n, tempgemm);
 
     // Work with merges on level k. Each thread-group works with one vector.
@@ -1299,15 +1390,15 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S nrm;
     S* putvec = USEGEMM ? vecs : etmpd;
 
-    if(eid-p1 < dd)
+    if(eid - p1 < dd)
     {
         // compute vectors of rank-1 perturbed system and their norms
         nrm = 0;
         for(int i = tidb; i < dd; i += dim)
         {
-            S valf = z[p1 + i] / etmpd[i + eid*n];
+            S valf = z[p1 + i] / etmpd[i + eid * n];
             nrm += valf * valf;
-            putvec[i + eid*n] = valf;
+            putvec[i + eid * n] = valf;
         }
 
         // reduction (for the norms)
@@ -1334,8 +1425,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         {
             if(i >= p1 && (eid - p1) < dd && (i - p1) < dd)
             {
-                etmpd[i + eid * n]
-                    = vecs[i - p1 + eid * n] / nrm;
+                etmpd[i + eid * n] = vecs[i - p1 + eid * n] / nrm;
             }
             else
                 etmpd[i + eid * n] = 0;
@@ -1345,7 +1435,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     {
         // otherwise, use internal gemm-like procedure to
         // multiply by C (row by row)
-        if(eid-p1 < dd)
+        if(eid - p1 < dd)
         {
             for(int ii = 0; ii < sz; ++ii)
             {
@@ -1378,10 +1468,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     }
 }
 
-
-
 //--------------------------------------------------------------------------------------//
-/** STEDC_MERGEUPDATE_KERNEL updates vectors and values after a merge is done. 
+/** STEDC_MERGEUPDATE_KERNEL updates vectors and values after a merge is done.
         - Call this kernel with batch_count groups in y, and n groups in x.
           Each group works with a column. Groups are size STEDC_BDIM. **/
 template <typename S>
@@ -1410,10 +1498,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* ndd  = ptr_ndd(n, splits);
-    rocblas_int* nsz  = ptr_nsz(n, splits);
-    rocblas_int* nps  = ptr_nps(n, splits);
-    
+    rocblas_int* ndd = ptr_ndd(n, splits);
+    rocblas_int* nsz = ptr_nsz(n, splits);
+    rocblas_int* nps = ptr_nps(n, splits);
+
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* evs = ptr_evs(n, tmpz);
     // updated eigenvectors after merges
@@ -1434,7 +1522,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     }
 }
 
-
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_copyD(const rocblas_int n,
                                                                 S* DDin,
@@ -1445,7 +1532,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_copyD(const rocblas_in
     // batch instance id
     rocblas_int bid = hipBlockIdx_y;
 
-    S* Din  = DDin  + bid * strideDin;
+    S* Din = DDin + bid * strideDin;
     S* Dout = DDout + bid * strideDout;
 
     int tid = hipThreadIdx_x;
@@ -1455,13 +1542,16 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_copyD(const rocblas_in
     const int n_chunks = (n - 1) / chunk_width + 1;
     S bval[regs];
 
-    for(int chunk = 0; chunk < n_chunks; chunk++) {
-        for(int i = 0; i < regs; i++) {
+    for(int chunk = 0; chunk < n_chunks; chunk++)
+    {
+        for(int i = 0; i < regs; i++)
+        {
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < n)
                 bval[i] = Din[x];
         }
-        for(int i = 0; i < regs; i++) {
+        for(int i = 0; i < regs; i++)
+        {
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < n)
                 Dout[x] = bval[i];
@@ -1485,24 +1575,27 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_copyC(const rocblas_in
     // group id
     rocblas_int gid = hipBlockIdx_x;
 
-    T* Cin  = load_ptr_batch<T>(CCin,  bid, shiftCin,  strideCin);
+    T* Cin = load_ptr_batch<T>(CCin, bid, shiftCin, strideCin);
     T* Cout = load_ptr_batch<T>(CCout, bid, shiftCout, strideCout);
 
-    T* src =  Cin + ldcin  * gid;
+    T* src = Cin + ldcin * gid;
     T* dst = Cout + ldcout * gid;
-    
+
     constexpr int regs = 16;
     const int chunk_width = regs * hipBlockDim_x;
     const int n_chunks = (n - 1) / chunk_width + 1;
     T bval[regs];
-    
-    for(int chunk = 0; chunk < n_chunks; chunk++) {
-        for(int i = 0; i < regs; i++) {
+
+    for(int chunk = 0; chunk < n_chunks; chunk++)
+    {
+        for(int i = 0; i < regs; i++)
+        {
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < n)
                 bval[i] = src[x];
         }
-        for(int i = 0; i < regs; i++) {
+        for(int i = 0; i < regs; i++)
+        {
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < n)
                 dst[x] = bval[i];
@@ -1564,19 +1657,19 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_reshuffleC(const rocbl
 /** STEDC_SORT sorts computed eigenvalues and eigenvectors in increasing order **/
 template <typename T, typename S, typename U1, typename U2>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int n,
-                                                              S* DDin,
-                                                              const rocblas_stride strideDin,
-                                                              S* DDout,
-                                                              const rocblas_stride strideDout,
-                                                              U1 CCin,
-                                                              const rocblas_int shiftCin,
-                                                              const rocblas_int ldcin,
-                                                              const rocblas_stride strideCin,
-                                                              U2 CCout,
-                                                              const rocblas_int shiftCout,
-                                                              const rocblas_int ldcout,
-                                                              const rocblas_stride strideCout
-                                                              
+                                                               S* DDin,
+                                                               const rocblas_stride strideDin,
+                                                               S* DDout,
+                                                               const rocblas_stride strideDout,
+                                                               U1 CCin,
+                                                               const rocblas_int shiftCin,
+                                                               const rocblas_int ldcin,
+                                                               const rocblas_stride strideCin,
+                                                               U2 CCout,
+                                                               const rocblas_int shiftCout,
+                                                               const rocblas_int ldcout,
+                                                               const rocblas_stride strideCout
+
 )
 {
     // batch instance id
@@ -1584,8 +1677,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int
     // group id
     rocblas_int gid = hipBlockIdx_x;
 
-
-    S* Din  = DDin  + bid * strideDin;
+    S* Din = DDin + bid * strideDin;
     S* Dout = DDout + bid * strideDout;
 
     int tid = hipThreadIdx_x;
@@ -1604,14 +1696,16 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int
 
     for(int chunk = 0; chunk < n_chunks; chunk++)
     {
-        for(int i = 0; i < regs; i++) {
+        for(int i = 0; i < regs; i++)
+        {
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < n)
             {
                 bvalS[i] = Din[x];
             }
         }
-        for(int i = 0; i < regs; i++) {
+        for(int i = 0; i < regs; i++)
+        {
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < n)
             {
@@ -1623,7 +1717,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int
             }
         }
     }
-
 
     int pos = lt + eq;
     // reduction
@@ -1641,7 +1734,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int
     __syncthreads();
     pos = lpos[0];
 
-    if (hipThreadIdx_x == 0) {
+    if(hipThreadIdx_x == 0)
+    {
         Dout[pos] = d;
     }
 
@@ -1649,24 +1743,27 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int
     // new positions it would be silently overwriten with non NAN value.
     // Make sure we propagate NAN. It is likely to have more NANs in the output
     // than in the input, but the following computations are doomed anyway.
-    if (nan) {
+    if(nan)
+    {
         Dout[gid] = NAN;
     }
 
-    
-    T* Cin  = load_ptr_batch<T>(CCin,  bid, shiftCin,  strideCin);
+    T* Cin = load_ptr_batch<T>(CCin, bid, shiftCin, strideCin);
     T* Cout = load_ptr_batch<T>(CCout, bid, shiftCout, strideCout);
 
-    T* src =  Cin + ldcin  * gid;
+    T* src = Cin + ldcin * gid;
     T* dst = Cout + ldcout * pos;
-    
-    for(int chunk = 0; chunk < n_chunks; chunk++) {
-        for(int i = 0; i < regs; i++) {
+
+    for(int chunk = 0; chunk < n_chunks; chunk++)
+    {
+        for(int i = 0; i < regs; i++)
+        {
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < n)
                 bvalT[i] = src[x];
         }
-        for(int i = 0; i < regs; i++) {
+        for(int i = 0; i < regs; i++)
+        {
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < n)
                 dst[x] = bvalT[i];
@@ -1674,13 +1771,12 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int
     }
 }
 
-
 /******************* Host functions *********************************************/
 /*******************************************************************************/
 
 //--------------------------------------------------------------------------------------//
 /** STEDC_NUM_LEVELS returns the ideal number of times/levels in which a matrix
-    will be divided during the divide phase of divide & conquer algorithm 
+    will be divided during the divide phase of divide & conquer algorithm
     i.e. number of sub-blocks = 2^levels **/
 inline rocblas_int stedc_num_levels(const rocblas_int n)
 {
@@ -1813,7 +1909,14 @@ rocblas_status rocsolver_stedc_argCheck(rocblas_handle handle,
 
 #if DEBUG_OUTPUT
 template <typename S, typename I>
-void print_block_map(const char* tag, bool show_pres, bool show_cnt, int n, int n_merges, I* bsz, I* bps, S* matr)
+void print_block_map(const char* tag,
+                     bool show_pres,
+                     bool show_cnt,
+                     int n,
+                     int n_merges,
+                     I* bsz,
+                     I* bps,
+                     S* matr)
 {
     int n_blocks = n_merges * 2;
     std::vector<I> sz(n_blocks);
@@ -1830,16 +1933,21 @@ void print_block_map(const char* tag, bool show_pres, bool show_cnt, int n, int 
     {
         s += sz[i];
     }
-    if (s != n) {
-        std::cout << "ERROR: n("<< n <<") != s("<< s <<")\n";
+    if(s != n)
+    {
+        std::cout << "ERROR: n(" << n << ") != s(" << s << ")\n";
         std::exit(0);
     }
 
     bool is_blk_diag = true;
-    for(int jb = 0; jb < n_blocks; jb++) {
-        for (int jp = 0; jp < sz[jb]; jp++) {
-            for(int ib = 0; ib < n_blocks; ib++) {
-                for(int ip = 0; ip < sz[ib]; ip++) {
+    for(int jb = 0; jb < n_blocks; jb++)
+    {
+        for(int jp = 0; jp < sz[jb]; jp++)
+        {
+            for(int ib = 0; ib < n_blocks; ib++)
+            {
+                for(int ip = 0; ip < sz[ib]; ip++)
+                {
                     {
                         int j = ps[jb] + jp;
                         int i = ps[ib] + ip;
@@ -1853,23 +1961,29 @@ void print_block_map(const char* tag, bool show_pres, bool show_cnt, int n, int 
         }
     }
 
-    std::cout << (is_blk_diag ? "block diag matrix ("
-        : "matrix has off-blockdiag non-zeros (") << tag << ")\n";
+    std::cout << (is_blk_diag ? "block diag matrix (" : "matrix has off-blockdiag non-zeros (")
+              << tag << ")\n";
 
-    if (show_pres) {
+    if(show_pres)
+    {
         std::cout << tag << " present map " << n_blocks << "x" << n_blocks << ":\n";
-        for(int j = 0; j < n_blocks; j++) {
-            for(int i = 0; i < n_blocks; i++) {
+        for(int j = 0; j < n_blocks; j++)
+        {
+            for(int i = 0; i < n_blocks; i++)
+            {
                 std::cout << (cnt[j * n_blocks + i] ? " X" : " .");
             }
             std::cout << "\n";
         }
     }
 
-    if (show_cnt) {
+    if(show_cnt)
+    {
         std::cout << tag << " cnt map " << n_blocks << "x" << n_blocks << ":\n";
-        for(int j = 0; j < n_blocks; j++) {
-            for(int i = 0; i < n_blocks; i++) {
+        for(int j = 0; j < n_blocks; j++)
+        {
+            for(int i = 0; i < n_blocks; i++)
+            {
                 std::cout << "\t" << cnt[j * n_blocks + i];
             }
             std::cout << "\n";
@@ -1877,7 +1991,6 @@ void print_block_map(const char* tag, bool show_pres, bool show_cnt, int n, int 
     }
 }
 #endif
-
 
 //--------------------------------------------------------------------------------------//
 /** STEDC templated function **/
@@ -1913,7 +2026,8 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
     char* env_levs = std::getenv("LEVS");
     char* env_gemm = std::getenv("OLD_GEMM");
     bool old_gemm = false;
-    if (env_gemm) {
+    if(env_gemm)
+    {
         old_gemm = env_gemm[0] == '1';
     }
 #endif
@@ -1976,7 +2090,7 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         ssfmin = sqrt(ssfmin) / (eps * eps);
         ssfmax = sqrt(ssfmax) / S(3.0);
 
-        // find number of sub-blocks 
+        // find number of sub-blocks
         rocblas_int levs = stedc_num_levels(n);
         rocblas_int blks = 1 << levs;
 
@@ -1999,17 +2113,15 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         // 1. divide phase
         //-----------------------------
         rocblas_int groups = (batch_count - 1) / STEDC_BDIM + 1;
-        ROCSOLVER_LAUNCH_KERNEL((stedc_divide_kernel<S>),
-                                dim3(groups), dim3(STEDC_BDIM), 0, stream, levs, blks, n, D + shiftD,
-                                strideD, E + shiftE, strideE, batch_count, splits);
+        ROCSOLVER_LAUNCH_KERNEL((stedc_divide_kernel<S>), dim3(groups), dim3(STEDC_BDIM), 0, stream,
+                                levs, blks, n, D + shiftD, strideD, E + shiftE, strideE,
+                                batch_count, splits);
 
         // 2. solve phase
         //-----------------------------
-        ROCSOLVER_LAUNCH_KERNEL((stedc_solve_kernel<S>),
-                                dim3(blks, batch_count), dim3(64), 0, stream, levs,
-                                n, D + shiftD, strideD, E + shiftE, strideE, 
-                                V, 0, ldv, strideV, info, (S*)work_stack, splits, 
-                                eps, ssfmin, ssfmax);
+        ROCSOLVER_LAUNCH_KERNEL((stedc_solve_kernel<S>), dim3(blks, batch_count), dim3(64), 0,
+                                stream, levs, n, D + shiftD, strideD, E + shiftE, strideE, V, 0,
+                                ldv, strideV, info, (S*)work_stack, splits, eps, ssfmin, ssfmax);
 
         // 3. merge phase
         //----------------
@@ -2022,15 +2134,13 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
 
             // a. prepare secular equations
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_DeflateZero_kernel<S>),
-                                    dim3(n_merges, batch_count), dim3(STEDC_BDIM), 0, stream, 
-                                    k, n, D + shiftD, strideD,
-                                    E + shiftE, strideE, V, 0, ldv, strideV, tmpz, splits,
-                                    eps);
+                                    dim3(n_merges, batch_count), dim3(STEDC_BDIM), 0, stream, k, n,
+                                    D + shiftD, strideD, E + shiftE, strideE, V, 0, ldv, strideV,
+                                    tmpz, splits, eps);
 
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_SortD_kernel<S>),
-                                    dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream,
-                                    k, n, D + shiftD, strideD,
-                                    tmpz, splits);
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_SortD_kernel<S>), dim3(n, batch_count),
+                                    dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD, strideD, tmpz,
+                                    splits);
             rocblas_int numgrps_deflate = (n - 1) / STEDC_BDIM + 1;
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_SetCandFlags_kernel<S>),
                                     dim3(numgrps_deflate, batch_count), dim3(STEDC_BDIM), 0, stream,
@@ -2040,73 +2150,41 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     k, n, D + shiftD, strideD, tmpz, splits);
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_DeflateApply_kernel<S>),
                                     dim3(numgrps_deflate, batch_count), dim3(STEDC_BDIM), 0, stream,
-                                    k, n, D + shiftD, strideD,
-                                    tmpz, splits);
-                
+                                    k, n, D + shiftD, strideD, tmpz, splits);
+
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeRotate_kernel<S>), dim3(n, batch_count),
-                                    dim3(STEDC_BDIM), 0, stream, k, n, V, 0, ldv,
-                                    strideV, tmpz, splits);
-            
+                                    dim3(STEDC_BDIM), 0, stream, k, n, V, 0, ldv, strideV, tmpz,
+                                    splits);
 
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_SortDZ_kernel<S>), dim3(n, batch_count),
-                                    dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD,
-                                    strideD, tmpz, splits);
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_copyD_kernel<S>),
-                                    dim3(n, batch_count),
-                                    dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD,
-                                    strideD, tmpz, tempgemm, splits);
-
-
-            ROCSOLVER_LAUNCH_KERNEL(stedc_copyC<S>, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, n,
-                                    V, 0, ldv, strideV,
-                                    ptr_vecs(n, tempgemm), 0, n, get_tempgemm_size(n));
-                                    
-            ROCSOLVER_LAUNCH_KERNEL(stedc_reshuffleC<S>, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, n,
-                                    ptr_vecs(n, tempgemm), 0, n, get_tempgemm_size(n),
-                                    V, 0, ldv, strideV,
+                                    dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD, strideD, tmpz,
                                     splits);
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_copyD_kernel<S>), dim3(n, batch_count),
+                                    dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD, strideD, tmpz,
+                                    tempgemm, splits);
+
+            ROCSOLVER_LAUNCH_KERNEL(stedc_copyC<S>, dim3(n, batch_count), dim3(STEDC_BDIM), 0,
+                                    stream, n, V, 0, ldv, strideV, ptr_vecs(n, tempgemm), 0, n,
+                                    get_tempgemm_size(n));
+
+            ROCSOLVER_LAUNCH_KERNEL(stedc_reshuffleC<S>, dim3(n, batch_count), dim3(STEDC_BDIM), 0,
+                                    stream, n, ptr_vecs(n, tempgemm), 0, n, get_tempgemm_size(n), V,
+                                    0, ldv, strideV, splits);
 
             rocblas_int numgrps_solve = (n - 1) / STEDC_SOLVE_BDIM + 1;
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Solve_kernel<S>),
-                                    dim3(numgrps_solve, batch_count), dim3(STEDC_SOLVE_BDIM),
-                                    0, stream, k, n, D + shiftD,
-                                    strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
-                                    ssfmin, ssfmax);
+                                    dim3(numgrps_solve, batch_count), dim3(STEDC_SOLVE_BDIM), 0,
+                                    stream, k, n, D + shiftD, strideD, E + shiftE, strideE, tmpz,
+                                    tempgemm, splits, eps, ssfmin, ssfmax);
 
-#if DEBUG_OUTPUT
-            //hipError_t status = hipStreamSynchronize(stream);
-            if(env_levs && global_cnt == 1)
-            {
-                std::cout << "\nk=" << k << std::endl;
-                print_device_matrix(std::cout, "msz", 1, n_merges, ptr_msz(n, splits), 1);
-                print_device_matrix(std::cout, "mps", 1, n_merges, ptr_mps(n, splits), 1);
-                print_device_matrix(std::cout, "ndd", 1, n_merges, ptr_ndd(n, splits), 1);
-                print_device_matrix(std::cout, "nsz", 1, n, ptr_nsz(n, splits), 1);
-                print_device_matrix(std::cout, "nps", 1, n, ptr_nps(n, splits), 1);
-                print_device_matrix(std::cout, "mask", 1, n, ptr_mask(n, splits), 1);
-                //print_device_matrix(std::cout, "dbg", 1, n, ptr_dbg(n, splits), 1);
-                //print_device_matrix(std::cout, "map", 1, n, ptr_map(n, splits), 1);
-                print_device_matrix(std::cout, "D", 1, n, D, 1);
-                print_device_matrix(std::cout, "cd", 1, n, ptr_cd(n, tmpz), 1);
-                //print_device_matrix(std::cout, "etmpd", n, n, tempgemm +n*n, n);
-
-                //print_device_matrix(std::cout, "D", 1, n, D, 1);
-
-                //std::exit(0);
-            }
-#endif
-
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Rescale_kernel<S>),
-                                    dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream,
-                                    k, n, D + shiftD, strideD, E + shiftE, strideE,
-                                    tmpz, tempgemm, splits, eps, ssfmin, ssfmax);
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Rescale_kernel<S>), dim3(n, batch_count),
+                                    dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD, strideD,
+                                    E + shiftE, strideE, tmpz, tempgemm, splits, eps, ssfmin, ssfmax);
 
             // c. find merged eigenvectors
-            ROCSOLVER_LAUNCH_KERNEL(
-                (stedc_mergeVectors_kernel<STEDC_EXTERNAL_GEMM, S>),
-                dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
-                k, n, V, 0, ldv, strideV, 
-                tmpz, tempgemm, splits);
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeVectors_kernel<STEDC_EXTERNAL_GEMM, S>),
+                                    dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, k, n, V, 0,
+                                    ldv, strideV, tmpz, tempgemm, splits);
 
             if(STEDC_EXTERNAL_GEMM)
             {
@@ -2118,22 +2196,21 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                 if(old_gemm || n <= 1024 || batch_count > 1)
                 {
                     rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, n, n, n,
-                                   &one, V, 0, ldv, strideV,
-                                   ptr_etmpd(n, tempgemm), 0, n, get_tempgemm_size(n), &zero,
-                                   ptr_vecs(n, tempgemm),  0, n, get_tempgemm_size(n), batch_count, workArr);
+                                   &one, V, 0, ldv, strideV, ptr_etmpd(n, tempgemm), 0, n,
+                                   get_tempgemm_size(n), &zero, ptr_vecs(n, tempgemm), 0, n,
+                                   get_tempgemm_size(n), batch_count, workArr);
                 }
-                else {
+                else
+                {
                     HIP_CHECK(hipMemsetAsync((void*)tempgemm, 0, n * n * sizeof(S), stream));
 
                     if(n % n_merges == 0)
                     {
                         int sz = n / n_merges;
-                        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none,
-                                       sz, sz, sz, &one,
-                                       V,                      0, ldv, sz * ldv + sz,
-                                       ptr_etmpd(n, tempgemm), 0,   n, sz * n + sz, &zero,
-                                       ptr_vecs(n, tempgemm),  0,   n, sz * n + sz, n_merges,
-                                       workArr);
+                        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, sz,
+                                       sz, sz, &one, V, 0, ldv, sz * ldv + sz,
+                                       ptr_etmpd(n, tempgemm), 0, n, sz * n + sz, &zero,
+                                       ptr_vecs(n, tempgemm), 0, n, sz * n + sz, n_merges, workArr);
                     }
                     else
                     {
@@ -2176,14 +2253,12 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                         }
                     }
                 }
-
             }
 
             // d. update level
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeUpdate_kernel<S>),
-                                    dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
-                                    k, n, D + shiftD, strideD,
-                                    V, 0, ldv, strideV, tmpz, tempgemm, splits);
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeUpdate_kernel<S>), dim3(n, batch_count),
+                                    dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD, strideD, V, 0,
+                                    ldv, strideV, tmpz, tempgemm, splits);
         }
 
         // 4. update and sort
@@ -2215,14 +2290,12 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         ROCSOLVER_LAUNCH_KERNEL(stedc_copyD, dim3(1, batch_count), dim3(STEDC_BDIM), 0, stream, n,
                                 D + shiftD, strideD, tmpz, n);
 
-        ROCSOLVER_LAUNCH_KERNEL(stedc_copyC<T>, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, n,
-                                C,    shiftC, ldc, strideC,
-                                (T*)tempgemm, 0,      n,   n*n);
+        ROCSOLVER_LAUNCH_KERNEL(stedc_copyC<T>, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream,
+                                n, C, shiftC, ldc, strideC, (T*)tempgemm, 0, n, n * n);
 
-        ROCSOLVER_LAUNCH_KERNEL(stedc_sort<T>, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream,
-                                n, tmpz, n, D + shiftD, strideD,
-                                (T*)tempgemm, 0,      n,   n*n,
-                                C,    shiftC, ldc, strideC);
+        ROCSOLVER_LAUNCH_KERNEL(stedc_sort<T>, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, n,
+                                tmpz, n, D + shiftD, strideD, (T*)tempgemm, 0, n, n * n, C, shiftC,
+                                ldc, strideC);
 
         rocblas_set_pointer_mode(handle, old_mode);
     }

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -67,7 +67,7 @@ __host__ __device__ inline rocblas_int get_splits_size(const rocblas_int n)
     // 1     rocblas_int      ;               //
     // 2     rocblas_int      ;               //
     // 3     rocblas_int idd[n];              // if idd[i] = 0, the value in position i has been deflated  (aka mask)
-    // 4     rocblas_int pers[n];             // container of permutations when solving the secular eqns
+    // 4     rocblas_int ;             //
     // 5     rocblas_int ;      //
     // 6     rocblas_int ;      //
     // 7     rocblas_int dds[m], _[n-m];      // degrees of secular equation
@@ -82,7 +82,7 @@ __host__ __device__ inline rocblas_int get_splits_size(const rocblas_int n)
     // 16    rocblas_int mps[m], _[n-m];      // starting position of each merge
     // 17    rocblas_int bsz[2*m], _[n-2*m];  // size of each block
     // 18    rocblas_int bps[2*m], _[n-2*m];  // starting position of each block
-    // 19    rocblas_int dbg4[n];             //
+    // 19    rocblas_int dbg[n];              //
     // };
     return 20 * n + 64*64;
 }
@@ -90,7 +90,7 @@ __host__ __device__ inline rocblas_int get_splits_size(const rocblas_int n)
 template <typename S> __host__ __device__ inline S* ptr___    (rocblas_int n, S* splits) { return splits +  1 * n; }
 template <typename S> __host__ __device__ inline S* ptr____   (rocblas_int n, S* splits) { return splits +  2 * n; }
 template <typename S> __host__ __device__ inline S* ptr_idd   (rocblas_int n, S* splits) { return splits +  3 * n; }
-template <typename S> __host__ __device__ inline S* ptr_pers  (rocblas_int n, S* splits) { return splits +  4 * n; }
+template <typename S> __host__ __device__ inline S* ptr_____  (rocblas_int n, S* splits) { return splits +  4 * n; }
 template <typename S> __host__ __device__ inline S* ptr_      (rocblas_int n, S* splits) { return splits +  5 * n; }
 template <typename S> __host__ __device__ inline S* ptr__     (rocblas_int n, S* splits) { return splits +  6 * n; }
 template <typename S> __host__ __device__ inline S* ptr_dds   (rocblas_int n, S* splits) { return splits +  7 * n; }
@@ -371,7 +371,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_update_splits(const ro
 
     for (int i = hipThreadIdx_x; i < n; i += hipBlockDim_x)
     {
-        int m = em[i] / 2;
+        rocblas_int m = em[i] / 2;
         esz[i] = msz[m];
         eps[i] = mps[m];
         map[i] = 0;
@@ -1073,7 +1073,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     if (hipThreadIdx_x == 0) {
         dds[sid] = dd;
-        map [pos+p1] = gid - p1;
+        map [pos+p1] = gid;
         cd  [pos+p1] = d_;
         cz  [pos+p1] = z_;
         sidd[pos+p1] = def;
@@ -1342,7 +1342,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* em   = ptr_em(n, splits);
     rocblas_int* mps  = ptr_mps(n, splits);
     rocblas_int* idd  = ptr_idd(n, splits);
-    rocblas_int* pers = ptr_map(n, splits);
+    rocblas_int* map  = ptr_map(n, splits);
     rocblas_int* msz  = ptr_msz(n, splits);
     rocblas_int* dds  = ptr_dds(n, splits);
 
@@ -1368,7 +1368,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             if(idd[p1 + j] == 1)
             {
                 S valg = etmpd[(p1 + j) * n + i];
-                valf *= (pers[p1 + i] == j) ? valg : valg / (D[p1 + pers[p1 + i]] - D[p1 + j]);
+                valf *= (map[p1 + i] == (p1 + j)) ? valg : valg / (D[map[p1 + i]] - D[p1 + j]);
             }
         }
         __shared__ S lds[STEDC_BDIM];
@@ -1435,7 +1435,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* msz  = ptr_msz(n, splits);
     rocblas_int* mps  = ptr_mps(n, splits);
     rocblas_int* dds  = ptr_dds(n, splits);
-    rocblas_int* pers = ptr_map(n, splits);
+    rocblas_int* map  = ptr_map(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z    = ptr_cz(n, tmpz);
@@ -1502,7 +1502,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                     if(idd[k] == 0)
                         dd++;
                 }
-                etmpd[pers[i - dd] + p1 + eid * n]
+                etmpd[map[i - dd] + eid * n]
                     = vecs[i - dd - p1 + eid * n] / nrm;
             }
             else
@@ -1526,7 +1526,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 if(ii < sz)
                 {
                     for(int kk = tidb; kk < dd; kk += dim)
-                        temp += C[i + (pers[p1 + kk] + p1) * ldc] * etmpd[kk + eid * n];
+                        temp += C[i + map[p1 + kk] * ldc] * etmpd[kk + eid * n];
                 }
                 inrms[tidb] = temp;
                 __syncthreads();
@@ -1658,15 +1658,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int bid = hipBlockIdx_y;
     rocblas_int row = hipBlockIdx_x;
 
-    // temporary arrays in global memory
-    rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* em = ptr_em(n, splits);
-    rocblas_int* idd = ptr_idd(n, splits);
-    rocblas_int* msz = ptr_msz(n, splits);
-    rocblas_int* mps = ptr_mps(n, splits);
-    rocblas_int* dds = ptr_dds(n, splits);
-    rocblas_int* pers = ptr_map(n, splits);
-
     S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
     S* etmpd = ptr_etmpd(n, tempgemm);
 
@@ -1710,7 +1701,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* msz  = ptr_msz(n, splits);
     rocblas_int* mps  = ptr_mps(n, splits);
     rocblas_int* dds  = ptr_dds(n, splits);
-    rocblas_int* pers = ptr_map(n, splits);
+    rocblas_int* map  = ptr_map(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* nrms = ptr_nrms(n, tmpz);
@@ -1751,7 +1742,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                         if(idd[p1 + k] == 0)
                             dd++;
                     }
-                    etmpd[pers[p1 + i - dd] + p1 + eid * n]
+                    etmpd[map[p1 + i - dd] + eid * n]
                         = vecs[p1 + i - dd - p1 + eid * n] / nrm;
                 }
             }
@@ -1774,7 +1765,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 if(ii < sz)
                 {
                     for(int kk = tidb; kk < dd; kk += dim)
-                        temp += C[i + (pers[p1 + kk] + p1) * ldc] * etmpd[kk + eid * n];
+                        temp += C[i + map[p1 + kk] * ldc] * etmpd[kk + eid * n];
                 }
                 inrms[tidb] = temp;
                 __syncthreads();
@@ -2355,7 +2346,8 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_copyD_kernel<S>),
                                     dim3(n_merges, batch_count),
                                     dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
-                                    strideD, tmpz, tempgemm, splits);//*/
+                                    strideD, tmpz, tempgemm, splits);
+
 #if DEBUG_OUTPUT
             //hipError_t status = hipStreamSynchronize(stream);
             if(env_levs && global_cnt == 1)
@@ -2370,7 +2362,6 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                 print_device_matrix(std::cout, "idd", 1, n, ptr_idd(n, splits), 1);
                 print_device_matrix(std::cout, "sidd", 1, n, ptr_sidd(n, splits), 1);
                 print_device_matrix(std::cout, "map", 1, n, ptr_map(n, splits), 1);
-                //print_device_matrix(std::cout, "pers", 1, n, ptr_pers(n, splits), 1);
                 print_device_matrix(std::cout, "D", 1, n, D, 1);
                 print_device_matrix(std::cout, "cd", 1, n, ptr_cd(n, tmpz), 1);
                 //print_device_matrix(std::cout, "etmpd", n, n, tempgemm +n*n, n);

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1469,13 +1469,13 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_copyD(const rocblas_in
     }
 }
 
-template <typename S>
+template <typename T, typename U1, typename U2>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_copyC(const rocblas_int n,
-                                                                S* CCin,
+                                                                U1 CCin,
                                                                 const rocblas_int shiftCin,
                                                                 const rocblas_int ldcin,
                                                                 const rocblas_stride strideCin,
-                                                                S* CCout,
+                                                                U2 CCout,
                                                                 const rocblas_int shiftCout,
                                                                 const rocblas_int ldcout,
                                                                 const rocblas_stride strideCout)
@@ -1485,16 +1485,16 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_copyC(const rocblas_in
     // group id
     rocblas_int gid = hipBlockIdx_x;
 
-    S* Cin  = load_ptr_batch<S>(CCin,  bid, shiftCin,  strideCin);
-    S* Cout = load_ptr_batch<S>(CCout, bid, shiftCout, strideCout);
+    T* Cin  = load_ptr_batch<T>(CCin,  bid, shiftCin,  strideCin);
+    T* Cout = load_ptr_batch<T>(CCout, bid, shiftCout, strideCout);
 
-    S* src =  Cin + ldcin  * gid;
-    S* dst = Cout + ldcout * gid;
+    T* src =  Cin + ldcin  * gid;
+    T* dst = Cout + ldcout * gid;
     
     constexpr int regs = 16;
     const int chunk_width = regs * hipBlockDim_x;
     const int n_chunks = (n - 1) / chunk_width + 1;
-    S bval[regs];
+    T bval[regs];
     
     for(int chunk = 0; chunk < n_chunks; chunk++) {
         for(int i = 0; i < regs; i++) {
@@ -1510,13 +1510,13 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_copyC(const rocblas_in
     }
 }
 
-template <typename S>
+template <typename T, typename U1, typename U2>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_reshuffleC(const rocblas_int n,
-                                                                     S* CCin,
+                                                                     U1 CCin,
                                                                      const rocblas_int shiftCin,
                                                                      const rocblas_int ldcin,
                                                                      const rocblas_stride strideCin,
-                                                                     S* CCout,
+                                                                     U2 CCout,
                                                                      const rocblas_int shiftCout,
                                                                      const rocblas_int ldcout,
                                                                      const rocblas_stride strideCout,
@@ -1533,16 +1533,16 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_reshuffleC(const rocbl
     rocblas_int dst_row = gid;
     rocblas_int src_row = map[gid];
 
-    S* Cin = load_ptr_batch<S>(CCin, bid, shiftCin, strideCin);
-    S* Cout = load_ptr_batch<S>(CCout, bid, shiftCout, strideCout);
+    T* Cin = load_ptr_batch<T>(CCin, bid, shiftCin, strideCin);
+    T* Cout = load_ptr_batch<T>(CCout, bid, shiftCout, strideCout);
 
-    S* src = Cin + ldcin * src_row;
-    S* dst = Cout + ldcout * dst_row;
+    T* src = Cin + ldcin * src_row;
+    T* dst = Cout + ldcout * dst_row;
 
     constexpr int regs = 16;
     const int chunk_width = regs * hipBlockDim_x;
     const int n_chunks = (n - 1) / chunk_width + 1;
-    S bval[regs];
+    T bval[regs];
 
     for(int chunk = 0; chunk < n_chunks; chunk++)
     {
@@ -1562,17 +1562,17 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_reshuffleC(const rocbl
 }
 
 /** STEDC_SORT sorts computed eigenvalues and eigenvectors in increasing order **/
-template <typename S>
+template <typename T, typename S, typename U1, typename U2>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int n,
                                                               S* DDin,
                                                               const rocblas_stride strideDin,
                                                               S* DDout,
                                                               const rocblas_stride strideDout,
-                                                              S* CCin,
+                                                              U1 CCin,
                                                               const rocblas_int shiftCin,
                                                               const rocblas_int ldcin,
                                                               const rocblas_stride strideCin,
-                                                              S* CCout,
+                                                              U2 CCout,
                                                               const rocblas_int shiftCout,
                                                               const rocblas_int ldcout,
                                                               const rocblas_stride strideCout
@@ -1595,7 +1595,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int
     constexpr int regs = 16;
     const int chunk_width = regs * hipBlockDim_x;
     const int n_chunks = (n - 1) / chunk_width + 1;
-    S bval[regs];
+    T bvalT[regs];
+    S* bvalS = reinterpret_cast<S*>(bvalT);
 
     int nan = 0;
     int lt = 0;
@@ -1607,18 +1608,18 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < n)
             {
-                bval[i] = Din[x];
+                bvalS[i] = Din[x];
             }
         }
         for(int i = 0; i < regs; i++) {
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < n)
             {
-                nan += std::isnan(bval[i]);
+                nan += std::isnan(bvalS[i]);
                 // lt - how many values are less then the current
                 // eq - how many values are equal to the current
-                lt += (bval[i] < d);
-                eq += (bval[i] == d && x < gid);
+                lt += (bvalS[i] < d);
+                eq += (bvalS[i] == d && x < gid);
             }
         }
     }
@@ -1653,22 +1654,22 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int
     }
 
     
-    S* Cin  = load_ptr_batch<S>(CCin,  bid, shiftCin,  strideCin);
-    S* Cout = load_ptr_batch<S>(CCout, bid, shiftCout, strideCout);
+    T* Cin  = load_ptr_batch<T>(CCin,  bid, shiftCin,  strideCin);
+    T* Cout = load_ptr_batch<T>(CCout, bid, shiftCout, strideCout);
 
-    S* src =  Cin + ldcin  * gid;
-    S* dst = Cout + ldcout * pos;
+    T* src =  Cin + ldcin  * gid;
+    T* dst = Cout + ldcout * pos;
     
     for(int chunk = 0; chunk < n_chunks; chunk++) {
         for(int i = 0; i < regs; i++) {
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < n)
-                bval[i] = src[x];
+                bvalT[i] = src[x];
         }
         for(int i = 0; i < regs; i++) {
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < n)
-                dst[x] = bval[i];
+                dst[x] = bvalT[i];
         }
     }
 }
@@ -2056,11 +2057,11 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     strideD, tmpz, tempgemm, splits);
 
 
-            ROCSOLVER_LAUNCH_KERNEL(stedc_copyC, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, n,
+            ROCSOLVER_LAUNCH_KERNEL(stedc_copyC<S>, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, n,
                                     V, 0, ldv, strideV,
                                     ptr_vecs(n, tempgemm), 0, n, get_tempgemm_size(n));
                                     
-            ROCSOLVER_LAUNCH_KERNEL(stedc_reshuffleC, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, n,
+            ROCSOLVER_LAUNCH_KERNEL(stedc_reshuffleC<S>, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, n,
                                     ptr_vecs(n, tempgemm), 0, n, get_tempgemm_size(n),
                                     V, 0, ldv, strideV,
                                     splits);
@@ -2214,14 +2215,14 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         ROCSOLVER_LAUNCH_KERNEL(stedc_copyD, dim3(1, batch_count), dim3(STEDC_BDIM), 0, stream, n,
                                 D + shiftD, strideD, tmpz, n);
 
-        ROCSOLVER_LAUNCH_KERNEL(stedc_copyC, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, n,
-                                (S*)C,    shiftC, ldc, strideC,
-                                tempgemm, 0,      n,   n*n);
+        ROCSOLVER_LAUNCH_KERNEL(stedc_copyC<T>, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, n,
+                                C,    shiftC, ldc, strideC,
+                                (T*)tempgemm, 0,      n,   n*n);
 
-        ROCSOLVER_LAUNCH_KERNEL(stedc_sort, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream,
+        ROCSOLVER_LAUNCH_KERNEL(stedc_sort<T>, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream,
                                 n, tmpz, n, D + shiftD, strideD,
-                                tempgemm, 0,      n,   n*n,
-                                (S*)C,    shiftC, ldc, strideC);
+                                (T*)tempgemm, 0,      n,   n*n,
+                                C,    shiftC, ldc, strideC);
 
         rocblas_set_pointer_mode(handle, old_mode);
     }

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -81,17 +81,31 @@ __host__ __device__ inline rocblas_int get_splits_size(const rocblas_int n)
     return 17 * n;
 }
 
+template <typename S> __device__ inline S* ptr_ns    (rocblas_int n, S* splits) { return splits +  1 * n; }
+template <typename S> __device__ inline S* ptr_ps    (rocblas_int n, S* splits) { return splits +  2 * n; }
+template <typename S> __device__ inline S* ptr_idd   (rocblas_int n, S* splits) { return splits +  3 * n; }
+template <typename S> __device__ inline S* ptr_pers  (rocblas_int n, S* splits) { return splits +  4 * n; }
+template <typename S> __device__ inline S* ptr_szfs  (rocblas_int n, S* splits) { return splits +  5 * n; }
+template <typename S> __device__ inline S* ptr_szs   (rocblas_int n, S* splits) { return splits +  6 * n; }
+template <typename S> __device__ inline S* ptr_dds   (rocblas_int n, S* splits) { return splits +  7 * n; }
+template <typename S> __device__ inline S* ptr_map   (rocblas_int n, S* splits) { return splits +  8 * n; }
+template <typename S> __device__ inline S* ptr_dcount(rocblas_int n, S* splits) { return splits +  9 * n; }
+template <typename S> __device__ inline S* ptr_mns   (rocblas_int n, S* splits) { return splits + 10 * n; }
+template <typename S> __device__ inline S* ptr_mps   (rocblas_int n, S* splits) { return splits + 11 * n; }
+template <typename S> __device__ inline S* ptr_cand  (rocblas_int n, S* splits) { return splits + 12 * n; }
+template <typename S> __device__ inline S* ptr_midd  (rocblas_int n, S* splits) { return splits + 13 * n; }
+
 __host__ __device__ inline rocblas_int get_tmpz_size(const rocblas_int n)
 {
     // tmpz layout:
     // struct {
     // 0    S z[n];       // the rank-1 modification vectors in the merges
     // 1    S evs[n];     // roots of secular equations
-    // 2    S cc[n];
-    // 3    S ss[n];
-    // 4    S tolsD[n];
-    // 5    S tolsZ[n];
-    // 6    S md[n];
+    // 2    S cc[n];      // c value of rotation of corresponding deflation
+    // 3    S ss[n];      // s value of rotation of corresponding deflation
+    // 4    S tolsD[n];   // tollerance for deflation of repeaded values in D
+    // 5    S tolsZ[n];   // tollerance for deflation of zero values in z
+    // 6    S md[n];      // sorted d values
     return 7 * n;
 }
 
@@ -136,10 +150,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_divide_kernel(const ro
 
         // temporary arrays in global memory
         rocblas_int* splits = splitsA + bid * get_splits_size(n);
-        // the sub-blocks sizes
-        rocblas_int* ns = splits + n;
-        // the sub-blocks initial positions
-        rocblas_int* ps = ns + n;
+        rocblas_int* ns = ptr_ns(n, splits);
+        rocblas_int* ps = ptr_ps(n, splits);
 
         // find sizes of sub-blocks
         ns[0] = n;
@@ -213,12 +225,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_solve_kernel(const roc
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
+    rocblas_int* ns = ptr_ns(n, splits);
+    rocblas_int* ps = ptr_ps(n, splits);
     // workspace for solvers
-    S* W = WA + bid * get_tmpz_size(n);
+    S* W = WA + bid * 2 * n;
 
     // Solve the blks sub-blocks in parallel (using classic QR iteration).
     if(sid < blks)
@@ -271,21 +281,12 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
-    // container of permutations when solving the secular eqns
-    rocblas_int* pers = idd + n;
-    // sizes of the first sub-block in a merge
-    rocblas_int* szfs = pers + n;
-    // sizes of both sub-blocks in a merge
-    rocblas_int* szs = szfs + n;
-    // degrees of secular equation
-    rocblas_int* dds = szs + n;
-    // the rank-1 modification vectors in the merges
+    rocblas_int* ns   = ptr_ns(n, splits);
+    rocblas_int* ps   = ptr_ps(n, splits);
+    rocblas_int* idd  = ptr_idd(n, splits);
+    rocblas_int* szfs = ptr_szfs(n, splits);
+    rocblas_int* szs  = ptr_szs(n, splits);
+
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z     = ptr_z(n, tmpz);
     S* tolsD = ptr_tolsD(n, tmpz);
@@ -424,31 +425,16 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
-    // container of permutations when solving the secular eqns
-    rocblas_int* pers = idd + n;
-    // sizes of the first sub-block in a merge
-    rocblas_int* szfs = pers + n;
-    // sizes of both sub-blocks in a merge
-    rocblas_int* szs = szfs + n;
-    // degrees of secular equation
-    rocblas_int* dds = szs + n;
-    // the rank-1 modification vectors in the merges
+    rocblas_int* ps     = ptr_ps(n, splits);
+    rocblas_int* szs    = ptr_szs(n, splits);
+    rocblas_int* map    = ptr_map(n, splits);
+    rocblas_int* dcount = ptr_dcount(n, splits);
+    rocblas_int* mns    = ptr_mns(n, splits);
+    rocblas_int* mps    = ptr_mps(n, splits);
+
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* tolsD = ptr_tolsD(n, tmpz);
     S* tolsZ = ptr_tolsZ(n, tmpz);
-
-    rocblas_int* map    = splits +  8 * n;
-    rocblas_int* dcount = splits +  9 * n;
-    rocblas_int* mns    = splits + 10 * n;
-    rocblas_int* mps    = splits + 11 * n; 
-    rocblas_int* cand   = splits + 12 * n; 
-    rocblas_int* midd   = splits + 13 * n;
 
     rocblas_int in = sid << (k + 1);
     rocblas_int sz = szs[in];
@@ -491,31 +477,17 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
-    // container of permutations when solving the secular eqns
-    rocblas_int* pers = idd + n;
-    // sizes of the first sub-block in a merge
-    rocblas_int* szfs = pers + n;
-    // sizes of both sub-blocks in a merge
-    rocblas_int* szs = szfs + n;
-    // degrees of secular equation
-    rocblas_int* dds = szs + n;
-    // the rank-1 modification vectors in the merges
+    rocblas_int* idd    = ptr_idd(n, splits);
+    rocblas_int* map    = ptr_map(n, splits);
+    rocblas_int* mns    = ptr_mns (n, splits);
+    rocblas_int* mps    = ptr_mps (n, splits); 
+    rocblas_int* cand   = ptr_cand(n, splits); 
+    rocblas_int* midd   = ptr_midd(n, splits);
+    
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* md    = ptr_md(n, tmpz);
     S* tolsD = ptr_tolsD(n, tmpz);
 
-    rocblas_int* map    = splits +  8 * n;
-    rocblas_int* dcount = splits +  9 * n;
-    rocblas_int* mns    = splits + 10 * n;
-    rocblas_int* mps    = splits + 11 * n; 
-    rocblas_int* cand   = splits + 12 * n; 
-    rocblas_int* midd   = splits + 13 * n;
 
     S d = D[sid];
     rocblas_int sz = mns[sid];
@@ -617,16 +589,15 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    rocblas_int* mps    = ptr_mps (n, splits); 
+    rocblas_int* cand   = ptr_cand(n, splits); 
+    rocblas_int* midd   = ptr_midd(n, splits);
+
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* md    = ptr_md(n, tmpz);
     S* tolsD = ptr_tolsD(n, tmpz);
 
-    rocblas_int* map    = splits +  8 * n;
-    rocblas_int* dcount = splits +  9 * n;
-    rocblas_int* mns    = splits + 10 * n;
-    rocblas_int* mps    = splits + 11 * n; 
-    rocblas_int* cand   = splits + 12 * n; 
-    rocblas_int* midd   = splits + 13 * n;
+    
 
     constexpr int F_BCAND = 1 << L_F_BCAND_BIT;
     constexpr int F_TCAND = 1 << L_F_TCAND_BIT;
@@ -685,23 +656,13 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
-    // the rank-1 modification vectors in the merges
+    rocblas_int* dcount = ptr_dcount(n, splits);
+    rocblas_int* cand   = ptr_cand(n, splits);
+
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* md    = ptr_md(n, tmpz);
     S* tolsD = ptr_tolsD(n, tmpz);
 
-    rocblas_int* map    = splits +  8 * n;
-    rocblas_int* dcount = splits +  9 * n;
-    rocblas_int* mns    = splits + 10 * n;
-    rocblas_int* mps    = splits + 11 * n; 
-    rocblas_int* cand   = splits + 12 * n; 
-    rocblas_int* midd   = splits + 13 * n;
 
     constexpr rocblas_int max_len = 4096;
     __shared__ S   ldsD[max_len];
@@ -781,23 +742,14 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
+    rocblas_int* idd    = ptr_idd(n, splits);
+    rocblas_int* map    = ptr_map(n, splits);
+    rocblas_int* dcount = ptr_dcount(n, splits);
+
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z  = ptr_z(n, tmpz);
     S* cc = ptr_cc(n, tmpz);
     S* ss = ptr_ss(n, tmpz);
-
-    rocblas_int* map    = splits +  8 * n;
-    rocblas_int* dcount = splits +  9 * n;
-    rocblas_int* mns    = splits + 10 * n;
-    rocblas_int* mps    = splits + 11 * n; 
-    rocblas_int* cand   = splits + 12 * n; 
-    rocblas_int* midd   = splits + 13 * n;
 
     constexpr rocblas_int max_len = 4096;
     __shared__ S   lz[max_len];
@@ -869,8 +821,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
     
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* map     = splits + 8 * n;         
-    rocblas_int* dcounts = splits + 9 * n; 
+    rocblas_int* map     = ptr_map(n, splits);         
+    rocblas_int* dcounts = ptr_dcount(n, splits); 
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* cc = ptr_cc(n, tmpz);
@@ -973,21 +925,13 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
-    // container of permutations when solving the secular eqns
-    rocblas_int* pers = idd + n;
-    // sizes of the first sub-block in a merge
-    rocblas_int* szfs = pers + n;
-    // sizes of both sub-blocks in a merge
-    rocblas_int* szs = szfs + n;
-    // degrees of secular equation
-    rocblas_int* dds = szs + n;
-    // the rank-1 modification vectors in the merges
+    rocblas_int* ps   = ptr_ps(n, splits);
+    rocblas_int* idd  = ptr_idd(n, splits);
+    rocblas_int* pers = ptr_pers(n, splits);
+    rocblas_int* szfs = ptr_szfs(n, splits);
+    rocblas_int* szs  = ptr_szs(n, splits);
+    rocblas_int* dds  = ptr_dds(n, splits);
+
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z     = ptr_z(n, tmpz);
     S* tolsD = ptr_tolsD(n, tmpz);
@@ -1019,13 +963,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // ----------------------------------------------------------------
         // Threads with iam = 0 work with components below the merge point;
         // threads with iam = 1 work above the merge point
-        //sz = ns[tid];
-        //for(int j = 1; j < bd; ++j)
-        //    sz += ns[tid + j];
         sz = szfs[tid];
         // with this, all threads involved in a merge
         // will point to the same row of C and the same off-diag element
-        S* ptz = (iam == 0) ? C + p2 - 1 + sz : C + p2;
         S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
 
 
@@ -1035,9 +975,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // 'in' will be its initial position.
         // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
         rocblas_int in = tid - iam * bd;
-        //sz = ns[in];
-        //for(int i = 1; i < bdm; ++i)
-        //    sz += ns[in + i];
         sz = szs[in];
         in = ps[in];
 
@@ -1208,21 +1145,12 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
-    // container of permutations when solving the secular eqns
-    rocblas_int* pers = idd + n;
-    // sizes of the first sub-block in a merge
-    rocblas_int* szfs = pers + n;
-    // sizes of both sub-blocks in a merge
-    rocblas_int* szs = szfs + n;
-    // degrees of secular equation
-    rocblas_int* dds = szs + n;
-    // the rank-1 modification vectors in the merges
+    rocblas_int* ps   = ptr_ps(n, splits);
+    rocblas_int* idd  = ptr_idd(n, splits);
+    rocblas_int* pers = ptr_pers(n, splits);
+    rocblas_int* szs  = ptr_szs(n, splits);
+    rocblas_int* dds  = ptr_dds(n, splits);
+    
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z   = ptr_z(n, tmpz);
     S* evs = ptr_evs(n, tmpz);
@@ -1240,8 +1168,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // all threads work together to solve the secular equation.
     if(sid < tn)
     {
-        rocblas_int iam, sz, dim, p2;
-        S valf, valg;
+        rocblas_int iam, sz, dim;
 
         // tid indexes the sub-blocks in the entire split block
         // iam indexes the sub-blocks in the context of the merge
@@ -1249,26 +1176,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         dim = hipBlockDim_x / 2;
         iam = tidb / dim;
         tid = sid * bdm + iam * bd;
-        p2 = ps[tid];
-
-        // Find off-diagonal element of the merge
-        // Threads with iam = 0 work with components below the merge point;
-        // threads with iam = 1 work above the merge point
-        //sz = ns[tid];
-        //for(int j = 1; j < bd; ++j)
-        //    sz += ns[tid + j];
-        sz = szfs[tid];
-        // with this, all threads involved in a merge
-        // will point to the same row of C and the same off-diag element
-        S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
 
         // determine boundaries of what would be the new merged sub-block
         // 'in' will be its initial position.
         // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
         rocblas_int in = tid - iam * bd;
-        //sz = ns[in];
-        //for(int i = 1; i < bdm; ++i)
-        //    sz += ns[in + i];
         sz = szs[in];
         in = ps[in];
 
@@ -1365,21 +1277,13 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
-    // container of permutations when solving the secular eqns
-    rocblas_int* pers = idd + n;
-    // sizes of the first sub-block in a merge
-    rocblas_int* szfs = pers + n;
-    // sizes of both sub-blocks in a merge
-    rocblas_int* szs = szfs + n;
-    // degrees of secular equation
-    rocblas_int* dds = szs + n;
-    // the rank-1 modification vectors in the merges
+    rocblas_int* ps   = ptr_ps(n, splits);
+    rocblas_int* idd  = ptr_idd(n, splits);
+    rocblas_int* pers = ptr_pers(n, splits);
+    rocblas_int* szfs = ptr_szfs(n, splits);
+    rocblas_int* szs  = ptr_szs(n, splits);
+    rocblas_int* dds  = ptr_dds(n, splits);
+    
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z   = ptr_z(n, tmpz);
     S* evs = ptr_evs(n, tmpz);
@@ -1411,9 +1315,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // Find off-diagonal element of the merge
         // Threads with iam = 0 work with components below the merge point;
         // threads with iam = 1 work above the merge point
-        //sz = ns[tid];
-        //for(int j = 1; j < bd; ++j)
-        //    sz += ns[tid + j];
         sz = szfs[tid];
         // with this, all threads involved in a merge
         // will point to the same row of C and the same off-diag element
@@ -1423,9 +1324,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // 'in' will be its initial position.
         // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
         rocblas_int in = tid - iam * bd;
-        //sz = ns[in];
-        //for(int i = 1; i < bdm; ++i)
-        //    sz += ns[in + i];
         sz = szs[in];
         in = ps[in];
 
@@ -1489,21 +1387,13 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
-    // container of permutations when solving the secular eqns
-    rocblas_int* pers = idd + n;
-    // sizes of the first sub-block in a merge
-    rocblas_int* szfs = pers + n;
-    // sizes of both sub-blocks in a merge
-    rocblas_int* szs = szfs + n;
-    // degrees of secular equation
-    rocblas_int* dds = szs + n;
-    // the rank-1 modification vectors in the merges
+    rocblas_int* ps   = ptr_ps(n, splits);
+    rocblas_int* idd  = ptr_idd(n, splits);
+    rocblas_int* pers = ptr_pers(n, splits);
+    rocblas_int* szfs = ptr_szfs(n, splits);
+    rocblas_int* szs  = ptr_szs(n, splits);
+    rocblas_int* dds  = ptr_dds(n, splits);
+    
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z   = ptr_z(n, tmpz);
     S* evs = ptr_evs(n, tmpz);
@@ -1521,8 +1411,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // all threads work together to solve the secular equation.
     if(sid < tn)
     {
-        rocblas_int iam, sz, dim, p2;
-        S valf, valg;
+        rocblas_int iam, sz, dim;
 
         // tid indexes the sub-blocks in the entire split block
         // iam indexes the sub-blocks in the context of the merge
@@ -1530,26 +1419,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         dim = hipBlockDim_x / 2;
         iam = tidb / dim;
         tid = sid * bdm + iam * bd;
-        p2 = ps[tid];
-
-        // Find off-diagonal element of the merge
-        // Threads with iam = 0 work with components below the merge point;
-        // threads with iam = 1 work above the merge point
-        //sz = ns[tid];
-        //for(int j = 1; j < bd; ++j)
-        //    sz += ns[tid + j];
-        sz = szfs[tid];
-        // with this, all threads involved in a merge
-        // will point to the same row of C and the same off-diag element
-        S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
 
         // determine boundaries of what would be the new merged sub-block
         // 'in' will be its initial position.
         // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
         rocblas_int in = tid - iam * bd;
-        //sz = ns[in];
-        //for(int i = 1; i < bdm; ++i)
-        //    sz += ns[in + i];
         sz = szs[in];
         in = ps[in];
 
@@ -1625,21 +1499,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
-    // container of permutations when solving the secular eqns
-    rocblas_int* pers = idd + n;
-    // sizes of the first sub-block in a merge
-    rocblas_int* szfs = pers + n;
-    // sizes of both sub-blocks in a merge
-    rocblas_int* szs = szfs + n;
-    // degrees of secular equation
-    rocblas_int* dds = szs + n;
-    // the rank-1 modification vectors in the merges
+    rocblas_int* ns   = ptr_ns(n, splits);
+    rocblas_int* ps   = ptr_ps(n, splits);
+    rocblas_int* idd  = ptr_idd(n, splits);
+    rocblas_int* pers = ptr_pers(n, splits);
+
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z   = ptr_z(n, tmpz);
     // updated eigenvectors after merges
@@ -1838,12 +1702,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
+    rocblas_int* ns   = ptr_ns(n, splits);
+    rocblas_int* ps   = ptr_ps(n, splits);
+    rocblas_int* idd  = ptr_idd(n, splits);
     
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* evs = ptr_evs(n, tmpz);
@@ -1859,7 +1720,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     if(sid < tn * blks)
     {
         rocblas_int iam, sz, p2;
-        S valf, valg;
 
         // tid indexes the sub-blocks in the entire split block
         tid = sid / tn;

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1558,10 +1558,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
 //--------------------------------------------------------------------------------------//
 /** STEDC_MERGEUPDATE_KERNEL updates vectors and values after a merge is done. 
-        - Call this kernel with batch_count groups in y, and as many groups as columns would 
-          be in the matrix if its size is exact multiple of the number of sub-blocks 'blks'.
-          Each group works with a column. Groups are size STEDC_BDIM.
-        - If a group has an id larger than the actual number of columns it will do nothing. **/
+        - Call this kernel with batch_count groups in y, and n groups in x.
+          Each group works with a column. Groups are size STEDC_BDIM. **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     stedc_mergeUpdate_kernel(const rocblas_int levs,
@@ -1581,12 +1579,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // threads and groups indices
     // batch instance id
     rocblas_int bid = hipBlockIdx_y;
-    // merge sub-block id
-    rocblas_int sid = hipBlockIdx_x;
-    // thread id
-    rocblas_int tidb = hipThreadIdx_x;
-    rocblas_int dim = hipBlockDim_x;
-    rocblas_int tid, vidb;
+    // eigenvalue id
+    rocblas_int eid = hipBlockIdx_x;
 
     // select batch instance to work with
     S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
@@ -1594,9 +1588,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* ns   = ptr_ns(n, splits);
-    rocblas_int* ps   = ptr_ps(n, splits);
+    rocblas_int* em   = ptr_em(n, splits);
     rocblas_int* idd  = ptr_idd(n, splits);
+    rocblas_int* msz  = ptr_msz(n, splits);
+    rocblas_int* mps  = ptr_mps(n, splits);
     
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* evs = ptr_evs(n, tmpz);
@@ -1604,44 +1599,17 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
     S* vecs = ptr_vecs(n, tempgemm);
 
-    // tn is max number of vectors in each sub-block
-    rocblas_int bdm = 1 << (k + 1);
-    rocblas_int tn = (n - 1) / blks + 1;
+    rocblas_int merge_id = em[eid];
+    rocblas_int p1 = mps[merge_id];
+    rocblas_int sz = msz[merge_id];
 
-    // Work with merges on level k. Each thread-group works with one vector.
-    if(sid < tn * blks)
+    // update D and C with computed values and vectors
+    if(idd[eid] == 1)
     {
-        rocblas_int iam, sz, p2;
-
-        // tid indexes the sub-blocks in the entire split block
-        tid = sid / tn;
-        p2 = ps[tid];
-        // vidb indexes the vectors associated with each sub-block
-        vidb = sid % tn;
-        // iam indexes the sub-blocks in the context of the merge
-        // (according to its level in the merge tree)
-        iam = tid % bdm;
-
-        // determine boundaries of what would be the new merged sub-block
-        // 'in' will be its initial position
-        rocblas_int in = ps[tid - iam];
-        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        sz = ns[tid];
-        for(int i = iam; i > 0; --i)
-            sz += ns[tid - i];
-        for(int i = bdm - 1 - iam; i > 0; --i)
-            sz += ns[tid + i];
-
-        // update D and C with computed values and vectors
-        rocblas_int j = vidb;
-        bool go = (j < ns[tid] && idd[p2 + j] == 1);
-        if(go)
-        {
-            if(tidb == 0)
-                D[p2 + j] = evs[p2 + j];
-            for(int i = in + tidb; i < in + sz; i += dim)
-                C[i + (p2 + j) * ldc] = vecs[i + (p2 + j) * n];
-        }
+        if(hipThreadIdx_x == 0)
+            D[eid] = evs[eid];
+        for(int i = p1 + hipThreadIdx_x; i < p1 + sz; i += hipBlockDim_x)
+            C[i + eid * ldc] = vecs[i + eid * n];
     }
 }
 
@@ -2158,7 +2126,6 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     levs, blks, k, n, D + shiftD, strideD, E + shiftE, strideE,
                                     tmpz, tempgemm, splits, eps, ssfmin, ssfmax);
 
-            rocblas_int numgrps3 = ((n - 1) / blks + 1) * blks;
             // c. find merged eigenvectors
             ROCSOLVER_LAUNCH_KERNEL(
                 (stedc_mergeVectors_kernel<STEDC_EXTERNAL_GEMM, S>),
@@ -2167,6 +2134,7 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                 tmpz, tempgemm, splits);
 
 #if DEBUG_OUTPUT
+            rocblas_int numgrps3 = ((n - 1) / blks + 1) * blks;
             //hipError_t status = hipStreamSynchronize(stream);
             if(env_levs && global_cnt == 1)
             {
@@ -2217,7 +2185,7 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
 
             // d. update level
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeUpdate_kernel<S>),
-                                    dim3(numgrps3, batch_count), dim3(STEDC_BDIM), 0, stream, 
+                                    dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
                                     levs, blks, k, n, D + shiftD, strideD,
                                     V, 0, ldv, strideV, tmpz, tempgemm, splits);
         }

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1813,6 +1813,74 @@ rocblas_status rocsolver_stedc_argCheck(rocblas_handle handle,
     return rocblas_status_continue;
 }
 
+#if DEBUG_OUTPUT
+template <typename S, typename I>
+void print_block_map(const char* tag, bool show_pres, bool show_cnt, int n, int n_merges, I* bsz, I* bps, S* matr)
+{
+    int n_blocks = n_merges * 2;
+    std::vector<I> sz(n_blocks);
+    std::vector<I> ps(n_blocks);
+    std::vector<S> m(n * n);
+    std::vector<I> cnt(n_blocks * n_blocks);
+
+    THROW_IF_HIP_ERROR(hipMemcpy(sz.data(), bsz, sizeof(I) * sz.size(), hipMemcpyDeviceToHost));
+    THROW_IF_HIP_ERROR(hipMemcpy(ps.data(), bps, sizeof(I) * ps.size(), hipMemcpyDeviceToHost));
+    THROW_IF_HIP_ERROR(hipMemcpy(m.data(), matr, sizeof(S) * m.size(), hipMemcpyDeviceToHost));
+
+    int s = 0;
+    for(int i = 0; i < n_blocks; i++)
+    {
+        s += sz[i];
+    }
+    if (s != n) {
+        std::cout << "ERROR: n("<< n <<") != s("<< s <<")\n";
+        std::exit(0);
+    }
+
+    bool is_blk_diag = true;
+    for(int jb = 0; jb < n_blocks; jb++) {
+        for (int jp = 0; jp < sz[jb]; jp++) {
+            for(int ib = 0; ib < n_blocks; ib++) {
+                for(int ip = 0; ip < sz[ib]; ip++) {
+                    {
+                        int j = ps[jb] + jp;
+                        int i = ps[ib] + ip;
+                        bool non_zero = m[j * n + i] != 0;
+                        cnt[jb * n_blocks + ib] += non_zero;
+                        if((jb / 2 != ib / 2) && non_zero)
+                            is_blk_diag = false;
+                    }
+                }
+            }
+        }
+    }
+
+    std::cout << (is_blk_diag ? "block diag matrix ("
+        : "matrix has off-blockdiag non-zeros (") << tag << ")\n";
+
+    if (show_pres) {
+        std::cout << tag << " present map " << n_blocks << "x" << n_blocks << ":\n";
+        for(int j = 0; j < n_blocks; j++) {
+            for(int i = 0; i < n_blocks; i++) {
+                std::cout << (cnt[j * n_blocks + i] ? " X" : " .");
+            }
+            std::cout << "\n";
+        }
+    }
+
+    if (show_cnt) {
+        std::cout << tag << " cnt map " << n_blocks << "x" << n_blocks << ":\n";
+        for(int j = 0; j < n_blocks; j++) {
+            for(int i = 0; i < n_blocks; i++) {
+                std::cout << "\t" << cnt[j * n_blocks + i];
+            }
+            std::cout << "\n";
+        }
+    }
+}
+#endif
+
+
 //--------------------------------------------------------------------------------------//
 /** STEDC templated function **/
 template <bool BATCHED, bool STRIDED, typename T, typename S, typename U>
@@ -1989,7 +2057,7 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             ROCSOLVER_LAUNCH_KERNEL(stedc_copyC, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, n,
                                     V, 0, ldv, strideV,
                                     ptr_vecs(n, tempgemm), 0, n, get_tempgemm_size(n));
-
+                                    
             ROCSOLVER_LAUNCH_KERNEL(stedc_reshuffleC, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, n,
                                     ptr_vecs(n, tempgemm), 0, n, get_tempgemm_size(n),
                                     V, 0, ldv, strideV,

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1089,96 +1089,45 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // threads and groups indices
     // batch instance id
     rocblas_int bid = hipBlockIdx_y;
-    rocblas_int sid = hipBlockIdx_x;
+    rocblas_int eid = hipBlockIdx_x;
 
     // select batch instance to work with
-    S* D = DD + bid * strideD; //trololo
+    S* D = DD + bid * strideD;
 
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
     rocblas_int* dds = ptr_dds(n, splits);
+    rocblas_int* em  = ptr_em(n, splits);
     rocblas_int* mps = ptr_mps(n, splits);
-    rocblas_int* msz = ptr_msz(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
-    S* evs = ptr_evs(n, tmpz); //trololo
+    S* evs = ptr_evs(n, tmpz);
     S* cd  = ptr_cd(n, tmpz);
 
     S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
     S* etmpd = ptr_etmpd(n, tempgemm);
 
-    rocblas_int dd = dds[sid];
-    rocblas_int p1 = mps[sid];
-    rocblas_int sz = msz[sid];
+    rocblas_int merge_id = em[eid];
+    rocblas_int dd = dds[merge_id];
+    rocblas_int p1 = mps[merge_id];
 
 
     // copy sorted values back to D
-    for(int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x)
+    int x = hipThreadIdx_x + hipBlockDim_x * hipBlockIdx_x;
+    if(x < n)
     {
-        D[p1 + i] = evs[p1 + i];
+        D[x] = evs[x];
     }
 
 
-    // make dd copies of the non-deflated ordered diagonal elements
+    // make copies of the non-deflated ordered diagonal elements
     // (i.e. the poles of the secular eqn) so that the distances to the
     // eigenvalues (D - lambda_i) are updated while computing each eigenvalue.
     // This will prevent collapses and division by zero when an eigenvalue
     // is too close to a pole.
-#if TRANSPOSED_TMPD
-    constexpr int max_pref = 8;
-    constexpr int chunk_width = max_pref * STEDC_BDIM;
-    int n_chunks = (dd - 1) / chunk_width + 1;
-    __shared__ S lds[chunk_width];
-    
-    for (int chunk = 0; chunk < n_chunks; chunk++) {
-        // prefetch current chunk of d values into lds
-        for (int i = hipThreadIdx_x; i < chunk_width; i += hipBlockDim_x) {
-            int x = chunk * chunk_width + i;
-            if (x < dd) {
-                lds[i] = cd[p1 + x];
-            }
-        }
-        __syncthreads();
-
-        int values_left = dd - chunk * chunk_width;
-        int max_cnt = std::min(values_left, chunk_width);
-        for (int j = 0; j < max_cnt; j++) {
-            S d = lds[j];
-            int row = chunk * chunk_width + j;
-            // TODO: check if that should be dd or sz
-            //for (int i = hipThreadIdx_x; i < dd; i += hipBlockDim_x) {
-            for (int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x) {
-                etmpd[row * n + p1 + i] = d;
-            }
-        }
+    for (int i = hipThreadIdx_x; i < dd; i += hipBlockDim_x)
+    {
+        etmpd[eid * n + i] = cd[p1 + i];
     }
-#else
-    constexpr int regs = 16;
-    constexpr int chunk_width = regs * STEDC_BDIM;
-    int n_chunks = (dd - 1) / chunk_width + 1;
-    S bval[regs];
-
-    for(int chunk = 0; chunk < n_chunks; chunk++) {
-        for (int i = 0; i < regs; i++) {
-            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
-            if(x < dd) {
-                bval[i] = cd[p1 + x];
-            }
-        }
-
-        // TODO: check if that should be dd or sz
-        // for (int j = 0; j < dd; j++) {
-        for (int j = 0; j < sz; j++) {
-            __syncthreads();
-            for(int i = 0; i < regs; i++) {
-                int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
-                if(x < dd) {
-                    etmpd[(p1 + j) * n + x] = bval[i];
-                }
-            }
-        }
-
-    }
-#endif
 }
 
 //--------------------------------------------------------------------------------------//
@@ -2183,6 +2132,10 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
 #if DEBUG_OUTPUT
     static int global_cnt = 0;
     global_cnt++;
+    hipEvent_t solve_begin;
+    hipEvent_t solve_end;
+    HIP_CHECK(hipEventCreate(&solve_begin));
+    HIP_CHECK(hipEventCreate(&solve_end));
 #endif
 
     // quick return
@@ -2327,7 +2280,7 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD,
                                     strideD, tmpz, splits);
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_copyD_kernel<S>),
-                                    dim3(n_merges, batch_count),
+                                    dim3(n, batch_count),
                                     dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD,
                                     strideD, tmpz, tempgemm, splits);
 
@@ -2367,12 +2320,24 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             }
 #endif
 
+#if DEBUG_OUTPUT
+            if(k == levs - 1)
+            {
+                HIP_CHECK(hipEventRecord(solve_begin, stream));
+            }
+#endif
             rocblas_int numgrps_solve = (n - 1) / STEDC_BDIM + 1;
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Solve_kernel<S>),
                                     dim3(numgrps_solve, batch_count),
                                     dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD,
                                     strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
                                     ssfmin, ssfmax);
+#if DEBUG_OUTPUT
+            if(k == levs - 1)
+            {
+                HIP_CHECK(hipEventRecord(solve_end, stream));
+            }
+#endif
 
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Rescale_kernel<S>),
                                     dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream,
@@ -2380,7 +2345,7 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     tmpz, tempgemm, splits, eps, ssfmin, ssfmax);
 
             // c. find merged eigenvectors
-            if (1) {
+            if (0) {
                 ROCSOLVER_LAUNCH_KERNEL(
                     (stedc_mergeVectors_ComputeNorms_kernel<STEDC_EXTERNAL_GEMM, S>),
                     dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
@@ -2468,6 +2433,20 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
 
         rocblas_set_pointer_mode(handle, old_mode);
     }
+
+#if DEBUG_OUTPUT
+    HIP_CHECK(hipStreamSynchronize(stream));
+    float elapsed_solve;
+    HIP_CHECK(hipEventElapsedTime(&elapsed_solve, solve_begin, solve_end));
+    HIP_CHECK(hipEventDestroy(solve_begin));
+    HIP_CHECK(hipEventDestroy(solve_end));
+
+    char* show_time = std::getenv("ST");
+    if(global_cnt==2 && show_time && show_time[0] == '1')
+    {
+        std::cout << elapsed_solve << "\t";
+    }
+#endif
 
     return rocblas_status_success;
 }

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1575,9 +1575,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int tidb = hipThreadIdx_x;
     rocblas_int dim = hipBlockDim_x;
 
-    // select batch instance to work with
-    S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
-
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
     rocblas_int* em   = ptr_em(n, splits);
@@ -1644,6 +1641,44 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
 template <bool USEGEMM, typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+    stedc_mergeVectors_ZeroEtmpd_kernel(const rocblas_int levs,
+                                        const rocblas_int blks,
+                                        const rocblas_int k,
+                                        const rocblas_int n,
+                                        S* CC,
+                                        const rocblas_int shiftC,
+                                        const rocblas_int ldc,
+                                        const rocblas_stride strideC,
+                                        S* tmpzA,
+                                        S* tempgemmA,
+                                        rocblas_int* splitsA)
+{
+    // threads and groups indices
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+    rocblas_int row = hipBlockIdx_x;
+
+    // temporary arrays in global memory
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    rocblas_int* em = ptr_em(n, splits);
+    rocblas_int* idd = ptr_idd(n, splits);
+    rocblas_int* msz = ptr_msz(n, splits);
+    rocblas_int* mps = ptr_mps(n, splits);
+    rocblas_int* dds = ptr_dds(n, splits);
+    rocblas_int* pers = ptr_map(n, splits);
+
+    S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
+    S* etmpd = ptr_etmpd(n, tempgemm);
+
+    for(int i = hipThreadIdx_x; i < n; i += hipBlockDim_x)
+    {
+        etmpd[row*n + i] = 0;
+    }
+}
+
+
+template <bool USEGEMM, typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     stedc_mergeVectors_ApplyNorms_kernel(const rocblas_int levs,
                                          const rocblas_int blks,
                                          const rocblas_int k,
@@ -1699,28 +1734,27 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // Prepare vectors corresponding to non-deflated values
     S nrm = nrms[eid];
-    S* putvec = USEGEMM ? vecs : etmpd;
 
     if(USEGEMM)
     {
         // when using external gemms for the update, we need to
         // put vectors in padded matrix 'etmpd'
         // (this is to compute 'vecs = C * etmpd' using external gemm call)
-        for(int i = tidb; i < p1 + sz; i += dim)
-        {
-            if(i >= p1 && idd[eid] == 1 && idd[i] == 1)
+        if(idd[eid] == 1) {
+            for(int i = tidb; i < sz; i += dim)
             {
-                dd = 0;
-                for(int k = p1; k < i; ++k)
+                if(idd[p1 + i] == 1)
                 {
-                    if(idd[k] == 0)
-                        dd++;
+                    dd = 0;
+                    for(int k = 0; k < i; ++k)
+                    {
+                        if(idd[p1 + k] == 0)
+                            dd++;
+                    }
+                    etmpd[pers[p1 + i - dd] + p1 + eid * n]
+                        = vecs[p1 + i - dd - p1 + eid * n] / nrm;
                 }
-                etmpd[pers[i - dd] + p1 + eid * n]
-                    = vecs[i - dd - p1 + eid * n] / nrm;
             }
-            else
-                etmpd[i + eid * n] = 0;
         }
     }
     else
@@ -2322,7 +2356,32 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     dim3(n_merges, batch_count),
                                     dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
                                     strideD, tmpz, tempgemm, splits);//*/
+#if DEBUG_OUTPUT
+            //hipError_t status = hipStreamSynchronize(stream);
+            if(env_levs && global_cnt == 1)
+            {
+                std::cout << "\nk=" << k << std::endl;
+                print_device_matrix(std::cout, "msz", 1, n_merges, ptr_msz(n, splits), 1);
+                print_device_matrix(std::cout, "mps", 1, n_merges, ptr_mps(n, splits), 1);
+                print_device_matrix(std::cout, "esz", 1, n, ptr_esz(n, splits), 1);
+                print_device_matrix(std::cout, "eps", 1, n, ptr_eps(n, splits), 1);
+                //print_device_matrix(std::cout, "dds", 1, n_merges, ptr_dds(n, splits), 1);
+                //print_device_matrix(std::cout, "em", 1, n, ptr_em(n, splits), 1);
+                print_device_matrix(std::cout, "idd", 1, n, ptr_idd(n, splits), 1);
+                print_device_matrix(std::cout, "sidd", 1, n, ptr_sidd(n, splits), 1);
+                print_device_matrix(std::cout, "map", 1, n, ptr_map(n, splits), 1);
+                //print_device_matrix(std::cout, "pers", 1, n, ptr_pers(n, splits), 1);
+                print_device_matrix(std::cout, "D", 1, n, D, 1);
+                print_device_matrix(std::cout, "cd", 1, n, ptr_cd(n, tmpz), 1);
+                //print_device_matrix(std::cout, "etmpd", n, n, tempgemm +n*n, n);
 
+                //print_device_matrix(std::cout, "dbg", 1, n, ptr_dbg(n, splits), 1);
+
+                //print_device_matrix(std::cout, "D", 1, n, D, 1);
+
+                //std::exit(0);
+            }
+#endif
 
             rocblas_int numgrps_solve = (n - 1) / STEDC_BDIM + 1;
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Solve_kernel<S>),
@@ -2344,6 +2403,11 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                     levs, blks, k, n, V, 0, ldv, strideV, 
                     tmpz, tempgemm, splits);
                 ROCSOLVER_LAUNCH_KERNEL(
+                    (stedc_mergeVectors_ZeroEtmpd_kernel<STEDC_EXTERNAL_GEMM, S>),
+                    dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
+                    levs, blks, k, n, V, 0, ldv, strideV, 
+                    tmpz, tempgemm, splits);
+                ROCSOLVER_LAUNCH_KERNEL(
                     (stedc_mergeVectors_ApplyNorms_kernel<STEDC_EXTERNAL_GEMM, S>),
                     dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
                     levs, blks, k, n, V, 0, ldv, strideV, 
@@ -2358,41 +2422,6 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                     tmpz, tempgemm, splits);
             }
 
-#if DEBUG_OUTPUT
-            rocblas_int numgrps3 = ((n - 1) / blks + 1) * blks;
-            //hipError_t status = hipStreamSynchronize(stream);
-            if(env_levs && global_cnt == 1)
-            {
-                std::cout << "\nk=" << k << std::endl;
-                std::cout << "numgrps3=" << numgrps3 << "\tblks=" << blks << std::endl;
-                print_device_matrix(std::cout, "msz", 1, n_merges, ptr_msz(n, splits), 1);
-                print_device_matrix(std::cout, "mps", 1, n_merges, ptr_mps(n, splits), 1);
-                print_device_matrix(std::cout, "esz", 1, n, ptr_esz(n, splits), 1);
-                print_device_matrix(std::cout, "eps", 1, n, ptr_eps(n, splits), 1);
-                //print_device_matrix(std::cout, "dds", 1, n_merges, ptr_dds(n, splits), 1);
-                print_device_matrix(std::cout, "sid          ", 1, numgrps3, ptr_dbg(n, splits), 1);
-                print_device_matrix(std::cout, "tid", 1, numgrps3, ptr_dbg1(n, splits), 1);
-                print_device_matrix(std::cout, "iam", 1, numgrps3, ptr_dbg2(n, splits), 1);
-                print_device_matrix(std::cout, "tid - iam", 1, numgrps3, ptr_dbg3(n, splits), 1);
-                print_device_matrix(std::cout, "merge_id", 1, numgrps3, ptr_dbg4(n, splits), 1);
-                print_device_matrix(std::cout, "mps[merge_id]", 1, numgrps3, ptr_dbg5(n, splits), 1);
-                print_device_matrix(std::cout, "ps[tid-iam]", 1, numgrps3, ptr_dbg6(n, splits), 1);
-                //print_device_matrix(std::cout, "em", 1, n, ptr_em(n, splits), 1);
-                //print_device_matrix(std::cout, "idd", 1, n, ptr_idd(n, splits), 1);
-                //print_device_matrix(std::cout, "sidd", 1, n, ptr_sidd(n, splits), 1);
-                //print_device_matrix(std::cout, "map", 1, n, ptr_map(n, splits), 1);
-                //print_device_matrix(std::cout, "pers", 1, n, ptr_pers(n, splits), 1);
-                //print_device_matrix(std::cout, "D", 1, n, D, 1);
-                //print_device_matrix(std::cout, "cd", 1, n, ptr_cd(n, tmpz), 1);
-                //print_device_matrix(std::cout, "etmpd", n, n, tempgemm +n*n, n);
-                
-                //print_device_matrix(std::cout, "dbg", 1, n, ptr_dbg(n, splits), 1);
-
-                //print_device_matrix(std::cout, "D", 1, n, D, 1);
-
-                //std::exit(0);
-            }
-#endif
             if(STEDC_EXTERNAL_GEMM)
             {
                 // using external gemms with padded matrices to do the vector update

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -959,7 +959,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
     rocblas_int* idd  = ptr_idd(n, splits);
-    rocblas_int* pers = ptr_pers(n, splits);
     rocblas_int* msz  = ptr_msz(n, splits);
     rocblas_int* dds  = ptr_dds(n, splits);
     rocblas_int* mps = ptr_mps(n, splits);
@@ -997,6 +996,19 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // etmpd contains the non-deflated diagonal elements (ie. poles of the
         // secular eqn) zz contains the corresponding non-zero elements of the
         // rank-1 modif vector
+
+        for(int i = 0; i < sz; ++i)
+        {
+            for(int j = 0; j < sz; ++j)
+            {
+                if(hipThreadIdx_x == 0)
+                {
+                    etmpd[(p1+j) * n + i] = 0;
+                }
+            }
+        }
+        __syncthreads();
+
         rocblas_int dd = 0;
         for(int i = 0; i < sz; ++i)
         {
@@ -1004,7 +1016,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             {
                 if(hipThreadIdx_x == 0)
                 {
-                    pers[p1 + dd] = i;
                     etmpd[p1 * n + dd] = p < 0 ? -D[p1 + i] : D[p1 + i];
                     if(dd != i)
                         z[p1 + dd] = z[p1 + i];
@@ -1053,13 +1064,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
     rocblas_int* mps  = ptr_mps(n, splits);
     rocblas_int* idd  = ptr_idd(n, splits);
-    rocblas_int* pers = ptr_pers(n, splits);
     rocblas_int* msz  = ptr_msz(n, splits);
     rocblas_int* dds  = ptr_dds(n, splits);
     
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z   = ptr_z(n, tmpz);
-    S* evs = ptr_evs(n, tmpz);
     S* sdbg = ptr_sdbg(n, tmpz);
     // updated eigenvectors after merges
     S* vecs = vecsA + bid * 2 * (n * n);
@@ -1085,7 +1094,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         S* etmpd = temps;
         rocblas_int* mask = idd + p1;
         S* zz = z + p1;
-        rocblas_int* per = pers + p1;
 
         // find degree of secular equation
         rocblas_int dd = dds[sid];
@@ -1100,7 +1108,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 {
                     swap(etmpd[p1 * n + j], etmpd[p1 * n + j + 1]);
                     swap(zz[j], zz[j + 1]);
-                    swap(per[j], per[j + 1]);
                 }
             }
             __syncthreads();
@@ -1111,16 +1118,12 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // eigenvalues (D - lambda_i) are updated while computing each eigenvalue.
         // This will prevent collapses and division by zero when an eigenvalue
         // is too close to a pole.
-        for(int i = hipThreadIdx_x; i < dd; i += hipBlockDim_x)
-        {
-            for(int j = 1; j < sz; j ++)
-                etmpd[(p1 + j) * n + i] = etmpd[p1 * n + i];
-        }
+        //for(int i = hipThreadIdx_x; i < dd; i += hipBlockDim_x)
+        //{
+        //    for(int j = 1; j < sz; j ++)
+        //        etmpd[(p1 + j) * n + i] = etmpd[p1 * n + i];
+        //}
 
-        // finally copy over all diagonal elements in ev. ev will be overwritten
-        // by the new computed eigenvalues of the merged block
-        for(int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x)
-            evs[p1 + i] = D[p1 + i];
     }
 }
 
@@ -1267,15 +1270,15 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // threads and groups indices
     // batch instance id
     rocblas_int bid = hipBlockIdx_y;
-    rocblas_int eid = hipThreadIdx_x + hipBlockDim_x * hipBlockIdx_x;
+    rocblas_int sid = hipBlockIdx_x;
 
     // select batch instance to work with
     S* D = DD + bid * strideD;
 
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* em  = ptr_em(n, splits);
     rocblas_int* dds = ptr_dds(n, splits);
     rocblas_int* mps = ptr_mps(n, splits);
+    rocblas_int* msz = ptr_msz(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* evs = ptr_evs(n, tmpz);
@@ -1285,22 +1288,79 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* temps = vecs + (n * n);
     S* etmpd = temps;
 
-    if (eid < n)
+    rocblas_int dd = dds[sid];
+    rocblas_int p1 = mps[sid];
+    rocblas_int sz = msz[sid];
+
+
+    // copy over all diagonal elements in ev. ev will be overwritten
+    // by the new computed eigenvalues of the merged block
+    for(int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x)
     {
-        evs[eid] = D[eid];
+        evs[p1 + i] = D[p1 + i];
+    }
 
-        rocblas_int sid = em[eid];
-        rocblas_int dd = dds[sid];
-        rocblas_int p1 = mps[sid];
 
-        S d = cd[eid];
+    // make dd copies of the non-deflated ordered diagonal elements
+    // (i.e. the poles of the secular eqn) so that the distances to the
+    // eigenvalues (D - lambda_i) are updated while computing each eigenvalue.
+    // This will prevent collapses and division by zero when an eigenvalue
+    // is too close to a pole.
+#if TRANSPOSED_TMPD
+    constexpr int max_pref = 8;
+    constexpr int chunk_width = max_pref * STEDC_BDIM;
+    int n_chunks = (dd - 1) / chunk_width + 1;
+    __shared__ S lds[chunk_width];
+    
+    for (int chunk = 0; chunk < n_chunks; chunk++) {
+        // prefetch current chunk of d values into lds
+        for (int i = hipThreadIdx_x; i < chunk_width; i += hipBlockDim_x) {
+            int x = chunk * chunk_width + i;
+            if (x < dd) {
+                lds[i] = cd[p1 + x];
+            }
+        }
+        __syncthreads();
 
-        if (eid - p1 < dd) {
-            for (int j = 0; j < dd; j++) {
-                etmpd[(p1 + j) * n + eid - p1] = d;
+        int values_left = dd - chunk * chunk_width;
+        int max_cnt = std::min(values_left, chunk_width);
+        for (int j = 0; j < max_cnt; j++) {
+            S d = lds[j];
+            int row = chunk * chunk_width + j;
+            // TODO: check if that should be dd or sz
+            //for (int i = hipThreadIdx_x; i < dd; i += hipBlockDim_x) {
+            for (int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x) {
+                etmpd[row * n + p1 + i] = d;
             }
         }
     }
+#else
+    constexpr int regs = 16;
+    constexpr int chunk_width = regs * STEDC_BDIM;
+    int n_chunks = (dd - 1) / chunk_width + 1;
+    S bval[regs];
+
+    for(int chunk = 0; chunk < n_chunks; chunk++) {
+        for (int i = 0; i < regs; i++) {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < dd) {
+                bval[i] = cd[p1 + x];
+            }
+        }
+
+        // TODO: check if that should be dd or sz
+        // for (int j = 0; j < dd; j++) {
+        for (int j = 0; j < sz; j++) {
+            for(int i = 0; i < regs; i++) {
+                int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+                if(x < dd) {
+                    etmpd[(p1 + j) * n + x] = bval[i];
+                }
+            }
+        }
+
+    }
+#endif
 }
 
 template <typename S>
@@ -1443,7 +1503,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
     rocblas_int* mps  = ptr_mps(n, splits);
     rocblas_int* idd  = ptr_idd(n, splits);
-    rocblas_int* pers = ptr_pers(n, splits);
+    rocblas_int* pers = ptr_map(n, splits);
     rocblas_int* msz  = ptr_msz(n, splits);
     rocblas_int* dds  = ptr_dds(n, splits);
     
@@ -1541,7 +1601,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* ns   = ptr_ns(n, splits);
     rocblas_int* ps   = ptr_ps(n, splits);
     rocblas_int* idd  = ptr_idd(n, splits);
-    rocblas_int* pers = ptr_pers(n, splits);
+    rocblas_int* pers = ptr_map(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z   = ptr_z(n, tmpz);
@@ -2289,29 +2349,34 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     E + shiftE, strideE, V, 0, ldv, strideV, tmpz, tempgemm, splits,
                                     eps);
 
+            if(env_levs && global_cnt == 1)
+            {
+                std::cout << "\nk=" << k << std::endl;
+                print_device_matrix(std::cout, "etmpdOrg", n, n, tempgemm + n * n, n);
+            }
+
+
             // b. solve secular eq to find merged eigenvalues
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Sort_kernel<S>), dim3(n_merges, batch_count),
                                     dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
                                     strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
                                     ssfmin, ssfmax);
-            /*
+            //*
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_SortDZ_kernel<S>), dim3(n, batch_count),
                                     dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
                                     strideD, tmpz, splits);
 
             rocblas_int numgrps_copyd = (n - 1) / STEDC_BDIM + 1;
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_copyD_kernel<S>),
-                                    dim3(numgrps_copyd, batch_count),
+                                    dim3(n_merges, batch_count),
                                     dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
-                                    strideD, tmpz, tempgemm, splits);*/
+                                    strideD, tmpz, tempgemm, splits);//*/
 
 #if DEBUG_OUTPUT
             //hipError_t status = hipStreamSynchronize(stream);
             if(env_levs && global_cnt == 1)
             {
-                std::cout << "\nk=" << k << std::endl;
-                //print_device_matrix(std::cout, "ns", 1, 1 << levs, ptr_ns(n, splits), 1);
-                //print_device_matrix(std::cout, "ps", 1, 1 << levs, ptr_ps(n, splits), 1);
+                //std::cout << "\nk=" << k << std::endl;
                 print_device_matrix(std::cout, "msz", 1, n_merges, ptr_msz(n, splits), 1);
                 print_device_matrix(std::cout, "mps", 1, n_merges, ptr_mps(n, splits), 1);
                 print_device_matrix(std::cout, "dds", 1, n_merges, ptr_dds(n, splits), 1);
@@ -2322,12 +2387,15 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                 print_device_matrix(std::cout, "pers", 1, n, ptr_pers(n, splits), 1);
                 print_device_matrix(std::cout, "D", 1, n, D, 1);
                 print_device_matrix(std::cout, "cd", 1, n, ptr_cd(n, tmpz), 1);
+                print_device_matrix(std::cout, "etmpd", n, n, tempgemm +n*n, n);
                 
                 //print_device_matrix(std::cout, "dbg", 1, n, ptr_dbg(n, splits), 1);
 
                 //print_device_matrix(std::cout, "D", 1, n, D, 1);
                 //print_device_matrix(std::cout, "mtols", 1, n, tempgemm + n * 4, 1);
                 //print_device_matrix(std::cout, "mD", 1, n, tempgemm + n * 5, 1);
+
+                //std::exit(0);
             }
 #endif
 

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -64,8 +64,8 @@ __host__ __device__ inline rocblas_int get_splits_size(const rocblas_int n)
     // m - number of merges on a current level
     // struct {
     // 0     rocblas_int sort_tmp[n];         // temp buffer used for mapping in stedc_sort()
-    // 1     rocblas_int ns[n];               // the sub-blocks sizes
-    // 2     rocblas_int ps[n];               // the sub-blocks initial positions
+    // 1     rocblas_int      ;               //
+    // 2     rocblas_int      ;               //
     // 3     rocblas_int idd[n];              // if idd[i] = 0, the value in position i has been deflated  (aka mask)
     // 4     rocblas_int pers[n];             // container of permutations when solving the secular eqns
     // 5     rocblas_int ;      //
@@ -87,8 +87,8 @@ __host__ __device__ inline rocblas_int get_splits_size(const rocblas_int n)
     return 20 * n + 64*64;
 }
 
-template <typename S> __host__ __device__ inline S* ptr_ns    (rocblas_int n, S* splits) { return splits +  1 * n; }
-template <typename S> __host__ __device__ inline S* ptr_ps    (rocblas_int n, S* splits) { return splits +  2 * n; }
+template <typename S> __host__ __device__ inline S* ptr___    (rocblas_int n, S* splits) { return splits +  1 * n; }
+template <typename S> __host__ __device__ inline S* ptr____   (rocblas_int n, S* splits) { return splits +  2 * n; }
 template <typename S> __host__ __device__ inline S* ptr_idd   (rocblas_int n, S* splits) { return splits +  3 * n; }
 template <typename S> __host__ __device__ inline S* ptr_pers  (rocblas_int n, S* splits) { return splits +  4 * n; }
 template <typename S> __host__ __device__ inline S* ptr_      (rocblas_int n, S* splits) { return splits +  5 * n; }
@@ -209,30 +209,30 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_divide_kernel(const ro
 
         // temporary arrays in global memory
         rocblas_int* splits = splitsA + bid * get_splits_size(n);
-        rocblas_int* ns = ptr_ns(n, splits);
-        rocblas_int* ps = ptr_ps(n, splits);
+        rocblas_int* msz = ptr_msz(n, splits);
+        rocblas_int* mps = ptr_mps(n, splits);
 
         // find sizes of sub-blocks
-        ns[0] = n;
+        msz[0] = n;
         rocblas_int t, t2;
         for(int i = 0; i < levs; ++i)
         {
             for(int j = (1 << i); j > 0; --j)
             {
-                t = ns[j - 1];
+                t = msz[j - 1];
                 t2 = t / 2;
-                ns[j * 2 - 1] = (2 * t2 < t) ? t2 + 1 : t2;
-                ns[j * 2 - 2] = t2;
+                msz[j * 2 - 1] = (2 * t2 < t) ? t2 + 1 : t2;
+                msz[j * 2 - 2] = t2;
             }
         }
 
         // find beginning of sub-blocks and update elements in D
         rocblas_int p2 = 0;
-        ps[0] = p2;
+        mps[0] = p2;
         for(int i = 1; i < blks; ++i)
         {
-            p2 += ns[i - 1];
-            ps[i] = p2;
+            p2 += msz[i - 1];
+            mps[i] = p2;
 
             // perform sub-block division
             S p = E[p2 - 1];
@@ -284,19 +284,19 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_solve_kernel(const roc
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* ns = ptr_ns(n, splits);
-    rocblas_int* ps = ptr_ps(n, splits);
+    rocblas_int* msz = ptr_msz(n, splits);
+    rocblas_int* mps = ptr_mps(n, splits);
     // workspace for solvers
     S* W = WA + bid * 2 * n;
 
     // Solve the blks sub-blocks in parallel (using classic QR iteration).
     if(sid < blks)
     {
-        rocblas_int sbs = ns[sid];  // size of sub-block
-        rocblas_int p2 = ps[sid];   // start position of sub-block
+        rocblas_int sz = msz[sid];  // size of sub-block
+        rocblas_int p2 = mps[sid];  // start position of sub-block
 
-        run_steqr(tidb, tidb_inc, sbs, D + p2, E + p2, C + p2 + p2 * ldc, ldc, info, W + p2 * 2,
-                  30 * sbs, eps, ssfmin, ssfmax, false);
+        run_steqr(tidb, tidb_inc, sz, D + p2, E + p2, C + p2 + p2 * ldc, ldc, info, W + p2 * 2,
+                  30 * sz, eps, ssfmin, ssfmax, false);
     }
 }
 
@@ -311,8 +311,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_init_splits(const rocb
 {
     rocblas_int bid = hipBlockIdx_y;
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* ns  = ptr_ns(n, splits);
-    rocblas_int* ps  = ptr_ps(n, splits);
     rocblas_int* em  = ptr_em(n, splits);
     rocblas_int* msz = ptr_msz(n, splits);
     rocblas_int* mps = ptr_mps(n, splits);
@@ -321,10 +319,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_init_splits(const rocb
 
     for(int i = hipThreadIdx_x; i < n_blocks; i+=hipBlockDim_x)
     {
-        rocblas_int sz = ns[i];
-        rocblas_int p1 = ps[i];
-        msz[i] = sz;
-        mps[i] = p1;
+        rocblas_int sz = msz[i];
+        rocblas_int p1 = mps[i];
         for (int j = 0; j < sz; j++) {
             em[p1 + j] = i;
         }
@@ -2145,8 +2141,6 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                 print_device_matrix(std::cout, "esz", 1, n, ptr_esz(n, splits), 1);
                 print_device_matrix(std::cout, "eps", 1, n, ptr_eps(n, splits), 1);
                 //print_device_matrix(std::cout, "dds", 1, n_merges, ptr_dds(n, splits), 1);
-                print_device_matrix(std::cout, "ns", 1, blks, ptr_ns(n, splits), 1);
-                print_device_matrix(std::cout, "ps", 1, blks, ptr_ps(n, splits), 1);
                 print_device_matrix(std::cout, "sid          ", 1, numgrps3, ptr_dbg(n, splits), 1);
                 print_device_matrix(std::cout, "tid", 1, numgrps3, ptr_dbg1(n, splits), 1);
                 print_device_matrix(std::cout, "iam", 1, numgrps3, ptr_dbg2(n, splits), 1);

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -143,8 +143,10 @@ __host__ __device__ inline rocblas_int get_tmpz_size(const rocblas_int n)
     // 7    S cd[n];             // sorted and compacted d values
     // 8    S cz[n];             // sorted and compacted z values
     // 9    S r1p[m], _[n-m];    // p component of the rank-1 modification
-    // 10   S sdbg[n];           //
-    return 11 * n;
+    // 10   S nrms[n];           // norms of vectors
+    // 11   S sdbg[n];           //
+    // };
+    return 12 * n;
 }
 
 template <typename S> __host__ __device__ inline S* ptr_z    (rocblas_int n, S* tmpz) { return tmpz +  0 * n; }
@@ -157,7 +159,22 @@ template <typename S> __host__ __device__ inline S* ptr_md   (rocblas_int n, S* 
 template <typename S> __host__ __device__ inline S* ptr_cd   (rocblas_int n, S* tmpz) { return tmpz +  7 * n; }
 template <typename S> __host__ __device__ inline S* ptr_cz   (rocblas_int n, S* tmpz) { return tmpz +  8 * n; }
 template <typename S> __host__ __device__ inline S* ptr_r1p  (rocblas_int n, S* tmpz) { return tmpz +  9 * n; }
-template <typename S> __host__ __device__ inline S* ptr_sdbg (rocblas_int n, S* tmpz) { return tmpz + 10 * n; }
+template <typename S> __host__ __device__ inline S* ptr_nrms (rocblas_int n, S* tmpz) { return tmpz + 10 * n; }
+template <typename S> __host__ __device__ inline S* ptr_sdbg (rocblas_int n, S* tmpz) { return tmpz + 11 * n; }
+
+
+__host__ __device__ inline rocblas_int get_tempgemm_size(const rocblas_int n)
+{
+    // tempgemm layout:
+    // struct {
+    // 0    S vecs[n*n];      // 
+    // 1    S etmpd[n*n];     // temp deltas used in solving secular equations
+    // };
+    return 2 * n * n;
+}
+
+template <typename S> __host__ __device__ inline S* ptr_vecs (rocblas_int n, S* tempgemm) { return tempgemm +  0 * n * n; }
+template <typename S> __host__ __device__ inline S* ptr_etmpd(rocblas_int n, S* tempgemm) { return tempgemm +  1 * n * n; }
 
 
 /*************** Main kernels *********************************************************/
@@ -1085,7 +1102,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                                    S* DD,
                                    const rocblas_stride strideD,
                                    S* tmpzA,
-                                   S* vecsA,
+                                   S* tempgemmA,
                                    rocblas_int* splitsA)
 {
     // threads and groups indices
@@ -1105,9 +1122,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* evs = ptr_evs(n, tmpz);
     S* cd  = ptr_cd(n, tmpz);
 
-    S* vecs = vecsA + bid * 2 * (n * n);
-    S* temps = vecs + (n * n);
-    S* etmpd = temps;
+    S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
+    S* etmpd = ptr_etmpd(n, tempgemm);
 
     rocblas_int dd = dds[sid];
     rocblas_int p1 = mps[sid];
@@ -1202,7 +1218,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                                    S* EE,
                                    const rocblas_stride strideE,
                                    S* tmpzA,
-                                   S* vecsA,
+                                   S* tempgemmA,
                                    rocblas_int* splitsA,
                                    const S eps,
                                    const S ssfmin,
@@ -1228,10 +1244,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* r1p = ptr_r1p(n, tmpz);
     S* evs = ptr_evs(n, tmpz);
     // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
-    S* etmpd = temps;
+    S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
+    S* etmpd = ptr_etmpd(n, tempgemm);
 
     int i = hipThreadIdx_x + hipBlockDim_x * hipBlockIdx_x;
     if(i < n)
@@ -1312,7 +1326,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                                      S* EE,
                                      const rocblas_stride strideE,
                                      S* tmpzA,
-                                     S* vecsA,
+                                     S* tempgemmA,
                                      rocblas_int* splitsA,
                                      const S eps,
                                      const S ssfmin,
@@ -1339,10 +1353,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z = ptr_cz(n, tmpz);
     // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
-    S* etmpd = temps;
+    S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
+    S* etmpd = ptr_etmpd(n, tempgemm);
 
     rocblas_int sid = em[eid];
     rocblas_int sz = msz[sid];
@@ -1400,16 +1412,12 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                               const rocblas_int blks,
                               const rocblas_int k,
                               const rocblas_int n,
-                              S* DD,
-                              const rocblas_stride strideD,
-                              S* EE,
-                              const rocblas_stride strideE,
                               S* CC,
                               const rocblas_int shiftC,
                               const rocblas_int ldc,
                               const rocblas_stride strideC,
                               S* tmpzA,
-                              S* vecsA,
+                              S* tempgemmA,
                               rocblas_int* splitsA)
 {
     // threads and groups indices
@@ -1423,7 +1431,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // select batch instance to work with
     S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
-    S* D = DD + bid * strideD;
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
@@ -1437,13 +1444,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z    = ptr_cz(n, tmpz);
     // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
-
-    // temporary arrays in shared memory
-    // used to store temp values during the different reductions
-    __shared__ S inrms[STEDC_BDIM];
+    S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
+    S* vecs  = ptr_vecs(n, tempgemm);
+    S* etmpd = ptr_etmpd(n, tempgemm);
 
     // Work with merges on level k. Each thread-group works with one vector.
     // determine boundaries of what would be the new merged sub-block
@@ -1454,10 +1457,13 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     __syncthreads();
 
+    // temporary arrays in shared memory
+    // used to store temp values during the different reductions
+    __shared__ S inrms[STEDC_BDIM];
 
     // Prepare vectors corresponding to non-deflated values
     S nrm;
-    S* putvec = USEGEMM ? vecs : temps;
+    S* putvec = USEGEMM ? vecs : etmpd;
 
     if(idd[eid] == 1)
     {
@@ -1465,7 +1471,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         nrm = 0;
         for(int i = tidb; i < dd; i += dim)
         {
-            S valf = z[p1 + i] / temps[i + eid*n];
+            S valf = z[p1 + i] / etmpd[i + eid*n];
             nrm += valf * valf;
             putvec[i + eid*n] = valf;
         }
@@ -1488,8 +1494,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     if(USEGEMM)
     {
         // when using external gemms for the update, we need to
-        // put vectors in padded matrix 'temps'
-        // (this is to compute 'vecs = C * temps' using external gemm call)
+        // put vectors in padded matrix 'etmpd'
+        // (this is to compute 'vecs = C * etmpd' using external gemm call)
         for(int i = tidb; i < p1 + sz; i += dim)
         {
             if(i >= p1 && idd[eid] == 1 && idd[i] == 1)
@@ -1500,11 +1506,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                     if(idd[k] == 0)
                         dd++;
                 }
-                temps[pers[i - dd] + p1 + eid * n]
+                etmpd[pers[i - dd] + p1 + eid * n]
                     = vecs[i - dd - p1 + eid * n] / nrm;
             }
             else
-                temps[i + eid * n] = 0;
+                etmpd[i + eid * n] = 0;
         }
     }
     else
@@ -1524,7 +1530,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 if(ii < sz)
                 {
                     for(int kk = tidb; kk < dd; kk += dim)
-                        temp += C[i + (pers[p1 + kk] + p1) * ldc] * temps[kk + eid * n];
+                        temp += C[i + (pers[p1 + kk] + p1) * ldc] * etmpd[kk + eid * n];
                 }
                 inrms[tidb] = temp;
                 __syncthreads();
@@ -1569,7 +1575,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                              const rocblas_int ldc,
                              const rocblas_stride strideC,
                              S* tmpzA,
-                             S* vecsA,
+                             S* tempgemmA,
                              rocblas_int* splitsA)
 {
     // threads and groups indices
@@ -1595,7 +1601,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* evs = ptr_evs(n, tmpz);
     // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
+    S* vecs = tempgemmA + bid * get_tempgemm_size(n);
 
     // tn is max number of vectors in each sub-block
     rocblas_int bdm = 1 << (k + 1);
@@ -1908,7 +1914,7 @@ void rocsolver_stedc_getMemorySize(const rocblas_evect evect,
             *size_tempvect = sizeof(S) * (n * n) * batch_count;
         else
             *size_tempvect = 0;
-        *size_tempgemm = sizeof(S) * 2 * (n * n) * batch_count;
+        *size_tempgemm = sizeof(S) * get_tempgemm_size(n) * batch_count;
         if(BATCHED && !COMPLEX)
             *size_workArr = sizeof(S*) * batch_count;
         else
@@ -2033,7 +2039,7 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
     else
     {
         // initialize temporary array for vector updates
-        size_t size_tempgemm = sizeof(S) * 2 * n * n * batch_count;
+        size_t size_tempgemm = sizeof(S) * get_tempgemm_size(n) * batch_count;
         HIP_CHECK(hipMemsetAsync((void*)tempgemm, 0, size_tempgemm, stream));
 
         // everything must be executed with scalars on the host
@@ -2156,7 +2162,7 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             ROCSOLVER_LAUNCH_KERNEL(
                 (stedc_mergeVectors_kernel<STEDC_EXTERNAL_GEMM, S>),
                 dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
-                levs, blks, k, n, D + shiftD, strideD, E + shiftE, strideE, V, 0, ldv, strideV, 
+                levs, blks, k, n, V, 0, ldv, strideV, 
                 tmpz, tempgemm, splits);
 
 #if DEBUG_OUTPUT

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -927,205 +927,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     }
 }
 
-template <typename S>
-ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergePrepare_Organize_kernel(const rocblas_int levs,
-                                       const rocblas_int blks,
-                                       const rocblas_int k,
-                                       const rocblas_int n,
-                                       S* DD,
-                                       const rocblas_stride strideD,
-                                       S* EE,
-                                       const rocblas_stride strideE,
-                                       S* CC,
-                                       const rocblas_int shiftC,
-                                       const rocblas_int ldc,
-                                       const rocblas_stride strideC,
-                                       S* tmpzA,
-                                       S* vecsA,
-                                       rocblas_int* splitsA,
-                                       const S eps)
-{
-    // threads and groups indices
-    // batch instance id
-    rocblas_int bid = hipBlockIdx_y;
-    // merge sub-block id
-    rocblas_int sid = hipBlockIdx_x;
-
-    // select batch instance to work with
-    S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
-    S* D = DD + bid * strideD;
-
-    // temporary arrays in global memory
-    rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* idd  = ptr_idd(n, splits);
-    rocblas_int* msz  = ptr_msz(n, splits);
-    rocblas_int* dds  = ptr_dds(n, splits);
-    rocblas_int* mps = ptr_mps(n, splits);
-
-    S* tmpz = tmpzA + bid * get_tmpz_size(n);
-    S* z     = ptr_z(n, tmpz);
-    S* r1p   = ptr_r1p(n, tmpz);
-    S* sdbg  = ptr_sdbg(n, tmpz);
-    // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
-
-    // Work with merges on level k. A thread-group works with two leaves in the merge tree.
-    {
-        // 1. find rank-1 modification component (p) for this merge
-        // ----------------------------------------------------------------
-        // rank-1 modification component p correspond to the last element in the first sub-block
-        S p = r1p[sid];
-
-        // 3. deflate eigenvalues
-        // ----------------------------------------------------------------
-        // determine boundaries of what would be the new merged sub-block
-        // 'p1' will be its initial position.
-        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        rocblas_int sz = msz[sid];
-        rocblas_int p1 = mps[sid];
-
-        // 4. Organize data with non-deflated values to prepare secular equation
-        // ------------------------------------------------------------------------ 
-        // define shifted arrays
-        S* etmpd = temps;
-
-        // find degree and components of secular equation
-        // etmpd contains the non-deflated diagonal elements (ie. poles of the
-        // secular eqn) zz contains the corresponding non-zero elements of the
-        // rank-1 modif vector
-
-        for(int i = 0; i < sz; ++i)
-        {
-            for(int j = 0; j < sz; ++j)
-            {
-                if(hipThreadIdx_x == 0)
-                {
-                    etmpd[(p1+j) * n + i] = 0;
-                }
-            }
-        }
-        __syncthreads();
-
-        rocblas_int dd = 0;
-        for(int i = 0; i < sz; ++i)
-        {
-            if(idd[p1 + i] == 1)
-            {
-                if(hipThreadIdx_x == 0)
-                {
-                    etmpd[p1 * n + dd] = p < 0 ? -D[p1 + i] : D[p1 + i];
-                    if(dd != i)
-                        z[p1 + dd] = z[p1 + i];
-                }
-                dd++;
-            }
-        }
-        dds[sid] = dd;
-    }
-}
-
-
-//--------------------------------------------------------------------------------------//
-/** STEDC_MERGEVALUES_KERNEL solves the secular equation for every pair of sub-blocks 
-    that need to be merged. 
-        - Call this kernel with batch_count groups in y, and as many groups as half of the 
-          unmerged sub-blocks in current level in x. Each group works with a merge of a pair
-          of sub-blocks. Groups are size STEDC_BDIM **/
-template <typename S>
-ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeValues_Sort_kernel(const rocblas_int levs,
-                                  const rocblas_int blks,
-                                  const rocblas_int k,
-                                  const rocblas_int n,
-                                  S* DD,
-                                  const rocblas_stride strideD,
-                                  S* EE,
-                                  const rocblas_stride strideE,
-                                  S* tmpzA,
-                                  S* vecsA,
-                                  rocblas_int* splitsA,
-                                  const S eps,
-                                  const S ssfmin,
-                                  const S ssfmax)
-{
-    // threads and groups indices
-    // batch instance id
-    rocblas_int bid = hipBlockIdx_y;
-    // merge sub-block id
-    rocblas_int sid = hipBlockIdx_x;
-
-    // select batch instance to work with
-    S* D = DD + bid * strideD;
-
-    // temporary arrays in global memory
-    rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* mps  = ptr_mps(n, splits);
-    rocblas_int* idd  = ptr_idd(n, splits);
-    rocblas_int* msz  = ptr_msz(n, splits);
-    rocblas_int* dds  = ptr_dds(n, splits);
-    
-    S* tmpz = tmpzA + bid * get_tmpz_size(n);
-    S* z   = ptr_z(n, tmpz);
-    S* sdbg = ptr_sdbg(n, tmpz);
-    // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
-
-    // Work with merges on level k. A thread-group works with two leaves in the merge tree;
-    // all threads work together to solve the secular equation.
-    {
-        // determine boundaries of what would be the new merged sub-block
-        // 'p1' will be its initial position.
-        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        rocblas_int sz = msz[sid];
-        rocblas_int p1 = mps[sid];
-
-
-        // 1. Organize data with non-deflated values to prepare secular equation
-        // ----------------------------------------------------------------- 
-        // All threads of the group participating in the merge will work together
-        // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
-
-        // define shifted arrays
-        S* etmpd = temps;
-        rocblas_int* mask = idd + p1;
-        S* zz = z + p1;
-
-        // find degree of secular equation
-        rocblas_int dd = dds[sid];
-
-        // Order the elements in etmpd and zz using a simple parallel selection/bubble sort.
-        // This will allow us to find initial intervals for eigenvalue guesses
-        for(int i = 0; i < dd; i++)
-        {
-            for(int j = 2 * hipThreadIdx_x + i % 2; j < dd - 1; j += 2 * hipBlockDim_x)
-            {
-                if(etmpd[p1 * n + j] > etmpd[p1 * n + j + 1])
-                {
-                    swap(etmpd[p1 * n + j], etmpd[p1 * n + j + 1]);
-                    swap(zz[j], zz[j + 1]);
-                }
-            }
-            __syncthreads();
-        }
-        
-        // make dd copies of the non-deflated ordered diagonal elements
-        // (i.e. the poles of the secular eqn) so that the distances to the
-        // eigenvalues (D - lambda_i) are updated while computing each eigenvalue.
-        // This will prevent collapses and division by zero when an eigenvalue
-        // is too close to a pole.
-        //for(int i = hipThreadIdx_x; i < dd; i += hipBlockDim_x)
-        //{
-        //    for(int j = 1; j < sz; j ++)
-        //        etmpd[(p1 + j) * n + i] = etmpd[p1 * n + i];
-        //}
-
-    }
-}
 
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
@@ -1363,6 +1164,12 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 #endif
 }
 
+//--------------------------------------------------------------------------------------//
+/** STEDC_MERGEVALUES_KERNEL solves the secular equation for every pair of sub-blocks 
+    that need to be merged. 
+        - Call this kernel with batch_count groups in y, and as many groups in x as needed 
+          to cover n (i.e. n_groups_x * groups_size_x >= n). Groups are size STEDC_BDIM **/
+
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     stedc_mergeValues_Solve_kernel(const rocblas_int levs,
@@ -1396,7 +1203,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* em  = ptr_em(n, splits);
     
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
-    S* z   = ptr_z(n, tmpz);
+    S* z   = ptr_cz(n, tmpz);
     S* r1p = ptr_r1p(n, tmpz);
     S* evs = ptr_evs(n, tmpz);
     // updated eigenvectors after merges
@@ -1508,7 +1315,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* dds  = ptr_dds(n, splits);
     
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
-    S* z   = ptr_z(n, tmpz);
+    S* z   = ptr_cz(n, tmpz);
     // updated eigenvectors after merges
     S* vecs = vecsA + bid * 2 * (n * n);
     // temp values during the merges
@@ -1604,7 +1411,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* pers = ptr_map(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
-    S* z   = ptr_z(n, tmpz);
+    S* z   = ptr_cz(n, tmpz);
     // updated eigenvectors after merges
     S* vecs = vecsA + bid * 2 * (n * n);
     // temp values during the merges
@@ -2342,31 +2149,11 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeRotate_kernel<S>), dim3(n, batch_count),
                                     dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, V, 0, ldv,
                                     strideV, tmpz, splits);
+            
 
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_Organize_kernel<S>),
-                                    dim3(n_merges, batch_count), dim3(STEDC_BDIM), 0, stream, 
-                                    levs, blks, k, n, D + shiftD, strideD,
-                                    E + shiftE, strideE, V, 0, ldv, strideV, tmpz, tempgemm, splits,
-                                    eps);
-
-            if(env_levs && global_cnt == 1)
-            {
-                std::cout << "\nk=" << k << std::endl;
-                print_device_matrix(std::cout, "etmpdOrg", n, n, tempgemm + n * n, n);
-            }
-
-
-            // b. solve secular eq to find merged eigenvalues
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Sort_kernel<S>), dim3(n_merges, batch_count),
-                                    dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
-                                    strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
-                                    ssfmin, ssfmax);
-            //*
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_SortDZ_kernel<S>), dim3(n, batch_count),
                                     dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
                                     strideD, tmpz, splits);
-
-            rocblas_int numgrps_copyd = (n - 1) / STEDC_BDIM + 1;
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_copyD_kernel<S>),
                                     dim3(n_merges, batch_count),
                                     dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -143,10 +143,9 @@ __host__ __device__ inline rocblas_int get_tmpz_size(const rocblas_int n)
     // 7    S cd[n];             // sorted and compacted d values
     // 8    S cz[n];             // sorted and compacted z values
     // 9    S r1p[m], _[n-m];    // p component of the rank-1 modification
-    // 10   S nrms[n];           // norms of vectors
-    // 11   S sdbg[n];           //
+    // 10   S sdbg[n];           //
     // };
-    return 12 * n;
+    return 11 * n;
 }
 
 template <typename S> __host__ __device__ inline S* ptr_z    (rocblas_int n, S* tmpz) { return tmpz +  0 * n; }
@@ -159,8 +158,7 @@ template <typename S> __host__ __device__ inline S* ptr_md   (rocblas_int n, S* 
 template <typename S> __host__ __device__ inline S* ptr_cd   (rocblas_int n, S* tmpz) { return tmpz +  7 * n; }
 template <typename S> __host__ __device__ inline S* ptr_cz   (rocblas_int n, S* tmpz) { return tmpz +  8 * n; }
 template <typename S> __host__ __device__ inline S* ptr_r1p  (rocblas_int n, S* tmpz) { return tmpz +  9 * n; }
-template <typename S> __host__ __device__ inline S* ptr_nrms (rocblas_int n, S* tmpz) { return tmpz + 10 * n; }
-template <typename S> __host__ __device__ inline S* ptr_sdbg (rocblas_int n, S* tmpz) { return tmpz + 11 * n; }
+template <typename S> __host__ __device__ inline S* ptr_sdbg (rocblas_int n, S* tmpz) { return tmpz + 10 * n; }
 
 
 __host__ __device__ inline rocblas_int get_tempgemm_size(const rocblas_int n)
@@ -1457,221 +1455,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 }
 
 
-template <bool USEGEMM, typename S>
-ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeVectors_ComputeNorms_kernel(const rocblas_int k,
-                                           const rocblas_int n,
-                                           S* CC,
-                                           const rocblas_int shiftC,
-                                           const rocblas_int ldc,
-                                           const rocblas_stride strideC,
-                                           S* tmpzA,
-                                           S* tempgemmA,
-                                           rocblas_int* splitsA)
-{
-    // threads and groups indices
-    // batch instance id
-    rocblas_int bid = hipBlockIdx_y;
-    // eigenvalue id
-    rocblas_int eid = hipBlockIdx_x;
-    // thread id
-    rocblas_int tidb = hipThreadIdx_x;
-    rocblas_int dim = hipBlockDim_x;
-
-    // temporary arrays in global memory
-    rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* em   = ptr_em(n, splits);
-    rocblas_int* msz  = ptr_msz(n, splits);
-    rocblas_int* mps  = ptr_mps(n, splits);
-    rocblas_int* dds  = ptr_dds(n, splits);
-
-    S* tmpz = tmpzA + bid * get_tmpz_size(n);
-    S* z    = ptr_cz(n, tmpz);
-    S* nrms = ptr_nrms(n, tmpz);
-    // updated eigenvectors after merges
-    S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
-    S* vecs  = ptr_vecs(n, tempgemm);
-    S* etmpd = ptr_etmpd(n, tempgemm);
-
-    // Work with merges on level k. Each thread-group works with one vector.
-    // determine boundaries of what would be the new merged sub-block
-    rocblas_int merge_id = em[eid];
-    rocblas_int p1 = mps[merge_id];
-    rocblas_int sz = msz[merge_id];
-    rocblas_int dd = dds[merge_id];
-
-    __syncthreads();
-
-    // temporary arrays in shared memory
-    // used to store temp values during the different reductions
-    __shared__ S inrms[STEDC_BDIM];
-
-    // Prepare vectors corresponding to non-deflated values
-    S nrm;
-    S* putvec = USEGEMM ? vecs : etmpd;
-
-    if(eid - p1 < dd)
-    {
-        // compute vectors of rank-1 perturbed system and their norms
-        nrm = 0;
-        for(int i = tidb; i < dd; i += dim)
-        {
-            S valf = z[p1 + i] / etmpd[i + eid*n];
-            nrm += valf * valf;
-            putvec[i + eid*n] = valf;
-        }
-        inrms[tidb] = nrm;
-        __syncthreads();
-
-        // reduction (for the norms)
-        for(int r = dim / 2; r > 0; r /= 2)
-        {
-            if(tidb < r)
-            {
-                nrm += inrms[tidb + r];
-                inrms[tidb] = nrm;
-            }
-            __syncthreads();
-        }
-
-        if (tidb == 0) {
-            nrms[eid] = sqrt(nrm);
-        }
-    }
-}
-
-
-template <bool USEGEMM, typename S>
-ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeVectors_ZeroEtmpd_kernel(const rocblas_int k,
-                                        const rocblas_int n,
-                                        S* CC,
-                                        const rocblas_int shiftC,
-                                        const rocblas_int ldc,
-                                        const rocblas_stride strideC,
-                                        S* tmpzA,
-                                        S* tempgemmA,
-                                        rocblas_int* splitsA)
-{
-    // threads and groups indices
-    // batch instance id
-    rocblas_int bid = hipBlockIdx_y;
-    rocblas_int row = hipBlockIdx_x;
-
-    S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
-    S* etmpd = ptr_etmpd(n, tempgemm);
-
-    for(int i = hipThreadIdx_x; i < n; i += hipBlockDim_x)
-    {
-        etmpd[row*n + i] = 0;
-    }
-}
-
-
-template <bool USEGEMM, typename S>
-ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeVectors_ApplyNorms_kernel(const rocblas_int k,
-                                         const rocblas_int n,
-                                         S* CC,
-                                         const rocblas_int shiftC,
-                                         const rocblas_int ldc,
-                                         const rocblas_stride strideC,
-                                         S* tmpzA,
-                                         S* tempgemmA,
-                                         rocblas_int* splitsA)
-{
-    // threads and groups indices
-    // batch instance id
-    rocblas_int bid = hipBlockIdx_y;
-    // eigenvalue id
-    rocblas_int eid = hipBlockIdx_x;
-    // thread id
-    rocblas_int tidb = hipThreadIdx_x;
-    rocblas_int dim = hipBlockDim_x;
-
-    // select batch instance to work with
-    S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
-
-    // temporary arrays in global memory
-    rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* em   = ptr_em(n, splits);
-    rocblas_int* msz  = ptr_msz(n, splits);
-    rocblas_int* mps  = ptr_mps(n, splits);
-    rocblas_int* dds  = ptr_dds(n, splits);
-
-    S* tmpz = tmpzA + bid * get_tmpz_size(n);
-    S* nrms = ptr_nrms(n, tmpz);
-    // updated eigenvectors after merges
-    S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
-    S* vecs  = ptr_vecs(n, tempgemm);
-    S* etmpd = ptr_etmpd(n, tempgemm);
-
-    // Work with merges on level k. Each thread-group works with one vector.
-    // determine boundaries of what would be the new merged sub-block
-    rocblas_int merge_id = em[eid];
-    rocblas_int p1 = mps[merge_id];
-    rocblas_int sz = msz[merge_id];
-    rocblas_int dd = dds[merge_id];
-
-    __syncthreads();
-
-    // temporary arrays in shared memory
-    // used to store temp values during the different reductions
-    __shared__ S inrms[STEDC_BDIM];
-
-    // Prepare vectors corresponding to non-deflated values
-    S nrm = nrms[eid];
-
-    if(USEGEMM)
-    {
-        // when using external gemms for the update, we need to
-        // put vectors in padded matrix 'etmpd'
-        // (this is to compute 'vecs = C * etmpd' using external gemm call)
-        if(eid - p1 < dd) {
-            for(int i = tidb; i < dd; i += dim)
-            {
-                etmpd[p1 + i + eid * n]
-                    = vecs[i + eid * n] / nrm;
-            }
-        }
-    }
-    else
-    {
-        // otherwise, use internal gemm-like procedure to
-        // multiply by C (row by row)
-        if(eid - p1 < dd)
-        {
-            for(int ii = 0; ii < sz; ++ii)
-            {
-                rocblas_int i = p1 + ii;
-
-                // inner products
-                S temp = 0;
-                for(int kk = tidb; kk < dd; kk += dim)
-                    temp += C[i + (p1 + kk) * ldc] * etmpd[kk + eid * n];
-                inrms[tidb] = temp;
-                __syncthreads();
-
-                // reduction
-                for(int r = dim / 2; r > 0; r /= 2)
-                {
-                    if(tidb < r)
-                    {
-                        temp += inrms[tidb + r];
-                        inrms[tidb] = temp;
-                    }
-                    __syncthreads();
-                }
-
-                // result
-                if(tidb == 0)
-                    vecs[i + eid * n] = temp / nrm;
-                __syncthreads();
-            }
-        }
-    }
-}
-
 
 //--------------------------------------------------------------------------------------//
 /** STEDC_MERGEUPDATE_KERNEL updates vectors and values after a merge is done. 
@@ -2345,33 +2128,11 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     tmpz, tempgemm, splits, eps, ssfmin, ssfmax);
 
             // c. find merged eigenvectors
-            if (0) {
-                ROCSOLVER_LAUNCH_KERNEL(
-                    (stedc_mergeVectors_ComputeNorms_kernel<STEDC_EXTERNAL_GEMM, S>),
-                    dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
-                    k, n, V, 0, ldv, strideV, 
-                    tmpz, tempgemm, splits);
-#if STEDC_EXTERNAL_GEMM
-                ROCSOLVER_LAUNCH_KERNEL(
-                    (stedc_mergeVectors_ZeroEtmpd_kernel<STEDC_EXTERNAL_GEMM, S>),
-                    dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
-                    k, n, V, 0, ldv, strideV, 
-                    tmpz, tempgemm, splits);
-#endif
-                ROCSOLVER_LAUNCH_KERNEL(
-                    (stedc_mergeVectors_ApplyNorms_kernel<STEDC_EXTERNAL_GEMM, S>),
-                    dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
-                    k, n, V, 0, ldv, strideV, 
-                    tmpz, tempgemm, splits);
-            }
-            else
-            {
-                ROCSOLVER_LAUNCH_KERNEL(
-                    (stedc_mergeVectors_kernel<STEDC_EXTERNAL_GEMM, S>),
-                    dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
-                    k, n, V, 0, ldv, strideV, 
-                    tmpz, tempgemm, splits);
-            }
+            ROCSOLVER_LAUNCH_KERNEL(
+                (stedc_mergeVectors_kernel<STEDC_EXTERNAL_GEMM, S>),
+                dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
+                k, n, V, 0, ldv, strideV, 
+                tmpz, tempgemm, splits);
 
             if(STEDC_EXTERNAL_GEMM)
             {

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -250,7 +250,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_divide_kernel(const ro
           Groups are single-thread **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_solve_kernel(const rocblas_int levs,
-                                                                       const rocblas_int blks,
                                                                        const rocblas_int n,
                                                                        S* DD,
                                                                        const rocblas_stride strideD,
@@ -290,7 +289,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_solve_kernel(const roc
     S* W = WA + bid * 2 * n;
 
     // Solve the blks sub-blocks in parallel (using classic QR iteration).
-    if(sid < blks)
     {
         rocblas_int sz = msz[sid];  // size of sub-block
         rocblas_int p2 = mps[sid];  // start position of sub-block
@@ -393,9 +391,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_update_splits(const ro
           of sub-blocks. Groups are size STEDC_BDIM **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergePrepare_DeflateZero_kernel(const rocblas_int levs,
-                                          const rocblas_int blks,
-                                          const rocblas_int k,
+    stedc_mergePrepare_DeflateZero_kernel(const rocblas_int k,
                                           const rocblas_int n,
                                           S* DD,
                                           const rocblas_stride strideD,
@@ -529,9 +525,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         - Call this kernel with n groups in x and batch_count groups in y. Groups are size STEDC_BDIM **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergePrepare_SortD_kernel(const rocblas_int levs,
-                                    const rocblas_int blks,
-                                    const rocblas_int k,
+    stedc_mergePrepare_SortD_kernel(const rocblas_int k,
                                     const rocblas_int n,
                                     S* DD,
                                     const rocblas_stride strideD,
@@ -641,9 +635,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         Groups are size STEDC_BDIM **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergePrepare_SetCandFlags_kernel(const rocblas_int levs,
-                                           const rocblas_int blks,
-                                           const rocblas_int k,
+    stedc_mergePrepare_SetCandFlags_kernel(const rocblas_int k,
                                            const rocblas_int n,
                                            S* DD,
                                            const rocblas_stride strideD,
@@ -708,9 +700,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         Groups are size STEDC_BDIM **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergePrepare_DeflateCount_kernel(const rocblas_int levs,
-                                           const rocblas_int blks,
-                                           const rocblas_int k,
+    stedc_mergePrepare_DeflateCount_kernel(const rocblas_int k,
                                            const rocblas_int n,
                                            S* DD,
                                            const rocblas_stride strideD,
@@ -794,9 +784,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         Groups are size STEDC_BDIM **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergePrepare_DeflateApply_kernel(const rocblas_int levs,
-                                           const rocblas_int blks,
-                                           const rocblas_int k,
+    stedc_mergePrepare_DeflateApply_kernel(const rocblas_int k,
                                            const rocblas_int n,
                                            S* DD,
                                            const rocblas_stride strideD,
@@ -873,9 +861,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
           a deflation group will do nothing **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeRotate_kernel(const rocblas_int levs,
-                             const rocblas_int blks,
-                             const rocblas_int k,
+    stedc_mergeRotate_kernel(const rocblas_int k,
                              const rocblas_int n,
                              S* CC,
                              const rocblas_int shiftC,
@@ -963,9 +949,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeValues_SortDZ_kernel(const rocblas_int levs,
-                                    const rocblas_int blks,
-                                    const rocblas_int k,
+    stedc_mergeValues_SortDZ_kernel(const rocblas_int k,
                                     const rocblas_int n,
                                     S* DD,
                                     const rocblas_stride strideD,
@@ -1091,9 +1075,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeValues_copyD_kernel(const rocblas_int levs,
-                                   const rocblas_int blks,
-                                   const rocblas_int k,
+    stedc_mergeValues_copyD_kernel(const rocblas_int k,
                                    const rocblas_int n,
                                    S* DD,
                                    const rocblas_stride strideD,
@@ -1205,9 +1187,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeValues_Solve_kernel(const rocblas_int levs,
-                                   const rocblas_int blks,
-                                   const rocblas_int k,
+    stedc_mergeValues_Solve_kernel(const rocblas_int k,
                                    const rocblas_int n,
                                    S* DD,
                                    const rocblas_stride strideD,
@@ -1313,9 +1293,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeValues_Rescale_kernel(const rocblas_int levs,
-                                     const rocblas_int blks,
-                                     const rocblas_int k,
+    stedc_mergeValues_Rescale_kernel(const rocblas_int k,
                                      const rocblas_int n,
                                      S* DD,
                                      const rocblas_stride strideD,
@@ -1405,7 +1383,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 template <bool USEGEMM, typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     stedc_mergeVectors_kernel(const rocblas_int levs,
-                              const rocblas_int blks,
                               const rocblas_int k,
                               const rocblas_int n,
                               S* CC,
@@ -1554,9 +1531,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
 template <bool USEGEMM, typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeVectors_ComputeNorms_kernel(const rocblas_int levs,
-                                           const rocblas_int blks,
-                                           const rocblas_int k,
+    stedc_mergeVectors_ComputeNorms_kernel(const rocblas_int k,
                                            const rocblas_int n,
                                            S* CC,
                                            const rocblas_int shiftC,
@@ -1641,9 +1616,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
 template <bool USEGEMM, typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeVectors_ZeroEtmpd_kernel(const rocblas_int levs,
-                                        const rocblas_int blks,
-                                        const rocblas_int k,
+    stedc_mergeVectors_ZeroEtmpd_kernel(const rocblas_int k,
                                         const rocblas_int n,
                                         S* CC,
                                         const rocblas_int shiftC,
@@ -1671,7 +1644,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 template <bool USEGEMM, typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     stedc_mergeVectors_ApplyNorms_kernel(const rocblas_int levs,
-                                         const rocblas_int blks,
                                          const rocblas_int k,
                                          const rocblas_int n,
                                          S* CC,
@@ -1797,9 +1769,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
           Each group works with a column. Groups are size STEDC_BDIM. **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeUpdate_kernel(const rocblas_int levs,
-                             const rocblas_int blks,
-                             const rocblas_int k,
+    stedc_mergeUpdate_kernel(const rocblas_int k,
                              const rocblas_int n,
                              S* DD,
                              const rocblas_stride strideD,
@@ -2295,7 +2265,7 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         // 2. solve phase
         //-----------------------------
         ROCSOLVER_LAUNCH_KERNEL((stedc_solve_kernel<S>),
-                                dim3(blks, batch_count), dim3(64), 0, stream, levs, blks, 
+                                dim3(blks, batch_count), dim3(64), 0, stream, levs,
                                 n, D + shiftD, strideD, E + shiftE, strideE, 
                                 V, 0, ldv, strideV, info, (S*)work_stack, splits, 
                                 eps, ssfmin, ssfmax);
@@ -2315,37 +2285,37 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             // a. prepare secular equations
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_DeflateZero_kernel<S>),
                                     dim3(n_merges, batch_count), dim3(STEDC_BDIM), 0, stream, 
-                                    levs, blks, k, n, D + shiftD, strideD,
+                                    k, n, D + shiftD, strideD,
                                     E + shiftE, strideE, V, 0, ldv, strideV, tmpz, splits,
                                     eps);
 
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_SortD_kernel<S>),
                                     dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream,
-                                    levs, blks, k, n, D + shiftD, strideD,
+                                    k, n, D + shiftD, strideD,
                                     tmpz, splits);
             rocblas_int numgrps_deflate = (n - 1) / STEDC_BDIM + 1;
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_SetCandFlags_kernel<S>),
-                                    dim3(numgrps_deflate, batch_count), dim3(STEDC_BDIM), 0, stream, levs,
-                                    blks, k, n, D + shiftD, strideD, tmpz, splits);
+                                    dim3(numgrps_deflate, batch_count), dim3(STEDC_BDIM), 0, stream,
+                                    k, n, D + shiftD, strideD, tmpz, splits);
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_DeflateCount_kernel<S>),
-                                    dim3(numgrps_deflate, batch_count), dim3(STEDC_BDIM), 0, stream, levs,
-                                    blks, k, n, D + shiftD, strideD, tmpz, splits);
+                                    dim3(numgrps_deflate, batch_count), dim3(STEDC_BDIM), 0, stream,
+                                    k, n, D + shiftD, strideD, tmpz, splits);
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_DeflateApply_kernel<S>),
                                     dim3(numgrps_deflate, batch_count), dim3(STEDC_BDIM), 0, stream,
-                                    levs, blks, k, n, D + shiftD, strideD,
+                                    k, n, D + shiftD, strideD,
                                     tmpz, splits);
                 
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeRotate_kernel<S>), dim3(n, batch_count),
-                                    dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, V, 0, ldv,
+                                    dim3(STEDC_BDIM), 0, stream, k, n, V, 0, ldv,
                                     strideV, tmpz, splits);
             
 
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_SortDZ_kernel<S>), dim3(n, batch_count),
-                                    dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
+                                    dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD,
                                     strideD, tmpz, splits);
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_copyD_kernel<S>),
                                     dim3(n_merges, batch_count),
-                                    dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
+                                    dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD,
                                     strideD, tmpz, tempgemm, splits);
 
 #if DEBUG_OUTPUT
@@ -2377,13 +2347,13 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             rocblas_int numgrps_solve = (n - 1) / STEDC_BDIM + 1;
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Solve_kernel<S>),
                                     dim3(numgrps_solve, batch_count),
-                                    dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
+                                    dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD,
                                     strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
                                     ssfmin, ssfmax);
 
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Rescale_kernel<S>),
                                     dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream,
-                                    levs, blks, k, n, D + shiftD, strideD, E + shiftE, strideE,
+                                    k, n, D + shiftD, strideD, E + shiftE, strideE,
                                     tmpz, tempgemm, splits, eps, ssfmin, ssfmax);
 
             // c. find merged eigenvectors
@@ -2391,17 +2361,19 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                 ROCSOLVER_LAUNCH_KERNEL(
                     (stedc_mergeVectors_ComputeNorms_kernel<STEDC_EXTERNAL_GEMM, S>),
                     dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
-                    levs, blks, k, n, V, 0, ldv, strideV, 
+                    k, n, V, 0, ldv, strideV, 
                     tmpz, tempgemm, splits);
+#if STEDC_EXTERNAL_GEMM
                 ROCSOLVER_LAUNCH_KERNEL(
                     (stedc_mergeVectors_ZeroEtmpd_kernel<STEDC_EXTERNAL_GEMM, S>),
                     dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
-                    levs, blks, k, n, V, 0, ldv, strideV, 
+                    k, n, V, 0, ldv, strideV, 
                     tmpz, tempgemm, splits);
+#endif
                 ROCSOLVER_LAUNCH_KERNEL(
                     (stedc_mergeVectors_ApplyNorms_kernel<STEDC_EXTERNAL_GEMM, S>),
                     dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
-                    levs, blks, k, n, V, 0, ldv, strideV, 
+                    levs, k, n, V, 0, ldv, strideV, 
                     tmpz, tempgemm, splits);
             }
             else
@@ -2409,7 +2381,7 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                 ROCSOLVER_LAUNCH_KERNEL(
                     (stedc_mergeVectors_kernel<STEDC_EXTERNAL_GEMM, S>),
                     dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
-                    levs, blks, k, n, V, 0, ldv, strideV, 
+                    levs, k, n, V, 0, ldv, strideV, 
                     tmpz, tempgemm, splits);
             }
 
@@ -2429,7 +2401,7 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             // d. update level
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeUpdate_kernel<S>),
                                     dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
-                                    levs, blks, k, n, D + shiftD, strideD,
+                                    k, n, D + shiftD, strideD,
                                     V, 0, ldv, strideV, tmpz, tempgemm, splits);
         }
 

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1601,7 +1601,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* evs = ptr_evs(n, tmpz);
     // updated eigenvectors after merges
-    S* vecs = tempgemmA + bid * get_tempgemm_size(n);
+    S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
+    S* vecs = ptr_vecs(n, tempgemm);
 
     // tn is max number of vectors in each sub-block
     rocblas_int bdm = 1 << (k + 1);
@@ -2209,8 +2210,9 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                 // STEDC_EXTERNAL_GEMM at run time to switch between internal vector updates and
                 // external gemm based updates.
                 rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, n, n, n,
-                               &one, V, 0, ldv, strideV, tempgemm, n * n, n, 2 * n * n, &zero,
-                               tempgemm, 0, n, 2 * n * n, batch_count, workArr);
+                               &one, V, 0, ldv, strideV,
+                               ptr_etmpd(n, tempgemm), 0, n, get_tempgemm_size(n), &zero,
+                               ptr_vecs(n, tempgemm),  0, n, get_tempgemm_size(n), batch_count, workArr);
             }
 
             // d. update level

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1419,7 +1419,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // threads and groups indices
     // batch instance id
     rocblas_int bid = hipBlockIdx_y;
-    // merge sub-block id
+    // eigenvalue id
     rocblas_int eid = hipBlockIdx_x;
     // thread id
     rocblas_int tidb = hipThreadIdx_x;
@@ -1486,6 +1486,220 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         }
         nrm = sqrt(inrms[0]);
     }
+
+    if(USEGEMM)
+    {
+        // when using external gemms for the update, we need to
+        // put vectors in padded matrix 'etmpd'
+        // (this is to compute 'vecs = C * etmpd' using external gemm call)
+        for(int i = tidb; i < p1 + sz; i += dim)
+        {
+            if(i >= p1 && idd[eid] == 1 && idd[i] == 1)
+            {
+                dd = 0;
+                for(int k = p1; k < i; ++k)
+                {
+                    if(idd[k] == 0)
+                        dd++;
+                }
+                etmpd[pers[i - dd] + p1 + eid * n]
+                    = vecs[i - dd - p1 + eid * n] / nrm;
+            }
+            else
+                etmpd[i + eid * n] = 0;
+        }
+    }
+    else
+    {
+        // otherwise, use internal gemm-like procedure to
+        // multiply by C (row by row)
+        rocblas_int tsz = 1 << (levs - 1 - k);
+        tsz = (n - 1) / tsz + 1;
+        if(idd[eid] == 1)
+        {
+            for(int ii = 0; ii < tsz; ++ii)
+            {
+                rocblas_int i = p1 + ii;
+
+                // inner products
+                S temp = 0;
+                if(ii < sz)
+                {
+                    for(int kk = tidb; kk < dd; kk += dim)
+                        temp += C[i + (pers[p1 + kk] + p1) * ldc] * etmpd[kk + eid * n];
+                }
+                inrms[tidb] = temp;
+                __syncthreads();
+
+                // reduction
+                for(int r = dim / 2; r > 0; r /= 2)
+                {
+                    if(ii < sz && tidb < r)
+                    {
+                        temp += inrms[tidb + r];
+                        inrms[tidb] = temp;
+                    }
+                    __syncthreads();
+                }
+
+                // result
+                if(ii < sz && tidb == 0)
+                    vecs[i + eid * n] = temp / nrm;
+                __syncthreads();
+            }
+        }
+    }
+}
+
+
+template <bool USEGEMM, typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+    stedc_mergeVectors_ComputeNorms_kernel(const rocblas_int levs,
+                                           const rocblas_int blks,
+                                           const rocblas_int k,
+                                           const rocblas_int n,
+                                           S* CC,
+                                           const rocblas_int shiftC,
+                                           const rocblas_int ldc,
+                                           const rocblas_stride strideC,
+                                           S* tmpzA,
+                                           S* tempgemmA,
+                                           rocblas_int* splitsA)
+{
+    // threads and groups indices
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+    // eigenvalue id
+    rocblas_int eid = hipBlockIdx_x;
+    // thread id
+    rocblas_int tidb = hipThreadIdx_x;
+    rocblas_int dim = hipBlockDim_x;
+
+    // select batch instance to work with
+    S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
+
+    // temporary arrays in global memory
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    rocblas_int* em   = ptr_em(n, splits);
+    rocblas_int* idd  = ptr_idd(n, splits);
+    rocblas_int* msz  = ptr_msz(n, splits);
+    rocblas_int* mps  = ptr_mps(n, splits);
+    rocblas_int* dds  = ptr_dds(n, splits);
+
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* z    = ptr_cz(n, tmpz);
+    S* nrms = ptr_nrms(n, tmpz);
+    // updated eigenvectors after merges
+    S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
+    S* vecs  = ptr_vecs(n, tempgemm);
+    S* etmpd = ptr_etmpd(n, tempgemm);
+
+    // Work with merges on level k. Each thread-group works with one vector.
+    // determine boundaries of what would be the new merged sub-block
+    rocblas_int merge_id = em[eid];
+    rocblas_int p1 = mps[merge_id];
+    rocblas_int sz = msz[merge_id];
+    rocblas_int dd = dds[merge_id];
+
+    __syncthreads();
+
+    // temporary arrays in shared memory
+    // used to store temp values during the different reductions
+    __shared__ S inrms[STEDC_BDIM];
+
+    // Prepare vectors corresponding to non-deflated values
+    S nrm;
+    S* putvec = USEGEMM ? vecs : etmpd;
+
+    if(idd[eid] == 1)
+    {
+        // compute vectors of rank-1 perturbed system and their norms
+        nrm = 0;
+        for(int i = tidb; i < dd; i += dim)
+        {
+            S valf = z[p1 + i] / etmpd[i + eid*n];
+            nrm += valf * valf;
+            putvec[i + eid*n] = valf;
+        }
+        inrms[tidb] = nrm;
+        __syncthreads();
+
+        // reduction (for the norms)
+        for(int r = dim / 2; r > 0; r /= 2)
+        {
+            if(tidb < r)
+            {
+                nrm += inrms[tidb + r];
+                inrms[tidb] = nrm;
+            }
+            __syncthreads();
+        }
+
+        if (tidb == 0) {
+            nrms[eid] = sqrt(nrm);
+        }
+    }
+}
+
+
+template <bool USEGEMM, typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+    stedc_mergeVectors_ApplyNorms_kernel(const rocblas_int levs,
+                                         const rocblas_int blks,
+                                         const rocblas_int k,
+                                         const rocblas_int n,
+                                         S* CC,
+                                         const rocblas_int shiftC,
+                                         const rocblas_int ldc,
+                                         const rocblas_stride strideC,
+                                         S* tmpzA,
+                                         S* tempgemmA,
+                                         rocblas_int* splitsA)
+{
+    // threads and groups indices
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+    // eigenvalue id
+    rocblas_int eid = hipBlockIdx_x;
+    // thread id
+    rocblas_int tidb = hipThreadIdx_x;
+    rocblas_int dim = hipBlockDim_x;
+
+    // select batch instance to work with
+    S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
+
+    // temporary arrays in global memory
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    rocblas_int* em   = ptr_em(n, splits);
+    rocblas_int* idd  = ptr_idd(n, splits);
+    rocblas_int* msz  = ptr_msz(n, splits);
+    rocblas_int* mps  = ptr_mps(n, splits);
+    rocblas_int* dds  = ptr_dds(n, splits);
+    rocblas_int* pers = ptr_map(n, splits);
+
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* nrms = ptr_nrms(n, tmpz);
+    // updated eigenvectors after merges
+    S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
+    S* vecs  = ptr_vecs(n, tempgemm);
+    S* etmpd = ptr_etmpd(n, tempgemm);
+
+    // Work with merges on level k. Each thread-group works with one vector.
+    // determine boundaries of what would be the new merged sub-block
+    rocblas_int merge_id = em[eid];
+    rocblas_int p1 = mps[merge_id];
+    rocblas_int sz = msz[merge_id];
+    rocblas_int dd = dds[merge_id];
+
+    __syncthreads();
+
+    // temporary arrays in shared memory
+    // used to store temp values during the different reductions
+    __shared__ S inrms[STEDC_BDIM];
+
+    // Prepare vectors corresponding to non-deflated values
+    S nrm = nrms[eid];
+    S* putvec = USEGEMM ? vecs : etmpd;
 
     if(USEGEMM)
     {
@@ -2123,11 +2337,26 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     tmpz, tempgemm, splits, eps, ssfmin, ssfmax);
 
             // c. find merged eigenvectors
-            ROCSOLVER_LAUNCH_KERNEL(
-                (stedc_mergeVectors_kernel<STEDC_EXTERNAL_GEMM, S>),
-                dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
-                levs, blks, k, n, V, 0, ldv, strideV, 
-                tmpz, tempgemm, splits);
+            if (1) {
+                ROCSOLVER_LAUNCH_KERNEL(
+                    (stedc_mergeVectors_ComputeNorms_kernel<STEDC_EXTERNAL_GEMM, S>),
+                    dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
+                    levs, blks, k, n, V, 0, ldv, strideV, 
+                    tmpz, tempgemm, splits);
+                ROCSOLVER_LAUNCH_KERNEL(
+                    (stedc_mergeVectors_ApplyNorms_kernel<STEDC_EXTERNAL_GEMM, S>),
+                    dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
+                    levs, blks, k, n, V, 0, ldv, strideV, 
+                    tmpz, tempgemm, splits);
+            }
+            else
+            {
+                ROCSOLVER_LAUNCH_KERNEL(
+                    (stedc_mergeVectors_kernel<STEDC_EXTERNAL_GEMM, S>),
+                    dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
+                    levs, blks, k, n, V, 0, ldv, strideV, 
+                    tmpz, tempgemm, splits);
+            }
 
 #if DEBUG_OUTPUT
             rocblas_int numgrps3 = ((n - 1) / blks + 1) * blks;

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1181,7 +1181,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         rocblas_int p1 = mps[sid];
 
         // define shifted arrays
-        S* tmpd = temps + p1 * n;
+        S* etmpd = temps;
         S* zz = z + p1;
 
         // find degree of secular equation
@@ -1193,8 +1193,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // corresponding to non-deflated new eigenvalues of the merged block
         /* ----------------------------------------------------------------- */
         // each thread will find a different zero in parallel
-        S a, b;
-        int j = i - p1;
         if(idd[i] == 1)
         {
             // find position in the ordered array
@@ -1204,7 +1202,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             {
                 auto step = count / 2;
                 auto it = cc + step;
-                if(tmpd[it + j * n] < valf)
+                if(etmpd[it + i * n] < valf)
                 {
                     cc = ++it;
                     count -= step + 1;
@@ -1219,13 +1217,13 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             rocblas_int linfo;
 
 #if defined(ROCSOLVER_USE_REFERENCE_SECULAR_EQUATIONS_SOLVER)
-            linfo = slaed4(dd, cc, tmpd + j * n, zz, std::abs(p), evs[i]);
+            linfo = slaed4(dd, cc, etmpd + i * n, zz, std::abs(p), evs[i]);
 #else
             if(cc == dd - 1)
-                linfo = seq_solve_ext(dd, tmpd + j * n, zz, (p < 0 ? -p : p), evs + i, eps,
+                linfo = seq_solve_ext(dd, etmpd + i * n, zz, (p < 0 ? -p : p), evs + i, eps,
                                         ssfmin, ssfmax);
             else
-                linfo = seq_solve(dd, tmpd + j * n, zz, (p < 0 ? -p : p), cc, evs + i, eps,
+                linfo = seq_solve(dd, etmpd + i * n, zz, (p < 0 ? -p : p), cc, evs + i, eps,
                                     ssfmin, ssfmax);
 #endif
 

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -70,7 +70,7 @@ __host__ __device__ inline rocblas_int get_splits_size(const rocblas_int n)
     // 4     rocblas_int pers[n];             // container of permutations when solving the secular eqns
     // 5     rocblas_int ;      //
     // 6     rocblas_int ;      //
-    // 7     rocblas_int dds[n];              // degrees of secular equation
+    // 7     rocblas_int dds[m], _[n-m];      // degrees of secular equation
     // 8     rocblas_int map[n];              // 
     // 9     rocblas_int dcount[n];           // number of deflations
     // 10    rocblas_int esz[n];              // size of a corresponding merge (per each eigenvalue)
@@ -563,7 +563,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 // eq - how many values are equal to the current
                 // all zero deflated values have to be grouped at the end
                 // so we order any deflated value > any non-deflated value
-                // def == 0 - current is deflated, def[i] == 1 - other value is not deflated
+                // def == 0 - current is deflated, iddval[i] == 1 - other value is not deflated
                 lt += (def < iddval[i]) || (def == iddval[i] && bval[i] < d);
                 eq += (def == iddval[i]) && (bval[i] == d && (p1 + x) < gid);
             }
@@ -1012,7 +1012,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 dd++;
             }
         }
-        dds[p1] = dd;
+        dds[sid] = dd;
     }
 }
 
@@ -1088,7 +1088,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         rocblas_int* per = pers + p1;
 
         // find degree of secular equation
-        rocblas_int dd = dds[p1];
+        rocblas_int dd = dds[sid];
 
         // Order the elements in etmpd and zz using a simple parallel selection/bubble sort.
         // This will allow us to find initial intervals for eigenvalue guesses
@@ -1113,8 +1113,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // is too close to a pole.
         for(int i = hipThreadIdx_x; i < dd; i += hipBlockDim_x)
         {
-            for(int j = i + n; j < i + sz * n; j += n)
-                etmpd[p1 * n + j] = etmpd[p1 * n + i];
+            for(int j = 1; j < sz; j ++)
+                etmpd[(p1 + j) * n + i] = etmpd[p1 * n + i];
         }
 
         // finally copy over all diagonal elements in ev. ev will be overwritten
@@ -1126,14 +1126,14 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergePrepare_SortDZ_kernel(const rocblas_int levs,
-                                     const rocblas_int blks,
-                                     const rocblas_int k,
-                                     const rocblas_int n,
-                                     S* DD,
-                                     const rocblas_stride strideD,
-                                     S* tmpzA,
-                                     rocblas_int* splitsA)
+    stedc_mergeValues_SortDZ_kernel(const rocblas_int levs,
+                                    const rocblas_int blks,
+                                    const rocblas_int k,
+                                    const rocblas_int n,
+                                    S* DD,
+                                    const rocblas_stride strideD,
+                                    S* tmpzA,
+                                    rocblas_int* splitsA)
 {
     // threads and groups indices
     // batch instance id
@@ -1147,18 +1147,24 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
     rocblas_int* idd    = ptr_idd(n, splits);
+    rocblas_int* em     = ptr_em(n, splits);
     rocblas_int* map    = ptr_map(n, splits);
     rocblas_int* esz    = ptr_esz (n, splits);
     rocblas_int* eps    = ptr_eps (n, splits); 
     rocblas_int* sidd   = ptr_sidd(n, splits);
+    rocblas_int* dds    = ptr_dds(n, splits);
     
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z     = ptr_z(n, tmpz);
     S* cd    = ptr_cd(n, tmpz);
     S* cz    = ptr_cz(n, tmpz);
+    S* r1p   = ptr_r1p(n, tmpz);
 
 
-    S d_ = D[gid];
+    rocblas_int sid = em[gid];
+    S sig = (r1p[sid] < 0) ? -1 : 1;
+
+    S d_ = sig * D[gid];
     S z_ = z[gid];
     rocblas_int sz = esz[gid];
     rocblas_int p1 = eps[gid];
@@ -1175,6 +1181,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     int lt = 0;
     int eq = 0;
 
+    rocblas_int dd = 0;
+
     for(int chunk = 0; chunk < n_chunks; chunk++)
     {
         for(int i = 0; i < regs; i++)
@@ -1182,7 +1190,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < sz)
             {
-                bval[i] = D[p1 + x];
+                bval[i] = sig * D[p1 + x];
                 iddval[i]  = idd[p1 + x];
             }
         }
@@ -1196,7 +1204,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 // eq - how many values are equal to the current
                 // all zero deflated values have to be grouped at the end
                 // so we order any deflated value > any non-deflated value
-                // def == 0 - current is deflated, def[i] == 1 - other value is not deflated
+                // def == 0 - current is deflated, iddval[i] == 1 - other value is not deflated
+                dd += iddval[i] > 0;
                 lt += (def < iddval[i]) || (def == iddval[i] && bval[i] < d_);
                 eq += (def == iddval[i]) && (bval[i] == d_ && (p1 + x) < gid);
             }
@@ -1204,22 +1213,29 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     }
 
     int pos = lt + eq;
-    __shared__ int lds[STEDC_BDIM];
-    // Reduction (sum of pos across all lanes in a workgroup)
-    // on each iteration reduction is done within a subgroup of size of 2*bit
-    // by xoring corresponding bit of an address.
-    // The faster implementation should use dpp + a single trip through lds
-    // but keeping code simple for now.
-    int bit = 1;
-    while (bit < STEDC_BDIM) {
-        lds[hipThreadIdx_x ^ bit] = pos;
+
+    // Reduction of pos and dd across workgroup
+    __shared__ int lpos[STEDC_BDIM];
+    __shared__ int ldd[STEDC_BDIM];
+    lpos[hipThreadIdx_x] = pos;
+    ldd[hipThreadIdx_x] = dd;
+    __syncthreads();
+    rocblas_int dim2 = hipBlockDim_x / 2;
+    while(dim2 > 0)
+    {
+        if(hipThreadIdx_x < dim2)
+        {
+            pos += lpos[hipThreadIdx_x + dim2];
+            dd  += ldd[hipThreadIdx_x + dim2];
+            lpos[hipThreadIdx_x] = pos;
+            ldd[hipThreadIdx_x] = dd;
+        }
+        dim2 /= 2;
         __syncthreads();
-        pos += lds[hipThreadIdx_x];
-        __syncthreads();
-        bit *= 2;
     }
 
     if (hipThreadIdx_x == 0) {
+        dds[sid] = dd;
         map [pos+p1] = gid - p1;
         cd  [pos+p1] = d_;
         cz  [pos+p1] = z_;
@@ -1233,6 +1249,57 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // than in the input, but the following computations are doomed anyway.
     if (nan) {
         cd[gid] = NAN;
+    }
+}
+
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+    stedc_mergeValues_copyD_kernel(const rocblas_int levs,
+                                   const rocblas_int blks,
+                                   const rocblas_int k,
+                                   const rocblas_int n,
+                                   S* DD,
+                                   const rocblas_stride strideD,
+                                   S* tmpzA,
+                                   S* vecsA,
+                                   rocblas_int* splitsA)
+{
+    // threads and groups indices
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+    rocblas_int eid = hipThreadIdx_x + hipBlockDim_x * hipBlockIdx_x;
+
+    // select batch instance to work with
+    S* D = DD + bid * strideD;
+
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    rocblas_int* em  = ptr_em(n, splits);
+    rocblas_int* dds = ptr_dds(n, splits);
+    rocblas_int* mps = ptr_mps(n, splits);
+
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* evs = ptr_evs(n, tmpz);
+    S* cd  = ptr_cd(n, tmpz);
+
+    S* vecs = vecsA + bid * 2 * (n * n);
+    S* temps = vecs + (n * n);
+    S* etmpd = temps;
+
+    if (eid < n)
+    {
+        evs[eid] = D[eid];
+
+        rocblas_int sid = em[eid];
+        rocblas_int dd = dds[sid];
+        rocblas_int p1 = mps[sid];
+
+        S d = cd[eid];
+
+        if (eid - p1 < dd) {
+            for (int j = 0; j < dd; j++) {
+                etmpd[(p1 + j) * n + eid - p1] = d;
+            }
+        }
     }
 }
 
@@ -1298,7 +1365,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         S* zz = z + p1;
 
         // find degree of secular equation
-        rocblas_int dd = dds[p1];
+        rocblas_int dd = dds[sid];
 
         /* ----------------------------------------------------------------- */
 
@@ -1408,7 +1475,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         rocblas_int* per = pers + p1;
 
         // find degree of secular equation
-        rocblas_int dd = dds[p1];
+        rocblas_int dd = dds[sid];
 
         // Re-scale vector Z to avoid bad numerics when an eigenvalue
         // is too close to a pole
@@ -2227,10 +2294,16 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
                                     strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
                                     ssfmin, ssfmax);
-
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_SortDZ_kernel<S>), dim3(n, batch_count),
+            /*
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_SortDZ_kernel<S>), dim3(n, batch_count),
                                     dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
                                     strideD, tmpz, splits);
+
+            rocblas_int numgrps_copyd = (n - 1) / STEDC_BDIM + 1;
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_copyD_kernel<S>),
+                                    dim3(numgrps_copyd, batch_count),
+                                    dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
+                                    strideD, tmpz, tempgemm, splits);*/
 
 #if DEBUG_OUTPUT
             //hipError_t status = hipStreamSynchronize(stream);
@@ -2241,12 +2314,12 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                 //print_device_matrix(std::cout, "ps", 1, 1 << levs, ptr_ps(n, splits), 1);
                 print_device_matrix(std::cout, "msz", 1, n_merges, ptr_msz(n, splits), 1);
                 print_device_matrix(std::cout, "mps", 1, n_merges, ptr_mps(n, splits), 1);
+                print_device_matrix(std::cout, "dds", 1, n_merges, ptr_dds(n, splits), 1);
                 print_device_matrix(std::cout, "em", 1, n, ptr_em(n, splits), 1);
                 print_device_matrix(std::cout, "idd", 1, n, ptr_idd(n, splits), 1);
                 print_device_matrix(std::cout, "sidd", 1, n, ptr_sidd(n, splits), 1);
                 print_device_matrix(std::cout, "map", 1, n, ptr_map(n, splits), 1);
                 print_device_matrix(std::cout, "pers", 1, n, ptr_pers(n, splits), 1);
-                print_device_matrix(std::cout, "dds", 1, n, ptr_dds(n, splits), 1);
                 print_device_matrix(std::cout, "D", 1, n, D, 1);
                 print_device_matrix(std::cout, "cd", 1, n, ptr_cd(n, tmpz), 1);
                 

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1382,8 +1382,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         - If a group has an id larger than the actual number of columns it will do nothing. **/
 template <bool USEGEMM, typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeVectors_kernel(const rocblas_int levs,
-                              const rocblas_int k,
+    stedc_mergeVectors_kernel(const rocblas_int k,
                               const rocblas_int n,
                               S* CC,
                               const rocblas_int shiftC,
@@ -1490,28 +1489,23 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     {
         // otherwise, use internal gemm-like procedure to
         // multiply by C (row by row)
-        rocblas_int tsz = 1 << (levs - 1 - k);
-        tsz = (n - 1) / tsz + 1;
         if(idd[eid] == 1)
         {
-            for(int ii = 0; ii < tsz; ++ii)
+            for(int ii = 0; ii < sz; ++ii)
             {
                 rocblas_int i = p1 + ii;
 
                 // inner products
                 S temp = 0;
-                if(ii < sz)
-                {
-                    for(int kk = tidb; kk < dd; kk += dim)
-                        temp += C[i + map[p1 + kk] * ldc] * etmpd[kk + eid * n];
-                }
+                for(int kk = tidb; kk < dd; kk += dim)
+                    temp += C[i + map[p1 + kk] * ldc] * etmpd[kk + eid * n];
                 inrms[tidb] = temp;
                 __syncthreads();
 
                 // reduction
                 for(int r = dim / 2; r > 0; r /= 2)
                 {
-                    if(ii < sz && tidb < r)
+                    if(tidb < r)
                     {
                         temp += inrms[tidb + r];
                         inrms[tidb] = temp;
@@ -1520,7 +1514,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 }
 
                 // result
-                if(ii < sz && tidb == 0)
+                if(tidb == 0)
                     vecs[i + eid * n] = temp / nrm;
                 __syncthreads();
             }
@@ -1643,8 +1637,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
 template <bool USEGEMM, typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeVectors_ApplyNorms_kernel(const rocblas_int levs,
-                                         const rocblas_int k,
+    stedc_mergeVectors_ApplyNorms_kernel(const rocblas_int k,
                                          const rocblas_int n,
                                          S* CC,
                                          const rocblas_int shiftC,
@@ -1724,28 +1717,23 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     {
         // otherwise, use internal gemm-like procedure to
         // multiply by C (row by row)
-        rocblas_int tsz = 1 << (levs - 1 - k);
-        tsz = (n - 1) / tsz + 1;
         if(idd[eid] == 1)
         {
-            for(int ii = 0; ii < tsz; ++ii)
+            for(int ii = 0; ii < sz; ++ii)
             {
                 rocblas_int i = p1 + ii;
 
                 // inner products
                 S temp = 0;
-                if(ii < sz)
-                {
-                    for(int kk = tidb; kk < dd; kk += dim)
-                        temp += C[i + map[p1 + kk] * ldc] * etmpd[kk + eid * n];
-                }
+                for(int kk = tidb; kk < dd; kk += dim)
+                    temp += C[i + map[p1 + kk] * ldc] * etmpd[kk + eid * n];
                 inrms[tidb] = temp;
                 __syncthreads();
 
                 // reduction
                 for(int r = dim / 2; r > 0; r /= 2)
                 {
-                    if(ii < sz && tidb < r)
+                    if(tidb < r)
                     {
                         temp += inrms[tidb + r];
                         inrms[tidb] = temp;
@@ -1754,7 +1742,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 }
 
                 // result
-                if(ii < sz && tidb == 0)
+                if(tidb == 0)
                     vecs[i + eid * n] = temp / nrm;
                 __syncthreads();
             }
@@ -2373,7 +2361,7 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                 ROCSOLVER_LAUNCH_KERNEL(
                     (stedc_mergeVectors_ApplyNorms_kernel<STEDC_EXTERNAL_GEMM, S>),
                     dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
-                    levs, k, n, V, 0, ldv, strideV, 
+                    k, n, V, 0, ldv, strideV, 
                     tmpz, tempgemm, splits);
             }
             else
@@ -2381,7 +2369,7 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                 ROCSOLVER_LAUNCH_KERNEL(
                     (stedc_mergeVectors_kernel<STEDC_EXTERNAL_GEMM, S>),
                     dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, 
-                    levs, k, n, V, 0, ldv, strideV, 
+                    k, n, V, 0, ldv, strideV, 
                     tmpz, tempgemm, splits);
             }
 

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -40,6 +40,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 
 ROCSOLVER_BEGIN_NAMESPACE
 
@@ -59,41 +60,48 @@ ROCSOLVER_BEGIN_NAMESPACE
 __host__ __device__ inline rocblas_int get_splits_size(const rocblas_int n)
 {
     // splits_map layout:
+    // n - number of eigenvalues (matrix size)
+    // m - number of merges on a current level
     // struct {
-    // 0     rocblas_int sort_tmp[n]; // temp buffer used for mapping in stedc_sort()
-    // 1     rocblas_int ns[n];       // the sub-blocks sizes
-    // 2     rocblas_int ps[n];       // the sub-blocks initial positions
-    // 3     rocblas_int idd[n];      // if idd[i] = 0, the value in position i has been deflated  (aka mask)
-    // 4     rocblas_int pers[n];     // container of permutations when solving the secular eqns
-    // 5     rocblas_int r1p[n];      // position of a rank-1 modification component p
-    // 6     rocblas_int szs[n];      // sizes of both sub-blocks in a merge
-    // 7     rocblas_int dds[n];      // degrees of secular equation
-    // 8     rocblas_int map[n];      // 
-    // 9     rocblas_int dcount[n];   // number of deflations
-    // 10    rocblas_int mns[n];      // merge sizes
-    // 11    rocblas_int mps[n];      // merge initial positions
-    // 12    rocblas_int cand[n];     // deflation candidate flags
-    // 13    rocblas_int midd[n];     // sorted idd
-    // 14    rocblas_int dbg2[n];     //
-    // 15    rocblas_int dbg3[n];     //
-    // 16    rocblas_int dbg4[n];     //
+    // 0     rocblas_int sort_tmp[n];      // temp buffer used for mapping in stedc_sort()
+    // 1     rocblas_int ns[n];            // the sub-blocks sizes
+    // 2     rocblas_int ps[n];            // the sub-blocks initial positions
+    // 3     rocblas_int idd[n];           // if idd[i] = 0, the value in position i has been deflated  (aka mask)
+    // 4     rocblas_int pers[n];          // container of permutations when solving the secular eqns
+    // 5     rocblas_int r1p[m], _[n-m];   // position of a rank-1 modification component p (per each merge)
+    // 6     rocblas_int szs[n];           // sizes of both sub-blocks in a merge
+    // 7     rocblas_int dds[n];           // degrees of secular equation
+    // 8     rocblas_int map[n];           // 
+    // 9     rocblas_int dcount[n];        // number of deflations
+    // 10    rocblas_int esz[n];           // size of a corresponding merge (per each eigenvalue)
+    // 11    rocblas_int eps[n];           // starting position of a corresponding merge (per each eigenvalue)
+    // 12    rocblas_int cand[n];          // deflation candidate flags
+    // 13    rocblas_int sidd[n];          // sorted idd
+    // 14    rocblas_int em[n];            // id of a corresponding merge (per each eigenvalue)
+    // 15    rocblas_int msz[m], _[n-m];   // size of each merge
+    // 16    rocblas_int mps[m], _[n-m];   // starting position of each merge
+    // 17    rocblas_int dbg4[n];          //
     // };
-    return 17 * n;
+    return 18 * n;
 }
 
-template <typename S> __device__ inline S* ptr_ns    (rocblas_int n, S* splits) { return splits +  1 * n; }
-template <typename S> __device__ inline S* ptr_ps    (rocblas_int n, S* splits) { return splits +  2 * n; }
-template <typename S> __device__ inline S* ptr_idd   (rocblas_int n, S* splits) { return splits +  3 * n; }
-template <typename S> __device__ inline S* ptr_pers  (rocblas_int n, S* splits) { return splits +  4 * n; }
-template <typename S> __device__ inline S* ptr_r1p   (rocblas_int n, S* splits) { return splits +  5 * n; }
-template <typename S> __device__ inline S* ptr_szs   (rocblas_int n, S* splits) { return splits +  6 * n; }
-template <typename S> __device__ inline S* ptr_dds   (rocblas_int n, S* splits) { return splits +  7 * n; }
-template <typename S> __device__ inline S* ptr_map   (rocblas_int n, S* splits) { return splits +  8 * n; }
-template <typename S> __device__ inline S* ptr_dcount(rocblas_int n, S* splits) { return splits +  9 * n; }
-template <typename S> __device__ inline S* ptr_mns   (rocblas_int n, S* splits) { return splits + 10 * n; }
-template <typename S> __device__ inline S* ptr_mps   (rocblas_int n, S* splits) { return splits + 11 * n; }
-template <typename S> __device__ inline S* ptr_cand  (rocblas_int n, S* splits) { return splits + 12 * n; }
-template <typename S> __device__ inline S* ptr_midd  (rocblas_int n, S* splits) { return splits + 13 * n; }
+template <typename S> __host__ __device__ inline S* ptr_ns    (rocblas_int n, S* splits) { return splits +  1 * n; }
+template <typename S> __host__ __device__ inline S* ptr_ps    (rocblas_int n, S* splits) { return splits +  2 * n; }
+template <typename S> __host__ __device__ inline S* ptr_idd   (rocblas_int n, S* splits) { return splits +  3 * n; }
+template <typename S> __host__ __device__ inline S* ptr_pers  (rocblas_int n, S* splits) { return splits +  4 * n; }
+template <typename S> __host__ __device__ inline S* ptr_r1p   (rocblas_int n, S* splits) { return splits +  5 * n; }
+template <typename S> __host__ __device__ inline S* ptr_szs   (rocblas_int n, S* splits) { return splits +  6 * n; }
+template <typename S> __host__ __device__ inline S* ptr_dds   (rocblas_int n, S* splits) { return splits +  7 * n; }
+template <typename S> __host__ __device__ inline S* ptr_map   (rocblas_int n, S* splits) { return splits +  8 * n; }
+template <typename S> __host__ __device__ inline S* ptr_dcount(rocblas_int n, S* splits) { return splits +  9 * n; }
+template <typename S> __host__ __device__ inline S* ptr_esz   (rocblas_int n, S* splits) { return splits + 10 * n; }
+template <typename S> __host__ __device__ inline S* ptr_eps   (rocblas_int n, S* splits) { return splits + 11 * n; }
+template <typename S> __host__ __device__ inline S* ptr_cand  (rocblas_int n, S* splits) { return splits + 12 * n; }
+template <typename S> __host__ __device__ inline S* ptr_sidd  (rocblas_int n, S* splits) { return splits + 13 * n; }
+template <typename S> __host__ __device__ inline S* ptr_em    (rocblas_int n, S* splits) { return splits + 14 * n; }
+template <typename S> __host__ __device__ inline S* ptr_msz   (rocblas_int n, S* splits) { return splits + 15 * n; }
+template <typename S> __host__ __device__ inline S* ptr_mps   (rocblas_int n, S* splits) { return splits + 16 * n; }
+template <typename S> __host__ __device__ inline S* ptr_dbg   (rocblas_int n, S* splits) { return splits + 17 * n; }
 
 __host__ __device__ inline rocblas_int get_tmpz_size(const rocblas_int n)
 {
@@ -109,13 +117,13 @@ __host__ __device__ inline rocblas_int get_tmpz_size(const rocblas_int n)
     return 7 * n;
 }
 
-template <typename S> __device__ inline S* ptr_z    (rocblas_int n, S* tmpz) { return tmpz + 0 * n; }
-template <typename S> __device__ inline S* ptr_evs  (rocblas_int n, S* tmpz) { return tmpz + 1 * n; }
-template <typename S> __device__ inline S* ptr_cc   (rocblas_int n, S* tmpz) { return tmpz + 2 * n; }
-template <typename S> __device__ inline S* ptr_ss   (rocblas_int n, S* tmpz) { return tmpz + 3 * n; }
-template <typename S> __device__ inline S* ptr_tolsD(rocblas_int n, S* tmpz) { return tmpz + 4 * n; }
-template <typename S> __device__ inline S* ptr_tolsZ(rocblas_int n, S* tmpz) { return tmpz + 5 * n; }
-template <typename S> __device__ inline S* ptr_md   (rocblas_int n, S* tmpz) { return tmpz + 6 * n; }
+template <typename S> __host__ __device__ inline S* ptr_z    (rocblas_int n, S* tmpz) { return tmpz + 0 * n; }
+template <typename S> __host__ __device__ inline S* ptr_evs  (rocblas_int n, S* tmpz) { return tmpz + 1 * n; }
+template <typename S> __host__ __device__ inline S* ptr_cc   (rocblas_int n, S* tmpz) { return tmpz + 2 * n; }
+template <typename S> __host__ __device__ inline S* ptr_ss   (rocblas_int n, S* tmpz) { return tmpz + 3 * n; }
+template <typename S> __host__ __device__ inline S* ptr_tolsD(rocblas_int n, S* tmpz) { return tmpz + 4 * n; }
+template <typename S> __host__ __device__ inline S* ptr_tolsZ(rocblas_int n, S* tmpz) { return tmpz + 5 * n; }
+template <typename S> __host__ __device__ inline S* ptr_md   (rocblas_int n, S* tmpz) { return tmpz + 6 * n; }
 
 
 /*************** Main kernels *********************************************************/
@@ -243,6 +251,85 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_solve_kernel(const roc
 
 
 //--------------------------------------------------------------------------------------//
+/** STEDC_INIT_SPLITS initialize merge block related parts of a splits struct.
+        - This kernel is to be called with 1 group in x and batch_count groups in y. 
+        - Size of groups is set to STEDC_BDIM. **/
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_init_splits(const rocblas_int levs,
+                                                                      const rocblas_int n,
+                                                                      rocblas_int* splitsA)
+{
+    rocblas_int bid = hipBlockIdx_y;
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    rocblas_int* ns  = ptr_ns(n, splits);
+    rocblas_int* ps  = ptr_ps(n, splits);
+    rocblas_int* em  = ptr_em(n, splits);
+    rocblas_int* msz = ptr_msz(n, splits);
+    rocblas_int* mps = ptr_mps(n, splits);
+
+    rocblas_int n_blocks = 1 << levs;
+
+    for(int i = hipThreadIdx_x; i < n_blocks; i+=hipBlockDim_x)
+    {
+        rocblas_int sz = ns[i];
+        rocblas_int p = ps[i];
+        msz[i] = sz;
+        mps[i] = p;
+        for (int j = 0; j < sz; j++) {
+            em[p + j] = i;
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+/** STEDC_UPDATE_SPLITS updates merge block related parts of a splits struct.
+        - This kernel is to be called with 1 group in x and batch_count groups in y. 
+        - Size of groups is set to STEDC_BDIM. **/
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_update_splits(const rocblas_int levs,
+                                                                        const rocblas_int k,
+                                                                        const rocblas_int n,
+                                                                        rocblas_int* splitsA)
+{
+    rocblas_int bid = hipBlockIdx_y;
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    rocblas_int* em = ptr_em(n, splits);
+    rocblas_int* msz = ptr_msz(n, splits);
+    rocblas_int* mps = ptr_mps(n, splits);
+    rocblas_int* esz = ptr_esz(n, splits);
+    rocblas_int* eps = ptr_eps(n, splits);
+    rocblas_int* r1p = ptr_r1p(n, splits);
+    
+
+    rocblas_int n_merges = 1 << (levs - k - 1);
+
+    for(int i = hipThreadIdx_x; i < n_merges; i += hipBlockDim_x)
+    {
+        rocblas_int sz1 = msz[i * 2 + 0];
+        rocblas_int sz2 = msz[i * 2 + 1];
+        rocblas_int p   = mps[i * 2];
+        rocblas_int sz = sz1 + sz2;
+        __syncthreads();
+        msz[i] = sz;
+        mps[i] = p;
+        r1p[i] = p + sz1 - 1;
+    }
+    __syncthreads();
+
+    for (int i = hipThreadIdx_x; i < n; i += hipBlockDim_x)
+    {
+        int m = em[i] / 2;
+        esz[i] = msz[m];
+        eps[i] = mps[m];
+    }
+    __syncthreads();
+
+    for(int i = hipThreadIdx_x; i < n; i += hipBlockDim_x)
+    {
+        em[i] /= 2;
+    }
+}
+
+
+//--------------------------------------------------------------------------------------//
 /** STEDC_MERGEPREPARE_DEFLATEZERO_KERNEL performs deflation of zero values
         - Call this kernel with batch_count groups in y, and as many groups as half of the 
           unmerged sub-blocks in current level in x. Each group works with a merge of a pair
@@ -320,11 +407,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         sz = ns[tid];
         for(int j = 1; j < bd; ++j)
             sz += ns[tid + j];
-        r1p[tid] = (iam == 0) ? (p2 - 1 + sz) : (p2 - 1);
+        //r1p[tid] = (iam == 0) ? (p2 - 1 + sz) : (p2 - 1);
         // with this, all threads involved in a merge
         // will point to the same row of C and the same off-diag element
-        S* ptz = (iam == 0) ? C + p2 - 1 + sz : C + p2;
-        S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
+        S* ptz = C + r1p[sid] + iam;
+        S p = 2 * E[r1p[sid]];
 
         // copy elements of z
         for(int j = tx; j < sz; j += dim)
@@ -426,8 +513,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* szs    = ptr_szs(n, splits);
     rocblas_int* map    = ptr_map(n, splits);
     rocblas_int* dcount = ptr_dcount(n, splits);
-    rocblas_int* mns    = ptr_mns(n, splits);
-    rocblas_int* mps    = ptr_mps(n, splits);
+    rocblas_int* esz    = ptr_esz(n, splits);
+    rocblas_int* eps    = ptr_eps(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* tolsD = ptr_tolsD(n, tmpz);
@@ -440,8 +527,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     for (int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x) {
         int id = p + i;
-        mns[id] = sz;
-        mps[id] = p;
+        esz[id] = sz;
+        eps[id] = p;
         tolsD[id] = tol;
         tolsZ[id] = tol;
         dcount[id] = 0;
@@ -476,10 +563,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
     rocblas_int* idd    = ptr_idd(n, splits);
     rocblas_int* map    = ptr_map(n, splits);
-    rocblas_int* mns    = ptr_mns (n, splits);
-    rocblas_int* mps    = ptr_mps (n, splits); 
+    rocblas_int* esz    = ptr_esz (n, splits);
+    rocblas_int* eps    = ptr_eps (n, splits); 
     rocblas_int* cand   = ptr_cand(n, splits); 
-    rocblas_int* midd   = ptr_midd(n, splits);
+    rocblas_int* sidd   = ptr_sidd(n, splits);
     
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* md    = ptr_md(n, tmpz);
@@ -487,8 +574,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
 
     S d = D[sid];
-    rocblas_int sz = mns[sid];
-    rocblas_int p  = mps[sid];
+    rocblas_int sz = esz[sid];
+    rocblas_int p  = eps[sid];
     rocblas_int dz = idd[sid];
 
     constexpr int regs = 8;
@@ -549,7 +636,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     if (hipThreadIdx_x == 0) {
         map [pos+p] = sid;
         md  [pos+p] = d;
-        midd[pos+p] = dz;
+        sidd[pos+p] = dz;
     }
 
     __syncthreads();
@@ -586,9 +673,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* mps    = ptr_mps (n, splits); 
+    rocblas_int* eps    = ptr_eps (n, splits); 
     rocblas_int* cand   = ptr_cand(n, splits); 
-    rocblas_int* midd   = ptr_midd(n, splits);
+    rocblas_int* sidd   = ptr_sidd(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* md    = ptr_md(n, tmpz);
@@ -609,18 +696,18 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         S d   = md[i];
         S dn  = md[next];
         S dp  = md[prev];
-        rocblas_int p  = mps[i];
-        rocblas_int pn = mps[next];
-        rocblas_int pp = mps[prev];
+        rocblas_int p  = eps[i];
+        rocblas_int pn = eps[next];
+        rocblas_int pp = eps[prev];
 
         int bcandidate =
-            midd[i] && midd[next]       // not yet deflated
+            sidd[i] && sidd[next]       // not yet deflated
             && p == pn                  // in the same merge block
             && std::abs(d - dn) <= tol  // within tolerance
             && i != (n-1)               // isn't last 
             ;
         int tcandidate =
-            midd[i] && midd[prev]       // not yet deflated
+            sidd[i] && sidd[prev]       // not yet deflated
             && p == pp                  // in the same merge block
             && std::abs(d - dp) <= tol  // within tolerance
             && i > 0                    // isn't first
@@ -942,7 +1029,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     {
         // 1. find rank-1 modification component (p) for this merge
         // ----------------------------------------------------------------
-        S p = 2 * E[r1p[sid * bdm]];
+        S p = 2 * E[r1p[sid]];
 
         // 3. deflate eigenvalues
         // ----------------------------------------------------------------
@@ -1252,7 +1339,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // all threads work together to solve the secular equation.
     {
         // Find off-diagonal element of the merge
-        S p = 2 * E[r1p[sid * bdm]];
+        S p = 2 * E[r1p[sid]];
 
         // determine boundaries of what would be the new merged sub-block
         // 'in' will be its initial position.
@@ -2008,6 +2095,12 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
     ROCSOLVER_ENTER("stedc", "evect:", evect, "n:", n, "shiftD:", shiftD, "shiftE:", shiftE,
                     "shiftC:", shiftC, "ldc:", ldc, "bc:", batch_count);
 
+#define DEBUG_OUTPUT 1
+#if DEBUG_OUTPUT
+    static int global_cnt = 0;
+    global_cnt++;
+#endif
+
     // quick return
     if(batch_count == 0)
         return rocblas_status_success;
@@ -2068,6 +2161,11 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
 
         // find number of sub-blocks 
         rocblas_int levs = stedc_num_levels(n);
+        char* env_levs = std::getenv("LEVS");
+        if (env_levs) {
+            levs = env_levs[0] - '0';
+        }
+
         rocblas_int blks = 1 << levs;
 
         // initialize identity matrix in V
@@ -2101,6 +2199,9 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                 V, 0, ldv, strideV, info, (S*)work_stack, splits, 
                                 eps, ssfmin, ssfmax);
 
+        ROCSOLVER_LAUNCH_KERNEL(stedc_init_splits, dim3(1, batch_count), dim3(STEDC_BDIM), 0,
+                                stream, levs, n, splits);
+
         // 3. merge phase
         //----------------
         size_t lmemsize3 = sizeof(S) * STEDC_BDIM;
@@ -2109,6 +2210,9 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         // launch merge for level k
         for(rocblas_int k = 0; k < levs; ++k)
         {
+            ROCSOLVER_LAUNCH_KERNEL(stedc_update_splits, dim3(1, batch_count), dim3(STEDC_BDIM), 0,
+                                    stream, levs, k, n, splits);
+
             // a. prepare secular equations
             rocblas_int numgrps2 = 1 << (levs - 1 - k);
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_DeflateZero_kernel<S>),
@@ -2116,6 +2220,26 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     levs, blks, k, n, D + shiftD, strideD,
                                     E + shiftE, strideE, V, 0, ldv, strideV, tmpz, splits,
                                     eps);
+#if DEBUG_OUTPUT
+            rocblas_int n_merges = 1 << (levs - k - 1);
+            //hipError_t status = hipStreamSynchronize(stream);
+            if (env_levs && global_cnt == 1) {
+                std::cout << "\nk=" << k << std::endl;
+                //print_device_matrix(std::cout, "ns", 1, 1 << levs, ptr_ns(n, splits), 1);
+                //print_device_matrix(std::cout, "ps", 1, 1 << levs, ptr_ps(n, splits), 1);
+                print_device_matrix(std::cout, "msz", 1, n_merges, ptr_msz(n, splits), 1);
+                print_device_matrix(std::cout, "mps", 1, n_merges, ptr_mps(n, splits), 1);
+                print_device_matrix(std::cout, "em",  1, n, ptr_em(n, splits), 1);
+                print_device_matrix(std::cout, "esz", 1, n, ptr_esz(n, splits), 1);
+                print_device_matrix(std::cout, "eps", 1, n, ptr_eps(n, splits), 1);
+                print_device_matrix(std::cout, "r1p", 1, n, ptr_r1p(n, splits), 1);
+                print_device_matrix(std::cout, "dbg", 1, n, ptr_dbg(n, splits), 1);
+
+                //print_device_matrix(std::cout, "D", 1, n, D, 1);
+                //print_device_matrix(std::cout, "mtols", 1, n, tempgemm + n * 4, 1);
+                //print_device_matrix(std::cout, "mD", 1, n, tempgemm + n * 5, 1);
+            }
+#endif
 
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_Fill_kernel<S>),
                                     dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream,

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -980,13 +980,15 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* cd    = ptr_cd(n, tmpz);
     S* cz    = ptr_cz(n, tmpz);
     S* r1p   = ptr_r1p(n, tmpz);
+    S* evs   = ptr_evs(n, tmpz);
 
 
     rocblas_int sid = em[gid];
     S sig = (r1p[sid] < 0) ? -1 : 1;
 
-    S d_ = sig * D[gid];
-    S z_ = z[gid];
+    S d_  = D[gid];
+    S sd_ = sig * d_;
+    S z_  = z[gid];
     rocblas_int sz = esz[gid];
     rocblas_int p1 = eps[gid];
     rocblas_int def = idd[gid];
@@ -1027,8 +1029,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 // so we order any deflated value > any non-deflated value
                 // def == 0 - current is deflated, iddval[i] == 1 - other value is not deflated
                 dd += iddval[i] > 0;
-                lt += (def < iddval[i]) || (def == iddval[i] && bval[i] < d_);
-                eq += (def == iddval[i]) && (bval[i] == d_ && (p1 + x) < gid);
+                lt += (def < iddval[i]) || (def == iddval[i] && bval[i] < sd_);
+                eq += (def == iddval[i]) && (bval[i] == sd_ && (p1 + x) < gid);
             }
         }
     }
@@ -1058,7 +1060,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     if (hipThreadIdx_x == 0) {
         dds[sid] = dd;
         map [pos+p1] = gid;
-        cd  [pos+p1] = d_;
+        evs [pos+p1] = d_;
+        cd  [pos+p1] = sd_;
         cz  [pos+p1] = z_;
         sidd[pos+p1] = def;
     }
@@ -1070,6 +1073,42 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // than in the input, but the following computations are doomed anyway.
     if (nan) {
         cd[gid] = NAN;
+    }
+}
+
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+    stedc_mergeValues_Copium_kernel(const rocblas_int k,
+                                    const rocblas_int n,
+                                    S* DD,
+                                    const rocblas_stride strideD,
+                                    S* tmpzA,
+                                    rocblas_int* splitsA)
+{
+    // threads and groups indices
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+    // group id
+    rocblas_int gid = hipBlockIdx_x;
+
+    // select batch instance to work with
+    S* D = DD + bid * strideD;
+
+    // temporary arrays in global memory
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    rocblas_int* idd  = ptr_idd(n, splits);
+    rocblas_int* map  = ptr_map(n, splits);
+    rocblas_int* sidd = ptr_sidd(n, splits);
+
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* evs = ptr_evs(n, tmpz);
+
+    rocblas_int eid = hipBlockIdx_x;
+    if(hipThreadIdx_x == 0)
+    {
+        D[eid] = evs[eid];
+        map[eid] = eid;
+        idd[eid] = sidd[eid];
     }
 }
 
@@ -1089,7 +1128,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int sid = hipBlockIdx_x;
 
     // select batch instance to work with
-    S* D = DD + bid * strideD;
+    S* D = DD + bid * strideD; //trololo
 
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
     rocblas_int* dds = ptr_dds(n, splits);
@@ -1097,7 +1136,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* msz = ptr_msz(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
-    S* evs = ptr_evs(n, tmpz);
+    S* evs = ptr_evs(n, tmpz); //trololo
     S* cd  = ptr_cd(n, tmpz);
 
     S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
@@ -1112,7 +1151,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // by the new computed eigenvalues of the merged block
     for(int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x)
     {
-        evs[p1 + i] = D[p1 + i];
+        //evs[p1 + i] = D[p1 + i]; //trololo
     }
 
 
@@ -1203,9 +1242,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // threads and groups indices
     // batch instance id
     rocblas_int bid = hipBlockIdx_y;
-
-    // select batch instance to work with
-    S* D = DD + bid * strideD;
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
@@ -1313,7 +1349,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int eid = hipBlockIdx_x;
 
     // select batch instance to work with
-    S* D = DD + bid * strideD;
+    S* D = DD + bid * strideD; //trololo
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
@@ -1346,7 +1382,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             if(idd[p1 + j] == 1)
             {
                 S valg = etmpd[(p1 + j) * n + i];
-                valf *= (map[p1 + i] == (p1 + j)) ? valg : valg / (D[map[p1 + i]] - D[p1 + j]);
+                valf *= (map[p1 + i] == (p1 + j)) ? valg : valg / (D[map[p1 + i]] - D[p1 + j]); // trololo od evs
             }
         }
         __shared__ S lds[STEDC_BDIM];
@@ -1882,6 +1918,57 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_copyC(const rocblas_in
     }
 }
 
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_reshuffleC(const rocblas_int n,
+                                                                     S* CCin,
+                                                                     const rocblas_int shiftCin,
+                                                                     const rocblas_int ldcin,
+                                                                     const rocblas_stride strideCin,
+                                                                     S* CCout,
+                                                                     const rocblas_int shiftCout,
+                                                                     const rocblas_int ldcout,
+                                                                     const rocblas_stride strideCout,
+                                                                     rocblas_int* splitsA)
+{
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+    // group id
+    rocblas_int gid = hipBlockIdx_x;
+
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    rocblas_int* map = ptr_map(n, splits);
+
+    rocblas_int dst_row = gid;
+    rocblas_int src_row = map[gid];
+
+    S* Cin = load_ptr_batch<S>(CCin, bid, shiftCin, strideCin);
+    S* Cout = load_ptr_batch<S>(CCout, bid, shiftCout, strideCout);
+
+    S* src = Cin + ldcin * src_row;
+    S* dst = Cout + ldcout * dst_row;
+
+    constexpr int regs = 16;
+    const int chunk_width = regs * hipBlockDim_x;
+    const int n_chunks = (n - 1) / chunk_width + 1;
+    S bval[regs];
+
+    for(int chunk = 0; chunk < n_chunks; chunk++)
+    {
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < n)
+                bval[i] = src[x];
+        }
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < n)
+                dst[x] = bval[i];
+        }
+    }
+}
+
 /** STEDC_SORT sorts computed eigenvalues and eigenvectors in increasing order **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int n,
@@ -2305,6 +2392,23 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     dim3(n_merges, batch_count),
                                     dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD,
                                     strideD, tmpz, tempgemm, splits);
+
+
+            ROCSOLVER_LAUNCH_KERNEL(stedc_copyC, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, n,
+                                    V, 0, ldv, strideV,
+                                    ptr_vecs(n, tempgemm), 0, n, get_tempgemm_size(n));
+
+            ROCSOLVER_LAUNCH_KERNEL(stedc_reshuffleC, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, n,
+                                    ptr_vecs(n, tempgemm), 0, n, get_tempgemm_size(n),
+                                    V, 0, ldv, strideV,
+                                    splits);
+
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Copium_kernel<S>), dim3(n, batch_count),
+                                    dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD, strideD, tmpz,
+                                    splits);
+
+
+
 
 #if DEBUG_OUTPUT
             //hipError_t status = hipStreamSynchronize(stream);

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -972,7 +972,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int* map    = ptr_map(n, splits);
     rocblas_int* esz    = ptr_esz (n, splits);
     rocblas_int* eps    = ptr_eps (n, splits); 
-    rocblas_int* sidd   = ptr_sidd(n, splits);
     rocblas_int* dds    = ptr_dds(n, splits);
     
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
@@ -1060,10 +1059,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     if (hipThreadIdx_x == 0) {
         dds[sid] = dd;
         map [pos+p1] = gid;
-        evs [pos+p1] = d_;
         cd  [pos+p1] = sd_;
         cz  [pos+p1] = z_;
-        sidd[pos+p1] = def;
+        // copy over all diagonal elements in ev. ev will be overwritten
+        // by the new computed eigenvalues of the merged block
+        evs [pos+p1] = d_;
     }
 
     __syncthreads();
@@ -1073,42 +1073,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // than in the input, but the following computations are doomed anyway.
     if (nan) {
         cd[gid] = NAN;
-    }
-}
-
-template <typename S>
-ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeValues_Copium_kernel(const rocblas_int k,
-                                    const rocblas_int n,
-                                    S* DD,
-                                    const rocblas_stride strideD,
-                                    S* tmpzA,
-                                    rocblas_int* splitsA)
-{
-    // threads and groups indices
-    // batch instance id
-    rocblas_int bid = hipBlockIdx_y;
-    // group id
-    rocblas_int gid = hipBlockIdx_x;
-
-    // select batch instance to work with
-    S* D = DD + bid * strideD;
-
-    // temporary arrays in global memory
-    rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* idd  = ptr_idd(n, splits);
-    rocblas_int* map  = ptr_map(n, splits);
-    rocblas_int* sidd = ptr_sidd(n, splits);
-
-    S* tmpz = tmpzA + bid * get_tmpz_size(n);
-    S* evs = ptr_evs(n, tmpz);
-
-    rocblas_int eid = hipBlockIdx_x;
-    if(hipThreadIdx_x == 0)
-    {
-        D[eid] = evs[eid];
-        map[eid] = eid;
-        idd[eid] = sidd[eid];
     }
 }
 
@@ -1147,11 +1111,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int sz = msz[sid];
 
 
-    // copy over all diagonal elements in ev. ev will be overwritten
-    // by the new computed eigenvalues of the merged block
+    // copy sorted values back to D
     for(int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x)
     {
-        //evs[p1 + i] = D[p1 + i]; //trololo
+        D[p1 + i] = evs[p1 + i];
     }
 
 
@@ -1245,7 +1208,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    rocblas_int* idd = ptr_idd(n, splits);
     rocblas_int* msz = ptr_msz(n, splits);
     rocblas_int* dds = ptr_dds(n, splits);
     rocblas_int* mps = ptr_mps(n, splits);
@@ -1287,7 +1249,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // corresponding to non-deflated new eigenvalues of the merged block
         /* ----------------------------------------------------------------- */
         // each thread will find a different zero in parallel
-        if(idd[i] == 1)
+        if((i-p1) < dd)
         {
             // find position in the ordered array
             S valf = p < 0 ? -evs[i] : evs[i];
@@ -1349,14 +1311,12 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int eid = hipBlockIdx_x;
 
     // select batch instance to work with
-    S* D = DD + bid * strideD; //trololo
+    S* D = DD + bid * strideD;
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
     rocblas_int* em   = ptr_em(n, splits);
     rocblas_int* mps  = ptr_mps(n, splits);
-    rocblas_int* idd  = ptr_idd(n, splits);
-    rocblas_int* map  = ptr_map(n, splits);
     rocblas_int* msz  = ptr_msz(n, splits);
     rocblas_int* dds  = ptr_dds(n, splits);
 
@@ -1377,13 +1337,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     if(i < dd)
     {
         S valf = 1;
-        for(int j = hipThreadIdx_x; j < sz; j += hipBlockDim_x)
+        for(int j = hipThreadIdx_x; j < dd; j += hipBlockDim_x)
         {
-            if(idd[p1 + j] == 1)
-            {
-                S valg = etmpd[(p1 + j) * n + i];
-                valf *= (map[p1 + i] == (p1 + j)) ? valg : valg / (D[map[p1 + i]] - D[p1 + j]); // trololo od evs
-            }
+            S valg = etmpd[(p1 + j) * n + i];
+            valf *= ((p1 + i) == (p1 + j)) ? valg : valg / (D[p1 + i] - D[p1 + j]);
         }
         __shared__ S lds[STEDC_BDIM];
         rocblas_int dim2 = hipBlockDim_x / 2;
@@ -1443,11 +1400,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
     rocblas_int* em   = ptr_em(n, splits);
-    rocblas_int* idd  = ptr_idd(n, splits);
     rocblas_int* msz  = ptr_msz(n, splits);
     rocblas_int* mps  = ptr_mps(n, splits);
     rocblas_int* dds  = ptr_dds(n, splits);
-    rocblas_int* map  = ptr_map(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* z    = ptr_cz(n, tmpz);
@@ -1473,7 +1428,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S nrm;
     S* putvec = USEGEMM ? vecs : etmpd;
 
-    if(idd[eid] == 1)
+    if(eid-p1 < dd)
     {
         // compute vectors of rank-1 perturbed system and their norms
         nrm = 0;
@@ -1506,16 +1461,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // (this is to compute 'vecs = C * etmpd' using external gemm call)
         for(int i = tidb; i < p1 + sz; i += dim)
         {
-            if(i >= p1 && idd[eid] == 1 && idd[i] == 1)
+            if(i >= p1 && (eid - p1) < dd && (i - p1) < dd)
             {
-                dd = 0;
-                for(int k = p1; k < i; ++k)
-                {
-                    if(idd[k] == 0)
-                        dd++;
-                }
-                etmpd[map[i - dd] + eid * n]
-                    = vecs[i - dd - p1 + eid * n] / nrm;
+                etmpd[i + eid * n]
+                    = vecs[i - p1 + eid * n] / nrm;
             }
             else
                 etmpd[i + eid * n] = 0;
@@ -1525,7 +1474,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     {
         // otherwise, use internal gemm-like procedure to
         // multiply by C (row by row)
-        if(idd[eid] == 1)
+        if(eid-p1 < dd)
         {
             for(int ii = 0; ii < sz; ++ii)
             {
@@ -1534,7 +1483,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 // inner products
                 S temp = 0;
                 for(int kk = tidb; kk < dd; kk += dim)
-                    temp += C[i + map[p1 + kk] * ldc] * etmpd[kk + eid * n];
+                    temp += C[i + (p1 + kk) * ldc] * etmpd[kk + eid * n];
                 inrms[tidb] = temp;
                 __syncthreads();
 
@@ -1583,7 +1532,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
     rocblas_int* em   = ptr_em(n, splits);
-    rocblas_int* idd  = ptr_idd(n, splits);
     rocblas_int* msz  = ptr_msz(n, splits);
     rocblas_int* mps  = ptr_mps(n, splits);
     rocblas_int* dds  = ptr_dds(n, splits);
@@ -1613,7 +1561,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S nrm;
     S* putvec = USEGEMM ? vecs : etmpd;
 
-    if(idd[eid] == 1)
+    if(eid - p1 < dd)
     {
         // compute vectors of rank-1 perturbed system and their norms
         nrm = 0;
@@ -1698,11 +1646,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
     rocblas_int* em   = ptr_em(n, splits);
-    rocblas_int* idd  = ptr_idd(n, splits);
     rocblas_int* msz  = ptr_msz(n, splits);
     rocblas_int* mps  = ptr_mps(n, splits);
     rocblas_int* dds  = ptr_dds(n, splits);
-    rocblas_int* map  = ptr_map(n, splits);
 
     S* tmpz = tmpzA + bid * get_tmpz_size(n);
     S* nrms = ptr_nrms(n, tmpz);
@@ -1732,20 +1678,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // when using external gemms for the update, we need to
         // put vectors in padded matrix 'etmpd'
         // (this is to compute 'vecs = C * etmpd' using external gemm call)
-        if(idd[eid] == 1) {
-            for(int i = tidb; i < sz; i += dim)
+        if(eid - p1 < dd) {
+            for(int i = tidb; i < dd; i += dim)
             {
-                if(idd[p1 + i] == 1)
-                {
-                    dd = 0;
-                    for(int k = 0; k < i; ++k)
-                    {
-                        if(idd[p1 + k] == 0)
-                            dd++;
-                    }
-                    etmpd[map[p1 + i - dd] + eid * n]
-                        = vecs[p1 + i - dd - p1 + eid * n] / nrm;
-                }
+                etmpd[p1 + i + eid * n]
+                    = vecs[i + eid * n] / nrm;
             }
         }
     }
@@ -1753,7 +1690,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     {
         // otherwise, use internal gemm-like procedure to
         // multiply by C (row by row)
-        if(idd[eid] == 1)
+        if(eid - p1 < dd)
         {
             for(int ii = 0; ii < sz; ++ii)
             {
@@ -1762,7 +1699,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 // inner products
                 S temp = 0;
                 for(int kk = tidb; kk < dd; kk += dim)
-                    temp += C[i + map[p1 + kk] * ldc] * etmpd[kk + eid * n];
+                    temp += C[i + (p1 + kk) * ldc] * etmpd[kk + eid * n];
                 inrms[tidb] = temp;
                 __syncthreads();
 
@@ -1818,7 +1755,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
     rocblas_int* em   = ptr_em(n, splits);
-    rocblas_int* idd  = ptr_idd(n, splits);
+    rocblas_int* dds  = ptr_dds(n, splits);
     rocblas_int* msz  = ptr_msz(n, splits);
     rocblas_int* mps  = ptr_mps(n, splits);
     
@@ -1831,9 +1768,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int merge_id = em[eid];
     rocblas_int p1 = mps[merge_id];
     rocblas_int sz = msz[merge_id];
+    rocblas_int dd = dds[merge_id];
 
     // update D and C with computed values and vectors
-    if(idd[eid] == 1)
+    if(eid - p1 < dd)
     {
         if(hipThreadIdx_x == 0)
             D[eid] = evs[eid];
@@ -2403,12 +2341,6 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     V, 0, ldv, strideV,
                                     splits);
 
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Copium_kernel<S>), dim3(n, batch_count),
-                                    dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD, strideD, tmpz,
-                                    splits);
-
-
-
 
 #if DEBUG_OUTPUT
             //hipError_t status = hipStreamSynchronize(stream);
@@ -2422,7 +2354,6 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                 //print_device_matrix(std::cout, "dds", 1, n_merges, ptr_dds(n, splits), 1);
                 //print_device_matrix(std::cout, "em", 1, n, ptr_em(n, splits), 1);
                 print_device_matrix(std::cout, "idd", 1, n, ptr_idd(n, splits), 1);
-                print_device_matrix(std::cout, "sidd", 1, n, ptr_sidd(n, splits), 1);
                 print_device_matrix(std::cout, "map", 1, n, ptr_map(n, splits), 1);
                 print_device_matrix(std::cout, "D", 1, n, D, 1);
                 print_device_matrix(std::cout, "cd", 1, n, ptr_cd(n, tmpz), 1);

--- a/library/src/lapack/roclapack_syevd_heevd.hpp
+++ b/library/src/lapack/roclapack_syevd_heevd.hpp
@@ -90,8 +90,9 @@ void rocsolver_syevd_heevd_getMemorySize(rocblas_handle handle,
     if(alg_mode != rocsolver_alg_mode_hybrid || evect == rocblas_evect_original)
     {
         // extra requirements for computing eigenvalues and vectors (stedc)
-        rocsolver_stedc_getMemorySize<BATCHED, T, S>(rocblas_evect_tridiagonal, n, batch_count, &w31,
-                                                     &w22, &w12, size_tmpz, size_splits, size_workArr);
+        rocsolver_stedc_getMemorySize<BATCHED, T, S>(rocblas_evect_tridiagonal, n, batch_count,
+                                                     &w31, &w22, &w12, size_tmpz, size_splits,
+                                                     size_workArr);
     }
     else
     {

--- a/library/src/lapack/roclapack_syevd_heevd.hpp
+++ b/library/src/lapack/roclapack_syevd_heevd.hpp
@@ -91,7 +91,7 @@ void rocsolver_syevd_heevd_getMemorySize(rocblas_handle handle,
     {
         // extra requirements for computing eigenvalues and vectors (stedc)
         rocsolver_stedc_getMemorySize<BATCHED, T, S>(rocblas_evect_tridiagonal, n, batch_count, &w31,
-                                                     &w22, &w12, size_tmpz, size_splits, &unused);
+                                                     &w22, &w12, size_tmpz, size_splits, size_workArr);
     }
     else
     {
@@ -120,9 +120,7 @@ void rocsolver_syevd_heevd_getMemorySize(rocblas_handle handle,
 
     // size of array of pointers to workspace
     if(BATCHED)
-        *size_workArr = 2 * sizeof(T*) * batch_count;
-    else
-        *size_workArr = 0;
+        *size_workArr = std::max(*size_workArr, 2 * sizeof(T*) * batch_count);
 }
 
 template <bool BATCHED, bool STRIDED, typename T, typename S>
@@ -180,7 +178,7 @@ void rocsolver_syevd_heevd_getMemorySize(rocblas_handle handle,
     {
         // extra requirements for computing eigenvalues and vectors (stedc)
         rocsolver_stedc_getMemorySize<BATCHED, T, S>(rocblas_evect_tridiagonal, n, batch_count,
-                                                     &w31, &w22, &w12, &z1, &s1, &unused);
+                                                     &w31, &w22, &w12, &z1, &s1, size_workArr);
     }
 
     if(evect == rocblas_evect_original)
@@ -207,9 +205,7 @@ void rocsolver_syevd_heevd_getMemorySize(rocblas_handle handle,
 
     // size of array of pointers to workspace
     if(BATCHED)
-        *size_workArr = 2 * sizeof(T*) * batch_count;
-    else
-        *size_workArr = 0;
+        *size_workArr = std::max(*size_workArr, 2 * sizeof(T*) * batch_count);
 }
 
 template <bool BATCHED, bool STRIDED, typename T, typename S, typename W>


### PR DESCRIPTION
Code refactor and improvements to gemm calls.

- Original code used monolithic gemms that cover the entire matrix. Breaking them down to only work on blocks improves performance.
- Eigenvalues are now sorted. They are sorted before deflation to make deflation code faster, and after deflations to group non deflated values together. That allows to simplify and speedup the rest of the code.
- There are redundant data movements of D/ev and vectors (the reason is to localize the changes and structurally mimic original processing to reduce risks of a big refactoring). Optimizing it should provide additional (but probably minor) performance boost and simplify code. But it is best to postpone it to a separate PR
- Performance of the secular eq solver was improved.
- Performance of the mergeVectors was significantly improved.