### PR TITLE
Cherry-pick several optimizations to the Divide-and-Conquer eigensolver into ROCm 7.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 Full documentation for rocSOLVER is available at the [rocSOLVER documentation](https://rocm.docs.amd.com/projects/rocSOLVER/en/latest/index.html).
 
+## (Unreleased) rocSOLVER
+
+### Added
+### Changed
+### Removed
+### Optimized
+
+* Improved the performance of LARFT and downstream functions such as GEQRF and ORMTR
+* Improved the performance of LARF and downstream functions such as GEQR2
+* Improved the performance of ORMTR and downstream functions such as SYEVD
+* Improved the performance of GEQR2 and downstream functions such as GEQRF
+
+### Resolved issues
+### Known issues
+### Upcoming changes
+
+
+
 ## rocSOLVER 3.30.0 for ROCm 7.0.0
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ get_os_id(OS_ID)
 message(STATUS "OS detected is ${OS_ID}")
 
 # Versioning via rocm-cmake
-set(VERSION_STRING "3.30.0")
+set(VERSION_STRING "3.30.1")
 rocm_setup_version(VERSION ${VERSION_STRING})
 
 # Workaround until llvm and hip CMake modules fix symlink logic in their config files

--- a/clients/common/auxiliary/testing_stedc.hpp
+++ b/clients/common/auxiliary/testing_stedc.hpp
@@ -95,6 +95,14 @@ void testing_stedc_bad_arg()
     stedc_checkBadArgs(handle, evect, n, dD.data(), dE.data(), dC.data(), ldc, dInfo.data());
 }
 
+// For `n > 1`, creates a symmetrized `n` by `n` tridiagonal, Clement matrix T of the following form:
+//
+//             (   sqrt(n - 1)   sqrt(2(n - 2))     sqrt((n - 2)2)   sqrt(n - 1)   )
+// T = tridiag ( 0             0                ...                0             0 )
+//             (   sqrt(n - 1)   sqrt(2(n - 2))     sqrt((n - 2)2)   sqrt(n - 1)   )
+//
+// were the `i-th` off-diagonal entry is sqrt(i(n - i)), 1 <= i < n.
+//
 template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
 void stedc_clement_initData(const rocblas_handle handle,
                             const rocblas_evect evect,
@@ -205,6 +213,67 @@ void stedc_toeplitz_initData(const rocblas_handle handle,
                 auto C = HMatT::Eye(n, n);
                 auto D = 2 * HMatS::Ones(n, 1);
                 auto E = HMatS::Ones(n - 1, 1);
+
+                hCw->copy_data_from(C);
+                hDw->copy_data_from(D);
+                hEw->copy_data_from(E);
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dD.transfer_from(hD));
+        CHECK_HIP_ERROR(dE.transfer_from(hE));
+
+        if(evect == rocblas_evect_original)
+            CHECK_HIP_ERROR(dC.transfer_from(hC));
+    }
+}
+
+// Creates an `n` by `n` identity matrix.
+//
+template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+void stedc_identity_initData(const rocblas_handle handle,
+                             const rocblas_evect evect,
+                             const rocblas_int n,
+                             Sd& dD,
+                             Sd& dE,
+                             Td& dC,
+                             const rocblas_int ldc,
+                             Ud& /* dInfo */,
+                             Sh& hD,
+                             Sh& hE,
+                             Th& hC,
+                             Uh& /* hInfo */)
+{
+    using S = decltype(std::real(T{}));
+    rocblas_int bc = 1;
+
+    if(CPU)
+    {
+        rocblas_init<T>(hC, true);
+
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMatT = HostMatrix<T, rocblas_int>;
+            using HMatS = HostMatrix<S, rocblas_int>;
+            using BDesc = typename HMatT::BlockDescriptor;
+
+            auto hCw = HMatT::Wrap(hC[b], ldc, n);
+            hCw->set_to_zero();
+            auto hDw = HMatS::Wrap(hD[b], n, 1);
+            hDw->set_to_zero();
+            auto hEw = HMatS::Wrap(hE[b], n, 1);
+            hEw->set_to_zero();
+
+            if(hCw && hDw && hEw) // update matrices if n >= 1
+            {
+                auto C = HMatT::Eye(n, n);
+                auto D = HMatS::Ones(n, 1);
+                auto E = HMatS::Zeros(n - 1, 1);
 
                 hCw->copy_data_from(C);
                 hDw->copy_data_from(D);
@@ -532,6 +601,12 @@ void stedc_initData(const rocblas_handle handle,
         stedc_toeplitz_initData<CPU, GPU, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
                                              hInfo);
     }
+    else if((std::getenv("TEST_IDENTITY") != nullptr)
+            || (std::getenv("STEDC_TEST_IDENTITY") != nullptr))
+    {
+        stedc_identity_initData<CPU, GPU, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
+                                             hInfo);
+    }
     else if((std::getenv("TEST_RANDOM") != nullptr) || (std::getenv("STEDC_TEST_RANDOM") != nullptr))
     {
         stedc_random_initData<CPU, GPU, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
@@ -568,6 +643,11 @@ void stedc_getError(const rocblas_handle handle,
 {
     constexpr bool COMPLEX = rocblas_is_complex<T>;
     using S = decltype(std::real(T{}));
+
+    using HMatT = HostMatrix<T, rocblas_int>;
+    using HMatS = HostMatrix<S, rocblas_int>;
+    using BDescT = typename HMatT::BlockDescriptor;
+    using BDescS = typename HMatS::BlockDescriptor;
 
     int lgn = floor(log(n - 1) / log(2)) + 1;
     size_t lwork = (COMPLEX) ? n * n : 0;
@@ -614,6 +694,29 @@ void stedc_getError(const rocblas_handle handle,
     cpu_stedc(evect, n, hD[0], hE[0], hC[0], ldc, work.data(), lwork, rwork.data(), lrwork,
               iwork.data(), liwork, hInfo[0]);
 
+    // Depending on `evect`, stedc can return the eigenvectors of the original
+    // matrix (A) or the eigenvectors of the tridiagonal matrix (T).  Thus,
+    // given a pair U, D of eigenvectors and eigenvalues computed by stedc the
+    // reconstructed matrix
+    //
+    // U * D * adjoint(U)
+    //
+    // can be either A or T.  The following code uses lapack to compute
+    //
+    // AorT = U * D * adjoint(U),
+    //
+    // which will be later used to compare with the eigenvectors and
+    // eigenvalues computed by rocSOLVER.
+    //
+    auto AorT = HMatT::Empty();
+    if((evect != rocblas_evect_none) && (n > 0))
+    {
+        auto C = HMatT::Wrap(hC[0], ldc, n)->block(BDescT().nrows(n).ncols(n));
+        auto d = HMatT::Convert(hD[0], 1, n)->block(BDescT().nrows(1).ncols(n));
+        auto D = HMatT::Zeros(n, n).diag(d);
+        AorT = C * D * adjoint(C);
+    }
+
     // check info
     EXPECT_EQ(hInfo[0][0], hInfoRes[0][0]);
     if(hInfo[0][0] != hInfoRes[0][0])
@@ -622,8 +725,9 @@ void stedc_getError(const rocblas_handle handle,
         *max_err = 0;
 
     double err;
+    *max_errv = 0;
 
-    if(hInfo[0][0] == 0)
+    if((hInfo[0][0] == 0) && (n > 0))
     {
         // check that eigenvalues are correct and in order
         // error is ||hD - hDRes|| / ||hD||
@@ -634,23 +738,22 @@ void stedc_getError(const rocblas_handle handle,
         // check eigenvectors if required
         if(evect != rocblas_evect_none)
         {
-            // both eigenvalues and eigenvectors needed; need to implicitly test
-            // eigenvectors due to non-uniqueness of eigenvectors under scaling
+            // Input matrix
+            auto C = HMatT::Wrap(hCRes[0], ldc, n)->block(BDescT().nrows(n).ncols(n));
+            // Computed eigenvalues
+            auto d = HMatT::Convert(hDRes[0], 1, n)->block(BDescT().nrows(1).ncols(n));
+            // Diagonal matrix of size n by n with computed eigenvalues
+            auto D = HMatT::Zeros(n, n).diag(d);
 
-            // multiply A with each of the n eigenvectors and divide by corresponding
-            // eigenvalues
-            T alpha;
-            T beta = 0;
-            for(int j = 0; j < n; j++)
-            {
-                alpha = T(1) / hDRes[0][j];
-                cpu_symv_hemv(rocblas_fill_upper, n, alpha, hA[0], lda, hCRes[0] + j * ldc, 1, beta,
-                              hC[0] + j * ldc, 1);
-            }
+            // Orthogonal error
+            auto OE = C * adjoint(C) - HMatT::Eye(n, n);
+            err = OE.max_col_norm();
+            *max_errv = err > *max_err ? err : *max_err;
 
-            // error is ||hC - hCRes|| / ||hC||
-            // using frobenius norm
-            *max_errv = norm_error('F', n, n, ldc, hCRes[0], hC[0]);
+            // Residual error
+            auto RE = AorT - C * D * adjoint(C);
+            err = RE.norm() / AorT.norm();
+            *max_err = err > *max_err ? err : *max_err;
         }
     }
 }
@@ -839,7 +942,7 @@ void testing_stedc(Arguments& argus)
     {
         ROCSOLVER_TEST_CHECK(T, max_err, n);
         if(evect != rocblas_evect_none)
-            ROCSOLVER_TEST_CHECK(T, max_errv, n * n);
+            ROCSOLVER_TEST_CHECK(T, max_errv, n);
     }
 
     // output results for rocsolver-bench

--- a/clients/common/auxiliary/testing_stedc.hpp
+++ b/clients/common/auxiliary/testing_stedc.hpp
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include "common/matrix_utils/matrix_utils.hpp"
 #include "common/misc/client_util.hpp"
 #include "common/misc/clientcommon.hpp"
 #include "common/misc/lapack_host_reference.hpp"
@@ -95,18 +96,278 @@ void testing_stedc_bad_arg()
 }
 
 template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
-void stedc_initData(const rocblas_handle handle,
-                    const rocblas_evect evect,
-                    const rocblas_int n,
-                    Sd& dD,
-                    Sd& dE,
-                    Td& dC,
-                    const rocblas_int ldc,
-                    Ud& dInfo,
-                    Sh& hD,
-                    Sh& hE,
-                    Th& hC,
-                    Uh& hInfo)
+void stedc_clement_initData(const rocblas_handle handle,
+                            const rocblas_evect evect,
+                            const rocblas_int n,
+                            Sd& dD,
+                            Sd& dE,
+                            Td& dC,
+                            const rocblas_int ldc,
+                            Ud& /* dInfo */,
+                            Sh& hD,
+                            Sh& hE,
+                            Th& hC,
+                            Uh& /* hInfo */)
+{
+    using S = decltype(std::real(T{}));
+    rocblas_int bc = 1;
+
+    if(CPU)
+    {
+        rocblas_init<T>(hC, true);
+
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMatT = HostMatrix<T, rocblas_int>;
+            using HMatS = HostMatrix<S, rocblas_int>;
+            using BDesc = typename HMatT::BlockDescriptor;
+
+            auto hCw = HMatT::Wrap(hC[b], ldc, n);
+            hCw->set_to_zero();
+            auto hDw = HMatS::Wrap(hD[b], n, 1);
+            hDw->set_to_zero();
+            auto hEw = HMatS::Wrap(hE[b], n, 1);
+            hEw->set_to_zero();
+
+            if(hCw && hDw && hEw) // update matrices if n >= 1
+            {
+                auto C = HMatT::Eye(n, n);
+                auto D = HMatS::Zeros(n, 1);
+                auto E = HMatS::Ones(n - 1, 1);
+
+                for(rocblas_int i = 1; i < n; ++i)
+                {
+                    E[i - 1] = std::sqrt(i * (n - i));
+                }
+
+                hCw->copy_data_from(C);
+                hDw->copy_data_from(D);
+                hEw->copy_data_from(E);
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dD.transfer_from(hD));
+        CHECK_HIP_ERROR(dE.transfer_from(hE));
+
+        if(evect == rocblas_evect_original)
+            CHECK_HIP_ERROR(dC.transfer_from(hC));
+    }
+}
+
+// Creates an `n` by `n` tridiagonal, Toeplitz matrix T of the following form:
+//
+//             (   1         1         1    )
+// T = tridiag ( 2   2 ... 2   2 ... 2    2 )
+//             (   1         1         1    )
+//
+template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+void stedc_toeplitz_initData(const rocblas_handle handle,
+                             const rocblas_evect evect,
+                             const rocblas_int n,
+                             Sd& dD,
+                             Sd& dE,
+                             Td& dC,
+                             const rocblas_int ldc,
+                             Ud& /* dInfo */,
+                             Sh& hD,
+                             Sh& hE,
+                             Th& hC,
+                             Uh& /* hInfo */)
+{
+    using S = decltype(std::real(T{}));
+    rocblas_int bc = 1;
+
+    if(CPU)
+    {
+        rocblas_init<T>(hC, true);
+
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMatT = HostMatrix<T, rocblas_int>;
+            using HMatS = HostMatrix<S, rocblas_int>;
+            using BDesc = typename HMatT::BlockDescriptor;
+
+            auto hCw = HMatT::Wrap(hC[b], ldc, n);
+            hCw->set_to_zero();
+            auto hDw = HMatS::Wrap(hD[b], n, 1);
+            hDw->set_to_zero();
+            auto hEw = HMatS::Wrap(hE[b], n, 1);
+            hEw->set_to_zero();
+
+            if(hCw && hDw && hEw) // update matrices if n >= 1
+            {
+                auto C = HMatT::Eye(n, n);
+                auto D = 2 * HMatS::Ones(n, 1);
+                auto E = HMatS::Ones(n - 1, 1);
+
+                hCw->copy_data_from(C);
+                hDw->copy_data_from(D);
+                hEw->copy_data_from(E);
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dD.transfer_from(hD));
+        CHECK_HIP_ERROR(dE.transfer_from(hE));
+
+        if(evect == rocblas_evect_original)
+            CHECK_HIP_ERROR(dC.transfer_from(hC));
+    }
+}
+
+// Creates an `n` by `n` tridiagonal, Wilkinson matrix, which is formed as follows:
+//
+// 1. If `n` is even:
+//                      (   1          1            1          1   )
+// W_{2m + 1} = tridiag ( m   (m - 1) ... 0.5 0.5 ... (m - 1)    m )
+//                      (   1          1            1          1   )
+//
+// 2. If `n` is odd:
+//                      (   1          1         1          1   )
+// W_{2m + 1} = tridiag ( m   (m - 1) ... 1 0 1 ... (m - 1)   m )
+//                      (   1          1         1          1   )
+//
+// where `n = 2m + 1`.
+//
+template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+void stedc_wilkinson_initData(const rocblas_handle handle,
+                              const rocblas_evect evect,
+                              const rocblas_int n,
+                              Sd& dD,
+                              Sd& dE,
+                              Td& dC,
+                              const rocblas_int ldc,
+                              Ud& /* dInfo */,
+                              Sh& hD,
+                              Sh& hE,
+                              Th& hC,
+                              Uh& /* hInfo */)
+{
+    using S = decltype(std::real(T{}));
+    rocblas_int bc = 1;
+
+    if(CPU)
+    {
+        rocblas_init<T>(hC, true);
+
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMatT = HostMatrix<T, rocblas_int>;
+            using HMatS = HostMatrix<S, rocblas_int>;
+            using BDesc = typename HMatT::BlockDescriptor;
+
+            auto hCw = HMatT::Wrap(hC[b], ldc, n);
+            hCw->set_to_zero();
+            auto hDw = HMatS::Wrap(hD[b], n, 1);
+            hDw->set_to_zero();
+            auto hEw = HMatS::Wrap(hE[b], n, 1);
+            hEw->set_to_zero();
+
+            if(hCw && hDw && hEw) // update matrices if n >= 1
+            {
+                S m = (n - 1) / S(2);
+                auto C = HMatT::Eye(n, n);
+                auto D = HMatS::Zeros(n, 1);
+                auto E = HMatS::Ones(n - 1, 1);
+
+                for(rocblas_int i = 0; i < n / 2; ++i)
+                {
+                    D[i] = m - i;
+                    D[n - 1 - i] = m - i;
+                }
+
+                hCw->copy_data_from(C);
+                hDw->copy_data_from(D);
+                hEw->copy_data_from(E);
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dD.transfer_from(hD));
+        CHECK_HIP_ERROR(dE.transfer_from(hE));
+
+        if(evect == rocblas_evect_original)
+            CHECK_HIP_ERROR(dC.transfer_from(hC));
+    }
+}
+
+template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+void stedc_random_initData(const rocblas_handle handle,
+                           const rocblas_evect evect,
+                           const rocblas_int n,
+                           Sd& dD,
+                           Sd& dE,
+                           Td& dC,
+                           const rocblas_int ldc,
+                           Ud& dInfo,
+                           Sh& hD,
+                           Sh& hE,
+                           Th& hC,
+                           Uh& hInfo)
+{
+    if(CPU)
+    {
+        using S = decltype(std::real(T{}));
+
+        rocblas_init<S>(hD, true);
+        rocblas_init<S>(hE, true);
+
+        for(int i = 0; i < n - 1; ++i)
+            hE[0][i] -= 4;
+
+        // initialize C to the identity matrix
+        if(evect == rocblas_evect_original)
+        {
+            for(rocblas_int j = 0; j < n; j++)
+            {
+                for(rocblas_int i = 0; i < n; i++)
+                {
+                    if(i == j)
+                        hC[0][i + j * ldc] = 1;
+                    else
+                        hC[0][i + j * ldc] = 0;
+                }
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dD.transfer_from(hD));
+        CHECK_HIP_ERROR(dE.transfer_from(hE));
+
+        if(evect == rocblas_evect_original)
+            CHECK_HIP_ERROR(dC.transfer_from(hC));
+    }
+}
+
+template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+void stedc_default_initData(const rocblas_handle handle,
+                            const rocblas_evect evect,
+                            const rocblas_int n,
+                            Sd& dD,
+                            Sd& dE,
+                            Td& dC,
+                            const rocblas_int ldc,
+                            Ud& /* dInfo */,
+                            Sh& hD,
+                            Sh& hE,
+                            Th& hC,
+                            Uh& /* hInfo */)
 {
     if(CPU)
     {
@@ -238,6 +499,51 @@ void stedc_initData(const rocblas_handle handle,
         if(evect == rocblas_evect_original)
             CHECK_HIP_ERROR(dC.transfer_from(hC));
     }
+}
+
+template <bool CPU, bool GPU, typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
+void stedc_initData(const rocblas_handle handle,
+                    const rocblas_evect evect,
+                    const rocblas_int n,
+                    Sd& dD,
+                    Sd& dE,
+                    Td& dC,
+                    const rocblas_int ldc,
+                    Ud& dInfo,
+                    Sh& hD,
+                    Sh& hE,
+                    Th& hC,
+                    Uh& hInfo)
+{
+    if((std::getenv("TEST_WILKINSON") != nullptr) || (std::getenv("STEDC_TEST_WILKINSON") != nullptr))
+    {
+        stedc_wilkinson_initData<CPU, GPU, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
+                                              hInfo);
+    }
+    else if((std::getenv("TEST_CLEMENT") != nullptr)
+            || (std::getenv("STEDC_TEST_CLEMENT") != nullptr))
+    {
+        stedc_clement_initData<CPU, GPU, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
+                                            hInfo);
+    }
+    else if((std::getenv("TEST_TOEPLITZ") != nullptr)
+            || (std::getenv("STEDC_TEST_TOEPLITZ") != nullptr))
+    {
+        stedc_toeplitz_initData<CPU, GPU, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
+                                             hInfo);
+    }
+    else if((std::getenv("TEST_RANDOM") != nullptr) || (std::getenv("STEDC_TEST_RANDOM") != nullptr))
+    {
+        stedc_random_initData<CPU, GPU, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
+                                           hInfo);
+    }
+    else
+    {
+        stedc_default_initData<CPU, GPU, T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC,
+                                            hInfo);
+    }
+
+    return;
 }
 
 template <typename T, typename Sd, typename Td, typename Ud, typename Sh, typename Th, typename Uh>
@@ -522,7 +828,7 @@ void testing_stedc(Arguments& argus)
                           hInfo, hInfoRes, &max_err, &max_errv);
 
     // collect performance data
-    if(argus.timing)
+    if(argus.timing && hot_calls > 0)
         stedc_getPerfData<T>(handle, evect, n, dD, dE, dC, ldc, dInfo, hD, hE, hC, hInfo,
                              &gpu_time_used, &cpu_time_used, hot_calls, argus.profile,
                              argus.profile_kernels, argus.perf);

--- a/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/clients/common/lapack/testing_syevd_heevd.hpp
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include "common/matrix_utils/matrix_utils.hpp"
 #include "common/misc/client_util.hpp"
 #include "common/misc/clientcommon.hpp"
 #include "common/misc/lapack_host_reference.hpp"
@@ -146,15 +147,15 @@ void testing_syevd_heevd_bad_arg()
 }
 
 template <bool CPU, bool GPU, typename T, typename Td, typename Th>
-void syevd_heevd_initData(const rocblas_handle handle,
-                          const rocblas_evect evect,
-                          const rocblas_int n,
-                          Td& dA,
-                          const rocblas_int lda,
-                          const rocblas_int bc,
-                          Th& hA,
-                          std::vector<T>& A,
-                          bool test = true)
+void syevd_heevd_default_initData(const rocblas_handle handle,
+                                  const rocblas_evect evect,
+                                  const rocblas_int n,
+                                  Td& dA,
+                                  const rocblas_int lda,
+                                  const rocblas_int bc,
+                                  Th& hA,
+                                  std::vector<T>& A,
+                                  bool test = true)
 {
     if(CPU)
     {
@@ -165,12 +166,15 @@ void syevd_heevd_initData(const rocblas_handle handle,
         {
             for(rocblas_int i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(rocblas_int j = i; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] = std::real(hA[b][i + j * lda]) + 400;
                     else
+                    {
                         hA[b][i + j * lda] -= 4;
+                        hA[b][j + i * lda] = sconj(hA[b][i + j * lda]);
+                    }
                 }
             }
 
@@ -193,6 +197,317 @@ void syevd_heevd_initData(const rocblas_handle handle,
     }
 }
 
+// Creates an `n` by `n` matrix `A` with the following eigenvalues:
+//
+// spectrum(A) = { l_i = ulp * i, for 1 <= i <= n - 1; l_n = 1 }
+//
+// where `ulp` is the smallest floating point number such that `1 + ulp > 1`.
+//
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void syevd_heevd_eig7_initData(const rocblas_handle handle,
+                               const rocblas_evect evect,
+                               const rocblas_int n,
+                               Td& dA,
+                               const rocblas_int lda,
+                               const rocblas_int bc,
+                               Th& hA,
+                               std::vector<T>& A,
+                               bool test = true)
+{
+    using S = decltype(std::real(T{}));
+
+    if(CPU)
+    {
+        rocblas_init<T>(hA, true);
+
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMat = HostMatrix<T, rocblas_int>;
+            using BDesc = typename HMat::BlockDescriptor;
+
+            auto hAw = HMat::Wrap(hA[b], lda, n);
+            if(hAw) // update matrix hA if n >= 1
+            {
+                auto eigs = std::numeric_limits<S>::epsilon() * HMat::FromRange(1, n - 1, n - 1);
+                eigs = cat(eigs, HMat::Ones(1, 1));
+                auto [Q, _] = qr((*hAw).block(BDesc().nrows(n).ncols(n)));
+                hAw->set_to_zero();
+
+                hAw->copy_data_from(Q * HMat::Zeros(n).diag(eigs) * adjoint(Q));
+            }
+
+            // make copy of original data to test vectors if required
+            if(test && evect == rocblas_evect_original)
+            {
+                for(rocblas_int i = 0; i < n; i++)
+                {
+                    for(rocblas_int j = 0; j < n; j++)
+                        A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
+                }
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+    }
+}
+
+// Creates an `n` by `n` tridiagonal, Wilkinson matrix, which is formed as follows:
+//
+// 1. If `n` is even:
+//                      (   1          1            1          1   )
+// W_{2m + 1} = tridiag ( m   (m - 1) ... 0.5 0.5 ... (m - 1)    m )
+//                      (   1          1            1          1   )
+//
+// 2. If `n` is odd:
+//                      (   1          1         1          1   )
+// W_{2m + 1} = tridiag ( m   (m - 1) ... 1 0 1 ... (m - 1)   m )
+//                      (   1          1         1          1   )
+//
+// where `n = 2m + 1`.
+//
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void syevd_heevd_wilkinson_initData(const rocblas_handle handle,
+                                    const rocblas_evect evect,
+                                    const rocblas_int n,
+                                    Td& dA,
+                                    const rocblas_int lda,
+                                    const rocblas_int bc,
+                                    Th& hA,
+                                    std::vector<T>& A,
+                                    bool test = true)
+{
+    using S = decltype(std::real(T{}));
+
+    if(CPU)
+    {
+        rocblas_init<T>(hA, true);
+
+        // scale A to avoid singularities
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMat = HostMatrix<T, rocblas_int>;
+            using BDesc = typename HMat::BlockDescriptor;
+
+            auto hAw = HMat::Wrap(hA[b], lda, n);
+            if(hAw) // update matrix hA if n >= 1
+            {
+                S m = (n - 1) / S(2);
+                auto A = HMat::Zeros(n, n);
+                auto E = HMat::Ones(n - 1, 1);
+                auto D = HMat::Zeros(n, 1);
+
+                for(rocblas_int i = 0; i < n / 2; ++i)
+                {
+                    D[i] = m - i;
+                    D[n - 1 - i] = m - i;
+                }
+
+                A.diag(D);
+                A.sup_diag(E);
+                A.sub_diag(E);
+
+                hAw->set_to_zero();
+                hAw->copy_data_from(A);
+            }
+
+            // make copy of original data to test vectors if required
+            if(test && evect == rocblas_evect_original)
+            {
+                for(rocblas_int i = 0; i < n; i++)
+                {
+                    for(rocblas_int j = 0; j < n; j++)
+                        A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
+                }
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+    }
+}
+
+// Creates an `n` by `n` tridiagonal, Toeplitz matrix T of the following form:
+//
+//             (   1         1         1    )
+// T = tridiag ( 2   2 ... 2   2 ... 2    2 )
+//             (   1         1         1    )
+//
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void syevd_heevd_toeplitz_initData(const rocblas_handle handle,
+                                   const rocblas_evect evect,
+                                   const rocblas_int n,
+                                   Td& dA,
+                                   const rocblas_int lda,
+                                   const rocblas_int bc,
+                                   Th& hA,
+                                   std::vector<T>& A,
+                                   bool test = true)
+{
+    using S = decltype(std::real(T{}));
+
+    if(CPU)
+    {
+        rocblas_init<T>(hA, true);
+
+        // scale A to avoid singularities
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMat = HostMatrix<T, rocblas_int>;
+            using BDesc = typename HMat::BlockDescriptor;
+
+            auto hAw = HMat::Wrap(hA[b], lda, n);
+            if(hAw) // update matrix hA if n >= 1
+            {
+                auto A = HMat::Zeros(n, n);
+                auto E = HMat::Ones(n - 1, 1);
+                auto D = 2 * HMat::Ones(n, 1);
+
+                A.diag(D);
+                A.sup_diag(E);
+                A.sub_diag(E);
+
+                hAw->set_to_zero();
+                hAw->copy_data_from(A);
+            }
+
+            // make copy of original data to test vectors if required
+            if(test && evect == rocblas_evect_original)
+            {
+                for(rocblas_int i = 0; i < n; i++)
+                {
+                    for(rocblas_int j = 0; j < n; j++)
+                        A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
+                }
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+    }
+}
+
+// For `n > 1`, creates a symmetrized `n` by `n` tridiagonal, Clement matrix T of the following form:
+//
+//             (   sqrt(n - 1)   sqrt(2(n - 2))     sqrt((n - 2)2)   sqrt(n - 1)   )
+// T = tridiag ( 0             0                ...                0             0 )
+//             (   sqrt(n - 1)   sqrt(2(n - 2))     sqrt((n - 2)2)   sqrt(n - 1)   )
+//
+// were the `i-th` off-diagonal entry is sqrt(i(n - i)), 1 <= i < n.
+//
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void syevd_heevd_clement_initData(const rocblas_handle handle,
+                                  const rocblas_evect evect,
+                                  const rocblas_int n,
+                                  Td& dA,
+                                  const rocblas_int lda,
+                                  const rocblas_int bc,
+                                  Th& hA,
+                                  std::vector<T>& A,
+                                  bool test = true)
+{
+    using S = decltype(std::real(T{}));
+
+    if(CPU)
+    {
+        rocblas_init<T>(hA, true);
+
+        // scale A to avoid singularities
+        for(rocblas_int b = 0; b < bc; ++b)
+        {
+            // New matrix initialization
+            using HMat = HostMatrix<T, rocblas_int>;
+            using BDesc = typename HMat::BlockDescriptor;
+
+            auto hAw = HMat::Wrap(hA[b], lda, n);
+            if(hAw) // update matrix hA if n >= 1
+            {
+                auto A = HMat::Zeros(n, n);
+                auto E = HMat::Ones(n - 1, 1);
+                auto D = HMat::Zeros(n, 1);
+
+                for(rocblas_int i = 1; i < n; ++i)
+                {
+                    E[i - 1] = std::sqrt(i * (n - i));
+                }
+
+                A.diag(D);
+                A.sup_diag(E);
+                A.sub_diag(E);
+
+                hAw->set_to_zero();
+                hAw->copy_data_from(A);
+            }
+
+            // make copy of original data to test vectors if required
+            if(test && evect == rocblas_evect_original)
+            {
+                for(rocblas_int i = 0; i < n; i++)
+                {
+                    for(rocblas_int j = 0; j < n; j++)
+                        A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
+                }
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy to the GPU
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+    }
+}
+
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void syevd_heevd_initData(const rocblas_handle handle,
+                          const rocblas_evect evect,
+                          const rocblas_int n,
+                          Td& dA,
+                          const rocblas_int lda,
+                          const rocblas_int bc,
+                          Th& hA,
+                          std::vector<T>& A,
+                          bool test = true)
+{
+    if((std::getenv("TEST_EIG7") != nullptr) || (std::getenv("SYEVD_TEST_EIG7") != nullptr))
+    {
+        syevd_heevd_eig7_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+    }
+    else if((std::getenv("TEST_WILKINSON") != nullptr)
+            || (std::getenv("SYEVD_TEST_WILKINSON") != nullptr))
+    {
+        syevd_heevd_wilkinson_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+    }
+    else if((std::getenv("TEST_CLEMENT") != nullptr)
+            || (std::getenv("SYEVD_TEST_CLEMENT") != nullptr))
+    {
+        syevd_heevd_clement_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+    }
+    else if((std::getenv("TEST_TOEPLITZ") != nullptr)
+            || (std::getenv("SYEVD_TEST_TOEPLITZ") != nullptr))
+    {
+        syevd_heevd_toeplitz_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+    }
+    else
+    {
+        syevd_heevd_default_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+    }
+
+    return;
+}
+
 template <bool STRIDED, typename T, typename Sd, typename Td, typename Id, typename Sh, typename Th, typename Ih>
 void syevd_heevd_getError(const rocblas_handle handle,
                           const rocblas_evect evect,
@@ -213,11 +528,16 @@ void syevd_heevd_getError(const rocblas_handle handle,
                           Sh& hDres,
                           Ih& hinfo,
                           Ih& hinfoRes,
-                          double* max_err)
+                          double* max_err,
+                          double* max_errv)
 {
     constexpr bool COMPLEX = rocblas_is_complex<T>;
     using S = decltype(std::real(T{}));
 
+    using HMat = HostMatrix<T, rocblas_int>;
+    using BDesc = typename HMat::BlockDescriptor;
+
+    int lgn = floor(log(n - 1) / log(2)) + 1;
     int sizeE, lwork;
     if(!COMPLEX)
     {
@@ -273,7 +593,7 @@ void syevd_heevd_getError(const rocblas_handle handle,
     {
         if(evect != rocblas_evect_original)
         {
-            // only eigenvalues needed; can compare with LAPACK
+            // only eigenvalues needed; compare with LAPACK
 
             // error is ||hD - hDRes|| / ||hD||
             // using frobenius norm
@@ -283,24 +603,28 @@ void syevd_heevd_getError(const rocblas_handle handle,
         }
         else
         {
-            // both eigenvalues and eigenvectors needed; need to implicitly test
-            // eigenvectors due to non-uniqueness of eigenvectors under scaling
-            if(hinfo[b][0] == 0)
+            // both eigenvalues and eigenvectors needed; compare with input
+            // matrix
+            if((hinfo[b][0] == 0) && (n > 0))
             {
-                // multiply A with each of the n eigenvectors and divide by corresponding
-                // eigenvalues
-                T alpha;
-                T beta = 0;
-                for(int j = 0; j < n; j++)
-                {
-                    alpha = T(1) / hDres[b][j];
-                    cpu_symv_hemv(uplo, n, alpha, A.data() + b * lda * n, lda, hAres[b] + j * lda,
-                                  1, beta, hA[b] + j * lda, 1);
-                }
+                // Input matrix
+                auto M = HMat::Wrap(A.data() + b * lda * n, lda, n)->block(BDesc().nrows(n).ncols(n));
 
-                // error is ||hA - hARes|| / ||hA||
-                // using frobenius norm
-                err = norm_error('F', n, n, lda, hA[b], hAres[b]);
+                // Computed eigenvectors
+                auto U = HMat::Wrap(hAres[b], lda, n)->block(BDesc().nrows(n).ncols(n));
+                // Computed eigenvalues
+                auto d = HMat::Convert(hDres[b], 1, n)->block(BDesc().nrows(1).ncols(n));
+                // Diagonal matrix of size n by n with computed eigenvalues
+                auto D = HMat::Zeros(n, n).diag(d);
+
+                // Orthogonal error
+                auto OE = U * adjoint(U) - HMat::Eye(n, n);
+                err = OE.max_col_norm();
+                *max_errv = err > *max_err ? err : *max_err;
+
+                // Residual error
+                auto RE = M - U * D * adjoint(U);
+                err = RE.norm() / M.norm();
                 *max_err = err > *max_err ? err : *max_err;
             }
         }
@@ -462,7 +786,7 @@ void testing_syevd_heevd(Arguments& argus)
     size_t size_Ares = (argus.unit_check || argus.norm_check) ? size_A : 0;
     size_t size_Dres = (argus.unit_check || argus.norm_check) ? size_D : 0;
 
-    double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
+    double max_error = 0, max_ortho_error = 0, gpu_time_used = 0, cpu_time_used = 0;
 
     // check invalid sizes
     bool invalid_size = (n < 0 || lda < n || bc < 0);
@@ -548,7 +872,7 @@ void testing_syevd_heevd(Arguments& argus)
         {
             syevd_heevd_getError<STRIDED, T>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE, stE,
                                              dinfo, bc, hA, hAres, hD, hDres, hinfo, hinfoRes,
-                                             &max_error);
+                                             &max_error, &max_ortho_error);
         }
 
         // collect performance data
@@ -588,7 +912,7 @@ void testing_syevd_heevd(Arguments& argus)
         {
             syevd_heevd_getError<STRIDED, T>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE, stE,
                                              dinfo, bc, hA, hAres, hD, hDres, hinfo, hinfoRes,
-                                             &max_error);
+                                             &max_error, &max_ortho_error);
         }
 
         // collect performance data
@@ -602,9 +926,13 @@ void testing_syevd_heevd(Arguments& argus)
     }
 
     // validate results for rocsolver-test
-    // using n * machine_precision as tolerance
+    // using 10 * n * machine_precision as tolerance
     if(argus.unit_check)
-        ROCSOLVER_TEST_CHECK(T, max_error, n);
+    {
+        ROCSOLVER_TEST_CHECK(T, max_error, 10 * n);
+        if(evect != rocblas_evect_none)
+            ROCSOLVER_TEST_CHECK(T, max_ortho_error, 10 * n);
+    }
 
     // output results for rocsolver-bench
     if(argus.timing)

--- a/library/src/auxiliary/rocauxiliary_larf.hpp
+++ b/library/src/auxiliary/rocauxiliary_larf.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,8 +35,161 @@
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
 #include "rocsolver_run_specialized_kernels.hpp"
+#include <hip/hip_cooperative_groups.h>
 
 ROCSOLVER_BEGIN_NAMESPACE
+
+/*
+*   LARF kernel for the left side case. Each work group of NB_X threads
+*   operates on a column of matrix A. (m + NB_X / warpSize) * sizeof(T)
+*   bytes of LDS memory is required. Grid dimensions = dim3(1, n, batch count)
+*   and block dimensions = dim3(NB_X).
+*/
+template <int NB_X, typename T, typename I, typename U>
+ROCSOLVER_KERNEL void __launch_bounds__(NB_X) larf_left_kernel(const I m,
+                                                               const I n,
+                                                               U xx,
+                                                               const rocblas_stride shiftX,
+                                                               const I incX,
+                                                               const rocblas_stride strideX,
+                                                               const T* tauA,
+                                                               const rocblas_stride strideP,
+                                                               U AA,
+                                                               const rocblas_stride shiftA,
+                                                               const I lda,
+                                                               const rocblas_stride strideA)
+{
+    I bid = blockIdx.z;
+    I tx = threadIdx.x;
+    I col = blockIdx.y;
+
+    // select batch instance
+    T* x = load_ptr_batch<T>(xx, bid, shiftX, strideX);
+    T* A = load_ptr_batch<T>(AA, bid, shiftA, strideA);
+    const T* tau = tauA + bid * strideP;
+
+    A += col * size_t(lda);
+
+    I start = (incX > 0 ? 0 : (m - 1) * -incX);
+
+    T res = 0;
+
+    extern __shared__ double smem[];
+    T* sdata = reinterpret_cast<T*>(smem);
+    T* xs = sdata + (NB_X / warpSize);
+
+    for(I i = tx; i < m; i += NB_X)
+        xs[i] = x[start + i * size_t(incX)];
+
+    //
+    // GEMV
+    //
+    for(I i = tx; i < m; i += NB_X)
+        res += conj(A[i]) * xs[i];
+
+    // reduction
+    res += shift_left(res, 1);
+    res += shift_left(res, 2);
+    res += shift_left(res, 4);
+    res += shift_left(res, 8);
+    res += shift_left(res, 16);
+    if(warpSize > 32)
+        res += shift_left(res, 32);
+    if(tx % warpSize == 0)
+        sdata[tx / warpSize] = res;
+    __syncthreads();
+    if(tx == 0)
+    {
+        for(I k = 1; k < NB_X / warpSize; k++)
+            res += sdata[k];
+
+        sdata[0] = res;
+    }
+    __syncthreads();
+
+    //
+    // GER
+    //
+    res = -tau[0] * conj(sdata[0]);
+    for(I i = tx; i < m; i += NB_X)
+        A[i] += res * xs[i];
+}
+
+/*
+*   LARF kernel for the right side case. Each work group of NB_X threads
+*   operates on a row of matrix A. (n + NB_X / warpSize) * sizeof(T)
+*   bytes of LDS memory is required. Grid dimensions = dim3(1, m, batch count)
+*   and block dimensions = dim3(NB_X).
+*/
+template <int NB_X, typename T, typename I, typename U>
+ROCSOLVER_KERNEL void __launch_bounds__(NB_X) larf_right_kernel(const I m,
+                                                                const I n,
+                                                                U xx,
+                                                                const rocblas_stride shiftX,
+                                                                const I incX,
+                                                                const rocblas_stride strideX,
+                                                                const T* tauA,
+                                                                const rocblas_stride strideP,
+                                                                U AA,
+                                                                const rocblas_stride shiftA,
+                                                                const I lda,
+                                                                const rocblas_stride strideA)
+{
+    I bid = blockIdx.z;
+    I tx = threadIdx.x;
+    I row = blockIdx.y;
+
+    // select batch instance
+    T* x = load_ptr_batch<T>(xx, bid, shiftX, strideX);
+    T* A = load_ptr_batch<T>(AA, bid, shiftA, strideA);
+    const T* tau = tauA + bid * strideP;
+
+    A += row;
+
+    I start = (incX > 0 ? 0 : (n - 1) * -incX);
+
+    T res = 0;
+
+    extern __shared__ double smem[];
+    T* sdata = reinterpret_cast<T*>(smem);
+    T* xs = sdata + (NB_X / warpSize);
+
+    for(I j = tx; j < n; j += NB_X)
+        xs[j] = x[start + j * size_t(incX)];
+
+    //
+    // GEMV
+    //
+    for(I j = tx; j < n; j += NB_X)
+        res += A[j * size_t(lda)] * xs[j];
+
+    // reduction
+    res += shift_left(res, 1);
+    res += shift_left(res, 2);
+    res += shift_left(res, 4);
+    res += shift_left(res, 8);
+    res += shift_left(res, 16);
+    if(warpSize > 32)
+        res += shift_left(res, 32);
+    if(tx % warpSize == 0)
+        sdata[tx / warpSize] = res;
+    __syncthreads();
+    if(tx == 0)
+    {
+        for(I k = 1; k < NB_X / warpSize; k++)
+            res += sdata[k];
+
+        sdata[0] = res;
+    }
+    __syncthreads();
+
+    //
+    // GER
+    //
+    res = -tau[0] * sdata[0];
+    for(I j = tx; j < n; j += NB_X)
+        A[j * size_t(lda)] += res * conj(xs[j]);
+}
 
 template <bool BATCHED, typename T, typename I>
 void rocsolver_larf_getMemorySize(const rocblas_side side,
@@ -160,13 +313,42 @@ rocblas_status rocsolver_larf_template(rocblas_handle handle,
                               shiftA, lda, stridea, batch_count);
     }
 
+    // get device prop
+    const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
+
+    // determine side
+    bool leftside = (side == rocblas_side_left);
+
+    static constexpr int NB = 1024;
+    const int lds_size = leftside ? (m + (NB / props->warpSize)) * sizeof(T)
+                                  : (n + (NB / props->warpSize)) * sizeof(T);
+
+    if(lds_size <= props->sharedMemPerBlock)
+    {
+        // Launch larf kernel if tune parameters are met.
+        if(leftside && (n <= 1024 || m >= 2048))
+        {
+            ROCSOLVER_LAUNCH_KERNEL((larf_left_kernel<NB>), dim3(1, n, batch_count), dim3(NB),
+                                    lds_size, stream, m, n, x, shiftx, incx, stridex, alpha,
+                                    stridep, A, shiftA, lda, stridea);
+            return rocblas_status_success;
+        }
+        // TODO: investigate right side tuning.
+        else if(!leftside && (m <= 1024 || n >= 2048))
+        {
+            ROCSOLVER_LAUNCH_KERNEL((larf_right_kernel<NB>), dim3(1, m, batch_count), dim3(NB),
+                                    lds_size, stream, m, n, x, shiftx, incx, stridex, alpha,
+                                    stridep, A, shiftA, lda, stridea);
+            return rocblas_status_success;
+        }
+    }
+
     // everything must be executed with scalars on the device
     rocblas_pointer_mode old_mode;
     rocblas_get_pointer_mode(handle, &old_mode);
     rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
 
-    // determine side and order of H
-    bool leftside = (side == rocblas_side_left);
+    // determine order of H
     I order = m;
     rocblas_operation trans = rocblas_operation_none;
     if(leftside)

--- a/library/src/auxiliary/rocauxiliary_larfb.hpp
+++ b/library/src/auxiliary/rocauxiliary_larfb.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     June 2013
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -341,6 +341,285 @@ rocblas_status rocsolver_larfb_template(rocblas_handle handle,
     //    or    (A1 * V1 + A2 * V2) * trans(T)
     rocblasCall_trmm(handle, side, uploT, transt, rocblas_diagonal_non_unit, ldw, order, &one, 0, F,
                      shiftF, ldf, strideF, tmptr, 0, ldw, strideW, batch_count, workArr);
+
+    // compute: A2 - V2 * trans(T) * (V1' * A1 + V2' * A2)
+    //    or    A2 - (A1 * V1 + A2 * V2) * trans(T) * V2'
+    if(transp == rocblas_operation_none)
+        transp = rocblas_operation_conjugate_transpose;
+    else
+        transp = rocblas_operation_none;
+
+    if(trap)
+    {
+        if(leftside)
+            rocsolver_gemm(handle, transp, rocblas_operation_none, m - k, order, ldw, &minone, V,
+                           offsetV2, ldv, strideV, tmptr, 0, ldw, strideW, &one, A, offsetA2, lda,
+                           strideA, batch_count, workArr);
+        else
+            rocsolver_gemm(handle, rocblas_operation_none, transp, ldw, n - k, order, &minone,
+                           tmptr, 0, ldw, strideW, V, offsetV2, ldv, strideV, &one, A, offsetA2,
+                           lda, strideA, batch_count, workArr);
+    }
+
+    // compute: V1 * trans(T) * (V1' * A1 + V2' * A2)
+    //    or    (A1 * V1 + A2 * V2) * trans(T) * V1'
+    rocblasCall_trmm(handle, side, uploV, transp, rocblas_diagonal_unit, ldw, order, &one, 0, V,
+                     offsetV1, ldv, strideV, tmptr, 0, ldw, strideW, batch_count, workArr);
+
+    // compute: A1 - V1 * trans(T) * (V1' * A1 + V2' * A2)
+    //    or    A1 - (A1 * V1 + A2 * V2) * trans(T) * V1'
+    ROCSOLVER_LAUNCH_KERNEL(addmatA1, dim3(blocksx, blocksy, batch_count), dim3(32, 32), 0, stream,
+                            ldw, order, A, offsetA1, lda, strideA, tmptr);
+
+    rocblas_set_pointer_mode(handle, old_mode);
+    return rocblas_status_success;
+}
+
+template <bool BATCHED, bool STRIDED, typename T>
+void rocsolver_larfb_inverse_getMemorySize(const rocblas_side side,
+                                           const rocblas_operation trans,
+                                           const rocblas_int m,
+                                           const rocblas_int n,
+                                           const rocblas_int k,
+                                           const rocblas_int batch_count,
+                                           size_t* size_tmptr,
+                                           size_t* size_work1,
+                                           size_t* size_work2,
+                                           size_t* size_work3,
+                                           size_t* size_work4,
+                                           size_t* size_workArr,
+                                           bool* optim_mem)
+{
+    // if quick return, no workspace needed
+    if(m == 0 || n == 0 || batch_count == 0)
+    {
+        *size_tmptr = 0;
+        *size_workArr = 0;
+        *size_work1 = 0;
+        *size_work2 = 0;
+        *size_work3 = 0;
+        *size_work4 = 0;
+        *optim_mem = true;
+        return;
+    }
+
+    bool leftside = (side == rocblas_side_left);
+    rocblas_operation transt
+        = (leftside && trans == rocblas_operation_transpose ? rocblas_operation_conjugate_transpose
+                                                            : trans);
+
+    rocblas_int order, ldw;
+    if(leftside)
+    {
+        order = n;
+        ldw = k;
+    }
+    else
+    {
+        order = k;
+        ldw = m;
+    }
+
+    rocsolver_trsm_mem<false, BATCHED || STRIDED, T>(side, transt, ldw, order, batch_count,
+                                                     size_work1, size_work2, size_work3, size_work4,
+                                                     optim_mem, true);
+
+    // size of temporary array for computations with
+    // triangular part of V
+    if(side == rocblas_side_left)
+        *size_tmptr = n;
+    else
+        *size_tmptr = m;
+    *size_tmptr *= sizeof(T) * k * batch_count;
+
+    // size of array of pointers to workspace
+    if(BATCHED)
+        *size_workArr = sizeof(T*) * batch_count;
+    else
+        *size_workArr = 0;
+}
+
+template <bool BATCHED, bool STRIDED, typename T, typename U>
+rocblas_status rocsolver_larfb_inverse_template(rocblas_handle handle,
+                                                const rocblas_side side,
+                                                const rocblas_operation trans,
+                                                const rocblas_direct direct,
+                                                const rocblas_storev storev,
+                                                const rocblas_int m,
+                                                const rocblas_int n,
+                                                const rocblas_int k,
+                                                U V,
+                                                const rocblas_int shiftV,
+                                                const rocblas_int ldv,
+                                                const rocblas_stride strideV,
+                                                T* F,
+                                                const rocblas_int shiftF,
+                                                const rocblas_int ldf,
+                                                const rocblas_stride strideF,
+                                                U A,
+                                                const rocblas_int shiftA,
+                                                const rocblas_int lda,
+                                                const rocblas_stride strideA,
+                                                const rocblas_int batch_count,
+                                                T* tmptr,
+                                                void* work1,
+                                                void* work2,
+                                                void* work3,
+                                                void* work4,
+                                                T** workArr,
+                                                bool optim_mem)
+{
+    ROCSOLVER_ENTER("larfb_inverse", "side:", side, "trans:", trans, "direct:", direct,
+                    "storev:", storev, "m:", m, "n:", n, "k:", k, "shiftV:", shiftV, "ldv:", ldv,
+                    "shiftF:", shiftF, "ldf:", ldf, "shiftA:", shiftA, "lda:", lda,
+                    "bc:", batch_count);
+
+    // quick return
+    if(m == 0 || n == 0 || batch_count == 0)
+        return rocblas_status_success;
+
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+    T *Vp, *Fp;
+
+    // everything must be executed with scalars on the host
+    rocblas_pointer_mode old_mode;
+    rocblas_get_pointer_mode(handle, &old_mode);
+    rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
+
+    // constants to use when calling rocablas functions
+    T minone = -1;
+    T one = 1;
+
+    // determine the side, size of workspace
+    // and whether V is trapezoidal
+    bool trap;
+    bool colwise = (storev == rocblas_column_wise);
+    bool forward = (direct == rocblas_forward_direction);
+    bool leftside = (side == rocblas_side_left);
+    rocblas_operation transt
+        = (leftside && trans == rocblas_operation_transpose ? rocblas_operation_conjugate_transpose
+                                                            : trans);
+    rocblas_operation transp;
+    rocblas_fill uploV, uploT;
+    rocblas_int order, ldw;
+    rocblas_int shift1, shift2;
+    size_t offsetA1, offsetA2;
+    size_t offsetV1, offsetV2;
+
+    if(leftside)
+    {
+        order = n;
+        ldw = k;
+        trap = (m > k);
+
+        if(forward)
+        {
+            offsetA1 = shiftA;
+            offsetA2 = shiftA + idx2D(k, 0, lda);
+        }
+        else
+        {
+            offsetA1 = shiftA + idx2D(m - k, 0, lda);
+            offsetA2 = shiftA;
+        }
+    }
+    else
+    {
+        order = k;
+        ldw = m;
+        trap = (n > k);
+
+        if(forward)
+        {
+            offsetA1 = shiftA;
+            offsetA2 = shiftA + idx2D(0, k, lda);
+        }
+        else
+        {
+            offsetA1 = shiftA + idx2D(0, n - k, lda);
+            offsetA2 = shiftA;
+        }
+    }
+
+    if(colwise)
+    {
+        if(leftside)
+            transp = rocblas_operation_conjugate_transpose;
+        else
+            transp = rocblas_operation_none;
+
+        if(forward)
+        {
+            uploV = rocblas_fill_lower;
+            offsetV1 = shiftV;
+            offsetV2 = shiftV + idx2D(k, 0, ldv);
+        }
+        else
+        {
+            uploV = rocblas_fill_upper;
+            offsetV1 = shiftV + idx2D((leftside ? m - k : n - k), 0, ldv);
+            offsetV2 = shiftV;
+        }
+    }
+    else
+    {
+        if(leftside)
+            transp = rocblas_operation_none;
+        else
+            transp = rocblas_operation_conjugate_transpose;
+
+        if(forward)
+        {
+            uploV = rocblas_fill_upper;
+            offsetV1 = shiftV;
+            offsetV2 = shiftV + idx2D(0, k, ldv);
+        }
+        else
+        {
+            uploV = rocblas_fill_lower;
+            offsetV1 = shiftV + idx2D(0, (leftside ? m - k : n - k), ldv);
+            offsetV2 = shiftV;
+        }
+    }
+    rocblas_stride strideW = rocblas_stride(ldw) * order;
+    uploT = (forward ? rocblas_fill_upper : rocblas_fill_lower);
+
+    // copy A1 to tmptr
+    rocblas_int blocksx = (order - 1) / 32 + 1;
+    rocblas_int blocksy = (ldw - 1) / 32 + 1;
+    ROCSOLVER_LAUNCH_KERNEL(copymatA1, dim3(blocksx, blocksy, batch_count), dim3(32, 32), 0, stream,
+                            ldw, order, A, offsetA1, lda, strideA, tmptr);
+
+    // compute: V1' * A1
+    //   or    A1 * V1
+    rocblasCall_trmm(handle, side, uploV, transp, rocblas_diagonal_unit, ldw, order, &one, 0, V,
+                     offsetV1, ldv, strideV, tmptr, 0, ldw, strideW, batch_count, workArr);
+
+    // compute: V1' * A1 + V2' * A2
+    //    or    A1 * V1 + A2 * V2
+    if(trap)
+    {
+        if(leftside)
+            rocsolver_gemm(handle, transp, rocblas_operation_none, ldw, order, m - k, &one, V,
+                           offsetV2, ldv, strideV, A, offsetA2, lda, strideA, &one, tmptr, 0, ldw,
+                           strideW, batch_count, workArr);
+        else
+            rocsolver_gemm(handle, rocblas_operation_none, transp, ldw, order, n - k, &one, A,
+                           offsetA2, lda, strideA, V, offsetV2, ldv, strideV, &one, tmptr, 0, ldw,
+                           strideW, batch_count, workArr);
+    }
+
+    // compute: inv(trans(T)) * (V1' * A1 + V2' * A2)
+    //    or    (A1 * V1 + A2 * V2) * inv(trans(T))
+    if(forward)
+        rocsolver_trsm_upper<false, BATCHED || STRIDED, T>(
+            handle, side, transt, rocblas_diagonal_non_unit, ldw, order, F, shiftF, ldf, strideF,
+            tmptr, 0, ldw, strideW, batch_count, optim_mem, work1, work2, work3, work4);
+    else
+        rocsolver_trsm_lower<false, BATCHED || STRIDED, T>(
+            handle, side, transt, rocblas_diagonal_non_unit, ldw, order, F, shiftF, ldf, strideF,
+            tmptr, 0, ldw, strideW, batch_count, optim_mem, work1, work2, work3, work4);
 
     // compute: A2 - V2 * trans(T) * (V1' * A1 + V2' * A2)
     //    or    A2 - (A1 * V1 + A2 * V2) * trans(T) * V2'

--- a/library/src/auxiliary/rocauxiliary_larfg.hpp
+++ b/library/src/auxiliary/rocauxiliary_larfg.hpp
@@ -182,9 +182,9 @@ rocblas_status rocsolver_larfg_getMemorySize(const I n,
         // TODO: Some architectures have failures in sygvx with small-size kernels enabled, more investigation needed
         int device;
         HIP_CHECK(hipGetDevice(&device));
-        hipDeviceProp_t deviceProperties;
-        HIP_CHECK(hipGetDeviceProperties(&deviceProperties, device));
-        if(deviceProperties.warpSize >= 64)
+        hipDeviceProp_t props;
+        HIP_CHECK(hipGetDeviceProperties(&props, device));
+        if(props.warpSize >= 64)
             return rocblas_status_success;
     }
 
@@ -273,11 +273,8 @@ rocblas_status rocsolver_larfg_template(rocblas_handle handle,
     if(true)
     {
         // TODO: Some architectures have failures in sygvx with small-size kernels enabled, more investigation needed
-        int device;
-        HIP_CHECK(hipGetDevice(&device));
-        hipDeviceProp_t deviceProperties;
-        HIP_CHECK(hipGetDeviceProperties(&deviceProperties, device));
-        if(deviceProperties.warpSize >= 64)
+        const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
+        if(props->warpSize >= 64)
         {
             return larfg_run_small(handle, n, alpha, shifta, stridex, beta, shiftb, strideb, x,
                                    shiftx, incx, stridex, tau, strideP, batch_count);

--- a/library/src/auxiliary/rocauxiliary_larft.hpp
+++ b/library/src/auxiliary/rocauxiliary_larft.hpp
@@ -721,4 +721,200 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
     return rocblas_status_success;
 }
 
+template <typename T, typename U>
+ROCSOLVER_KERNEL void larft_set_tri(const rocblas_fill uplo,
+                                    const rocblas_int k,
+                                    U A,
+                                    const rocblas_int shiftA,
+                                    const rocblas_int lda,
+                                    const rocblas_stride strideA,
+                                    T* buffer)
+{
+    const auto b = hipBlockIdx_z;
+    const auto j = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    const auto i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+
+    const rocblas_int ldb = k;
+    const rocblas_stride strideB = rocblas_stride(ldb) * k;
+
+    const bool upper = (uplo == rocblas_fill_upper);
+    const bool lower = (uplo == rocblas_fill_lower);
+
+    if(i < k && j < k)
+    {
+        if((upper && j >= i) || (lower && i >= j))
+        {
+            T* Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
+            T* Bp = &buffer[b * strideB];
+
+            // copy A to buffer
+            Bp[i + j * ldb] = Ap[i + j * lda];
+
+            // set A to unit triangular
+            Ap[i + j * lda] = (i == j) ? 1 : 0;
+        }
+    }
+}
+
+template <typename T, typename U>
+ROCSOLVER_KERNEL void larft_restore_tri(const rocblas_fill uplo,
+                                        const rocblas_int k,
+                                        U A,
+                                        const rocblas_int shiftA,
+                                        const rocblas_int lda,
+                                        const rocblas_stride strideA,
+                                        T* buffer)
+{
+    const auto b = hipBlockIdx_z;
+    const auto j = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    const auto i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+
+    const rocblas_int ldb = k;
+    const rocblas_stride strideB = rocblas_stride(ldb) * k;
+
+    const bool upper = (uplo == rocblas_fill_upper);
+    const bool lower = (uplo == rocblas_fill_lower);
+
+    if(i < k && j < k)
+    {
+        if((upper && j >= i) || (lower && i >= j))
+        {
+            T* Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
+            T* Bp = &buffer[b * strideB];
+
+            // copy buffer to A
+            Ap[i + j * lda] = Bp[i + j * ldb];
+        }
+    }
+}
+
+template <typename T>
+ROCSOLVER_KERNEL void larft_set_diag(rocblas_int k,
+                                     T* tau,
+                                     const rocblas_stride strideT,
+                                     T* F,
+                                     const rocblas_int ldf,
+                                     const rocblas_stride strideF)
+{
+    const auto b = hipBlockIdx_z;
+    const auto i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+
+    if(i < k)
+    {
+        T *tp, *Fp;
+        tp = tau + b * strideT;
+        Fp = F + b * strideF;
+
+        Fp[i + i * ldf] = 1 / tp[i];
+    }
+}
+
+template <bool BATCHED, typename T>
+void rocsolver_larft_inverse_getMemorySize(const rocblas_int n,
+                                           const rocblas_int k,
+                                           const rocblas_int batch_count,
+                                           size_t* size_work,
+                                           size_t* size_workArr)
+{
+    // if quick return, no workspace is needed
+    if(n == 0 || batch_count == 0)
+    {
+        *size_work = 0;
+        *size_workArr = 0;
+        return;
+    }
+
+    // size of re-usable workspace
+    *size_work = sizeof(T) * k * k * batch_count;
+
+    // size of array of pointers to workspace
+    if(BATCHED)
+        *size_workArr = sizeof(T*) * batch_count;
+    else
+        *size_workArr = 0;
+}
+
+template <typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
+rocblas_status rocsolver_larft_inverse_template(rocblas_handle handle,
+                                                const rocblas_direct direct,
+                                                const rocblas_storev storev,
+                                                const rocblas_int n,
+                                                const rocblas_int k,
+                                                U V,
+                                                const rocblas_int shiftV,
+                                                const rocblas_int ldv,
+                                                const rocblas_stride strideV,
+                                                T* tau,
+                                                const rocblas_stride strideT,
+                                                T* F,
+                                                const rocblas_int ldf,
+                                                const rocblas_stride strideF,
+                                                const rocblas_int batch_count,
+                                                T* work,
+                                                T** workArr)
+{
+    ROCSOLVER_ENTER("larft_inverse", "direct:", direct, "storev:", storev, "n:", n, "k:", k,
+                    "shiftV:", shiftV, "ldv:", ldv, "ldf:", ldf, "bc:", batch_count);
+
+    // quick return
+    if(n == 0 || batch_count == 0)
+        return rocblas_status_success;
+
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    // everything must be executed with scalars on the device
+    rocblas_pointer_mode old_mode;
+    rocblas_get_pointer_mode(handle, &old_mode);
+    rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
+
+    T one = 1;
+    T zero = 0;
+
+    const bool colwise = (storev == rocblas_column_wise);
+    const bool forward = (direct == rocblas_forward_direction);
+
+    rocblas_operation transA
+        = colwise ? rocblas_operation_conjugate_transpose : rocblas_operation_none;
+    rocblas_operation transB
+        = colwise ? rocblas_operation_none : rocblas_operation_conjugate_transpose;
+
+    rocblas_int tri_offset;
+    rocblas_fill tri_uplo;
+
+    if(colwise)
+    {
+        tri_uplo = forward ? rocblas_fill_upper : rocblas_fill_lower;
+        tri_offset = (!forward && n > k) ? idx2D(n - k, 0, ldv) : 0;
+    }
+    else
+    {
+        tri_uplo = forward ? rocblas_fill_lower : rocblas_fill_upper;
+        tri_offset = (!forward && n > k) ? idx2D(0, n - k, ldv) : 0;
+    }
+
+    rocblas_int blocks = (k - 1) / 32 + 1;
+    dim3 gridTri(blocks, blocks, batch_count);
+    dim3 blockTri(32, 32);
+
+    // set V to unit triangular/trapezoidal
+    ROCSOLVER_LAUNCH_KERNEL((larft_set_tri), gridTri, blockTri, 0, stream, tri_uplo, k, V,
+                            shiftV + tri_offset, ldv, strideV, work);
+
+    // compute: V' * V or V * V'
+    rocsolver_gemm(handle, transA, transB, k, k, n, &one, V, shiftV, ldv, strideV, V, shiftV, ldv,
+                   strideV, &zero, F, 0, ldf, strideF, batch_count, workArr);
+
+    // set F diag to 1 / tau
+    ROCSOLVER_LAUNCH_KERNEL(larft_set_diag, dim3(blocks, 1, batch_count), dim3(32, 1), 0, stream, k,
+                            tau, strideT, F, ldf, strideF);
+
+    // restore original V
+    ROCSOLVER_LAUNCH_KERNEL((larft_restore_tri), gridTri, blockTri, 0, stream, tri_uplo, k, V,
+                            shiftV + tri_offset, ldv, strideV, work);
+
+    rocblas_set_pointer_mode(handle, old_mode);
+    return rocblas_status_success;
+}
+
 ROCSOLVER_END_NAMESPACE

--- a/library/src/auxiliary/rocauxiliary_larft.hpp
+++ b/library/src/auxiliary/rocauxiliary_larft.hpp
@@ -538,10 +538,9 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
 
-    // everything must be executed with scalars on the device
+    // save old pointer mode
     rocblas_pointer_mode old_mode;
     rocblas_get_pointer_mode(handle, &old_mode);
-    rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
 
     rocblas_stride stridew = rocblas_stride(k);
     rocblas_diagonal diag = rocblas_diagonal_non_unit;
@@ -549,6 +548,8 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
     rocblas_operation trans;
 
     const bool use_gemm = n > k;
+    const T zero = T(0);
+    const T one = T(1);
 
     const rocblas_int u1_n = use_gemm ? k : n;
     const rocblas_int u2_n = use_gemm ? n - k : 0;
@@ -557,33 +558,32 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
     // SYRK/HERK can be used alternatively, but GEMM is currently more performant.
     if(use_gemm)
     {
+        rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
         if(direct == rocblas_forward_direction && storev == rocblas_column_wise)
         {
             rocsolver_gemm(handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, k,
-                           k, u2_n, scalars + 2, V, shiftV + idx2D(u1_n, 0, ldv), ldv, strideV, V,
-                           shiftV + idx2D(u1_n, 0, ldv), ldv, strideV, scalars + 1, F,
-                           idx2D(0, 0, ldf), ldf, strideF, batch_count, workArr);
+                           k, u2_n, &one, V, shiftV + idx2D(u1_n, 0, ldv), ldv, strideV, V,
+                           shiftV + idx2D(u1_n, 0, ldv), ldv, strideV, &zero, F, 0, ldf, strideF,
+                           batch_count, workArr);
         }
         else if(direct == rocblas_backward_direction && storev == rocblas_column_wise)
         {
             rocsolver_gemm(handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, k,
-                           k, u2_n, scalars + 2, V, shiftV + idx2D(0, 0, ldv), ldv, strideV, V,
-                           shiftV + idx2D(0, 0, ldv), ldv, strideV, scalars + 1, F,
-                           idx2D(0, 0, ldf), ldf, strideF, batch_count, workArr);
+                           k, u2_n, &one, V, shiftV, ldv, strideV, V, shiftV, ldv, strideV, &zero,
+                           F, 0, ldf, strideF, batch_count, workArr);
         }
         else if(direct == rocblas_forward_direction && storev == rocblas_row_wise)
         {
             rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_conjugate_transpose, k,
-                           k, u2_n, scalars + 2, V, shiftV + idx2D(0, u1_n, ldv), ldv, strideV, V,
-                           shiftV + idx2D(0, u1_n, ldv), ldv, strideV, scalars + 1, F,
-                           idx2D(0, 0, ldf), ldf, strideF, batch_count, workArr);
+                           k, u2_n, &one, V, shiftV + idx2D(0, u1_n, ldv), ldv, strideV, V,
+                           shiftV + idx2D(0, u1_n, ldv), ldv, strideV, &zero, F, 0, ldf, strideF,
+                           batch_count, workArr);
         }
         else if(direct == rocblas_backward_direction && storev == rocblas_row_wise)
         {
             rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_conjugate_transpose, k,
-                           k, u2_n, scalars + 2, V, shiftV + idx2D(0, 0, ldv), ldv, strideV, V,
-                           shiftV + idx2D(0, 0, ldv), ldv, strideV, scalars + 1, F,
-                           idx2D(0, 0, ldf), ldf, strideF, batch_count, workArr);
+                           k, u2_n, &one, V, shiftV, ldv, strideV, V, shiftV, ldv, strideV, &zero,
+                           F, 0, ldf, strideF, batch_count, workArr);
         }
     }
 
@@ -602,6 +602,8 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
     hipDeviceProp_t props;
     HIP_CHECK(hipGetDeviceProperties(&props, device));
     size_t lmemsize = sizeof(T) * (k + 1) * k;
+
+    rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
 
     if(direct == rocblas_forward_direction)
     {

--- a/library/src/auxiliary/rocauxiliary_larft.hpp
+++ b/library/src/auxiliary/rocauxiliary_larft.hpp
@@ -597,10 +597,7 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
     ROCSOLVER_LAUNCH_KERNEL(set_tau, dim3(blocks, batch_count), dim3(32, 1), 0, stream, k, tau,
                             strideT);
 
-    int device;
-    HIP_CHECK(hipGetDevice(&device));
-    hipDeviceProp_t props;
-    HIP_CHECK(hipGetDeviceProperties(&props, device));
+    const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
     size_t lmemsize = sizeof(T) * (k + 1) * k;
 
     rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
@@ -614,7 +611,7 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
         //      IT WILL WORK ON THE ENTIRE MATRIX/VECTOR REGARDLESS OF
         //      ZERO ENTRIES ****
 
-        if(k <= LARFT_SWITCHSIZE && lmemsize <= props.sharedMemPerBlock)
+        if(k <= LARFT_SWITCHSIZE && lmemsize <= props->sharedMemPerBlock)
         {
             ROCSOLVER_LAUNCH_KERNEL(larft_kernel_forward, dim3(1, batch_count), dim3(BS1, 1),
                                     lmemsize, stream, storev, u1_n, k, V, shiftV, ldv, strideV, tau,
@@ -668,7 +665,7 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
         //      IT WILL WORK ON THE ENTIRE MATRIX/VECTOR REGARDLESS OF
         //      ZERO ENTRIES ****
 
-        if(k <= LARFT_SWITCHSIZE && lmemsize <= props.sharedMemPerBlock)
+        if(k <= LARFT_SWITCHSIZE && lmemsize <= props->sharedMemPerBlock)
         {
             auto shiftU2 = shiftV
                 + ((storev == rocblas_column_wise) ? idx2D(u2_n, 0, ldv) : idx2D(0, u2_n, ldv));

--- a/library/src/auxiliary/rocauxiliary_ormql_unmql.hpp
+++ b/library/src/auxiliary/rocauxiliary_ormql_unmql.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -78,6 +78,68 @@ void rocsolver_ormql_unmql_getMemorySize(const rocblas_side side,
         // requirements for calling larfb
         rocsolver_larfb_getMemorySize<BATCHED, T>(side, m, n, std::min(jb, k), batch_count,
                                                   size_diagORtmptr, &unused);
+
+        // size of temporary array for triangular factor
+        *size_trfact = sizeof(T) * jb * jb * batch_count;
+    }
+    else
+        *size_trfact = 0;
+}
+
+template <bool BATCHED, bool STRIDED, typename T>
+void rocsolver_ormql_unmql_getMemorySize(const rocblas_side side,
+                                         const rocblas_operation trans,
+                                         const rocblas_int m,
+                                         const rocblas_int n,
+                                         const rocblas_int k,
+                                         const rocblas_int batch_count,
+                                         size_t* size_scalars,
+                                         size_t* size_AbyxORwork,
+                                         size_t* size_work2,
+                                         size_t* size_work3,
+                                         size_t* size_work4,
+                                         size_t* size_diagORtmptr,
+                                         size_t* size_trfact,
+                                         size_t* size_workArr,
+                                         bool* optim_mem)
+{
+    *size_scalars = 0;
+    *size_AbyxORwork = 0;
+    *size_diagORtmptr = 0;
+    *size_trfact = 0;
+    *size_workArr = 0;
+    *size_work2 = 0;
+    *size_work3 = 0;
+    *size_work4 = 0;
+    *optim_mem = true;
+
+    // if quick return no workspace needed
+    if(m == 0 || n == 0 || k == 0 || batch_count == 0)
+    {
+        return;
+    }
+
+    size_t unused;
+    rocsolver_orm2l_unm2l_getMemorySize<BATCHED, T>(side, m, n, k, batch_count, size_scalars,
+                                                    size_AbyxORwork, size_diagORtmptr, size_workArr);
+
+    if(k > xxMQx_BLOCKSIZE)
+    {
+        size_t w1, w2;
+
+        rocblas_int jb = xxMQx_BLOCKSIZE;
+
+        // requirements for calling larft
+        rocsolver_larft_inverse_getMemorySize<BATCHED, T>(std::max(m, n), std::min(jb, k),
+                                                          batch_count, &w1, &unused);
+        *size_AbyxORwork = std::max(w1, *size_AbyxORwork);
+
+        // requirements for calling larfb
+        rocsolver_larfb_inverse_getMemorySize<BATCHED, STRIDED, T>(
+            side, trans, m, n, std::min(jb, k), batch_count, &w2, &w1, size_work2, size_work3,
+            size_work4, &unused, optim_mem);
+        *size_AbyxORwork = std::max(w1, *size_AbyxORwork);
+        *size_diagORtmptr = std::max(w2, *size_diagORtmptr);
 
         // size of temporary array for triangular factor
         *size_trfact = sizeof(T) * jb * jb * batch_count;
@@ -190,6 +252,119 @@ rocblas_status rocsolver_ormql_unmql_template(rocblas_handle handle,
             handle, side, trans, rocblas_backward_direction, rocblas_column_wise, nrow, ncol, ib, A,
             shiftA + idx2D(0, i, lda), lda, strideA, trfact, 0, ldw, strideW, C, shiftC, ldc,
             strideC, batch_count, diagORtmptr, workArr);
+    }
+
+    return rocblas_status_success;
+}
+
+template <bool BATCHED, bool STRIDED, typename T, typename U>
+rocblas_status rocsolver_ormql_unmql_template(rocblas_handle handle,
+                                              const rocblas_side side,
+                                              const rocblas_operation trans,
+                                              const rocblas_int m,
+                                              const rocblas_int n,
+                                              const rocblas_int k,
+                                              U A,
+                                              const rocblas_int shiftA,
+                                              const rocblas_int lda,
+                                              const rocblas_stride strideA,
+                                              T* ipiv,
+                                              const rocblas_stride strideP,
+                                              U C,
+                                              const rocblas_int shiftC,
+                                              const rocblas_int ldc,
+                                              const rocblas_stride strideC,
+                                              const rocblas_int batch_count,
+                                              T* scalars,
+                                              T* AbyxORwork,
+                                              void* work2,
+                                              void* work3,
+                                              void* work4,
+                                              T* diagORtmptr,
+                                              T* trfact,
+                                              T** workArr,
+                                              bool optim_mem)
+{
+    ROCSOLVER_ENTER("ormql_unmql", "side:", side, "trans:", trans, "m:", m, "n:", n, "k:", k,
+                    "shiftA:", shiftA, "lda:", lda, "shiftC:", shiftC, "ldc:", ldc,
+                    "bc:", batch_count);
+
+    // quick return
+    if(!n || !m || !k || !batch_count)
+        return rocblas_status_success;
+
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    // if the matrix is small, use the unblocked variant of the algorithm
+    if(k <= xxMQx_BLOCKSIZE)
+        return rocsolver_orm2l_unm2l_template<T>(
+            handle, side, trans, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, C, shiftC, ldc,
+            strideC, batch_count, scalars, AbyxORwork, diagORtmptr, workArr);
+
+    rocblas_int ldw = xxMQx_BLOCKSIZE;
+    rocblas_stride strideW = rocblas_stride(ldw) * ldw;
+
+    // determine limits and indices
+    bool left = (side == rocblas_side_left);
+    bool transpose = (trans != rocblas_operation_none);
+    rocblas_int start, step, nq, ncol, nrow;
+    if(left)
+    {
+        nq = m;
+        ncol = n;
+        if(!transpose)
+        {
+            start = 0;
+            step = 1;
+        }
+        else
+        {
+            start = (k - 1) / ldw * ldw;
+            step = -1;
+        }
+    }
+    else
+    {
+        nq = n;
+        nrow = m;
+        if(!transpose)
+        {
+            start = (k - 1) / ldw * ldw;
+            step = -1;
+        }
+        else
+        {
+            start = 0;
+            step = 1;
+        }
+    }
+
+    rocblas_int i, ib;
+    for(rocblas_int j = 0; j < k; j += ldw)
+    {
+        i = start + step * j; // current householder block
+        ib = std::min(ldw, k - i);
+        if(left)
+        {
+            nrow = m - k + i + ib;
+        }
+        else
+        {
+            ncol = n - k + i + ib;
+        }
+
+        // generate triangular factor of current block reflector
+        rocsolver_larft_inverse_template<T>(handle, rocblas_backward_direction, rocblas_column_wise,
+                                            nq - k + i + ib, ib, A, shiftA + idx2D(0, i, lda), lda,
+                                            strideA, ipiv + i, strideP, trfact, ldw, strideW,
+                                            batch_count, AbyxORwork, workArr);
+
+        // apply current block reflector
+        rocsolver_larfb_inverse_template<BATCHED, STRIDED, T>(
+            handle, side, trans, rocblas_backward_direction, rocblas_column_wise, nrow, ncol, ib, A,
+            shiftA + idx2D(0, i, lda), lda, strideA, trfact, 0, ldw, strideW, C, shiftC, ldc,
+            strideC, batch_count, diagORtmptr, AbyxORwork, work2, work3, work4, workArr, optim_mem);
     }
 
     return rocblas_status_success;

--- a/library/src/auxiliary/rocauxiliary_ormqr_unmqr.hpp
+++ b/library/src/auxiliary/rocauxiliary_ormqr_unmqr.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -78,6 +78,68 @@ void rocsolver_ormqr_unmqr_getMemorySize(const rocblas_side side,
         // requirements for calling larfb
         rocsolver_larfb_getMemorySize<BATCHED, T>(side, m, n, std::min(jb, k), batch_count,
                                                   size_diagORtmptr, &unused);
+
+        // size of temporary array for triangular factor
+        *size_trfact = sizeof(T) * jb * jb * batch_count;
+    }
+    else
+        *size_trfact = 0;
+}
+
+template <bool BATCHED, bool STRIDED, typename T>
+void rocsolver_ormqr_unmqr_getMemorySize(const rocblas_side side,
+                                         const rocblas_operation trans,
+                                         const rocblas_int m,
+                                         const rocblas_int n,
+                                         const rocblas_int k,
+                                         const rocblas_int batch_count,
+                                         size_t* size_scalars,
+                                         size_t* size_AbyxORwork,
+                                         size_t* size_work2,
+                                         size_t* size_work3,
+                                         size_t* size_work4,
+                                         size_t* size_diagORtmptr,
+                                         size_t* size_trfact,
+                                         size_t* size_workArr,
+                                         bool* optim_mem)
+{
+    *size_scalars = 0;
+    *size_AbyxORwork = 0;
+    *size_diagORtmptr = 0;
+    *size_trfact = 0;
+    *size_workArr = 0;
+    *size_work2 = 0;
+    *size_work3 = 0;
+    *size_work4 = 0;
+    *optim_mem = true;
+
+    // if quick return no workspace needed
+    if(m == 0 || n == 0 || k == 0 || batch_count == 0)
+    {
+        return;
+    }
+
+    size_t unused;
+    rocsolver_orm2r_unm2r_getMemorySize<BATCHED, T>(side, m, n, k, batch_count, size_scalars,
+                                                    size_AbyxORwork, size_diagORtmptr, size_workArr);
+
+    if(k > xxMQx_BLOCKSIZE)
+    {
+        size_t w1, w2;
+
+        rocblas_int jb = xxMQx_BLOCKSIZE;
+
+        // requirements for calling larft
+        rocsolver_larft_inverse_getMemorySize<BATCHED, T>(std::max(m, n), std::min(jb, k),
+                                                          batch_count, &w1, &unused);
+        *size_AbyxORwork = std::max(w1, *size_AbyxORwork);
+
+        // requirements for calling larfb
+        rocsolver_larfb_inverse_getMemorySize<BATCHED, STRIDED, T>(
+            side, trans, m, n, std::min(jb, k), batch_count, &w2, &w1, size_work2, size_work3,
+            size_work4, &unused, optim_mem);
+        *size_AbyxORwork = std::max(w1, *size_AbyxORwork);
+        *size_diagORtmptr = std::max(w2, *size_diagORtmptr);
 
         // size of temporary array for triangular factor
         *size_trfact = sizeof(T) * jb * jb * batch_count;
@@ -194,6 +256,125 @@ rocblas_status rocsolver_ormqr_unmqr_template(rocblas_handle handle,
             handle, side, trans, rocblas_forward_direction, rocblas_column_wise, nrow, ncol, ib, A,
             shiftA + idx2D(i, i, lda), lda, strideA, trfact, 0, ldw, strideW, C,
             shiftC + idx2D(ic, jc, ldc), ldc, strideC, batch_count, diagORtmptr, workArr);
+    }
+
+    return rocblas_status_success;
+}
+
+template <bool BATCHED, bool STRIDED, typename T, typename U>
+rocblas_status rocsolver_ormqr_unmqr_template(rocblas_handle handle,
+                                              const rocblas_side side,
+                                              const rocblas_operation trans,
+                                              const rocblas_int m,
+                                              const rocblas_int n,
+                                              const rocblas_int k,
+                                              U A,
+                                              const rocblas_int shiftA,
+                                              const rocblas_int lda,
+                                              const rocblas_stride strideA,
+                                              T* ipiv,
+                                              const rocblas_stride strideP,
+                                              U C,
+                                              const rocblas_int shiftC,
+                                              const rocblas_int ldc,
+                                              const rocblas_stride strideC,
+                                              const rocblas_int batch_count,
+                                              T* scalars,
+                                              T* AbyxORwork,
+                                              void* work2,
+                                              void* work3,
+                                              void* work4,
+                                              T* diagORtmptr,
+                                              T* trfact,
+                                              T** workArr,
+                                              bool optim_mem,
+                                              T** workArr2 = nullptr)
+{
+    ROCSOLVER_ENTER("ormqr_unmqr", "side:", side, "trans:", trans, "m:", m, "n:", n, "k:", k,
+                    "shiftA:", shiftA, "lda:", lda, "shiftC:", shiftC, "ldc:", ldc,
+                    "bc:", batch_count);
+
+    // quick return
+    if(!n || !m || !k || !batch_count)
+        return rocblas_status_success;
+
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    // if the matrix is small, use the unblocked variant of the algorithm
+    if(k <= xxMQx_BLOCKSIZE)
+        return rocsolver_orm2r_unm2r_template<T>(
+            handle, side, trans, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, C, shiftC, ldc,
+            strideC, batch_count, scalars, AbyxORwork, diagORtmptr, workArr);
+
+    rocblas_int ldw = xxMQx_BLOCKSIZE;
+    rocblas_stride strideW = rocblas_stride(ldw) * ldw;
+
+    // determine limits and indices
+    bool left = (side == rocblas_side_left);
+    bool transpose = (trans != rocblas_operation_none);
+    rocblas_int start, step, nq, ncol, nrow, ic, jc;
+    if(left)
+    {
+        nq = m;
+        ncol = n;
+        jc = 0;
+        if(transpose)
+        {
+            start = 0;
+            step = 1;
+        }
+        else
+        {
+            start = (k - 1) / ldw * ldw;
+            step = -1;
+        }
+    }
+    else
+    {
+        nq = n;
+        nrow = m;
+        ic = 0;
+        if(transpose)
+        {
+            start = (k - 1) / ldw * ldw;
+            step = -1;
+        }
+        else
+        {
+            start = 0;
+            step = 1;
+        }
+    }
+
+    rocblas_int i, ib;
+    for(rocblas_int j = 0; j < k; j += ldw)
+    {
+        i = start + step * j; // current householder block
+        ib = std::min(ldw, k - i);
+        if(left)
+        {
+            nrow = m - i;
+            ic = i;
+        }
+        else
+        {
+            ncol = n - i;
+            jc = i;
+        }
+
+        // generate triangular factor of current block reflector
+        rocsolver_larft_inverse_template<T>(handle, rocblas_forward_direction, rocblas_column_wise,
+                                            nq - i, ib, A, shiftA + idx2D(i, i, lda), lda, strideA,
+                                            ipiv + i, strideP, trfact, ldw, strideW, batch_count,
+                                            AbyxORwork, workArr);
+
+        // apply current block reflector
+        rocsolver_larfb_inverse_template<BATCHED, STRIDED, T>(
+            handle, side, trans, rocblas_forward_direction, rocblas_column_wise, nrow, ncol, ib, A,
+            shiftA + idx2D(i, i, lda), lda, strideA, trfact, 0, ldw, strideW, C,
+            shiftC + idx2D(ic, jc, ldc), ldc, strideC, batch_count, diagORtmptr, AbyxORwork, work2,
+            work3, work4, workArr, optim_mem);
     }
 
     return rocblas_status_success;

--- a/library/src/auxiliary/rocauxiliary_ormtr_unmtr.cpp
+++ b/library/src/auxiliary/rocauxiliary_ormtr_unmtr.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -67,37 +67,43 @@ rocblas_status rocsolver_ormtr_unmtr_impl(rocblas_handle handle,
 
     // memory workspace sizes:
     // requirements for calling ORMQL/UNMQL or ORMQR/UNMQR
+    bool optim_mem;
     size_t size_scalars;
-    size_t size_AbyxORwork, size_diagORtmptr;
+    size_t size_AbyxORwork, size_work2, size_work3, size_work4, size_diagORtmptr;
     size_t size_trfact;
     size_t size_workArr;
-    rocsolver_ormtr_unmtr_getMemorySize<false, T>(side, uplo, m, n, batch_count, &size_scalars,
-                                                  &size_AbyxORwork, &size_diagORtmptr, &size_trfact,
-                                                  &size_workArr);
+    rocsolver_ormtr_unmtr_getMemorySize<false, false, T>(
+        side, uplo, trans, m, n, batch_count, &size_scalars, &size_AbyxORwork, &size_work2,
+        &size_work3, &size_work4, &size_diagORtmptr, &size_trfact, &size_workArr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_AbyxORwork,
+                                                      size_work2, size_work3, size_work4,
                                                       size_diagORtmptr, size_trfact, size_workArr);
 
     // memory workspace allocation
-    void *scalars, *AbyxORwork, *diagORtmptr, *trfact, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_AbyxORwork, size_diagORtmptr, size_trfact,
-                              size_workArr);
+    void *scalars, *AbyxORwork, *work2, *work3, *work4, *diagORtmptr, *trfact, *workArr;
+    rocblas_device_malloc mem(handle, size_scalars, size_AbyxORwork, size_work2, size_work3,
+                              size_work4, size_diagORtmptr, size_trfact, size_workArr);
     if(!mem)
         return rocblas_status_memory_error;
 
     scalars = mem[0];
     AbyxORwork = mem[1];
-    diagORtmptr = mem[2];
-    trfact = mem[3];
-    workArr = mem[4];
+    work2 = mem[2];
+    work3 = mem[3];
+    work4 = mem[4];
+    diagORtmptr = mem[5];
+    trfact = mem[6];
+    workArr = mem[7];
     if(size_scalars > 0)
         init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_ormtr_unmtr_template<false, false, T>(
         handle, side, uplo, trans, m, n, A, shiftA, lda, strideA, ipiv, strideP, C, shiftC, ldc,
-        strideC, batch_count, (T*)scalars, (T*)AbyxORwork, (T*)diagORtmptr, (T*)trfact, (T**)workArr);
+        strideC, batch_count, (T*)scalars, (T*)AbyxORwork, work2, work3, work4, (T*)diagORtmptr,
+        (T*)trfact, (T**)workArr, optim_mem);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/library/src/auxiliary/rocauxiliary_ormtr_unmtr.hpp
+++ b/library/src/auxiliary/rocauxiliary_ormtr_unmtr.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -74,6 +74,53 @@ void rocsolver_ormtr_unmtr_getMemorySize(const rocblas_side side,
         rocsolver_ormqr_unmqr_getMemorySize<BATCHED, T>(side, m, n, nq, batch_count, size_scalars,
                                                         size_AbyxORwork, size_diagORtmptr,
                                                         size_trfact, size_workArr);
+}
+
+template <bool BATCHED, bool STRIDED, typename T>
+void rocsolver_ormtr_unmtr_getMemorySize(const rocblas_side side,
+                                         const rocblas_fill uplo,
+                                         const rocblas_operation trans,
+                                         const rocblas_int m,
+                                         const rocblas_int n,
+                                         const rocblas_int batch_count,
+                                         size_t* size_scalars,
+                                         size_t* size_AbyxORwork,
+                                         size_t* size_work2,
+                                         size_t* size_work3,
+                                         size_t* size_work4,
+                                         size_t* size_diagORtmptr,
+                                         size_t* size_trfact,
+                                         size_t* size_workArr,
+                                         bool* optim_mem)
+{
+    *size_scalars = 0;
+    *size_AbyxORwork = 0;
+    *size_diagORtmptr = 0;
+    *size_trfact = 0;
+    *size_workArr = 0;
+    *size_work2 = 0;
+    *size_work3 = 0;
+    *size_work4 = 0;
+    *optim_mem = true;
+
+    // if quick return no workspace needed
+    if(m == 0 || n == 0 || batch_count == 0)
+    {
+        return;
+    }
+
+    rocblas_int nq = side == rocblas_side_left ? m : n;
+
+    // requirements for calling ORMQL/UNMQL or ORMQR/UNMQR
+    if(uplo == rocblas_fill_upper)
+        rocsolver_ormql_unmql_getMemorySize<BATCHED, STRIDED, T>(
+            side, trans, m, n, nq, batch_count, size_scalars, size_AbyxORwork, size_work2,
+            size_work3, size_work4, size_diagORtmptr, size_trfact, size_workArr, optim_mem);
+
+    else
+        rocsolver_ormqr_unmqr_getMemorySize<BATCHED, STRIDED, T>(
+            side, trans, m, n, nq, batch_count, size_scalars, size_AbyxORwork, size_work2,
+            size_work3, size_work4, size_diagORtmptr, size_trfact, size_workArr, optim_mem);
 }
 
 template <bool COMPLEX, typename T, typename U>
@@ -190,6 +237,80 @@ rocblas_status rocsolver_ormtr_unmtr_template(rocblas_handle handle,
     return rocblas_status_success;
 }
 
+template <bool BATCHED, bool STRIDED, typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
+rocblas_status rocsolver_ormtr_unmtr_template(rocblas_handle handle,
+                                              const rocblas_side side,
+                                              const rocblas_fill uplo,
+                                              const rocblas_operation trans,
+                                              const rocblas_int m,
+                                              const rocblas_int n,
+                                              U A,
+                                              const rocblas_int shiftA,
+                                              const rocblas_int lda,
+                                              const rocblas_stride strideA,
+                                              T* ipiv,
+                                              const rocblas_stride strideP,
+                                              U C,
+                                              const rocblas_int shiftC,
+                                              const rocblas_int ldc,
+                                              const rocblas_stride strideC,
+                                              const rocblas_int batch_count,
+                                              T* scalars,
+                                              T* AbyxORwork,
+                                              void* work2,
+                                              void* work3,
+                                              void* work4,
+                                              T* diagORtmptr,
+                                              T* trfact,
+                                              T** workArr,
+                                              bool optim_mem)
+{
+    ROCSOLVER_ENTER("ormtr_unmtr", "side:", side, "uplo:", uplo, "trans:", trans, "m:", m, "n:", n,
+                    "shiftA:", shiftA, "lda:", lda, "shiftC:", shiftC, "ldc:", ldc,
+                    "bc:", batch_count);
+
+    // quick return
+    if(!n || !m || !batch_count)
+        return rocblas_status_success;
+
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    rocblas_int nq = side == rocblas_side_left ? m : n;
+    rocblas_int cols, rows, colC, rowC;
+    if(side == rocblas_side_left)
+    {
+        rows = m - 1;
+        cols = n;
+        rowC = 1;
+        colC = 0;
+    }
+    else
+    {
+        rows = m;
+        cols = n - 1;
+        rowC = 0;
+        colC = 1;
+    }
+
+    if(uplo == rocblas_fill_upper)
+    {
+        rocsolver_ormql_unmql_template<BATCHED, STRIDED, T>(
+            handle, side, trans, rows, cols, nq - 1, A, shiftA + idx2D(0, 1, lda), lda, strideA,
+            ipiv, strideP, C, shiftC, ldc, strideC, batch_count, scalars, AbyxORwork, work2, work3,
+            work4, diagORtmptr, trfact, workArr, optim_mem);
+    }
+    else
+    {
+        rocsolver_ormqr_unmqr_template<BATCHED, STRIDED, T>(
+            handle, side, trans, rows, cols, nq - 1, A, shiftA + idx2D(1, 0, lda), lda, strideA,
+            ipiv, strideP, C, shiftC + idx2D(rowC, colC, ldc), ldc, strideC, batch_count, scalars,
+            AbyxORwork, work2, work3, work4, diagORtmptr, trfact, workArr, optim_mem);
+    }
+
+    return rocblas_status_success;
+}
+
 /** Adapts A and C to be of the same type **/
 template <bool BATCHED, bool STRIDED, typename T>
 rocblas_status rocsolver_ormtr_unmtr_template(rocblas_handle handle,
@@ -226,6 +347,47 @@ rocblas_status rocsolver_ormtr_unmtr_template(rocblas_handle handle,
         handle, side, uplo, trans, m, n, A, shiftA, lda, strideA, ipiv, strideP,
         cast2constType(workArr), shiftC, ldc, strideC, batch_count, scalars, AbyxORwork,
         diagORtmptr, trfact, workArr + batch_count);
+}
+
+template <bool BATCHED, bool STRIDED, typename T>
+rocblas_status rocsolver_ormtr_unmtr_template(rocblas_handle handle,
+                                              const rocblas_side side,
+                                              const rocblas_fill uplo,
+                                              const rocblas_operation trans,
+                                              const rocblas_int m,
+                                              const rocblas_int n,
+                                              T* const A[],
+                                              const rocblas_int shiftA,
+                                              const rocblas_int lda,
+                                              const rocblas_stride strideA,
+                                              T* ipiv,
+                                              const rocblas_stride strideP,
+                                              T* C,
+                                              const rocblas_int shiftC,
+                                              const rocblas_int ldc,
+                                              const rocblas_stride strideC,
+                                              const rocblas_int batch_count,
+                                              T* scalars,
+                                              T* AbyxORwork,
+                                              void* work2,
+                                              void* work3,
+                                              void* work4,
+                                              T* diagORtmptr,
+                                              T* trfact,
+                                              T** workArr,
+                                              bool optim_mem)
+{
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    rocblas_int blocks = (batch_count - 1) / 256 + 1;
+    ROCSOLVER_LAUNCH_KERNEL(get_array, dim3(blocks), dim3(256), 0, stream, workArr, C, strideC,
+                            batch_count);
+
+    return rocsolver_ormtr_unmtr_template<BATCHED, STRIDED>(
+        handle, side, uplo, trans, m, n, A, shiftA, lda, strideA, ipiv, strideP,
+        cast2constType(workArr), shiftC, ldc, strideC, batch_count, scalars, AbyxORwork, work2,
+        work3, work4, diagORtmptr, trfact, workArr + batch_count, optim_mem);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1463,33 +1463,15 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
             // Order the elements in tmpd and zz using a simple parallel selection/bubble sort.
             // This will allow us to find initial intervals for eigenvalue guesses
-            for(int i = 0; i < tsz; ++i)
+            for(int i = 0; i < dd; i++)
             {
-                if(i < dd)
+                for(int j = 2 * iam + i % 2; j < dd - 1; j += 2 * bdm)
                 {
-                    if(i % 2 == 0)
+                    if(tmpd[j] > tmpd[j + 1])
                     {
-                        for(int j = iam; j < dd / 2; j += bdm)
-                        {
-                            if(tmpd[2 * j] > tmpd[2 * j + 1])
-                            {
-                                swap(tmpd[2 * j], tmpd[2 * j + 1]);
-                                swap(zz[2 * j], zz[2 * j + 1]);
-                                swap(per[2 * j], per[2 * j + 1]);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        for(int j = iam; j < (dd - 1) / 2; j += bdm)
-                        {
-                            if(tmpd[2 * j + 1] > tmpd[2 * j + 2])
-                            {
-                                swap(tmpd[2 * j + 1], tmpd[2 * j + 2]);
-                                swap(zz[2 * j + 1], zz[2 * j + 2]);
-                                swap(per[2 * j + 1], per[2 * j + 2]);
-                            }
-                        }
+                        swap(tmpd[j], tmpd[j + 1]);
+                        swap(zz[j], zz[j + 1]);
+                        swap(per[j], per[j + 1]);
                     }
                 }
                 __syncthreads();
@@ -1500,10 +1482,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             // eigenvalues (D - lambda_i) are updated while computing each eigenvalue.
             // This will prevent collapses and division by zero when an eigenvalue
             // is too close to a pole.
-            for(int j = iam + 1; j < sz; j += bdm)
+            for(int i = iam; i < dd; i += bdm)
             {
-                for(int i = 0; i < dd; ++i)
-                    tmpd[i + j * n] = tmpd[i];
+                for(int j = i + n; j < i + sz * n; j += n)
+                    tmpd[j] = tmpd[i];
             }
 
             // finally copy over all diagonal elements in ev. ev will be overwritten
@@ -1523,14 +1505,19 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 if(mask[j] == 1)
                 {
                     // find position in the ordered array
-                    int cc = 0;
                     valf = p < 0 ? -ev[j] : ev[j];
-                    for(int jj = 0; jj < dd; ++jj)
+                    int count = dd, cc = 0;
+                    while(count > 0)
                     {
-                        if(tmpd[jj + j * n] == valf)
-                            break;
+                        auto step = count / 2;
+                        auto it = cc + step;
+                        if(tmpd[it + j * n] < valf)
+                        {
+                            cc = ++it;
+                            count -= step + 1;
+                        }
                         else
-                            cc++;
+                            count = step;
                     }
 
                     // computed zero will overwrite 'ev' at the corresponding position.

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -39,16 +39,46 @@
 #include "rocsolver/rocsolver.h"
 
 #include <algorithm>
+#include <cmath>
 
 ROCSOLVER_BEGIN_NAMESPACE
 
 #define STEDC_BDIM 512 // Number of threads per thread-block used in main stedc kernels
+
+// bit indicating base deflation candidate
+#define L_F_BCAND_BIT 0
+// bit indicating top deflation candidate
+#define L_F_TCAND_BIT 1
 
 // TODO: using macro STEDC_EXTERNAL_GEMM = true for now. In the future we can pass
 // STEDC_EXTERNAL_GEMM at run time to switch between internal vector updates and
 // external gemm-based updates.
 #define STEDC_EXTERNAL_GEMM true
 
+__host__ __device__ inline rocblas_int get_splits_size(const rocblas_int n)
+{
+    // splits_map layout:
+    // struct {
+    // 0     rocblas_int sort_tmp[n]; // temp buffer used for mapping in stedc_sort()
+    // 1     rocblas_int ns[n];       // the sub-blocks sizes
+    // 2     rocblas_int ps[n];       // the sub-blocks initial positions
+    // 3     rocblas_int idd[n];      // if idd[i] = 0, the value in position i has been deflated  (aka mask)
+    // 4     rocblas_int pers[n];     // container of permutations when solving the secular eqns
+    // 5     rocblas_int szfs[n];     // sizes of the first sub-block in a merge
+    // 6     rocblas_int szs[n];      // sizes of both sub-blocks in a merge
+    // 7     rocblas_int dds[n];      // degrees of secular equation
+    // 8     rocblas_int map[n];      //
+    // 9     rocblas_int dcount[n];   // number of deflations
+    // 10    rocblas_int mns[n];      // merge sizes
+    // 11    rocblas_int mps[n];      // merge initial positions
+    // 12    rocblas_int cand[n];     // deflation candidate flags
+    // 13    rocblas_int midd[n];     // sorted idd
+    // 14    rocblas_int dbg2[n];     //
+    // 15    rocblas_int dbg3[n];     //
+    // 16    rocblas_int dbg4[n];     //
+    // };
+    return 17 * n;
+}
 
 /*************** Main kernels *********************************************************/
 /**************************************************************************************/
@@ -57,18 +87,19 @@ ROCSOLVER_BEGIN_NAMESPACE
 /** STEDC_DIVIDE_KERNEL implements the divide phase of the DC algorithm. It
     divides the input matrix into a 'blks' sub-blocks.
         - This kernel is to be called with as many groups in x as needed to cover all
-        the batch_count problems. Each thread will work with a matrix in the batch. 
+        the batch_count problems. Each thread will work with a matrix in the batch.
         - Size of groups is set to STEDC_BDIM. **/
 template <typename S>
-ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_divide_kernel(const rocblas_int levs,
-                                                                        const rocblas_int blks,
-                                                                        const rocblas_int n,
-                                                                        S* DD,
-                                                                        const rocblas_stride strideD,
-                                                                        S* EE,
-                                                                        const rocblas_stride strideE,
-                                                                        const rocblas_int batch_count,
-                                                                        rocblas_int* splitsA)
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+    stedc_divide_kernel(const rocblas_int levs,
+                        const rocblas_int blks,
+                        const rocblas_int n,
+                        S* DD,
+                        const rocblas_stride strideD,
+                        S* EE,
+                        const rocblas_stride strideE,
+                        const rocblas_int batch_count,
+                        rocblas_int* splitsA)
 {
     // threads and groups indices
     rocblas_int bid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
@@ -81,9 +112,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_divide_kernel(const ro
         S* E = EE + bid * strideE;
 
         // temporary arrays in global memory
-        rocblas_int* splits = splitsA + bid * (5 * n + 2);
+        rocblas_int* splits = splitsA + bid * get_splits_size(n);
         // the sub-blocks sizes
-        rocblas_int* ns = splits + n + 2;
+        rocblas_int* ns = splits + n;
         // the sub-blocks initial positions
         rocblas_int* ps = ns + n;
 
@@ -117,11 +148,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_divide_kernel(const ro
     }
 }
 
-
 //--------------------------------------------------------------------------------------//
 /** STEDC_SOLVE_KERNEL implements the solver phase of the DC algorithm to
    compute the eigenvalues/eigenvectors of the 'blks' different sub-blocks of a matrix.
-        - Call this kernel with batch_count groups in y, and 'blks' groups in x. 
+        - Call this kernel with batch_count groups in y, and 'blks' groups in x.
           Groups are single-thread **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_solve_kernel(const rocblas_int levs,
@@ -160,9 +190,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_solve_kernel(const roc
     rocblas_int* info = iinfo + bid;
 
     // temporary arrays in global memory
-    rocblas_int* splits = splitsA + bid * (5 * n + 2);
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
     // the sub-blocks sizes
-    rocblas_int* ns = splits + n + 2;
+    rocblas_int* ns = splits + n;
     // the sub-blocks initial positions
     rocblas_int* ps = ns + n;
     // workspace for solvers
@@ -171,39 +201,37 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_solve_kernel(const roc
     // Solve the blks sub-blocks in parallel (using classic QR iteration).
     if(sid < blks)
     {
-        rocblas_int sbs = ns[sid];  // size of sub-block
-        rocblas_int p2 = ps[sid];   // start position of sub-block
+        rocblas_int sbs = ns[sid]; // size of sub-block
+        rocblas_int p2 = ps[sid]; // start position of sub-block
 
         run_steqr(tidb, tidb_inc, sbs, D + p2, E + p2, C + p2 + p2 * ldc, ldc, info, W + p2 * 2,
                   30 * sbs, eps, ssfmin, ssfmax, false);
     }
 }
 
-
 //--------------------------------------------------------------------------------------//
-/** STEDC_MERGEPREPARE_KERNEL performs deflation and prepares the secular equation for
-    every pair of sub-blocks that need to be merged. 
-        - Call this kernel with batch_count groups in y, and as many groups as half of the 
+/** STEDC_MERGEPREPARE_DEFLATEZERO_KERNEL performs deflation of zero values
+        - Call this kernel with batch_count groups in y, and as many groups as half of the
           unmerged sub-blocks in current level in x. Each group works with a merge of a pair
           of sub-blocks. Groups are size STEDC_BDIM **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergePrepare_kernel(const rocblas_int levs,
-                              const rocblas_int blks,
-                              const rocblas_int k,
-                              const rocblas_int n,
-                              S* DD,
-                              const rocblas_stride strideD,
-                              S* EE,
-                              const rocblas_stride strideE,
-                              S* CC,
-                              const rocblas_int shiftC,
-                              const rocblas_int ldc,
-                              const rocblas_stride strideC,
-                              S* tmpzA,
-                              S* vecsA,
-                              rocblas_int* splitsA,
-                              const S eps)
+    stedc_mergePrepare_DeflateZero_kernel(const rocblas_int levs,
+                                          const rocblas_int blks,
+                                          const rocblas_int k,
+                                          const rocblas_int n,
+                                          S* DD,
+                                          const rocblas_stride strideD,
+                                          S* EE,
+                                          const rocblas_stride strideE,
+                                          S* CC,
+                                          const rocblas_int shiftC,
+                                          const rocblas_int ldc,
+                                          const rocblas_stride strideC,
+                                          S* tmpzA,
+                                          S* vecsA,
+                                          rocblas_int* splitsA,
+                                          const S eps)
 {
     // threads and groups indices
     // batch instance id
@@ -215,26 +243,31 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int tid, tx;
 
     // select batch instance to work with
-    S* C;
-    if(CC)
-        C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
+    S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
     S* D = DD + bid * strideD;
     S* E = EE + bid * strideE;
 
     // temporary arrays in global memory
-    rocblas_int* splits = splitsA + bid * (5 * n + 2);
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
     // the sub-blocks sizes
-    rocblas_int* ns = splits + n + 2;
+    rocblas_int* ns = splits + n;
     // the sub-blocks initial positions
     rocblas_int* ps = ns + n;
     // if idd[i] = 0, the value in position i has been deflated
     rocblas_int* idd = ps + n;
     // container of permutations when solving the secular eqns
     rocblas_int* pers = idd + n;
+    // sizes of the first sub-block in a merge
+    rocblas_int* szfs = pers + n;
+    // sizes of both sub-blocks in a merge
+    rocblas_int* szs = szfs + n;
+    // degrees of secular equation
+    rocblas_int* dds = szs + n;
     // the rank-1 modification vectors in the merges
     S* z = tmpzA + bid * (2 * n);
-    // roots of secular equations
-    S* evs = z + n;
+    // temp for tolerance values used in deflation
+    // IMPORTANT: tols maps to the same memory as evs
+    S* tols = z + n;
     // updated eigenvectors after merges
     S* vecs = vecsA + bid * 2 * (n * n);
     // temp values during the merges
@@ -242,9 +275,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in shared memory
     // used to store temp values during the different reductions
-    extern __shared__ rocblas_int lsmem[];
-    S* inrmsd = reinterpret_cast<S*>(lsmem);
-    S* inrmsz = inrmsd + hipBlockDim_x;
+    __shared__ S inrmsd[STEDC_BDIM];
+    __shared__ S inrmsz[STEDC_BDIM];
 
     // tn is the number of thread-groups needed in level k of the merge
     rocblas_int bd = 1 << k;
@@ -272,6 +304,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         sz = ns[tid];
         for(int j = 1; j < bd; ++j)
             sz += ns[tid + j];
+        szfs[tid] = sz;
         // with this, all threads involved in a merge
         // will point to the same row of C and the same off-diag element
         S* ptz = (iam == 0) ? C + p2 - 1 + sz : C + p2;
@@ -280,7 +313,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // copy elements of z
         for(int j = tx; j < sz; j += dim)
             z[p2 + j] = ptz[(p2 + j) * ldc] / sqrt(2);
-
 
         // 2. calculate deflation tolerance
         // ----------------------------------------------------------------
@@ -321,7 +353,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         maxd = maxz > maxd ? maxz : maxd;
         S tol = 8 * eps * maxd;
 
-
         // 3. deflate eigenvalues
         // ----------------------------------------------------------------
         // determine boundaries of what would be the new merged sub-block
@@ -331,92 +362,728 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         sz = ns[in];
         for(int i = 1; i < bdm; ++i)
             sz += ns[in + i];
+        szs[in] = sz;
+        tols[in] = tol;
         in = ps[in];
 
         // first deflate zero components
-        S f, g, c, s, rr;
         for(int i = tidb; i < sz; i += hipBlockDim_x)
         {
             tx = in + i;
-            g = z[tx];
+            S g = z[tx];
             if(abs(p * g) <= tol)
                 // deflated ev because component in z is zero
                 idd[tx] = 0;
             else
                 idd[tx] = 1;
         }
-        __syncthreads();
+    }
+}
 
-        // now deflate repeated values
-        rocblas_int sz_even, sz_half, base, top, com;
-        sz_even = (sz % 2 == 1) ? sz + 1 : sz;
-        sz_half = sz_even / 2;
+//--------------------------------------------------------------------------------------//
+/** STEDC_MERGEPREPARE_FILL_KERNEL fills different arrays in splits struct
+        - Call this kernel with batch_count groups in y, and as many groups as half of the
+          unmerged sub-blocks in current level in x. Each group works with a merge of a pair
+          of sub-blocks. Groups are size STEDC_BDIM **/
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+    stedc_mergePrepare_Fill_kernel(const rocblas_int levs,
+                                   const rocblas_int blks,
+                                   const rocblas_int k,
+                                   const rocblas_int n,
+                                   S* tmpzA,
+                                   S* vecsA,
+                                   rocblas_int* splitsA)
+{
+    // threads and groups indices
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+    // merge sub-block id
+    rocblas_int sid = hipBlockIdx_x;
 
-        // the number of rounds needed is sz_even - 1
-        for(int r = 0; r < sz_even - 1; ++r)
+    // temporary arrays in global memory
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    // the sub-blocks sizes
+    rocblas_int* ns = splits + n;
+    // the sub-blocks initial positions
+    rocblas_int* ps = ns + n;
+    // if idd[i] = 0, the value in position i has been deflated
+    rocblas_int* idd = ps + n;
+    // container of permutations when solving the secular eqns
+    rocblas_int* pers = idd + n;
+    // sizes of the first sub-block in a merge
+    rocblas_int* szfs = pers + n;
+    // sizes of both sub-blocks in a merge
+    rocblas_int* szs = szfs + n;
+    // degrees of secular equation
+    rocblas_int* dds = szs + n;
+    // the rank-1 modification vectors in the merges
+    S* z = tmpzA + bid * (2 * n);
+    // temp for tolerance values used in deflation
+    // IMPORTANT: tols maps to the same memory as evs
+    S* tols = z + n;
+    // updated eigenvectors after merges
+    S* vecs = vecsA + bid * 2 * (n * n);
+    // temp values during the merges
+    S* temps = vecs + (n * n);
+
+    S* cc = vecs + 2 * n;
+    S* ss = vecs + 3 * n;
+    S* mtols = vecs + 4 * n;
+    S* md = vecs + 5 * n;
+
+    rocblas_int* map = splits + 8 * n;
+    rocblas_int* dcount = splits + 9 * n;
+    rocblas_int* mns = splits + 10 * n;
+    rocblas_int* mps = splits + 11 * n;
+    rocblas_int* cand = splits + 12 * n;
+    rocblas_int* midd = splits + 13 * n;
+
+    rocblas_int in = sid << (k + 1);
+    rocblas_int sz = szs[in];
+    rocblas_int p = ps[in];
+    S tol = tols[in];
+
+    for(int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x)
+    {
+        int id = p + i;
+        mns[id] = sz;
+        mps[id] = p;
+        mtols[id] = tol;
+        dcount[id] = 0;
+        map[id] = 0;
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+/** STEDC_MERGEPREPARE_SORTD_KERNEL sorts D array and construct map of original positions
+        - Call this kernel with n groups in x and batch_count groups in y. Groups are size STEDC_BDIM **/
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+    stedc_mergePrepare_SortD_kernel(const rocblas_int levs,
+                                    const rocblas_int blks,
+                                    const rocblas_int k,
+                                    const rocblas_int n,
+                                    S* DD,
+                                    const rocblas_stride strideD,
+                                    S* tmpzA,
+                                    S* vecsA,
+                                    rocblas_int* splitsA)
+{
+    // threads and groups indices
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+    // merge sub-block id
+    rocblas_int sid = hipBlockIdx_x;
+
+    // select batch instance to work with
+    S* D = DD + bid * strideD;
+
+    // temporary arrays in global memory
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    // the sub-blocks sizes
+    rocblas_int* ns = splits + n;
+    // the sub-blocks initial positions
+    rocblas_int* ps = ns + n;
+    // if idd[i] = 0, the value in position i has been deflated
+    rocblas_int* idd = ps + n;
+    // container of permutations when solving the secular eqns
+    rocblas_int* pers = idd + n;
+    // sizes of the first sub-block in a merge
+    rocblas_int* szfs = pers + n;
+    // sizes of both sub-blocks in a merge
+    rocblas_int* szs = szfs + n;
+    // degrees of secular equation
+    rocblas_int* dds = szs + n;
+    // the rank-1 modification vectors in the merges
+    S* z = tmpzA + bid * (2 * n);
+    // temp for tolerance values used in deflation
+    // IMPORTANT: tols maps to the same memory as evs
+    S* tols = z + n;
+    // updated eigenvectors after merges
+    S* vecs = vecsA + bid * 2 * (n * n);
+    // temp values during the merges
+    S* temps = vecs + (n * n);
+
+    S* cc = vecs + 2 * n;
+    S* ss = vecs + 3 * n;
+    S* mtols = vecs + 4 * n;
+    S* md = vecs + 5 * n;
+
+    rocblas_int* map = splits + 8 * n;
+    rocblas_int* dcount = splits + 9 * n;
+    rocblas_int* mns = splits + 10 * n;
+    rocblas_int* mps = splits + 11 * n;
+    rocblas_int* cand = splits + 12 * n;
+    rocblas_int* midd = splits + 13 * n;
+
+    S d = D[sid];
+    rocblas_int sz = mns[sid];
+    rocblas_int p = mps[sid];
+    rocblas_int dz = idd[sid];
+
+    constexpr int regs = 8;
+    const int chunk_width = regs * hipBlockDim_x;
+    const int n_chunks = (sz - 1) / chunk_width + 1;
+    S bval[regs];
+    int dzs[regs];
+
+    int nan = 0;
+    int lt = 0;
+    int eq = 0;
+
+    for(int chunk = 0; chunk < n_chunks; chunk++)
+    {
+        for(int i = 0; i < regs; i++)
         {
-            // in each round threads analyze pairs of values in parallel
-            // sz_half pairs are needed
-            for(int i = tidb; i < sz_half; i += hipBlockDim_x)
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < sz)
             {
-                // determine pair of values (base, top)
-                com = 2 * (i - r);
-                base = (i == 0)             ? 0
-                    : (r < i)               ? com
-                    : (r > i - 1 + sz_half) ? 2 * (sz_even - 1) + com
-                                            : 1 - com;
+                bval[i] = D[p + x];
+                dzs[i] = idd[p + x];
+            }
+        }
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < sz)
+            {
+                nan += (bval[i] != bval[i]);
+                // lt - how many values are less then the current
+                // eq - how many values are equal to the current
+                // all zero deflated values have to be grouped at the end
+                // so we order any deflated value > any non-deflated value
+                // dz == 0 - current is deflated, dz[i] == 1 - other value is not deflated
+                lt += (dz < dzs[i]) || (dz == dzs[i] && bval[i] < d);
+                eq += (dz == dzs[i]) && (bval[i] == d && (p + x) < sid);
+            }
+        }
+    }
 
-                com = 2 * (i + r);
-                top = (r < sz_half - i)     ? 1 + com
-                    : (r > sz_even - 2 - i) ? 3 - 2 * sz_even + com
-                                            : 2 * (sz_even - 1) - com;
+    int pos = lt + eq;
+    __shared__ int lds[STEDC_BDIM];
+    // Reduction (sum of pos across all lanes in a workgroup)
+    // on each iteration reduction is done within a subgroup of size of 2*bit
+    // by xoring corresponding bit of an address.
+    // The faster implementation should use dpp + a single trip through lds
+    // but keeping code simple for now.
+    int bit = 1;
+    while(bit < STEDC_BDIM)
+    {
+        lds[hipThreadIdx_x ^ bit] = pos;
+        __syncthreads();
+        pos += lds[hipThreadIdx_x];
+        __syncthreads();
+        bit *= 2;
+    }
 
-                if(base > top)
+    if(hipThreadIdx_x == 0)
+    {
+        map[pos + p] = sid;
+        md[pos + p] = d;
+        midd[pos + p] = dz;
+    }
+
+    __syncthreads();
+    // The NAN fp value is unordered, so it is possible that with computed
+    // new positions it would be silently overwriten with non NAN value.
+    // Make sure we propagate NAN. It is likely to have more NANs in the output
+    // than in the input, but the following computations are doomed anyway.
+    if(nan)
+    {
+        md[sid] = NAN;
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+/** STEDC_MERGEPREPARE_SETCANDFLAGS_KERNEL fills cand[] array with deflation candidate flags
+        - Call this kernel with ((n - 1)/STEDC_BDIM+1) groups in x and batch_count groups in y.
+        Groups are size STEDC_BDIM **/
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+    stedc_mergePrepare_SetCandFlags_kernel(const rocblas_int levs,
+                                           const rocblas_int blks,
+                                           const rocblas_int k,
+                                           const rocblas_int n,
+                                           S* DD,
+                                           const rocblas_stride strideD,
+                                           S* tmpzA,
+                                           S* vecsA,
+                                           rocblas_int* splitsA)
+{
+    // threads and groups indices
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+
+    // select batch instance to work with
+    S* D = DD + bid * strideD;
+
+    // temporary arrays in global memory
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    S* z = tmpzA + bid * (2 * n);
+    // updated eigenvectors after merges
+    S* vecs = vecsA + bid * 2 * (n * n);
+    // temp values during the merges
+    S* temps = vecs + (n * n);
+
+    S* cc = vecs + 2 * n;
+    S* ss = vecs + 3 * n;
+    S* mtols = vecs + 4 * n;
+    S* md = vecs + 5 * n;
+
+    rocblas_int* map = splits + 8 * n;
+    rocblas_int* dcount = splits + 9 * n;
+    rocblas_int* mns = splits + 10 * n;
+    rocblas_int* mps = splits + 11 * n;
+    rocblas_int* cand = splits + 12 * n;
+    rocblas_int* midd = splits + 13 * n;
+
+    constexpr int F_BCAND = 1 << L_F_BCAND_BIT;
+    constexpr int F_TCAND = 1 << L_F_TCAND_BIT;
+
+    // find deflate candidates
+    int i = hipThreadIdx_x + hipBlockDim_x * hipBlockIdx_x;
+    if(i < n)
+    {
+        int next = (i + 1) < n ? (i + 1) : i;
+        int prev = (i > 0) ? (i - 1) : 0;
+        S tol = mtols[i];
+        S d = md[i];
+        S dn = md[next];
+        S dp = md[prev];
+        rocblas_int p = mps[i];
+        rocblas_int pn = mps[next];
+        rocblas_int pp = mps[prev];
+
+        int bcandidate = midd[i] && midd[next] // not yet deflated
+            && p == pn // in the same merge block
+            && std::abs(d - dn) <= tol // within tolerance
+            && i != (n - 1) // isn't last
+            ;
+        int tcandidate = midd[i] && midd[prev] // not yet deflated
+            && p == pp // in the same merge block
+            && std::abs(d - dp) <= tol // within tolerance
+            && i > 0 // isn't first
+            ;
+        cand[i] = (bcandidate << L_F_BCAND_BIT) + (tcandidate << L_F_TCAND_BIT);
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+/** STEDC_MERGEPREPARE_DEFLATECOUNT_KERNEL fills dcount[] array with number of deflations for each base point
+        - Call this kernel with ((n - 1)/STEDC_BDIM+1) groups in x and batch_count groups in y.
+        Groups are size STEDC_BDIM **/
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+    stedc_mergePrepare_DeflateCount_kernel(const rocblas_int levs,
+                                           const rocblas_int blks,
+                                           const rocblas_int k,
+                                           const rocblas_int n,
+                                           S* DD,
+                                           const rocblas_stride strideD,
+                                           S* tmpzA,
+                                           S* vecsA,
+                                           rocblas_int* splitsA)
+{
+    // threads and groups indices
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+
+    // select batch instance to work with
+    S* D = DD + bid * strideD;
+
+    // temporary arrays in global memory
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    // the sub-blocks sizes
+    rocblas_int* ns = splits + n;
+    // the sub-blocks initial positions
+    rocblas_int* ps = ns + n;
+    // if idd[i] = 0, the value in position i has been deflated
+    rocblas_int* idd = ps + n;
+    // the rank-1 modification vectors in the merges
+    S* z = tmpzA + bid * (2 * n);
+    // updated eigenvectors after merges
+    S* vecs = vecsA + bid * 2 * (n * n);
+    // temp values during the merges
+    S* temps = vecs + (n * n);
+
+    S* cc = vecs + 2 * n;
+    S* ss = vecs + 3 * n;
+    S* mtols = vecs + 4 * n;
+    S* md = vecs + 5 * n;
+
+    rocblas_int* map = splits + 8 * n;
+    rocblas_int* dcount = splits + 9 * n;
+    rocblas_int* mns = splits + 10 * n;
+    rocblas_int* mps = splits + 11 * n;
+    rocblas_int* cand = splits + 12 * n;
+    rocblas_int* midd = splits + 13 * n;
+
+    constexpr rocblas_int max_len = 4096;
+    __shared__ S ldsD[max_len];
+    __shared__ int lcand[max_len];
+    constexpr int F_BCAND = 1 << L_F_BCAND_BIT;
+    constexpr int F_TCAND = 1 << L_F_TCAND_BIT;
+
+    int start = hipBlockDim_x * hipBlockIdx_x;
+    int base = start + hipThreadIdx_x;
+    int prev = (base > 0) ? (base - 1) : 0;
+    int candp = (prev < n) ? cand[prev] : 0;
+    int candb = (base < n) ? cand[base] : 0;
+    S bval = (base < n) ? md[base] : 0;
+    S tol = (base < n) ? mtols[base] : 0;
+
+    // cache max_len values of D[] and cand[]
+    for(int i = hipThreadIdx_x; i < max_len; i += hipBlockDim_x)
+    {
+        int x = start + i;
+        ldsD[i] = (x < n) ? md[x] : 0;
+        lcand[i] = (x < n) ? cand[x] : 0;
+    }
+    __syncthreads();
+
+    if((candb & F_BCAND) && (base == 0 || !(candp & F_BCAND)))
+    {
+        int top = base + 2;
+        int candt = lcand[top - start];
+        while(top < n && (candt & F_TCAND))
+        {
+            // first max_len values are prefetched into lds,
+            // access global memory only if need to go beyond that
+            // which is very unlikely
+            S tval = (top - start) < max_len ? ldsD[top - start] : md[top];
+
+            if((tval - bval) > tol)
+            {
+                dcount[base] = top - base - 1;
+                base = top;
+                bval = tval;
+            }
+            top++;
+
+            // first max_len values are prefetched into lds,
+            // access global memory only if need to go beyond that
+            // which is very unlikely
+            candt = (top - start) < max_len ? lcand[top - start] : cand[top];
+        }
+        dcount[base] = top - base - 1;
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+/** STEDC_MERGEPREPARE_DEFLATEAPPLY_KERNEL applies deflations and saves c/s values used to rotate C vectors
+        - Call this kernel with ((n - 1)/STEDC_BDIM+1) groups in x and batch_count groups in y.
+        Groups are size STEDC_BDIM **/
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+    stedc_mergePrepare_DeflateApply_kernel(const rocblas_int levs,
+                                           const rocblas_int blks,
+                                           const rocblas_int k,
+                                           const rocblas_int n,
+                                           S* DD,
+                                           const rocblas_stride strideD,
+                                           S* tmpzA,
+                                           S* vecsA,
+                                           rocblas_int* splitsA)
+{
+    // threads and groups indices
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+
+    // select batch instance to work with
+    S* D = DD + bid * strideD;
+
+    // temporary arrays in global memory
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    // the sub-blocks sizes
+    rocblas_int* ns = splits + n;
+    // the sub-blocks initial positions
+    rocblas_int* ps = ns + n;
+    // if idd[i] = 0, the value in position i has been deflated
+    rocblas_int* idd = ps + n;
+    // the rank-1 modification vectors in the merges
+    S* z = tmpzA + bid * (2 * n);
+    // updated eigenvectors after merges
+    S* vecs = vecsA + bid * 2 * (n * n);
+    // temp values during the merges
+    S* temps = vecs + (n * n);
+
+    S* cc = vecs + 2 * n;
+    S* ss = vecs + 3 * n;
+    S* mtols = vecs + 4 * n;
+    S* md = vecs + 5 * n;
+
+    rocblas_int* map = splits + 8 * n;
+    rocblas_int* dcount = splits + 9 * n;
+    rocblas_int* mns = splits + 10 * n;
+    rocblas_int* mps = splits + 11 * n;
+    rocblas_int* cand = splits + 12 * n;
+    rocblas_int* midd = splits + 13 * n;
+
+    constexpr rocblas_int max_len = 4096;
+    __shared__ S lz[max_len];
+    __shared__ int lmap[max_len];
+
+    int start = hipBlockDim_x * hipBlockIdx_x;
+    int base = start + hipThreadIdx_x;
+    int cnt = (base < n) ? dcount[base] : 0;
+
+    // cache max_len values of map[] and appropriate z[]
+    for(int i = hipThreadIdx_x; i < max_len; i += hipBlockDim_x)
+    {
+        int x = start + i;
+        lmap[i] = (x < n) ? map[x] : 0;
+        lz[i] = (x < n) ? z[map[x]] : 0;
+    }
+    __syncthreads();
+
+    if(cnt)
+    {
+        S baseval = lz[hipThreadIdx_x];
+        for(int j = 0; j < cnt; j++)
+        {
+            int top = base + j + 1;
+
+            // first max_len values are prefetched into lds,
+            // access global memory only if need to go beyond that
+            // which is very unlikely
+            int idx = (top - start) < max_len ? lmap[top - start] : map[top];
+            S g = (top - start) < max_len ? lz[top - start] : z[idx];
+
+            S f = baseval;
+            S c, s, rr;
+            lartg(f, g, c, s, rr);
+            baseval = rr;
+
+            idd[idx] = 0;
+            z[idx] = 0;
+            cc[idx] = c;
+            ss[idx] = s;
+        }
+        z[lmap[hipThreadIdx_x]] = baseval;
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+/** STEDC_MERGEROTATE_KERNEL performs rotation of vectors corresponding to deflations
+        - Call this kernel with batch_count groups in y, and n (matrix size) groups in x.
+        - Each group will deal with one deflation group, groups that don't correspond to
+          a deflation group will do nothing **/
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+    stedc_mergeRotate_kernel(const rocblas_int levs,
+                             const rocblas_int blks,
+                             const rocblas_int k,
+                             const rocblas_int n,
+                             S* CC,
+                             const rocblas_int shiftC,
+                             const rocblas_int ldc,
+                             const rocblas_stride strideC,
+                             S* tmpzA,
+                             S* vecsA,
+                             rocblas_int* splitsA)
+{
+    // threads and groups indices
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+
+    // temporary arrays in global memory
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
+
+    // updated eigenvectors after merges
+    S* vecs = vecsA + bid * 2 * (n * n);
+    // temp values during the merges
+    S* temps = vecs + (n * n);
+
+    S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
+
+    rocblas_int* map = splits + 8 * n;
+    rocblas_int* dcounts = splits + 9 * n;
+    S* cc = vecs + 2 * n;
+    S* ss = vecs + 3 * n;
+
+    constexpr int regs = 16;
+    const int chunk_width = regs * hipBlockDim_x;
+    const int n_chunks = (n - 1) / chunk_width + 1;
+    S bval[regs];
+    S tval[regs];
+
+    rocblas_int dgs = hipBlockIdx_x;
+    rocblas_int dcnt = dcounts[dgs];
+    if(dcnt)
+    {
+        rocblas_int base = map[dgs];
+        S* Cbase = C + base * ldc;
+
+        for(int chunk = 0; chunk < n_chunks; chunk++)
+        {
+            for(int i = 0; i < regs; i++)
+            {
+                int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+                if(x < n)
                 {
-                    com = base;
-                    base = top;
-                    top = com;
+                    bval[i] = Cbase[x];
+                }
+            }
+
+            for(int dn = 0; dn < dcnt; dn++)
+            {
+                rocblas_int top = map[dgs + dn + 1];
+                S c = cc[top];
+                S s = ss[top];
+                S* Ctop = C + top * ldc;
+
+                for(int i = 0; i < regs; i++)
+                {
+                    int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+                    if(x < n)
+                    {
+                        tval[i] = Ctop[x];
+                    }
                 }
 
-                // compare values and deflate if needed
-                base += in;
-                top += in;
-                if(idd[base] == 1 && idd[top] == 1 && top < sz + in)
+                for(int i = 0; i < regs; i++)
                 {
-                    if(abs(D[base] - D[top]) <= tol)
+                    S valf = bval[i];
+                    S valg = tval[i];
+                    bval[i] = valf * c - valg * s;
+                    tval[i] = valf * s + valg * c;
+                }
+
+                for(int i = 0; i < regs; i++)
+                {
+                    int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+                    if(x < n)
                     {
-                        // deflated ev because it is repeated
-                        idd[top] = 0;
-                        // rotation to eliminate component in z
-                        g = z[top];
-                        f = z[base];
-                        lartg(f, g, c, s, rr);
-                        z[base] = rr;
-                        z[top] = 0;
-                        // update C with the rotation
-                        for(int ii = 0; ii < n; ++ii)
-                        {
-                            valf = C[ii + base * ldc];
-                            valg = C[ii + top * ldc];
-                            C[ii + base * ldc] = valf * c - valg * s;
-                            C[ii + top * ldc] = valf * s + valg * c;
-                        }
+                        Ctop[x] = tval[i];
                     }
                 }
                 __syncthreads();
             }
-        }
 
+            for(int i = 0; i < regs; i++)
+            {
+                int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+                if(x < n)
+                {
+                    Cbase[x] = bval[i];
+                }
+            }
+        }
+    }
+}
+
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+    stedc_mergePrepare_Organize_kernel(const rocblas_int levs,
+                                       const rocblas_int blks,
+                                       const rocblas_int k,
+                                       const rocblas_int n,
+                                       S* DD,
+                                       const rocblas_stride strideD,
+                                       S* EE,
+                                       const rocblas_stride strideE,
+                                       S* CC,
+                                       const rocblas_int shiftC,
+                                       const rocblas_int ldc,
+                                       const rocblas_stride strideC,
+                                       S* tmpzA,
+                                       S* vecsA,
+                                       rocblas_int* splitsA,
+                                       const S eps)
+{
+    // threads and groups indices
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+    // merge sub-block id
+    rocblas_int sid = hipBlockIdx_x;
+    // thread id
+    rocblas_int tidb = hipThreadIdx_x;
+    rocblas_int tid, tx;
+
+    // select batch instance to work with
+    S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
+    S* D = DD + bid * strideD;
+    S* E = EE + bid * strideE;
+
+    // temporary arrays in global memory
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    // the sub-blocks sizes
+    rocblas_int* ns = splits + n;
+    // the sub-blocks initial positions
+    rocblas_int* ps = ns + n;
+    // if idd[i] = 0, the value in position i has been deflated
+    rocblas_int* idd = ps + n;
+    // container of permutations when solving the secular eqns
+    rocblas_int* pers = idd + n;
+    // sizes of the first sub-block in a merge
+    rocblas_int* szfs = pers + n;
+    // sizes of both sub-blocks in a merge
+    rocblas_int* szs = szfs + n;
+    // degrees of secular equation
+    rocblas_int* dds = szs + n;
+    // the rank-1 modification vectors in the merges
+    S* z = tmpzA + bid * (2 * n);
+    // temp for tolerance values used in deflation
+    // IMPORTANT: tols maps to the same memory as evs
+    S* tols = z + n;
+    // updated eigenvectors after merges
+    S* vecs = vecsA + bid * 2 * (n * n);
+    // temp values during the merges
+    S* temps = vecs + (n * n);
+
+    // tn is the number of thread-groups needed in level k of the merge
+    rocblas_int bd = 1 << k;
+    rocblas_int bdm = bd << 1;
+    rocblas_int tn = blks / bdm;
+
+    // Work with merges on level k. A thread-group works with two leaves in the merge tree.
+    if(sid < tn)
+    {
+        rocblas_int iam, sz, dim, dim2, p2;
+
+        // tid indexes the sub-blocks in the entire matrix
+        // iam indexes the sub-blocks in the context of the merge
+        // (according to its level in the merge tree)
+        dim = hipBlockDim_x / 2;
+        iam = tidb / dim;
+        tx = tidb % dim;
+        tid = sid * bdm + iam * bd;
+        p2 = ps[tid];
+
+        // 1. find rank-1 modification components (z and p) for this merge
+        // ----------------------------------------------------------------
+        // Threads with iam = 0 work with components below the merge point;
+        // threads with iam = 1 work above the merge point
+        //sz = ns[tid];
+        //for(int j = 1; j < bd; ++j)
+        //    sz += ns[tid + j];
+        sz = szfs[tid];
+        // with this, all threads involved in a merge
+        // will point to the same row of C and the same off-diag element
+        S* ptz = (iam == 0) ? C + p2 - 1 + sz : C + p2;
+        S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
+
+        // 3. deflate eigenvalues
+        // ----------------------------------------------------------------
+        // determine boundaries of what would be the new merged sub-block
+        // 'in' will be its initial position.
+        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
+        rocblas_int in = tid - iam * bd;
+        //sz = ns[in];
+        //for(int i = 1; i < bdm; ++i)
+        //    sz += ns[in + i];
+        sz = szs[in];
+        in = ps[in];
 
         // 4. Organize data with non-deflated values to prepare secular equation
-        // ------------------------------------------------------------------------ 
+        // ------------------------------------------------------------------------
         // define shifted arrays
         S* tmpd = temps + in * n;
         S* diag = D + in;
         rocblas_int* mask = idd + in;
         S* zz = z + in;
         rocblas_int* per = pers + in;
-        S* ev = evs + in;
 
         // find degree and components of secular equation
         // tmpd contains the non-deflated diagonal elements (ie. poles of the
@@ -437,14 +1104,160 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 dd++;
             }
         }
+        dds[in] = dd;
     }
 }
 
+template <typename S>
+void __device__ inline sort_tmpd_zz(const rocblas_int dd,
+                                    const rocblas_int iam,
+                                    const rocblas_int bdm,
+                                    S* tmpd,
+                                    S* zz,
+                                    rocblas_int* per)
+{
+    // Order the elements in tmpd and zz using a simple parallel selection/bubble sort.
+    // This will allow us to find initial intervals for eigenvalue guesses
+    for(int i = 0; i < dd; i++)
+    {
+        for(int j = 2 * iam + i % 2; j < dd - 1; j += 2 * bdm)
+        {
+            if(tmpd[j] > tmpd[j + 1])
+            {
+                swap(tmpd[j], tmpd[j + 1]);
+                swap(zz[j], zz[j + 1]);
+                swap(per[j], per[j + 1]);
+            }
+        }
+        __syncthreads();
+    }
+}
+
+template <typename S>
+void __device__ inline copy_d_ev(const rocblas_int dd,
+                                 const rocblas_int iam,
+                                 const rocblas_int bdm,
+                                 const rocblas_int sz,
+                                 const rocblas_int n,
+                                 S* tmpd,
+                                 S* ev,
+                                 S* diag)
+{
+    // make dd copies of the non-deflated ordered diagonal elements
+    // (i.e. the poles of the secular eqn) so that the distances to the
+    // eigenvalues (D - lambda_i) are updated while computing each eigenvalue.
+    // This will prevent collapses and division by zero when an eigenvalue
+    // is too close to a pole.
+    for(int i = iam; i < dd; i += bdm)
+    {
+        for(int j = i + n; j < i + sz * n; j += n)
+            tmpd[j] = tmpd[i];
+    }
+
+    // finally copy over all diagonal elements in ev. ev will be overwritten
+    // by the new computed eigenvalues of the merged block
+    for(int i = iam; i < sz; i += bdm)
+        ev[i] = diag[i];
+}
+
+template <typename S>
+void __device__ inline solve_seq_eqns(const rocblas_int dd,
+                                      const rocblas_int iam,
+                                      const rocblas_int bdm,
+                                      const rocblas_int sz,
+                                      const rocblas_int n,
+                                      const S p,
+                                      const S eps,
+                                      const S ssfmin,
+                                      const S ssfmax,
+                                      const rocblas_int* mask,
+                                      S* tmpd,
+                                      S* ev,
+                                      S* zz)
+{
+    /* ----------------------------------------------------------------- */
+
+    // 2. Solve secular eqns, i.e. find the dd zeros
+    // corresponding to non-deflated new eigenvalues of the merged block
+    /* ----------------------------------------------------------------- */
+    // each thread will find a different zero in parallel
+    S a, b;
+    for(int j = iam; j < sz; j += bdm)
+    {
+        if(mask[j] == 1)
+        {
+            // find position in the ordered array
+            S valf = p < 0 ? -ev[j] : ev[j];
+            int count = dd, cc = 0;
+            while(count > 0)
+            {
+                auto step = count / 2;
+                auto it = cc + step;
+                if(tmpd[it + j * n] < valf)
+                {
+                    cc = ++it;
+                    count -= step + 1;
+                }
+                else
+                    count = step;
+            }
+
+            // computed zero will overwrite 'ev' at the corresponding position.
+            // 'tmpd' will be updated with the distances D - lambda_i.
+            // deflated values are not changed.
+            rocblas_int linfo;
+
+#if defined(ROCSOLVER_USE_REFERENCE_SECULAR_EQUATIONS_SOLVER)
+            linfo = slaed4(dd, cc, tmpd + j * n, zz, std::abs(p), ev[j]);
+#else
+            if(cc == dd - 1)
+                linfo = seq_solve_ext(dd, tmpd + j * n, zz, (p < 0 ? -p : p), ev + j, eps, ssfmin,
+                                      ssfmax);
+            else
+                linfo = seq_solve(dd, tmpd + j * n, zz, (p < 0 ? -p : p), cc, ev + j, eps, ssfmin,
+                                  ssfmax);
+#endif
+
+            if(p < 0)
+                ev[j] *= -1;
+        }
+    }
+}
+
+template <typename S>
+void __device__ inline rescale_z(const rocblas_int dd,
+                                 const rocblas_int iam,
+                                 const rocblas_int bdm,
+                                 const rocblas_int sz,
+                                 const rocblas_int n,
+                                 const rocblas_int* per,
+                                 const rocblas_int* mask,
+                                 const S* tmpd,
+                                 const S* diag,
+                                 S* zz)
+{
+    // Re-scale vector Z to avoid bad numerics when an eigenvalue
+    // is too close to a pole
+    for(int i = iam; i < dd; i += bdm)
+    {
+        S valf = 1;
+        for(int j = 0; j < sz; ++j)
+        {
+            if(mask[j] == 1)
+            {
+                S valg = tmpd[i + j * n];
+                valf *= (per[i] == j) ? valg : valg / (diag[per[i]] - diag[j]);
+            }
+        }
+        valf = sqrt(std::abs(valf));
+        zz[i] = zz[i] < 0 ? -valf : valf;
+    }
+}
 
 //--------------------------------------------------------------------------------------//
-/** STEDC_MERGEVALUES_KERNEL solves the secular equation for every pair of sub-blocks 
-    that need to be merged. 
-        - Call this kernel with batch_count groups in y, and as many groups as half of the 
+/** STEDC_MERGEVALUES_KERNEL solves the secular equation for every pair of sub-blocks
+    that need to be merged.
+        - Call this kernel with batch_count groups in y, and as many groups as half of the
           unmerged sub-blocks in current level in x. Each group works with a merge of a pair
           of sub-blocks. Groups are size STEDC_BDIM **/
 template <typename S>
@@ -478,15 +1291,21 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* E = EE + bid * strideE;
 
     // temporary arrays in global memory
-    rocblas_int* splits = splitsA + bid * (5 * n + 2);
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
     // the sub-blocks sizes
-    rocblas_int* ns = splits + n + 2;
+    rocblas_int* ns = splits + n;
     // the sub-blocks initial positions
     rocblas_int* ps = ns + n;
     // if idd[i] = 0, the value in position i has been deflated
     rocblas_int* idd = ps + n;
     // container of permutations when solving the secular eqns
     rocblas_int* pers = idd + n;
+    // sizes of the first sub-block in a merge
+    rocblas_int* szfs = pers + n;
+    // sizes of both sub-blocks in a merge
+    rocblas_int* szs = szfs + n;
+    // degrees of secular equation
+    rocblas_int* dds = szs + n;
     // the rank-1 modification vectors in the merges
     S* z = tmpzA + bid * (2 * n);
     // roots of secular equations
@@ -519,9 +1338,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // Find off-diagonal element of the merge
         // Threads with iam = 0 work with components below the merge point;
         // threads with iam = 1 work above the merge point
-        sz = ns[tid];
-        for(int j = 1; j < bd; ++j)
-            sz += ns[tid + j];
+        //sz = ns[tid];
+        //for(int j = 1; j < bd; ++j)
+        //    sz += ns[tid + j];
+        sz = szfs[tid];
         // with this, all threads involved in a merge
         // will point to the same row of C and the same off-diag element
         S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
@@ -530,14 +1350,14 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         // 'in' will be its initial position.
         // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
         rocblas_int in = tid - iam * bd;
-        sz = ns[in];
-        for(int i = 1; i < bdm; ++i)
-            sz += ns[in + i];
+        //sz = ns[in];
+        //for(int i = 1; i < bdm; ++i)
+        //    sz += ns[in + i];
+        sz = szs[in];
         in = ps[in];
 
-
         // 1. Organize data with non-deflated values to prepare secular equation
-        // ----------------------------------------------------------------- 
+        // -----------------------------------------------------------------
         // All threads of the group participating in the merge will work together
         // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
         iam = tidb;
@@ -552,117 +1372,406 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         rocblas_int* per = pers + in;
 
         // find degree of secular equation
-        rocblas_int dd = 0;
-        for(int i = 0; i < sz; ++i)
-        {
-            if(mask[i] == 1)
-                dd++;
-        }
+        rocblas_int dd = dds[in];
+        //rocblas_int dd = 0;
+        //for(int i = 0; i < sz; ++i)
+        //{
+        //    if(mask[i] == 1)
+        //        dd++;
+        //}
 
-        // Order the elements in tmpd and zz using a simple parallel selection/bubble sort.
-        // This will allow us to find initial intervals for eigenvalue guesses
-        for(int i = 0; i < dd; i++)
-        {
-            for(int j = 2 * iam + i % 2; j < dd - 1; j += 2 * bdm)
-            {
-                if(tmpd[j] > tmpd[j + 1])
-                {
-                    swap(tmpd[j], tmpd[j + 1]);
-                    swap(zz[j], zz[j + 1]);
-                    swap(per[j], per[j + 1]);
-                }
-            }
-            __syncthreads();
-        }
+        sort_tmpd_zz(dd, iam, bdm, tmpd, zz, per);
+        copy_d_ev(dd, iam, bdm, sz, n, tmpd, ev, diag);
 
-        // make dd copies of the non-deflated ordered diagonal elements
-        // (i.e. the poles of the secular eqn) so that the distances to the
-        // eigenvalues (D - lambda_i) are updated while computing each eigenvalue.
-        // This will prevent collapses and division by zero when an eigenvalue
-        // is too close to a pole.
-        for(int i = iam; i < dd; i += bdm)
-        {
-            for(int j = i + n; j < i + sz * n; j += n)
-                tmpd[j] = tmpd[i];
-        }
-
-        // finally copy over all diagonal elements in ev. ev will be overwritten
-        // by the new computed eigenvalues of the merged block
-        for(int i = iam; i < sz; i += bdm)
-            ev[i] = diag[i];
         __syncthreads();
 
+        solve_seq_eqns(dd, iam, bdm, sz, n, p, eps, ssfmin, ssfmax, mask, tmpd, ev, zz);
 
-        // 2. Solve secular eqns, i.e. find the dd zeros
-        // corresponding to non-deflated new eigenvalues of the merged block
-        // ----------------------------------------------------------------- 
-        // each thread will find a different zero in parallel
-        S a, b;
-        for(int j = iam; j < sz; j += bdm)
-        {
-            if(mask[j] == 1)
-            {
-                // find position in the ordered array
-                valf = p < 0 ? -ev[j] : ev[j];
-                int count = dd, cc = 0;
-                while(count > 0)
-                {
-                    auto step = count / 2;
-                    auto it = cc + step;
-                    if(tmpd[it + j * n] < valf)
-                    {
-                        cc = ++it;
-                        count -= step + 1;
-                    }
-                    else
-                        count = step;
-                }
-
-                // computed zero will overwrite 'ev' at the corresponding position.
-                // 'tmpd' will be updated with the distances D - lambda_i.
-                // deflated values are not changed.
-                rocblas_int linfo;
-
-#if defined(ROCSOLVER_USE_REFERENCE_SECULAR_EQUATIONS_SOLVER)
-                linfo = slaed4(dd, cc, tmpd + j * n, zz, std::abs(p), ev[j]);
-#else
-                if(cc == dd - 1)
-                    linfo = seq_solve_ext(dd, tmpd + j * n, zz, (p < 0 ? -p : p), ev + j, eps,
-                                          ssfmin, ssfmax);
-                else
-                    linfo = seq_solve(dd, tmpd + j * n, zz, (p < 0 ? -p : p), cc, ev + j, eps,
-                                      ssfmin, ssfmax);
-#endif
-                if(p < 0)
-                    ev[j] *= -1;
-            }
-        }
         __syncthreads();
 
-        // Re-scale vector Z to avoid bad numerics when an eigenvalue
-        // is too close to a pole
-        for(int i = iam; i < dd; i += bdm)
-        {
-            valf = 1;
-            for(int j = 0; j < sz; ++j)
-            {
-                if(mask[j] == 1)
-                {
-                    valg = tmpd[i + j * n];
-                    valf *= (per[i] == j) ? valg : valg / (diag[per[i]] - diag[j]);
-                }
-            }
-            valf = sqrt(std::abs(valf));
-            zz[i] = zz[i] < 0 ? -valf : valf;
-        }
+        rescale_z(dd, iam, bdm, sz, n, per, mask, tmpd, diag, zz);
     }
 }
 
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+    stedc_mergeValues_Sort_kernel(const rocblas_int levs,
+                                  const rocblas_int blks,
+                                  const rocblas_int k,
+                                  const rocblas_int n,
+                                  S* DD,
+                                  const rocblas_stride strideD,
+                                  S* EE,
+                                  const rocblas_stride strideE,
+                                  S* tmpzA,
+                                  S* vecsA,
+                                  rocblas_int* splitsA,
+                                  const S eps,
+                                  const S ssfmin,
+                                  const S ssfmax)
+{
+    // threads and groups indices
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+    // merge sub-block id
+    rocblas_int sid = hipBlockIdx_x;
+    // thread id
+    rocblas_int tidb = hipThreadIdx_x;
+    rocblas_int tid;
+
+    // select batch instance to work with
+    S* D = DD + bid * strideD;
+    S* E = EE + bid * strideE;
+
+    // temporary arrays in global memory
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    // the sub-blocks sizes
+    rocblas_int* ns = splits + n;
+    // the sub-blocks initial positions
+    rocblas_int* ps = ns + n;
+    // if idd[i] = 0, the value in position i has been deflated
+    rocblas_int* idd = ps + n;
+    // container of permutations when solving the secular eqns
+    rocblas_int* pers = idd + n;
+    // sizes of the first sub-block in a merge
+    rocblas_int* szfs = pers + n;
+    // sizes of both sub-blocks in a merge
+    rocblas_int* szs = szfs + n;
+    // degrees of secular equation
+    rocblas_int* dds = szs + n;
+    // the rank-1 modification vectors in the merges
+    S* z = tmpzA + bid * (2 * n);
+    // roots of secular equations
+    S* evs = z + n;
+    // updated eigenvectors after merges
+    S* vecs = vecsA + bid * 2 * (n * n);
+    // temp values during the merges
+    S* temps = vecs + (n * n);
+
+    // tn is the number of thread-groups needed in level k of the merge
+    rocblas_int bd = 1 << k;
+    rocblas_int bdm = bd << 1;
+    rocblas_int tn = blks / bdm;
+
+    // Work with merges on level k. A thread-group works with two leaves in the merge tree;
+    // all threads work together to solve the secular equation.
+    if(sid < tn)
+    {
+        rocblas_int iam, sz, dim, p2;
+        S valf, valg;
+
+        // tid indexes the sub-blocks in the entire split block
+        // iam indexes the sub-blocks in the context of the merge
+        // (according to its level in the merge tree)
+        dim = hipBlockDim_x / 2;
+        iam = tidb / dim;
+        tid = sid * bdm + iam * bd;
+        p2 = ps[tid];
+
+        // Find off-diagonal element of the merge
+        // Threads with iam = 0 work with components below the merge point;
+        // threads with iam = 1 work above the merge point
+        //sz = ns[tid];
+        //for(int j = 1; j < bd; ++j)
+        //    sz += ns[tid + j];
+        sz = szfs[tid];
+        // with this, all threads involved in a merge
+        // will point to the same row of C and the same off-diag element
+        S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
+
+        // determine boundaries of what would be the new merged sub-block
+        // 'in' will be its initial position.
+        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
+        rocblas_int in = tid - iam * bd;
+        //sz = ns[in];
+        //for(int i = 1; i < bdm; ++i)
+        //    sz += ns[in + i];
+        sz = szs[in];
+        in = ps[in];
+
+        // 1. Organize data with non-deflated values to prepare secular equation
+        // -----------------------------------------------------------------
+        // All threads of the group participating in the merge will work together
+        // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
+        iam = tidb;
+        bdm = hipBlockDim_x;
+
+        // define shifted arrays
+        S* tmpd = temps + in * n;
+        S* ev = evs + in;
+        S* diag = D + in;
+        rocblas_int* mask = idd + in;
+        S* zz = z + in;
+        rocblas_int* per = pers + in;
+
+        // find degree of secular equation
+        rocblas_int dd = dds[in];
+        //rocblas_int dd = 0;
+        //for(int i = 0; i < sz; ++i)
+        //{
+        //    if(mask[i] == 1)
+        //        dd++;
+        //}
+
+        sort_tmpd_zz(dd, iam, bdm, tmpd, zz, per);
+        copy_d_ev(dd, iam, bdm, sz, n, tmpd, ev, diag);
+    }
+}
+
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+    stedc_mergeValues_Solve_kernel(const rocblas_int levs,
+                                   const rocblas_int blks,
+                                   const rocblas_int k,
+                                   const rocblas_int n,
+                                   S* DD,
+                                   const rocblas_stride strideD,
+                                   S* EE,
+                                   const rocblas_stride strideE,
+                                   S* tmpzA,
+                                   S* vecsA,
+                                   rocblas_int* splitsA,
+                                   const S eps,
+                                   const S ssfmin,
+                                   const S ssfmax,
+                                   const rocblas_int groups_per_merge)
+{
+    // threads and groups indices
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+    // merge sub-block id
+    rocblas_int sid = hipBlockIdx_x / groups_per_merge;
+    // thread id
+    rocblas_int group_in_subblock = hipBlockIdx_x % groups_per_merge;
+    rocblas_int tidb = hipThreadIdx_x + group_in_subblock * hipBlockDim_x;
+    rocblas_int tid;
+
+    // select batch instance to work with
+    S* D = DD + bid * strideD;
+    S* E = EE + bid * strideE;
+
+    // temporary arrays in global memory
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    // the sub-blocks sizes
+    rocblas_int* ns = splits + n;
+    // the sub-blocks initial positions
+    rocblas_int* ps = ns + n;
+    // if idd[i] = 0, the value in position i has been deflated
+    rocblas_int* idd = ps + n;
+    // container of permutations when solving the secular eqns
+    rocblas_int* pers = idd + n;
+    // sizes of the first sub-block in a merge
+    rocblas_int* szfs = pers + n;
+    // sizes of both sub-blocks in a merge
+    rocblas_int* szs = szfs + n;
+    // degrees of secular equation
+    rocblas_int* dds = szs + n;
+    // the rank-1 modification vectors in the merges
+    S* z = tmpzA + bid * (2 * n);
+    // roots of secular equations
+    S* evs = z + n;
+    // updated eigenvectors after merges
+    S* vecs = vecsA + bid * 2 * (n * n);
+    // temp values during the merges
+    S* temps = vecs + (n * n);
+
+    // tn is the number of thread-groups needed in level k of the merge
+    rocblas_int bd = 1 << k;
+    rocblas_int bdm = bd << 1;
+    rocblas_int tn = blks / bdm;
+
+    // Work with merges on level k. A thread-group works with two leaves in the merge tree;
+    // all threads work together to solve the secular equation.
+    if(sid < tn)
+    {
+        rocblas_int iam, sz, dim, p2;
+        S valf, valg;
+
+        // tid indexes the sub-blocks in the entire split block
+        // iam indexes the sub-blocks in the context of the merge
+        // (according to its level in the merge tree)
+        dim = (hipBlockDim_x * groups_per_merge) / 2;
+        iam = tidb / dim;
+        tid = sid * bdm + iam * bd;
+        p2 = ps[tid];
+
+        // Find off-diagonal element of the merge
+        // Threads with iam = 0 work with components below the merge point;
+        // threads with iam = 1 work above the merge point
+        //sz = ns[tid];
+        //for(int j = 1; j < bd; ++j)
+        //    sz += ns[tid + j];
+        sz = szfs[tid];
+        // with this, all threads involved in a merge
+        // will point to the same row of C and the same off-diag element
+        S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
+
+        // determine boundaries of what would be the new merged sub-block
+        // 'in' will be its initial position.
+        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
+        rocblas_int in = tid - iam * bd;
+        //sz = ns[in];
+        //for(int i = 1; i < bdm; ++i)
+        //    sz += ns[in + i];
+        sz = szs[in];
+        in = ps[in];
+
+        // 1. Organize data with non-deflated values to prepare secular equation
+        // -----------------------------------------------------------------
+        // All threads of the group participating in the merge will work together
+        // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
+        iam = tidb;
+        bdm = hipBlockDim_x * groups_per_merge;
+
+        // define shifted arrays
+        S* tmpd = temps + in * n;
+        S* ev = evs + in;
+        S* diag = D + in;
+        rocblas_int* mask = idd + in;
+        S* zz = z + in;
+        rocblas_int* per = pers + in;
+
+        // find degree of secular equation
+        rocblas_int dd = dds[in];
+        //rocblas_int dd = 0;
+        //for(int i = 0; i < sz; ++i)
+        //{
+        //    if(mask[i] == 1)
+        //        dd++;
+        //}
+
+        solve_seq_eqns(dd, iam, bdm, sz, n, p, eps, ssfmin, ssfmax, mask, tmpd, ev, zz);
+    }
+}
+
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+    stedc_mergeValues_Rescale_kernel(const rocblas_int levs,
+                                     const rocblas_int blks,
+                                     const rocblas_int k,
+                                     const rocblas_int n,
+                                     S* DD,
+                                     const rocblas_stride strideD,
+                                     S* EE,
+                                     const rocblas_stride strideE,
+                                     S* tmpzA,
+                                     S* vecsA,
+                                     rocblas_int* splitsA,
+                                     const S eps,
+                                     const S ssfmin,
+                                     const S ssfmax)
+{
+    // threads and groups indices
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+    // merge sub-block id
+    rocblas_int sid = hipBlockIdx_x;
+    // thread id
+    rocblas_int tidb = hipThreadIdx_x;
+    rocblas_int tid;
+
+    // select batch instance to work with
+    S* D = DD + bid * strideD;
+    S* E = EE + bid * strideE;
+
+    // temporary arrays in global memory
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    // the sub-blocks sizes
+    rocblas_int* ns = splits + n;
+    // the sub-blocks initial positions
+    rocblas_int* ps = ns + n;
+    // if idd[i] = 0, the value in position i has been deflated
+    rocblas_int* idd = ps + n;
+    // container of permutations when solving the secular eqns
+    rocblas_int* pers = idd + n;
+    // sizes of the first sub-block in a merge
+    rocblas_int* szfs = pers + n;
+    // sizes of both sub-blocks in a merge
+    rocblas_int* szs = szfs + n;
+    // degrees of secular equation
+    rocblas_int* dds = szs + n;
+    // the rank-1 modification vectors in the merges
+    S* z = tmpzA + bid * (2 * n);
+    // roots of secular equations
+    S* evs = z + n;
+    // updated eigenvectors after merges
+    S* vecs = vecsA + bid * 2 * (n * n);
+    // temp values during the merges
+    S* temps = vecs + (n * n);
+
+    // tn is the number of thread-groups needed in level k of the merge
+    rocblas_int bd = 1 << k;
+    rocblas_int bdm = bd << 1;
+    rocblas_int tn = blks / bdm;
+
+    // Work with merges on level k. A thread-group works with two leaves in the merge tree;
+    // all threads work together to solve the secular equation.
+    if(sid < tn)
+    {
+        rocblas_int iam, sz, dim, p2;
+        S valf, valg;
+
+        // tid indexes the sub-blocks in the entire split block
+        // iam indexes the sub-blocks in the context of the merge
+        // (according to its level in the merge tree)
+        dim = hipBlockDim_x / 2;
+        iam = tidb / dim;
+        tid = sid * bdm + iam * bd;
+        p2 = ps[tid];
+
+        // Find off-diagonal element of the merge
+        // Threads with iam = 0 work with components below the merge point;
+        // threads with iam = 1 work above the merge point
+        //sz = ns[tid];
+        //for(int j = 1; j < bd; ++j)
+        //    sz += ns[tid + j];
+        sz = szfs[tid];
+        // with this, all threads involved in a merge
+        // will point to the same row of C and the same off-diag element
+        S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
+
+        // determine boundaries of what would be the new merged sub-block
+        // 'in' will be its initial position.
+        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
+        rocblas_int in = tid - iam * bd;
+        //sz = ns[in];
+        //for(int i = 1; i < bdm; ++i)
+        //    sz += ns[in + i];
+        sz = szs[in];
+        in = ps[in];
+
+        // 1. Organize data with non-deflated values to prepare secular equation
+        // -----------------------------------------------------------------
+        // All threads of the group participating in the merge will work together
+        // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
+        iam = tidb;
+        bdm = hipBlockDim_x;
+
+        // define shifted arrays
+        S* tmpd = temps + in * n;
+        S* ev = evs + in;
+        S* diag = D + in;
+        rocblas_int* mask = idd + in;
+        S* zz = z + in;
+        rocblas_int* per = pers + in;
+
+        // find degree of secular equation
+        rocblas_int dd = dds[in];
+        //rocblas_int dd = 0;
+        //for(int i = 0; i < sz; ++i)
+        //{
+        //    if(mask[i] == 1)
+        //        dd++;
+        //}
+
+        rescale_z(dd, iam, bdm, sz, n, per, mask, tmpd, diag, zz);
+    }
+}
 
 //--------------------------------------------------------------------------------------//
 /** STEDC_MERGEVECTORS_KERNEL prepares vectors from the secular equation for
     every pair of sub-blocks that need to be merged.
-        - Call this kernel with batch_count groups in y, and as many groups as columns would 
+        - Call this kernel with batch_count groups in y, and as many groups as columns would
           be in the matrix if its size is exact multiple of the number of sub-blocks 'blks'.
           Each group works with a column. Groups are size STEDC_BDIM.
         - If a group has an id larger than the actual number of columns it will do nothing. **/
@@ -702,15 +1811,21 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* E = EE + bid * strideE;
 
     // temporary arrays in global memory
-    rocblas_int* splits = splitsA + bid * (5 * n + 2);
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
     // the sub-blocks sizes
-    rocblas_int* ns = splits + n + 2;
+    rocblas_int* ns = splits + n;
     // the sub-blocks initial positions
     rocblas_int* ps = ns + n;
     // if idd[i] = 0, the value in position i has been deflated
     rocblas_int* idd = ps + n;
     // container of permutations when solving the secular eqns
     rocblas_int* pers = idd + n;
+    // sizes of the first sub-block in a merge
+    rocblas_int* szfs = pers + n;
+    // sizes of both sub-blocks in a merge
+    rocblas_int* szs = szfs + n;
+    // degrees of secular equation
+    rocblas_int* dds = szs + n;
     // the rank-1 modification vectors in the merges
     S* z = tmpzA + bid * (2 * n);
     // roots of secular equations
@@ -771,7 +1886,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                 dd++;
         }
         __syncthreads();
-
 
         // Prepare vectors corresponding to non-deflated values
         S temp, nrm;
@@ -873,10 +1987,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     }
 }
 
-
 //--------------------------------------------------------------------------------------//
-/** STEDC_MERGEUPDATE_KERNEL updates vectors and values after a merge is done. 
-        - Call this kernel with batch_count groups in y, and as many groups as columns would 
+/** STEDC_MERGEUPDATE_KERNEL updates vectors and values after a merge is done.
+        - Call this kernel with batch_count groups in y, and as many groups as columns would
           be in the matrix if its size is exact multiple of the number of sub-blocks 'blks'.
           Each group works with a column. Groups are size STEDC_BDIM.
         - If a group has an id larger than the actual number of columns it will do nothing. **/
@@ -913,9 +2026,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* D = DD + bid * strideD;
 
     // temporary arrays in global memory
-    rocblas_int* splits = splitsA + bid * (5 * n + 2);
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
     // the sub-blocks sizes
-    rocblas_int* ns = splits + n + 2;
+    rocblas_int* ns = splits + n;
     // the sub-blocks initial positions
     rocblas_int* ps = ns + n;
     // if idd[i] = 0, the value in position i has been deflated
@@ -970,68 +2083,215 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     }
 }
 
-
-/** STEDC_SORT sorts computed eigenvalues and eigenvectors in increasing order **/
-template <typename T, typename S, typename U>
-ROCSOLVER_KERNEL void __launch_bounds__(BS1) stedc_sort(const rocblas_int n,
-                                                        S* DD,
-                                                        const rocblas_stride strideD,
-                                                        U CC,
-                                                        const rocblas_int shiftC,
-                                                        const rocblas_int ldc,
-                                                        const rocblas_stride strideC,
-                                                        const rocblas_int batch_count,
-                                                        rocblas_int* work,
-                                                        rocblas_int* nev = nullptr)
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_copyD(const rocblas_int n,
+                                                                S* DDin,
+                                                                const rocblas_stride strideDin,
+                                                                S* DDout,
+                                                                const rocblas_stride strideDout)
 {
-    // -----------------------------------
-    // use z-grid dimension as batch index
-    // -----------------------------------
-    rocblas_int bid_start = hipBlockIdx_z;
-    rocblas_int bid_inc = hipGridDim_z;
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+
+    S* Din = DDin + bid * strideDin;
+    S* Dout = DDout + bid * strideDout;
 
     int tid = hipThreadIdx_x;
 
-    rocblas_int* const map = work + bid_start * ((int64_t)n);
+    constexpr int regs = 16;
+    const int chunk_width = regs * hipBlockDim_x;
+    const int n_chunks = (n - 1) / chunk_width + 1;
+    S bval[regs];
 
-    for(auto bid = bid_start; bid < batch_count; bid += bid_inc)
+    for(int chunk = 0; chunk < n_chunks; chunk++)
     {
-        // ---------------------------------------------
-        // select batch instance to work with
-        // (avoiding arithmetics with possible nullptrs)
-        // ---------------------------------------------
-        T* C = nullptr;
-        if(CC)
-            C = load_ptr_batch<T>(CC, bid, shiftC, strideC);
-        S* D = DD + (bid * strideD);
-        rocblas_int nn;
-        if(nev)
-            nn = nev[bid];
-        else
-            nn = n;
-
-        bool constexpr use_shell_sort = true;
-
-        __syncthreads();
-
-        if(use_shell_sort)
-            shell_sort(nn, D, map);
-        else
-            selection_sort(nn, D, map);
-        __syncthreads();
-
-        permute_swap(n, C, ldc, map, nn);
-        __syncthreads();
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < n)
+                bval[i] = Din[x];
+        }
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < n)
+                Dout[x] = bval[i];
+        }
     }
 }
 
+template <typename T, typename U1, typename U2>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_copyC(const rocblas_int n,
+                                                                U1 CCin,
+                                                                const rocblas_int shiftCin,
+                                                                const rocblas_int ldcin,
+                                                                const rocblas_stride strideCin,
+                                                                U2 CCout,
+                                                                const rocblas_int shiftCout,
+                                                                const rocblas_int ldcout,
+                                                                const rocblas_stride strideCout)
+{
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+    // group id
+    rocblas_int gid = hipBlockIdx_x;
+
+    T* Cin = load_ptr_batch<T>(CCin, bid, shiftCin, strideCin);
+    T* Cout = load_ptr_batch<T>(CCout, bid, shiftCout, strideCout);
+
+    T* src = Cin + ldcin * gid;
+    T* dst = Cout + ldcout * gid;
+
+    constexpr int regs = 16;
+    const int chunk_width = regs * hipBlockDim_x;
+    const int n_chunks = (n - 1) / chunk_width + 1;
+    T bval[regs];
+
+    for(int chunk = 0; chunk < n_chunks; chunk++)
+    {
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < n)
+                bval[i] = src[x];
+        }
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < n)
+                dst[x] = bval[i];
+        }
+    }
+}
+
+/** STEDC_SORT sorts computed eigenvalues and eigenvectors in increasing order **/
+template <typename T, typename S, typename U1, typename U2>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int n,
+                                                               S* DDin,
+                                                               const rocblas_stride strideDin,
+                                                               S* DDout,
+                                                               const rocblas_stride strideDout,
+                                                               U1 CCin,
+                                                               const rocblas_int shiftCin,
+                                                               const rocblas_int ldcin,
+                                                               const rocblas_stride strideCin,
+                                                               U2 CCout,
+                                                               const rocblas_int shiftCout,
+                                                               const rocblas_int ldcout,
+                                                               const rocblas_stride strideCout
+
+)
+{
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+    // group id
+    rocblas_int gid = hipBlockIdx_x;
+
+    S* Din = DDin + bid * strideDin;
+    S* Dout = DDout + bid * strideDout;
+
+    int tid = hipThreadIdx_x;
+
+    S d = Din[gid];
+
+    constexpr int regs = 16;
+    const int chunk_width = regs * hipBlockDim_x;
+    const int n_chunks = (n - 1) / chunk_width + 1;
+    T bvalT[regs];
+    S* bvalS = reinterpret_cast<S*>(bvalT);
+
+    int nan = 0;
+    int lt = 0;
+    int eq = 0;
+
+    for(int chunk = 0; chunk < n_chunks; chunk++)
+    {
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < n)
+            {
+                bvalS[i] = Din[x];
+            }
+        }
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < n)
+            {
+                nan += (bvalS[i] != bvalS[i]);
+                // lt - how many values are less then the current
+                // eq - how many values are equal to the current
+                // all zero deflated values have to be grouped at the end
+                // so we order any deflated value > any non-deflated value
+                // dz == 0 - current is deflated, dz[i] == 1 - other value is not deflated
+                lt += (bvalS[i] < d);
+                eq += (bvalS[i] == d && x < gid);
+            }
+        }
+    }
+
+    int pos = lt + eq;
+    __shared__ int lds[STEDC_BDIM];
+    // Reduction (sum of pos across all lanes in a workgroup)
+    // on each iteration reduction is done within a subgroup of size of 2*bit
+    // by xoring corresponding bit of an address.
+    // The faster implementation should use dpp + a single trip through lds
+    // but keeping code simple for now.
+    int bit = 1;
+    while(bit < STEDC_BDIM)
+    {
+        lds[hipThreadIdx_x ^ bit] = pos;
+        __syncthreads();
+        pos += lds[hipThreadIdx_x];
+        __syncthreads();
+        bit *= 2;
+    }
+
+    if(hipThreadIdx_x == 0)
+    {
+        Dout[pos] = d;
+    }
+
+    __syncthreads();
+    // The NAN fp value is unordered, so it is possible that with computed
+    // new positions it would be silently overwriten with non NAN value.
+    // Make sure we propagate NAN. It is likely to have more NANs in the output
+    // than in the input, but the following computations are doomed anyway.
+    if(nan)
+    {
+        Dout[gid] = NAN;
+    }
+
+    T* Cin = load_ptr_batch<T>(CCin, bid, shiftCin, strideCin);
+    T* Cout = load_ptr_batch<T>(CCout, bid, shiftCout, strideCout);
+
+    T* src = Cin + ldcin * gid;
+    T* dst = Cout + ldcout * pos;
+
+    for(int chunk = 0; chunk < n_chunks; chunk++)
+    {
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < n)
+                bvalT[i] = src[x];
+        }
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < n)
+                dst[x] = bvalT[i];
+        }
+    }
+}
 
 /******************* Host functions *********************************************/
 /*******************************************************************************/
 
 //--------------------------------------------------------------------------------------//
 /** STEDC_NUM_LEVELS returns the ideal number of times/levels in which a matrix
-    will be divided during the divide phase of divide & conquer algorithm 
+    will be divided during the divide phase of divide & conquer algorithm
     i.e. number of sub-blocks = 2^levels **/
 inline rocblas_int stedc_num_levels(const rocblas_int n)
 {
@@ -1041,6 +2301,8 @@ inline rocblas_int stedc_num_levels(const rocblas_int n)
         levels = 0;
     else
         levels = std::ceil(std::log2(n)) - 4;
+
+    //return 3;
 
     return levels;
 }
@@ -1112,7 +2374,7 @@ void rocsolver_stedc_getMemorySize(const rocblas_evect evect,
             *size_workArr = 0;
 
         // size for split blocks and sub-blocks positions
-        *size_splits_map = sizeof(rocblas_int) * (5 * n + 2) * batch_count;
+        *size_splits_map = sizeof(rocblas_int) * get_splits_size(n) * batch_count;
 
         // size for temporary diagonal and rank-1 modif vector
         *size_tmpz = sizeof(S) * (2 * n) * batch_count;
@@ -1241,7 +2503,7 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         ssfmin = sqrt(ssfmin) / (eps * eps);
         ssfmax = sqrt(ssfmax) / S(3.0);
 
-        // find number of sub-blocks 
+        // find number of sub-blocks
         rocblas_int levs = stedc_num_levels(n);
         rocblas_int blks = 1 << levs;
 
@@ -1264,21 +2526,18 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         // 1. divide phase
         //-----------------------------
         rocblas_int groups = (batch_count - 1) / STEDC_BDIM + 1;
-        ROCSOLVER_LAUNCH_KERNEL((stedc_divide_kernel<S>),
-                                dim3(groups), dim3(STEDC_BDIM), 0, stream, levs, blks, n, D + shiftD,
-                                strideD, E + shiftE, strideE, batch_count, splits);
+        ROCSOLVER_LAUNCH_KERNEL((stedc_divide_kernel<S>), dim3(groups), dim3(STEDC_BDIM), 0, stream,
+                                levs, blks, n, D + shiftD, strideD, E + shiftE, strideE,
+                                batch_count, splits);
 
         // 2. solve phase
         //-----------------------------
-        ROCSOLVER_LAUNCH_KERNEL((stedc_solve_kernel<S>),
-                                dim3(blks, batch_count), dim3(64), 0, stream, levs, blks, 
-                                n, D + shiftD, strideD, E + shiftE, strideE, 
-                                V, 0, ldv, strideV, info, (S*)work_stack, splits, 
-                                eps, ssfmin, ssfmax);
+        ROCSOLVER_LAUNCH_KERNEL((stedc_solve_kernel<S>), dim3(blks, batch_count), dim3(64), 0,
+                                stream, levs, blks, n, D + shiftD, strideD, E + shiftE, strideE, V,
+                                0, ldv, strideV, info, (S*)work_stack, splits, eps, ssfmin, ssfmax);
 
         // 3. merge phase
         //----------------
-        size_t lmemsize1 = sizeof(S) * 2 * STEDC_BDIM;
         size_t lmemsize3 = sizeof(S) * STEDC_BDIM;
         rocblas_int numgrps3 = ((n - 1) / blks + 1) * blks;
 
@@ -1287,24 +2546,73 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         {
             // a. prepare secular equations
             rocblas_int numgrps2 = 1 << (levs - 1 - k);
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_kernel<S>),
-                                    dim3(numgrps2, batch_count), dim3(STEDC_BDIM), lmemsize1, stream, 
-                                    levs, blks, k, n, D + shiftD, strideD,
-                                    E + shiftE, strideE, V, 0, ldv, strideV, tmpz, tempgemm, splits,
-                                    eps);
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_DeflateZero_kernel<S>),
+                                    dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream, levs,
+                                    blks, k, n, D + shiftD, strideD, E + shiftE, strideE, V, 0, ldv,
+                                    strideV, tmpz, tempgemm, splits, eps);
+
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_Fill_kernel<S>),
+                                    dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream, levs,
+                                    blks, k, n, tmpz, tempgemm, splits);
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_SortD_kernel<S>), dim3(n, batch_count),
+                                    dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
+                                    strideD, tmpz, tempgemm, splits);
+            rocblas_int numgrps_deflate = (n - 1) / STEDC_BDIM + 1;
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_SetCandFlags_kernel<S>),
+                                    dim3(numgrps_deflate, batch_count), dim3(STEDC_BDIM), 0, stream,
+                                    levs, blks, k, n, D + shiftD, strideD, tmpz, tempgemm, splits);
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_DeflateCount_kernel<S>),
+                                    dim3(numgrps_deflate, batch_count), dim3(STEDC_BDIM), 0, stream,
+                                    levs, blks, k, n, D + shiftD, strideD, tmpz, tempgemm, splits);
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_DeflateApply_kernel<S>),
+                                    dim3(numgrps_deflate, batch_count), dim3(STEDC_BDIM), 0, stream,
+                                    levs, blks, k, n, D + shiftD, strideD, tmpz, tempgemm, splits);
+
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeRotate_kernel<S>), dim3(n, batch_count),
+                                    dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, V, 0, ldv,
+                                    strideV, tmpz, tempgemm, splits);
+
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_Organize_kernel<S>),
+                                    dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream, levs,
+                                    blks, k, n, D + shiftD, strideD, E + shiftE, strideE, V, 0, ldv,
+                                    strideV, tmpz, tempgemm, splits, eps);
 
             // b. solve secular eq to find merged eigenvalues
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_kernel<S>),
-                                    dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream, 
-                                    levs, blks, k, n, D + shiftD, strideD,
-                                    E + shiftE, strideE, tmpz, tempgemm, splits, eps, ssfmin, ssfmax);
+            rocblas_int max_n_per_merge = (n + numgrps2 - 1) / numgrps2;
+
+            if(max_n_per_merge > STEDC_BDIM)
+            {
+                // split mergeValues into stages to run seqular eqns solver using more groups
+                ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Sort_kernel<S>),
+                                        dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream,
+                                        levs, blks, k, n, D + shiftD, strideD, E + shiftE, strideE,
+                                        tmpz, tempgemm, splits, eps, ssfmin, ssfmax);
+
+                rocblas_int groups_per_merge = (max_n_per_merge + STEDC_BDIM - 1) / STEDC_BDIM;
+                ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Solve_kernel<S>),
+                                        dim3(numgrps2 * groups_per_merge, batch_count),
+                                        dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
+                                        strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
+                                        ssfmin, ssfmax, groups_per_merge);
+                ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Rescale_kernel<S>),
+                                        dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream,
+                                        levs, blks, k, n, D + shiftD, strideD, E + shiftE, strideE,
+                                        tmpz, tempgemm, splits, eps, ssfmin, ssfmax);
+            }
+            else
+            {
+                // compute in one dispatch for small merges
+                ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_kernel<S>), dim3(numgrps2, batch_count),
+                                        dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
+                                        strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
+                                        ssfmin, ssfmax);
+            }
 
             // c. find merged eigenvectors
-            ROCSOLVER_LAUNCH_KERNEL(
-                (stedc_mergeVectors_kernel<STEDC_EXTERNAL_GEMM, S>),
-                dim3(numgrps3, batch_count), dim3(STEDC_BDIM), lmemsize3, stream, 
-                levs, blks, k, n, D + shiftD, strideD, E + shiftE, strideE, V, 0, ldv, strideV, 
-                tmpz, tempgemm, splits);
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeVectors_kernel<STEDC_EXTERNAL_GEMM, S>),
+                                    dim3(numgrps3, batch_count), dim3(STEDC_BDIM), lmemsize3,
+                                    stream, levs, blks, k, n, D + shiftD, strideD, E + shiftE,
+                                    strideE, V, 0, ldv, strideV, tmpz, tempgemm, splits);
 
             if(STEDC_EXTERNAL_GEMM)
             {
@@ -1319,10 +2627,9 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             }
 
             // d. update level
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeUpdate_kernel<S>),
-                                    dim3(numgrps3, batch_count), dim3(STEDC_BDIM), 0, stream, 
-                                    levs, blks, k, n, D + shiftD, strideD,
-                                    V, 0, ldv, strideV, tmpz, tempgemm, splits);
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeUpdate_kernel<S>), dim3(numgrps3, batch_count),
+                                    dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
+                                    strideD, V, 0, ldv, strideV, tmpz, tempgemm, splits);
         }
 
         // 4. update and sort
@@ -1351,10 +2658,15 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     ldc, strideC, tempgemm);
         }
 
-        // finally sort eigenvalues and eigenvectors
-        ROCSOLVER_LAUNCH_KERNEL((stedc_sort<T>), dim3(1, 1, batch_count), dim3(BS1), 0, stream, n,
-                                D + shiftD, strideD, C, shiftC, ldc, strideC, batch_count,
-                                splits_map);
+        ROCSOLVER_LAUNCH_KERNEL(stedc_copyD, dim3(1, batch_count), dim3(STEDC_BDIM), 0, stream, n,
+                                D + shiftD, strideD, tmpz, n);
+
+        ROCSOLVER_LAUNCH_KERNEL(stedc_copyC<T>, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream,
+                                n, C, shiftC, ldc, strideC, (T*)tempgemm, 0, n, n * n);
+
+        ROCSOLVER_LAUNCH_KERNEL(stedc_sort<T>, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, n,
+                                tmpz, n, D + shiftD, strideD, (T*)tempgemm, 0, n, n * n, C, shiftC,
+                                ldc, strideC);
 
         rocblas_set_pointer_mode(handle, old_mode);
     }

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -40,10 +40,12 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 
 ROCSOLVER_BEGIN_NAMESPACE
 
 #define STEDC_BDIM 512 // Number of threads per thread-block used in main stedc kernels
+#define STEDC_SOLVE_BDIM 4 // Number of threads per thread-block used in solver kernel
 
 // bit indicating base deflation candidate
 #define L_F_BCAND_BIT 0
@@ -58,26 +60,182 @@ ROCSOLVER_BEGIN_NAMESPACE
 __host__ __device__ inline rocblas_int get_splits_size(const rocblas_int n)
 {
     // splits_map layout:
+    // n - number of eigenvalues (matrix size)
+    // m - number of merges on a current level
     // struct {
-    // 0     rocblas_int sort_tmp[n]; // temp buffer used for mapping in stedc_sort()
-    // 1     rocblas_int ns[n];       // the sub-blocks sizes
-    // 2     rocblas_int ps[n];       // the sub-blocks initial positions
-    // 3     rocblas_int idd[n];      // if idd[i] = 0, the value in position i has been deflated  (aka mask)
-    // 4     rocblas_int pers[n];     // container of permutations when solving the secular eqns
-    // 5     rocblas_int szfs[n];     // sizes of the first sub-block in a merge
-    // 6     rocblas_int szs[n];      // sizes of both sub-blocks in a merge
-    // 7     rocblas_int dds[n];      // degrees of secular equation
-    // 8     rocblas_int map[n];      //
-    // 9     rocblas_int dcount[n];   // number of deflations
-    // 10    rocblas_int mns[n];      // merge sizes
-    // 11    rocblas_int mps[n];      // merge initial positions
-    // 12    rocblas_int cand[n];     // deflation candidate flags
-    // 13    rocblas_int midd[n];     // sorted idd
-    // 14    rocblas_int dbg2[n];     //
-    // 15    rocblas_int dbg3[n];     //
-    // 16    rocblas_int dbg4[n];     //
+    // 0     rocblas_int msz[m], _[n-m];      // size of each merge
+    // 1     rocblas_int mps[m], _[n-m];      // starting position of each merge
+    // 2     rocblas_int bsz[2*m], _[n-2*m];  // size of each block
+    // 3     rocblas_int bps[2*m], _[n-2*m];  // starting position of each block
+    // 4     rocblas_int em[n];               // id of a corresponding merge (per each eigenvalue)
+    // 5     rocblas_int nsz[n];              // size of a corresponding merge (per each eigenvalue)
+    // 6     rocblas_int nps[n];              // starting position of a corresponding merge (per each eigenvalue)
+    // 7     rocblas_int ndd[n];              // degrees of secular equation (per each eigenvalue)
+    // 8     rocblas_int mask[n];             // if mask[i] = 0, the value in position i has been deflated
+    // 9     rocblas_int dcount[n];           // number of deflations
+    // 10    rocblas_int map[n];              // original indices of a sorted values
+    // 11    rocblas_int cand[n];             // deflation candidate flags
+    // 12    rocblas_int dbg[n];              //
     // };
-    return 17 * n;
+    return 13 * n;
+}
+
+template <typename S>
+__host__ __device__ inline S* ptr_msz(rocblas_int n, S* splits)
+{
+    return splits + 0 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_mps(rocblas_int n, S* splits)
+{
+    return splits + 1 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_bsz(rocblas_int n, S* splits)
+{
+    return splits + 2 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_bps(rocblas_int n, S* splits)
+{
+    return splits + 3 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_em(rocblas_int n, S* splits)
+{
+    return splits + 4 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_nsz(rocblas_int n, S* splits)
+{
+    return splits + 5 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_nps(rocblas_int n, S* splits)
+{
+    return splits + 6 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_ndd(rocblas_int n, S* splits)
+{
+    return splits + 7 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_mask(rocblas_int n, S* splits)
+{
+    return splits + 8 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_dcount(rocblas_int n, S* splits)
+{
+    return splits + 9 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_map(rocblas_int n, S* splits)
+{
+    return splits + 10 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_cand(rocblas_int n, S* splits)
+{
+    return splits + 11 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_dbg(rocblas_int n, S* splits)
+{
+    return splits + 12 * n;
+}
+
+__host__ __device__ inline rocblas_int get_tmpz_size(const rocblas_int n)
+{
+    // tmpz layout:
+    // n - number of eigenvalues (matrix size)
+    // m - number of merges on a current level
+    // struct {
+    // 0    S z[n];              // the rank-1 modification vectors in the merges
+    // 1    S evs[n];            // roots of secular equations
+    // 2    S cc[n];             // c value of rotation of corresponding deflation
+    // 3    S ss[n];             // s value of rotation of corresponding deflation
+    // 4    S tolsD[n];          // tollerance for deflation of repeaded values in D
+    // 5    S tolsZ[n];          // tollerance for deflation of zero values in z
+    // 6    S md[n];             // sorted d values
+    // 7    S cd[n];             // sorted and compacted d values
+    // 8    S cz[n];             // sorted and compacted z values
+    // 9    S r1p[n];            // p component of the rank-1 modification
+    // };
+    return 10 * n;
+}
+
+template <typename S>
+__host__ __device__ inline S* ptr_z(rocblas_int n, S* tmpz)
+{
+    return tmpz + 0 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_evs(rocblas_int n, S* tmpz)
+{
+    return tmpz + 1 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_cc(rocblas_int n, S* tmpz)
+{
+    return tmpz + 2 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_ss(rocblas_int n, S* tmpz)
+{
+    return tmpz + 3 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_tolsD(rocblas_int n, S* tmpz)
+{
+    return tmpz + 4 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_tolsZ(rocblas_int n, S* tmpz)
+{
+    return tmpz + 5 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_md(rocblas_int n, S* tmpz)
+{
+    return tmpz + 6 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_cd(rocblas_int n, S* tmpz)
+{
+    return tmpz + 7 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_cz(rocblas_int n, S* tmpz)
+{
+    return tmpz + 8 * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_r1p(rocblas_int n, S* tmpz)
+{
+    return tmpz + 9 * n;
+}
+
+__host__ __device__ inline rocblas_int get_tempgemm_size(const rocblas_int n)
+{
+    // tempgemm layout:
+    // struct {
+    // 0    S vecs[n*n];      // temp vectors
+    // 1    S etmpd[n*n];     // temp deltas used in solving secular equations, also used for temp vectors
+    // };
+    return 2 * n * n;
+}
+
+template <typename S>
+__host__ __device__ inline S* ptr_vecs(rocblas_int n, S* tempgemm)
+{
+    return tempgemm + 0 * n * n;
+}
+template <typename S>
+__host__ __device__ inline S* ptr_etmpd(rocblas_int n, S* tempgemm)
+{
+    return tempgemm + 1 * n * n;
 }
 
 /*************** Main kernels *********************************************************/
@@ -113,32 +271,28 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
         // temporary arrays in global memory
         rocblas_int* splits = splitsA + bid * get_splits_size(n);
-        // the sub-blocks sizes
-        rocblas_int* ns = splits + n;
-        // the sub-blocks initial positions
-        rocblas_int* ps = ns + n;
+        rocblas_int* msz = ptr_msz(n, splits);
+        rocblas_int* mps = ptr_mps(n, splits);
 
         // find sizes of sub-blocks
-        ns[0] = n;
-        rocblas_int t, t2;
+        msz[0] = n;
         for(int i = 0; i < levs; ++i)
         {
             for(int j = (1 << i); j > 0; --j)
             {
-                t = ns[j - 1];
-                t2 = t / 2;
-                ns[j * 2 - 1] = (2 * t2 < t) ? t2 + 1 : t2;
-                ns[j * 2 - 2] = t2;
+                rocblas_int t = msz[j - 1];
+                msz[j * 2 - 1] = t / 2 + (t & 1);
+                msz[j * 2 - 2] = t / 2;
             }
         }
 
         // find beginning of sub-blocks and update elements in D
         rocblas_int p2 = 0;
-        ps[0] = p2;
+        mps[0] = p2;
         for(int i = 1; i < blks; ++i)
         {
-            p2 += ns[i - 1];
-            ps[i] = p2;
+            p2 += msz[i - 1];
+            mps[i] = p2;
 
             // perform sub-block division
             S p = E[p2 - 1];
@@ -155,7 +309,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
           Groups are single-thread **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_solve_kernel(const rocblas_int levs,
-                                                                       const rocblas_int blks,
                                                                        const rocblas_int n,
                                                                        S* DD,
                                                                        const rocblas_stride strideD,
@@ -182,43 +335,110 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_solve_kernel(const roc
     rocblas_int tidb_inc = hipBlockDim_x;
 
     // select batch instance to work with
-    S* C;
-    if(CC)
-        C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
+    S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
     S* D = DD + bid * strideD;
     S* E = EE + bid * strideE;
     rocblas_int* info = iinfo + bid;
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
+    rocblas_int* msz = ptr_msz(n, splits);
+    rocblas_int* mps = ptr_mps(n, splits);
     // workspace for solvers
-    S* W = WA + bid * (2 * n);
+    S* W = WA + bid * 2 * n;
 
     // Solve the blks sub-blocks in parallel (using classic QR iteration).
-    if(sid < blks)
     {
-        rocblas_int sbs = ns[sid]; // size of sub-block
-        rocblas_int p2 = ps[sid]; // start position of sub-block
+        rocblas_int sz = msz[sid]; // size of sub-block
+        rocblas_int p2 = mps[sid]; // start position of sub-block
 
-        run_steqr(tidb, tidb_inc, sbs, D + p2, E + p2, C + p2 + p2 * ldc, ldc, info, W + p2 * 2,
-                  30 * sbs, eps, ssfmin, ssfmax, false);
+        run_steqr(tidb, tidb_inc, sz, D + p2, E + p2, C + p2 + p2 * ldc, ldc, info, W + p2 * 2,
+                  30 * sz, eps, ssfmin, ssfmax, false);
     }
 }
 
 //--------------------------------------------------------------------------------------//
-/** STEDC_MERGEPREPARE_DEFLATEZERO_KERNEL performs deflation of zero values
+/** STEDC_UPDATE_SPLITS updates merge block related parts of a splits struct for each
+    level of merge.
+        - This kernel is to be called with 1 group in x and batch_count groups in y.
+        - Size of groups is set to STEDC_BDIM. **/
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_update_splits(const rocblas_int levs,
+                                                                        const rocblas_int k,
+                                                                        const rocblas_int n,
+                                                                        rocblas_int* splitsA)
+{
+    rocblas_int bid = hipBlockIdx_y;
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    rocblas_int* em = ptr_em(n, splits);
+    rocblas_int* msz = ptr_msz(n, splits);
+    rocblas_int* mps = ptr_mps(n, splits);
+    rocblas_int* nsz = ptr_nsz(n, splits);
+    rocblas_int* nps = ptr_nps(n, splits);
+    rocblas_int* bsz = ptr_bsz(n, splits);
+    rocblas_int* bps = ptr_bps(n, splits);
+    rocblas_int* map = ptr_map(n, splits);
+    rocblas_int* dcount = ptr_dcount(n, splits);
+
+    rocblas_int n_blocks = 1 << levs;
+    rocblas_int n_merges = 1 << (levs - k - 1);
+
+    // init em array
+    if(k == 0)
+    {
+        for(int i = hipThreadIdx_x; i < n_blocks; i += hipBlockDim_x)
+        {
+            rocblas_int sz = msz[i];
+            rocblas_int p1 = mps[i];
+            for(int j = 0; j < sz; j++)
+            {
+                em[p1 + j] = i;
+            }
+        }
+    }
+
+    // previous merges becomes blocks on a current level
+    for(int i = hipThreadIdx_x; i < n_merges * 2; i += hipBlockDim_x)
+    {
+        bsz[i] = msz[i];
+        bps[i] = mps[i];
+    }
+    __syncthreads();
+
+    // update sizes and initial positions
+    for(int i = hipThreadIdx_x; i < n_merges; i += hipBlockDim_x)
+    {
+        rocblas_int sz1 = bsz[i * 2 + 0];
+        rocblas_int sz2 = bsz[i * 2 + 1];
+        rocblas_int p1 = bps[i * 2];
+        msz[i] = sz1 + sz2;
+        mps[i] = p1;
+    }
+    __syncthreads();
+    for(int i = hipThreadIdx_x; i < n; i += hipBlockDim_x)
+    {
+        rocblas_int m = em[i] / 2;
+        nsz[i] = msz[m];
+        nps[i] = mps[m];
+        map[i] = 0;
+        dcount[i] = 0;
+    }
+    __syncthreads();
+
+    for(int i = hipThreadIdx_x; i < n; i += hipBlockDim_x)
+    {
+        em[i] /= 2;
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+/** STEDC_MERGEPREPARE_DEFLATEZERO_KERNEL finds and stores tolerances and performs
+    deflation of zero values
         - Call this kernel with batch_count groups in y, and as many groups as half of the
           unmerged sub-blocks in current level in x. Each group works with a merge of a pair
           of sub-blocks. Groups are size STEDC_BDIM **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergePrepare_DeflateZero_kernel(const rocblas_int levs,
-                                          const rocblas_int blks,
-                                          const rocblas_int k,
+    stedc_mergePrepare_DeflateZero_kernel(const rocblas_int k,
                                           const rocblas_int n,
                                           S* DD,
                                           const rocblas_stride strideD,
@@ -229,7 +449,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                                           const rocblas_int ldc,
                                           const rocblas_stride strideC,
                                           S* tmpzA,
-                                          S* vecsA,
                                           rocblas_int* splitsA,
                                           const S eps)
 {
@@ -238,9 +457,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     rocblas_int bid = hipBlockIdx_y;
     // merge sub-block id
     rocblas_int sid = hipBlockIdx_x;
-    // thread id
-    rocblas_int tidb = hipThreadIdx_x;
-    rocblas_int tid, tx;
 
     // select batch instance to work with
     S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
@@ -249,284 +465,153 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
-    // container of permutations when solving the secular eqns
-    rocblas_int* pers = idd + n;
-    // sizes of the first sub-block in a merge
-    rocblas_int* szfs = pers + n;
-    // sizes of both sub-blocks in a merge
-    rocblas_int* szs = szfs + n;
-    // degrees of secular equation
-    rocblas_int* dds = szs + n;
-    // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // temp for tolerance values used in deflation
-    // IMPORTANT: tols maps to the same memory as evs
-    S* tols = z + n;
-    // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
+    rocblas_int* mask = ptr_mask(n, splits);
+    rocblas_int* bsz = ptr_bsz(n, splits);
+    rocblas_int* bps = ptr_bps(n, splits);
 
-    // temporary arrays in shared memory
-    // used to store temp values during the different reductions
-    __shared__ S inrmsd[STEDC_BDIM];
-    __shared__ S inrmsz[STEDC_BDIM];
-
-    // tn is the number of thread-groups needed in level k of the merge
-    rocblas_int bd = 1 << k;
-    rocblas_int bdm = bd << 1;
-    rocblas_int tn = blks / bdm;
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* z = ptr_z(n, tmpz);
+    S* r1p = ptr_r1p(n, tmpz);
+    S* tolsD = ptr_tolsD(n, tmpz);
+    S* tolsZ = ptr_tolsZ(n, tmpz);
 
     // Work with merges on level k. A thread-group works with two leaves in the merge tree.
-    if(sid < tn)
     {
-        rocblas_int iam, sz, dim, dim2, p2;
-
-        // tid indexes the sub-blocks in the entire matrix
-        // iam indexes the sub-blocks in the context of the merge
-        // (according to its level in the merge tree)
-        dim = hipBlockDim_x / 2;
-        iam = tidb / dim;
-        tx = tidb % dim;
-        tid = sid * bdm + iam * bd;
-        p2 = ps[tid];
-
         // 1. find rank-1 modification components (z and p) for this merge
         // ----------------------------------------------------------------
-        // Threads with iam = 0 work with components below the merge point;
-        // threads with iam = 1 work above the merge point
-        sz = ns[tid];
-        for(int j = 1; j < bd; ++j)
-            sz += ns[tid + j];
-        szfs[tid] = sz;
-        // with this, all threads involved in a merge
-        // will point to the same row of C and the same off-diag element
-        S* ptz = (iam == 0) ? C + p2 - 1 + sz : C + p2;
-        S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
+        rocblas_int sz1 = bsz[sid * 2 + 0];
+        rocblas_int sz2 = bsz[sid * 2 + 1];
+        rocblas_int p1 = bps[sid * 2 + 0];
+        rocblas_int p2 = bps[sid * 2 + 1];
 
-        // copy elements of z
-        for(int j = tx; j < sz; j += dim)
-            z[p2 + j] = ptz[(p2 + j) * ldc] / sqrt(2);
+        // Find off-diagonal element of the merge
+        // rank-1 modification component p correspond to the last element in the first sub-block
+        S p = 2 * E[p2 - 1];
+        for(int i = hipThreadIdx_x; i < sz1 + sz2; i += hipBlockDim_x)
+        {
+            r1p[p1 + i] = p;
+        }
+
+        S maxd = 0;
+        S maxz = 0;
+        // copy z values from first sub-block
+        // copy last line of the first sub-block
+        for(int i = hipThreadIdx_x; i < sz1; i += hipBlockDim_x)
+        {
+            S val = C[p2 - 1 + (p1 + i) * ldc] / sqrt(2);
+            z[p1 + i] = val;
+            maxz = std::max(maxz, std::abs(val));
+        }
+        // copy first line of the second sub-block
+        for(int i = hipThreadIdx_x; i < sz2; i += hipBlockDim_x)
+        {
+            S val = C[p2 - 0 + (p2 + i) * ldc] / sqrt(2);
+            z[p2 + i] = val;
+            maxz = std::max(maxz, std::abs(val));
+        }
 
         // 2. calculate deflation tolerance
         // ----------------------------------------------------------------
         // compute maximum of diagonal and z in each merge block
-        S valf, valg, maxd, maxz;
-        maxd = 0;
-        maxz = 0;
-        for(int i = tx; i < sz; i += dim)
+        rocblas_int sz = sz1 + sz2;
+        for(int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x)
         {
-            valf = std::abs(D[p2 + i]);
-            valg = std::abs(z[p2 + i]);
-            maxd = valf > maxd ? valf : maxd;
-            maxz = valg > maxz ? valg : maxz;
+            maxd = std::max(maxd, abs(D[p1 + i]));
         }
-        inrmsd[tidb] = maxd;
-        inrmsz[tidb] = maxz;
+
+        // temporary arrays in shared memory
+        // used to store temp values during reduction
+        __shared__ S lmaxz[STEDC_BDIM];
+        __shared__ S lmaxd[STEDC_BDIM];
+        lmaxd[hipThreadIdx_x] = maxd;
+        lmaxz[hipThreadIdx_x] = maxz;
         __syncthreads();
 
-        dim2 = dim;
+        rocblas_int dim2 = hipBlockDim_x / 2;
         while(dim2 > 0)
         {
-            if(tidb < dim2)
+            if(hipThreadIdx_x < dim2)
             {
-                valf = inrmsd[tidb + dim2];
-                valg = inrmsz[tidb + dim2];
-                maxd = valf > maxd ? valf : maxd;
-                maxz = valg > maxz ? valg : maxz;
-                inrmsd[tidb] = maxd;
-                inrmsz[tidb] = maxz;
+                S vald = lmaxd[hipThreadIdx_x + dim2];
+                S valz = lmaxz[hipThreadIdx_x + dim2];
+                maxd = std::max(maxd, vald);
+                maxz = std::max(maxz, valz);
+                lmaxd[hipThreadIdx_x] = maxd;
+                lmaxz[hipThreadIdx_x] = maxz;
             }
             dim2 /= 2;
             __syncthreads();
         }
 
         // tol should be  8 * eps * (max diagonal or z element participating in merge)
-        maxd = inrmsd[0];
-        maxz = inrmsz[0];
-        maxd = maxz > maxd ? maxz : maxd;
-        S tol = 8 * eps * maxd;
+        maxd = lmaxd[0];
+        maxz = lmaxz[0];
+
+        S tolD = 8 * eps * std::max(maxd, maxz);
+        S tolZ = 8 * eps * std::max(maxd, maxz);
+        // store tolerances in global memory
+        for(int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x)
+        {
+            tolsD[p1 + i] = tolD;
+            tolsZ[p1 + i] = tolZ;
+        }
 
         // 3. deflate eigenvalues
         // ----------------------------------------------------------------
-        // determine boundaries of what would be the new merged sub-block
-        // 'in' will be its initial position.
-        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        rocblas_int in = tid - iam * bd;
-        sz = ns[in];
-        for(int i = 1; i < bdm; ++i)
-            sz += ns[in + i];
-        szs[in] = sz;
-        tols[in] = tol;
-        in = ps[in];
-
-        // first deflate zero components
-        for(int i = tidb; i < sz; i += hipBlockDim_x)
+        // deflate zero components
+        for(int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x)
         {
-            tx = in + i;
-            S g = z[tx];
-            if(abs(p * g) <= tol)
-                // deflated ev because component in z is zero
-                idd[tx] = 0;
-            else
-                idd[tx] = 1;
+            S g = z[p1 + i];
+            // deflated ev if component in z is zero
+            mask[p1 + i] = (abs(p * g) <= tolZ) ? 0 : 1;
         }
     }
 }
 
 //--------------------------------------------------------------------------------------//
-/** STEDC_MERGEPREPARE_FILL_KERNEL fills different arrays in splits struct
-        - Call this kernel with batch_count groups in y, and as many groups as half of the
-          unmerged sub-blocks in current level in x. Each group works with a merge of a pair
-          of sub-blocks. Groups are size STEDC_BDIM **/
-template <typename S>
-ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergePrepare_Fill_kernel(const rocblas_int levs,
-                                   const rocblas_int blks,
-                                   const rocblas_int k,
-                                   const rocblas_int n,
-                                   S* tmpzA,
-                                   S* vecsA,
-                                   rocblas_int* splitsA)
-{
-    // threads and groups indices
-    // batch instance id
-    rocblas_int bid = hipBlockIdx_y;
-    // merge sub-block id
-    rocblas_int sid = hipBlockIdx_x;
-
-    // temporary arrays in global memory
-    rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
-    // container of permutations when solving the secular eqns
-    rocblas_int* pers = idd + n;
-    // sizes of the first sub-block in a merge
-    rocblas_int* szfs = pers + n;
-    // sizes of both sub-blocks in a merge
-    rocblas_int* szs = szfs + n;
-    // degrees of secular equation
-    rocblas_int* dds = szs + n;
-    // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // temp for tolerance values used in deflation
-    // IMPORTANT: tols maps to the same memory as evs
-    S* tols = z + n;
-    // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
-
-    S* cc = vecs + 2 * n;
-    S* ss = vecs + 3 * n;
-    S* mtols = vecs + 4 * n;
-    S* md = vecs + 5 * n;
-
-    rocblas_int* map = splits + 8 * n;
-    rocblas_int* dcount = splits + 9 * n;
-    rocblas_int* mns = splits + 10 * n;
-    rocblas_int* mps = splits + 11 * n;
-    rocblas_int* cand = splits + 12 * n;
-    rocblas_int* midd = splits + 13 * n;
-
-    rocblas_int in = sid << (k + 1);
-    rocblas_int sz = szs[in];
-    rocblas_int p = ps[in];
-    S tol = tols[in];
-
-    for(int i = hipThreadIdx_x; i < sz; i += hipBlockDim_x)
-    {
-        int id = p + i;
-        mns[id] = sz;
-        mps[id] = p;
-        mtols[id] = tol;
-        dcount[id] = 0;
-        map[id] = 0;
-    }
-}
-
-//--------------------------------------------------------------------------------------//
 /** STEDC_MERGEPREPARE_SORTD_KERNEL sorts D array and construct map of original positions
-        - Call this kernel with n groups in x and batch_count groups in y. Groups are size STEDC_BDIM **/
+        - Call this kernel with n groups in x and batch_count groups in y.
+        Groups are size STEDC_BDIM **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergePrepare_SortD_kernel(const rocblas_int levs,
-                                    const rocblas_int blks,
-                                    const rocblas_int k,
+    stedc_mergePrepare_SortD_kernel(const rocblas_int k,
                                     const rocblas_int n,
                                     S* DD,
                                     const rocblas_stride strideD,
                                     S* tmpzA,
-                                    S* vecsA,
                                     rocblas_int* splitsA)
 {
     // threads and groups indices
     // batch instance id
     rocblas_int bid = hipBlockIdx_y;
-    // merge sub-block id
-    rocblas_int sid = hipBlockIdx_x;
+    // group id
+    rocblas_int gid = hipBlockIdx_x;
 
     // select batch instance to work with
     S* D = DD + bid * strideD;
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
-    // container of permutations when solving the secular eqns
-    rocblas_int* pers = idd + n;
-    // sizes of the first sub-block in a merge
-    rocblas_int* szfs = pers + n;
-    // sizes of both sub-blocks in a merge
-    rocblas_int* szs = szfs + n;
-    // degrees of secular equation
-    rocblas_int* dds = szs + n;
-    // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // temp for tolerance values used in deflation
-    // IMPORTANT: tols maps to the same memory as evs
-    S* tols = z + n;
-    // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
+    rocblas_int* mask = ptr_mask(n, splits);
+    rocblas_int* ndd = ptr_ndd(n, splits);
+    rocblas_int* map = ptr_map(n, splits);
+    rocblas_int* nsz = ptr_nsz(n, splits);
+    rocblas_int* nps = ptr_nps(n, splits);
 
-    S* cc = vecs + 2 * n;
-    S* ss = vecs + 3 * n;
-    S* mtols = vecs + 4 * n;
-    S* md = vecs + 5 * n;
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* md = ptr_md(n, tmpz);
 
-    rocblas_int* map = splits + 8 * n;
-    rocblas_int* dcount = splits + 9 * n;
-    rocblas_int* mns = splits + 10 * n;
-    rocblas_int* mps = splits + 11 * n;
-    rocblas_int* cand = splits + 12 * n;
-    rocblas_int* midd = splits + 13 * n;
-
-    S d = D[sid];
-    rocblas_int sz = mns[sid];
-    rocblas_int p = mps[sid];
-    rocblas_int dz = idd[sid];
+    S d = D[gid];
+    rocblas_int sz = nsz[gid];
+    rocblas_int p1 = nps[gid];
+    rocblas_int def = mask[gid];
+    rocblas_int dd = 0;
 
     constexpr int regs = 8;
     const int chunk_width = regs * hipBlockDim_x;
     const int n_chunks = (sz - 1) / chunk_width + 1;
     S bval[regs];
-    int dzs[regs];
+    int maskval[regs];
 
     int nan = 0;
     int lt = 0;
@@ -539,8 +624,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < sz)
             {
-                bval[i] = D[p + x];
-                dzs[i] = idd[p + x];
+                bval[i] = D[p1 + x];
+                maskval[i] = mask[p1 + x];
             }
         }
         for(int i = 0; i < regs; i++)
@@ -548,40 +633,43 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < sz)
             {
-                nan += (bval[i] != bval[i]);
+                nan += std::isnan(bval[i]);
+                dd += maskval[i] > 0;
                 // lt - how many values are less then the current
                 // eq - how many values are equal to the current
                 // all zero deflated values have to be grouped at the end
                 // so we order any deflated value > any non-deflated value
-                // dz == 0 - current is deflated, dz[i] == 1 - other value is not deflated
-                lt += (dz < dzs[i]) || (dz == dzs[i] && bval[i] < d);
-                eq += (dz == dzs[i]) && (bval[i] == d && (p + x) < sid);
+                // def == 0 - current is deflated, maskval[i] == 1 - other value is not deflated
+                lt += (def < maskval[i]) || (def == maskval[i] && bval[i] < d);
+                eq += (def == maskval[i]) && (bval[i] == d && (p1 + x) < gid);
             }
         }
     }
 
     int pos = lt + eq;
-    __shared__ int lds[STEDC_BDIM];
-    // Reduction (sum of pos across all lanes in a workgroup)
-    // on each iteration reduction is done within a subgroup of size of 2*bit
-    // by xoring corresponding bit of an address.
-    // The faster implementation should use dpp + a single trip through lds
-    // but keeping code simple for now.
-    int bit = 1;
-    while(bit < STEDC_BDIM)
+    __shared__ int lpos[STEDC_BDIM];
+    __shared__ int ldd[STEDC_BDIM];
+
+    // reduction
+    lpos[hipThreadIdx_x] = pos;
+    ldd[hipThreadIdx_x] = dd;
+    for(int r = hipBlockDim_x / 2; r > 0; r /= 2)
     {
-        lds[hipThreadIdx_x ^ bit] = pos;
         __syncthreads();
-        pos += lds[hipThreadIdx_x];
-        __syncthreads();
-        bit *= 2;
+        if(hipThreadIdx_x < r)
+        {
+            pos += lpos[hipThreadIdx_x + r];
+            dd += ldd[hipThreadIdx_x + r];
+            lpos[hipThreadIdx_x] = pos;
+            ldd[hipThreadIdx_x] = dd;
+        }
     }
 
     if(hipThreadIdx_x == 0)
     {
-        map[pos + p] = sid;
-        md[pos + p] = d;
-        midd[pos + p] = dz;
+        ndd[pos + p1] = dd;
+        map[pos + p1] = gid;
+        md[pos + p1] = d;
     }
 
     __syncthreads();
@@ -591,7 +679,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // than in the input, but the following computations are doomed anyway.
     if(nan)
     {
-        md[sid] = NAN;
+        md[gid] = NAN;
     }
 }
 
@@ -601,14 +689,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         Groups are size STEDC_BDIM **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergePrepare_SetCandFlags_kernel(const rocblas_int levs,
-                                           const rocblas_int blks,
-                                           const rocblas_int k,
+    stedc_mergePrepare_SetCandFlags_kernel(const rocblas_int k,
                                            const rocblas_int n,
                                            S* DD,
                                            const rocblas_stride strideD,
                                            S* tmpzA,
-                                           S* vecsA,
                                            rocblas_int* splitsA)
 {
     // threads and groups indices
@@ -620,23 +705,13 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    S* z = tmpzA + bid * (2 * n);
-    // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
+    rocblas_int* nps = ptr_nps(n, splits);
+    rocblas_int* ndd = ptr_ndd(n, splits);
+    rocblas_int* cand = ptr_cand(n, splits);
 
-    S* cc = vecs + 2 * n;
-    S* ss = vecs + 3 * n;
-    S* mtols = vecs + 4 * n;
-    S* md = vecs + 5 * n;
-
-    rocblas_int* map = splits + 8 * n;
-    rocblas_int* dcount = splits + 9 * n;
-    rocblas_int* mns = splits + 10 * n;
-    rocblas_int* mps = splits + 11 * n;
-    rocblas_int* cand = splits + 12 * n;
-    rocblas_int* midd = splits + 13 * n;
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* md = ptr_md(n, tmpz);
+    S* tolsD = ptr_tolsD(n, tmpz);
 
     constexpr int F_BCAND = 1 << L_F_BCAND_BIT;
     constexpr int F_TCAND = 1 << L_F_TCAND_BIT;
@@ -647,21 +722,22 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     {
         int next = (i + 1) < n ? (i + 1) : i;
         int prev = (i > 0) ? (i - 1) : 0;
-        S tol = mtols[i];
+        S tol = tolsD[i];
         S d = md[i];
         S dn = md[next];
         S dp = md[prev];
-        rocblas_int p = mps[i];
-        rocblas_int pn = mps[next];
-        rocblas_int pp = mps[prev];
+        rocblas_int dd = ndd[i];
+        rocblas_int p1 = nps[i];
+        rocblas_int pn = nps[next];
+        rocblas_int pp = nps[prev];
 
-        int bcandidate = midd[i] && midd[next] // not yet deflated
-            && p == pn // in the same merge block
+        int bcandidate = (i - p1 < dd - 1) // current and next are not yet deflated
+            && p1 == pn // in the same merge block
             && std::abs(d - dn) <= tol // within tolerance
             && i != (n - 1) // isn't last
             ;
-        int tcandidate = midd[i] && midd[prev] // not yet deflated
-            && p == pp // in the same merge block
+        int tcandidate = (i - p1 < dd) // current and prev are not yet deflated
+            && p1 == pp // in the same merge block
             && std::abs(d - dp) <= tol // within tolerance
             && i > 0 // isn't first
             ;
@@ -675,14 +751,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         Groups are size STEDC_BDIM **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergePrepare_DeflateCount_kernel(const rocblas_int levs,
-                                           const rocblas_int blks,
-                                           const rocblas_int k,
+    stedc_mergePrepare_DeflateCount_kernel(const rocblas_int k,
                                            const rocblas_int n,
                                            S* DD,
                                            const rocblas_stride strideD,
                                            S* tmpzA,
-                                           S* vecsA,
                                            rocblas_int* splitsA)
 {
     // threads and groups indices
@@ -694,30 +767,12 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
-    // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
+    rocblas_int* dcount = ptr_dcount(n, splits);
+    rocblas_int* cand = ptr_cand(n, splits);
 
-    S* cc = vecs + 2 * n;
-    S* ss = vecs + 3 * n;
-    S* mtols = vecs + 4 * n;
-    S* md = vecs + 5 * n;
-
-    rocblas_int* map = splits + 8 * n;
-    rocblas_int* dcount = splits + 9 * n;
-    rocblas_int* mns = splits + 10 * n;
-    rocblas_int* mps = splits + 11 * n;
-    rocblas_int* cand = splits + 12 * n;
-    rocblas_int* midd = splits + 13 * n;
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* md = ptr_md(n, tmpz);
+    S* tolsD = ptr_tolsD(n, tmpz);
 
     constexpr rocblas_int max_len = 4096;
     __shared__ S ldsD[max_len];
@@ -731,7 +786,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     int candp = (prev < n) ? cand[prev] : 0;
     int candb = (base < n) ? cand[base] : 0;
     S bval = (base < n) ? md[base] : 0;
-    S tol = (base < n) ? mtols[base] : 0;
+    S tol = (base < n) ? tolsD[base] : 0;
 
     // cache max_len values of D[] and cand[]
     for(int i = hipThreadIdx_x; i < max_len; i += hipBlockDim_x)
@@ -776,14 +831,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         Groups are size STEDC_BDIM **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergePrepare_DeflateApply_kernel(const rocblas_int levs,
-                                           const rocblas_int blks,
-                                           const rocblas_int k,
+    stedc_mergePrepare_DeflateApply_kernel(const rocblas_int k,
                                            const rocblas_int n,
                                            S* DD,
                                            const rocblas_stride strideD,
                                            S* tmpzA,
-                                           S* vecsA,
                                            rocblas_int* splitsA)
 {
     // threads and groups indices
@@ -795,30 +847,14 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
-    // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
+    rocblas_int* mask = ptr_mask(n, splits);
+    rocblas_int* map = ptr_map(n, splits);
+    rocblas_int* dcount = ptr_dcount(n, splits);
 
-    S* cc = vecs + 2 * n;
-    S* ss = vecs + 3 * n;
-    S* mtols = vecs + 4 * n;
-    S* md = vecs + 5 * n;
-
-    rocblas_int* map = splits + 8 * n;
-    rocblas_int* dcount = splits + 9 * n;
-    rocblas_int* mns = splits + 10 * n;
-    rocblas_int* mps = splits + 11 * n;
-    rocblas_int* cand = splits + 12 * n;
-    rocblas_int* midd = splits + 13 * n;
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* z = ptr_z(n, tmpz);
+    S* cc = ptr_cc(n, tmpz);
+    S* ss = ptr_ss(n, tmpz);
 
     constexpr rocblas_int max_len = 4096;
     __shared__ S lz[max_len];
@@ -855,7 +891,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             lartg(f, g, c, s, rr);
             baseval = rr;
 
-            idd[idx] = 0;
+            mask[idx] = 0;
             z[idx] = 0;
             cc[idx] = c;
             ss[idx] = s;
@@ -871,36 +907,28 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
           a deflation group will do nothing **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeRotate_kernel(const rocblas_int levs,
-                             const rocblas_int blks,
-                             const rocblas_int k,
+    stedc_mergeRotate_kernel(const rocblas_int k,
                              const rocblas_int n,
                              S* CC,
                              const rocblas_int shiftC,
                              const rocblas_int ldc,
                              const rocblas_stride strideC,
                              S* tmpzA,
-                             S* vecsA,
                              rocblas_int* splitsA)
 {
     // threads and groups indices
     // batch instance id
     rocblas_int bid = hipBlockIdx_y;
 
-    // temporary arrays in global memory
-    rocblas_int* splits = splitsA + bid * get_splits_size(n);
-
-    // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
-
     S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
 
-    rocblas_int* map = splits + 8 * n;
-    rocblas_int* dcounts = splits + 9 * n;
-    S* cc = vecs + 2 * n;
-    S* ss = vecs + 3 * n;
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    rocblas_int* map = ptr_map(n, splits);
+    rocblas_int* dcounts = ptr_dcount(n, splits);
+
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* cc = ptr_cc(n, tmpz);
+    S* ss = ptr_ss(n, tmpz);
 
     constexpr int regs = 16;
     const int chunk_width = regs * hipBlockDim_x;
@@ -975,687 +1003,267 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergePrepare_Organize_kernel(const rocblas_int levs,
-                                       const rocblas_int blks,
-                                       const rocblas_int k,
-                                       const rocblas_int n,
-                                       S* DD,
-                                       const rocblas_stride strideD,
-                                       S* EE,
-                                       const rocblas_stride strideE,
-                                       S* CC,
-                                       const rocblas_int shiftC,
-                                       const rocblas_int ldc,
-                                       const rocblas_stride strideC,
-                                       S* tmpzA,
-                                       S* vecsA,
-                                       rocblas_int* splitsA,
-                                       const S eps)
+    stedc_mergeValues_SortDZ_kernel(const rocblas_int k,
+                                    const rocblas_int n,
+                                    S* DD,
+                                    const rocblas_stride strideD,
+                                    S* tmpzA,
+                                    rocblas_int* splitsA)
 {
     // threads and groups indices
     // batch instance id
     rocblas_int bid = hipBlockIdx_y;
-    // merge sub-block id
-    rocblas_int sid = hipBlockIdx_x;
-    // thread id
-    rocblas_int tidb = hipThreadIdx_x;
-    rocblas_int tid, tx;
+    // group id
+    rocblas_int gid = hipBlockIdx_x;
 
     // select batch instance to work with
-    S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
     S* D = DD + bid * strideD;
-    S* E = EE + bid * strideE;
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
-    // container of permutations when solving the secular eqns
-    rocblas_int* pers = idd + n;
-    // sizes of the first sub-block in a merge
-    rocblas_int* szfs = pers + n;
-    // sizes of both sub-blocks in a merge
-    rocblas_int* szs = szfs + n;
-    // degrees of secular equation
-    rocblas_int* dds = szs + n;
-    // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // temp for tolerance values used in deflation
-    // IMPORTANT: tols maps to the same memory as evs
-    S* tols = z + n;
-    // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
+    rocblas_int* mask = ptr_mask(n, splits);
+    rocblas_int* map = ptr_map(n, splits);
+    rocblas_int* nsz = ptr_nsz(n, splits);
+    rocblas_int* nps = ptr_nps(n, splits);
+    rocblas_int* ndd = ptr_ndd(n, splits);
 
-    // tn is the number of thread-groups needed in level k of the merge
-    rocblas_int bd = 1 << k;
-    rocblas_int bdm = bd << 1;
-    rocblas_int tn = blks / bdm;
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* z = ptr_z(n, tmpz);
+    S* cd = ptr_cd(n, tmpz);
+    S* cz = ptr_cz(n, tmpz);
+    S* r1p = ptr_r1p(n, tmpz);
+    S* evs = ptr_evs(n, tmpz);
 
-    // Work with merges on level k. A thread-group works with two leaves in the merge tree.
-    if(sid < tn)
+    S sig = (r1p[gid] < 0) ? -1 : 1;
+    S d_ = D[gid];
+    S sd_ = sig * d_;
+    S z_ = z[gid];
+    rocblas_int sz = nsz[gid];
+    rocblas_int p1 = nps[gid];
+    rocblas_int def = mask[gid];
+
+    constexpr int regs = 8;
+    const int chunk_width = regs * hipBlockDim_x;
+    const int n_chunks = (sz - 1) / chunk_width + 1;
+    S bval[regs];
+    int maskval[regs];
+
+    int nan = 0;
+    int lt = 0;
+    int eq = 0;
+
+    rocblas_int dd = 0;
+
+    for(int chunk = 0; chunk < n_chunks; chunk++)
     {
-        rocblas_int iam, sz, dim, dim2, p2;
-
-        // tid indexes the sub-blocks in the entire matrix
-        // iam indexes the sub-blocks in the context of the merge
-        // (according to its level in the merge tree)
-        dim = hipBlockDim_x / 2;
-        iam = tidb / dim;
-        tx = tidb % dim;
-        tid = sid * bdm + iam * bd;
-        p2 = ps[tid];
-
-        // 1. find rank-1 modification components (z and p) for this merge
-        // ----------------------------------------------------------------
-        // Threads with iam = 0 work with components below the merge point;
-        // threads with iam = 1 work above the merge point
-        //sz = ns[tid];
-        //for(int j = 1; j < bd; ++j)
-        //    sz += ns[tid + j];
-        sz = szfs[tid];
-        // with this, all threads involved in a merge
-        // will point to the same row of C and the same off-diag element
-        S* ptz = (iam == 0) ? C + p2 - 1 + sz : C + p2;
-        S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
-
-        // 3. deflate eigenvalues
-        // ----------------------------------------------------------------
-        // determine boundaries of what would be the new merged sub-block
-        // 'in' will be its initial position.
-        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        rocblas_int in = tid - iam * bd;
-        //sz = ns[in];
-        //for(int i = 1; i < bdm; ++i)
-        //    sz += ns[in + i];
-        sz = szs[in];
-        in = ps[in];
-
-        // 4. Organize data with non-deflated values to prepare secular equation
-        // ------------------------------------------------------------------------
-        // define shifted arrays
-        S* tmpd = temps + in * n;
-        S* diag = D + in;
-        rocblas_int* mask = idd + in;
-        S* zz = z + in;
-        rocblas_int* per = pers + in;
-
-        // find degree and components of secular equation
-        // tmpd contains the non-deflated diagonal elements (ie. poles of the
-        // secular eqn) zz contains the corresponding non-zero elements of the
-        // rank-1 modif vector
-        rocblas_int dd = 0;
-        for(int i = 0; i < sz; ++i)
+        for(int i = 0; i < regs; i++)
         {
-            if(mask[i] == 1)
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < sz)
             {
-                if(tidb == 0)
-                {
-                    per[dd] = i;
-                    tmpd[dd] = p < 0 ? -diag[i] : diag[i];
-                    if(dd != i)
-                        zz[dd] = zz[i];
-                }
-                dd++;
+                bval[i] = sig * D[p1 + x];
+                maskval[i] = mask[p1 + x];
             }
         }
-        dds[in] = dd;
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < sz)
+            {
+                nan += std::isnan(bval[i]);
+                dd += maskval[i] > 0;
+                // lt - how many values are less then the current
+                // eq - how many values are equal to the current
+                // all zero deflated values have to be grouped at the end
+                // so we order any deflated value > any non-deflated value
+                // def == 0 - current is deflated, maskval[i] == 1 - other value is not deflated
+                lt += (def < maskval[i]) || (def == maskval[i] && bval[i] < sd_);
+                eq += (def == maskval[i]) && (bval[i] == sd_ && (p1 + x) < gid);
+            }
+        }
     }
-}
 
-template <typename S>
-void __device__ inline sort_tmpd_zz(const rocblas_int dd,
-                                    const rocblas_int iam,
-                                    const rocblas_int bdm,
-                                    S* tmpd,
-                                    S* zz,
-                                    rocblas_int* per)
-{
-    // Order the elements in tmpd and zz using a simple parallel selection/bubble sort.
-    // This will allow us to find initial intervals for eigenvalue guesses
-    for(int i = 0; i < dd; i++)
+    int pos = lt + eq;
+
+    // Reduction of pos and dd across workgroup
+    __shared__ int lpos[STEDC_BDIM];
+    __shared__ int ldd[STEDC_BDIM];
+    lpos[hipThreadIdx_x] = pos;
+    ldd[hipThreadIdx_x] = dd;
+    __syncthreads();
+    rocblas_int dim2 = hipBlockDim_x / 2;
+    while(dim2 > 0)
     {
-        for(int j = 2 * iam + i % 2; j < dd - 1; j += 2 * bdm)
+        if(hipThreadIdx_x < dim2)
         {
-            if(tmpd[j] > tmpd[j + 1])
-            {
-                swap(tmpd[j], tmpd[j + 1]);
-                swap(zz[j], zz[j + 1]);
-                swap(per[j], per[j + 1]);
-            }
+            pos += lpos[hipThreadIdx_x + dim2];
+            dd += ldd[hipThreadIdx_x + dim2];
+            lpos[hipThreadIdx_x] = pos;
+            ldd[hipThreadIdx_x] = dd;
         }
+        dim2 /= 2;
         __syncthreads();
     }
+
+    if(hipThreadIdx_x == 0)
+    {
+        ndd[pos + p1] = dd;
+        map[pos + p1] = gid;
+        cd[pos + p1] = sd_;
+        cz[pos + p1] = z_;
+        // copy over all diagonal elements in ev. ev will be overwritten
+        // by the new computed eigenvalues of the merged block
+        evs[pos + p1] = d_;
+    }
+
+    __syncthreads();
+    // The NAN fp value is unordered, so it is possible that with computed
+    // new positions it would be silently overwriten with non NAN value.
+    // Make sure we propagate NAN. It is likely to have more NANs in the output
+    // than in the input, but the following computations are doomed anyway.
+    if(nan)
+    {
+        cd[gid] = NAN;
+    }
 }
 
 template <typename S>
-void __device__ inline copy_d_ev(const rocblas_int dd,
-                                 const rocblas_int iam,
-                                 const rocblas_int bdm,
-                                 const rocblas_int sz,
-                                 const rocblas_int n,
-                                 S* tmpd,
-                                 S* ev,
-                                 S* diag)
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+    stedc_mergeValues_copyD_kernel(const rocblas_int k,
+                                   const rocblas_int n,
+                                   S* DD,
+                                   const rocblas_stride strideD,
+                                   S* tmpzA,
+                                   S* tempgemmA,
+                                   rocblas_int* splitsA)
 {
-    // make dd copies of the non-deflated ordered diagonal elements
+    // threads and groups indices
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+    rocblas_int eid = hipBlockIdx_x;
+
+    // select batch instance to work with
+    S* D = DD + bid * strideD;
+
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    rocblas_int* ndd = ptr_ndd(n, splits);
+    rocblas_int* nps = ptr_nps(n, splits);
+
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* evs = ptr_evs(n, tmpz);
+    S* cd = ptr_cd(n, tmpz);
+
+    S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
+    S* etmpd = ptr_etmpd(n, tempgemm);
+
+    rocblas_int dd = ndd[eid];
+    rocblas_int p1 = nps[eid];
+
+    // copy sorted values back to D
+    int x = hipThreadIdx_x + hipBlockDim_x * hipBlockIdx_x;
+    if(x < n)
+    {
+        D[x] = evs[x];
+    }
+
+    // make copies of the non-deflated ordered diagonal elements
     // (i.e. the poles of the secular eqn) so that the distances to the
     // eigenvalues (D - lambda_i) are updated while computing each eigenvalue.
     // This will prevent collapses and division by zero when an eigenvalue
     // is too close to a pole.
-    for(int i = iam; i < dd; i += bdm)
+    for(int i = hipThreadIdx_x; i < dd; i += hipBlockDim_x)
     {
-        for(int j = i + n; j < i + sz * n; j += n)
-            tmpd[j] = tmpd[i];
-    }
-
-    // finally copy over all diagonal elements in ev. ev will be overwritten
-    // by the new computed eigenvalues of the merged block
-    for(int i = iam; i < sz; i += bdm)
-        ev[i] = diag[i];
-}
-
-template <typename S>
-void __device__ inline solve_seq_eqns(const rocblas_int dd,
-                                      const rocblas_int iam,
-                                      const rocblas_int bdm,
-                                      const rocblas_int sz,
-                                      const rocblas_int n,
-                                      const S p,
-                                      const S eps,
-                                      const S ssfmin,
-                                      const S ssfmax,
-                                      const rocblas_int* mask,
-                                      S* tmpd,
-                                      S* ev,
-                                      S* zz)
-{
-    /* ----------------------------------------------------------------- */
-
-    // 2. Solve secular eqns, i.e. find the dd zeros
-    // corresponding to non-deflated new eigenvalues of the merged block
-    /* ----------------------------------------------------------------- */
-    // each thread will find a different zero in parallel
-    S a, b;
-    for(int j = iam; j < sz; j += bdm)
-    {
-        if(mask[j] == 1)
-        {
-            // find position in the ordered array
-            S valf = p < 0 ? -ev[j] : ev[j];
-            int count = dd, cc = 0;
-            while(count > 0)
-            {
-                auto step = count / 2;
-                auto it = cc + step;
-                if(tmpd[it + j * n] < valf)
-                {
-                    cc = ++it;
-                    count -= step + 1;
-                }
-                else
-                    count = step;
-            }
-
-            // computed zero will overwrite 'ev' at the corresponding position.
-            // 'tmpd' will be updated with the distances D - lambda_i.
-            // deflated values are not changed.
-            rocblas_int linfo;
-
-#if defined(ROCSOLVER_USE_REFERENCE_SECULAR_EQUATIONS_SOLVER)
-            linfo = slaed4(dd, cc, tmpd + j * n, zz, std::abs(p), ev[j]);
-#else
-            if(cc == dd - 1)
-                linfo = seq_solve_ext(dd, tmpd + j * n, zz, (p < 0 ? -p : p), ev + j, eps, ssfmin,
-                                      ssfmax);
-            else
-                linfo = seq_solve(dd, tmpd + j * n, zz, (p < 0 ? -p : p), cc, ev + j, eps, ssfmin,
-                                  ssfmax);
-#endif
-
-            if(p < 0)
-                ev[j] *= -1;
-        }
-    }
-}
-
-template <typename S>
-void __device__ inline rescale_z(const rocblas_int dd,
-                                 const rocblas_int iam,
-                                 const rocblas_int bdm,
-                                 const rocblas_int sz,
-                                 const rocblas_int n,
-                                 const rocblas_int* per,
-                                 const rocblas_int* mask,
-                                 const S* tmpd,
-                                 const S* diag,
-                                 S* zz)
-{
-    // Re-scale vector Z to avoid bad numerics when an eigenvalue
-    // is too close to a pole
-    for(int i = iam; i < dd; i += bdm)
-    {
-        S valf = 1;
-        for(int j = 0; j < sz; ++j)
-        {
-            if(mask[j] == 1)
-            {
-                S valg = tmpd[i + j * n];
-                valf *= (per[i] == j) ? valg : valg / (diag[per[i]] - diag[j]);
-            }
-        }
-        valf = sqrt(std::abs(valf));
-        zz[i] = zz[i] < 0 ? -valf : valf;
+        etmpd[eid * n + i] = cd[p1 + i];
     }
 }
 
 //--------------------------------------------------------------------------------------//
 /** STEDC_MERGEVALUES_KERNEL solves the secular equation for every pair of sub-blocks
     that need to be merged.
-        - Call this kernel with batch_count groups in y, and as many groups as half of the
-          unmerged sub-blocks in current level in x. Each group works with a merge of a pair
-          of sub-blocks. Groups are size STEDC_BDIM **/
-template <typename S>
-ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeValues_kernel(const rocblas_int levs,
-                             const rocblas_int blks,
-                             const rocblas_int k,
-                             const rocblas_int n,
-                             S* DD,
-                             const rocblas_stride strideD,
-                             S* EE,
-                             const rocblas_stride strideE,
-                             S* tmpzA,
-                             S* vecsA,
-                             rocblas_int* splitsA,
-                             const S eps,
-                             const S ssfmin,
-                             const S ssfmax)
-{
-    // threads and groups indices
-    // batch instance id
-    rocblas_int bid = hipBlockIdx_y;
-    // merge sub-block id
-    rocblas_int sid = hipBlockIdx_x;
-    // thread id
-    rocblas_int tidb = hipThreadIdx_x;
-    rocblas_int tid;
-
-    // select batch instance to work with
-    S* D = DD + bid * strideD;
-    S* E = EE + bid * strideE;
-
-    // temporary arrays in global memory
-    rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
-    // container of permutations when solving the secular eqns
-    rocblas_int* pers = idd + n;
-    // sizes of the first sub-block in a merge
-    rocblas_int* szfs = pers + n;
-    // sizes of both sub-blocks in a merge
-    rocblas_int* szs = szfs + n;
-    // degrees of secular equation
-    rocblas_int* dds = szs + n;
-    // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // roots of secular equations
-    S* evs = z + n;
-    // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
-
-    // tn is the number of thread-groups needed in level k of the merge
-    rocblas_int bd = 1 << k;
-    rocblas_int bdm = bd << 1;
-    rocblas_int tn = blks / bdm;
-
-    // Work with merges on level k. A thread-group works with two leaves in the merge tree;
-    // all threads work together to solve the secular equation.
-    if(sid < tn)
-    {
-        rocblas_int iam, sz, dim, p2;
-        S valf, valg;
-
-        // tid indexes the sub-blocks in the entire split block
-        // iam indexes the sub-blocks in the context of the merge
-        // (according to its level in the merge tree)
-        dim = hipBlockDim_x / 2;
-        iam = tidb / dim;
-        tid = sid * bdm + iam * bd;
-        p2 = ps[tid];
-
-        // Find off-diagonal element of the merge
-        // Threads with iam = 0 work with components below the merge point;
-        // threads with iam = 1 work above the merge point
-        //sz = ns[tid];
-        //for(int j = 1; j < bd; ++j)
-        //    sz += ns[tid + j];
-        sz = szfs[tid];
-        // with this, all threads involved in a merge
-        // will point to the same row of C and the same off-diag element
-        S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
-
-        // determine boundaries of what would be the new merged sub-block
-        // 'in' will be its initial position.
-        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        rocblas_int in = tid - iam * bd;
-        //sz = ns[in];
-        //for(int i = 1; i < bdm; ++i)
-        //    sz += ns[in + i];
-        sz = szs[in];
-        in = ps[in];
-
-        // 1. Organize data with non-deflated values to prepare secular equation
-        // -----------------------------------------------------------------
-        // All threads of the group participating in the merge will work together
-        // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
-        iam = tidb;
-        bdm = hipBlockDim_x;
-
-        // define shifted arrays
-        S* tmpd = temps + in * n;
-        S* ev = evs + in;
-        S* diag = D + in;
-        rocblas_int* mask = idd + in;
-        S* zz = z + in;
-        rocblas_int* per = pers + in;
-
-        // find degree of secular equation
-        rocblas_int dd = dds[in];
-        //rocblas_int dd = 0;
-        //for(int i = 0; i < sz; ++i)
-        //{
-        //    if(mask[i] == 1)
-        //        dd++;
-        //}
-
-        sort_tmpd_zz(dd, iam, bdm, tmpd, zz, per);
-        copy_d_ev(dd, iam, bdm, sz, n, tmpd, ev, diag);
-
-        __syncthreads();
-
-        solve_seq_eqns(dd, iam, bdm, sz, n, p, eps, ssfmin, ssfmax, mask, tmpd, ev, zz);
-
-        __syncthreads();
-
-        rescale_z(dd, iam, bdm, sz, n, per, mask, tmpd, diag, zz);
-    }
-}
+        - Call this kernel with batch_count groups in y, and as many groups in x as needed
+          to cover n (i.e. n_groups_x * groups_size_x >= n). Groups are size STEDC_SOLVE_BDIM **/
 
 template <typename S>
-ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeValues_Sort_kernel(const rocblas_int levs,
-                                  const rocblas_int blks,
-                                  const rocblas_int k,
-                                  const rocblas_int n,
-                                  S* DD,
-                                  const rocblas_stride strideD,
-                                  S* EE,
-                                  const rocblas_stride strideE,
-                                  S* tmpzA,
-                                  S* vecsA,
-                                  rocblas_int* splitsA,
-                                  const S eps,
-                                  const S ssfmin,
-                                  const S ssfmax)
-{
-    // threads and groups indices
-    // batch instance id
-    rocblas_int bid = hipBlockIdx_y;
-    // merge sub-block id
-    rocblas_int sid = hipBlockIdx_x;
-    // thread id
-    rocblas_int tidb = hipThreadIdx_x;
-    rocblas_int tid;
-
-    // select batch instance to work with
-    S* D = DD + bid * strideD;
-    S* E = EE + bid * strideE;
-
-    // temporary arrays in global memory
-    rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
-    // container of permutations when solving the secular eqns
-    rocblas_int* pers = idd + n;
-    // sizes of the first sub-block in a merge
-    rocblas_int* szfs = pers + n;
-    // sizes of both sub-blocks in a merge
-    rocblas_int* szs = szfs + n;
-    // degrees of secular equation
-    rocblas_int* dds = szs + n;
-    // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // roots of secular equations
-    S* evs = z + n;
-    // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
-
-    // tn is the number of thread-groups needed in level k of the merge
-    rocblas_int bd = 1 << k;
-    rocblas_int bdm = bd << 1;
-    rocblas_int tn = blks / bdm;
-
-    // Work with merges on level k. A thread-group works with two leaves in the merge tree;
-    // all threads work together to solve the secular equation.
-    if(sid < tn)
-    {
-        rocblas_int iam, sz, dim, p2;
-        S valf, valg;
-
-        // tid indexes the sub-blocks in the entire split block
-        // iam indexes the sub-blocks in the context of the merge
-        // (according to its level in the merge tree)
-        dim = hipBlockDim_x / 2;
-        iam = tidb / dim;
-        tid = sid * bdm + iam * bd;
-        p2 = ps[tid];
-
-        // Find off-diagonal element of the merge
-        // Threads with iam = 0 work with components below the merge point;
-        // threads with iam = 1 work above the merge point
-        //sz = ns[tid];
-        //for(int j = 1; j < bd; ++j)
-        //    sz += ns[tid + j];
-        sz = szfs[tid];
-        // with this, all threads involved in a merge
-        // will point to the same row of C and the same off-diag element
-        S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
-
-        // determine boundaries of what would be the new merged sub-block
-        // 'in' will be its initial position.
-        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        rocblas_int in = tid - iam * bd;
-        //sz = ns[in];
-        //for(int i = 1; i < bdm; ++i)
-        //    sz += ns[in + i];
-        sz = szs[in];
-        in = ps[in];
-
-        // 1. Organize data with non-deflated values to prepare secular equation
-        // -----------------------------------------------------------------
-        // All threads of the group participating in the merge will work together
-        // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
-        iam = tidb;
-        bdm = hipBlockDim_x;
-
-        // define shifted arrays
-        S* tmpd = temps + in * n;
-        S* ev = evs + in;
-        S* diag = D + in;
-        rocblas_int* mask = idd + in;
-        S* zz = z + in;
-        rocblas_int* per = pers + in;
-
-        // find degree of secular equation
-        rocblas_int dd = dds[in];
-        //rocblas_int dd = 0;
-        //for(int i = 0; i < sz; ++i)
-        //{
-        //    if(mask[i] == 1)
-        //        dd++;
-        //}
-
-        sort_tmpd_zz(dd, iam, bdm, tmpd, zz, per);
-        copy_d_ev(dd, iam, bdm, sz, n, tmpd, ev, diag);
-    }
-}
-
-template <typename S>
-ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeValues_Solve_kernel(const rocblas_int levs,
-                                   const rocblas_int blks,
-                                   const rocblas_int k,
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_SOLVE_BDIM)
+    stedc_mergeValues_Solve_kernel(const rocblas_int k,
                                    const rocblas_int n,
                                    S* DD,
                                    const rocblas_stride strideD,
                                    S* EE,
                                    const rocblas_stride strideE,
                                    S* tmpzA,
-                                   S* vecsA,
+                                   S* tempgemmA,
                                    rocblas_int* splitsA,
                                    const S eps,
                                    const S ssfmin,
-                                   const S ssfmax,
-                                   const rocblas_int groups_per_merge)
+                                   const S ssfmax)
 {
     // threads and groups indices
     // batch instance id
     rocblas_int bid = hipBlockIdx_y;
-    // merge sub-block id
-    rocblas_int sid = hipBlockIdx_x / groups_per_merge;
-    // thread id
-    rocblas_int group_in_subblock = hipBlockIdx_x % groups_per_merge;
-    rocblas_int tidb = hipThreadIdx_x + group_in_subblock * hipBlockDim_x;
-    rocblas_int tid;
-
-    // select batch instance to work with
-    S* D = DD + bid * strideD;
-    S* E = EE + bid * strideE;
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
-    // container of permutations when solving the secular eqns
-    rocblas_int* pers = idd + n;
-    // sizes of the first sub-block in a merge
-    rocblas_int* szfs = pers + n;
-    // sizes of both sub-blocks in a merge
-    rocblas_int* szs = szfs + n;
-    // degrees of secular equation
-    rocblas_int* dds = szs + n;
-    // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // roots of secular equations
-    S* evs = z + n;
+    rocblas_int* ndd = ptr_ndd(n, splits);
+    rocblas_int* nps = ptr_nps(n, splits);
+
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* z = ptr_cz(n, tmpz);
+    S* r1p = ptr_r1p(n, tmpz);
+    S* evs = ptr_evs(n, tmpz);
     // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
+    S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
+    S* etmpd = ptr_etmpd(n, tempgemm);
 
-    // tn is the number of thread-groups needed in level k of the merge
-    rocblas_int bd = 1 << k;
-    rocblas_int bdm = bd << 1;
-    rocblas_int tn = blks / bdm;
-
-    // Work with merges on level k. A thread-group works with two leaves in the merge tree;
-    // all threads work together to solve the secular equation.
-    if(sid < tn)
+    int i = hipThreadIdx_x + hipBlockDim_x * hipBlockIdx_x;
+    if(i < n)
     {
-        rocblas_int iam, sz, dim, p2;
-        S valf, valg;
+        S p = r1p[i];
+        rocblas_int p1 = nps[i];
+        rocblas_int dd = ndd[i];
 
-        // tid indexes the sub-blocks in the entire split block
-        // iam indexes the sub-blocks in the context of the merge
-        // (according to its level in the merge tree)
-        dim = (hipBlockDim_x * groups_per_merge) / 2;
-        iam = tidb / dim;
-        tid = sid * bdm + iam * bd;
-        p2 = ps[tid];
+        /* ----------------------------------------------------------------- */
 
-        // Find off-diagonal element of the merge
-        // Threads with iam = 0 work with components below the merge point;
-        // threads with iam = 1 work above the merge point
-        //sz = ns[tid];
-        //for(int j = 1; j < bd; ++j)
-        //    sz += ns[tid + j];
-        sz = szfs[tid];
-        // with this, all threads involved in a merge
-        // will point to the same row of C and the same off-diag element
-        S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
+        // 2. Solve secular eqns, i.e. find the dd zeros
+        // corresponding to non-deflated new eigenvalues of the merged block
+        /* ----------------------------------------------------------------- */
+        // each thread will find a different zero in parallel
+        if((i - p1) < dd)
+        {
+            int cc = i - p1;
 
-        // determine boundaries of what would be the new merged sub-block
-        // 'in' will be its initial position.
-        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        rocblas_int in = tid - iam * bd;
-        //sz = ns[in];
-        //for(int i = 1; i < bdm; ++i)
-        //    sz += ns[in + i];
-        sz = szs[in];
-        in = ps[in];
+            // computed zero will overwrite 'ev' at the corresponding position.
+            // 'etmpd' will be updated with the distances D - lambda_i.
+            // deflated values are not changed.
+            rocblas_int linfo;
 
-        // 1. Organize data with non-deflated values to prepare secular equation
-        // -----------------------------------------------------------------
-        // All threads of the group participating in the merge will work together
-        // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
-        iam = tidb;
-        bdm = hipBlockDim_x * groups_per_merge;
+#if defined(ROCSOLVER_USE_REFERENCE_SECULAR_EQUATIONS_SOLVER)
+            linfo = slaed4(dd, cc, etmpd + i * n, z + p1, std::abs(p), evs[i]);
+#else
+            if(cc == dd - 1)
+                linfo = seq_solve_ext(dd, etmpd + i * n, z + p1, std::abs(p), evs + i, eps, ssfmin,
+                                      ssfmax);
+            else
+                linfo = seq_solve(dd, etmpd + i * n, z + p1, std::abs(p), cc, evs + i, eps, ssfmin,
+                                  ssfmax);
+#endif
 
-        // define shifted arrays
-        S* tmpd = temps + in * n;
-        S* ev = evs + in;
-        S* diag = D + in;
-        rocblas_int* mask = idd + in;
-        S* zz = z + in;
-        rocblas_int* per = pers + in;
-
-        // find degree of secular equation
-        rocblas_int dd = dds[in];
-        //rocblas_int dd = 0;
-        //for(int i = 0; i < sz; ++i)
-        //{
-        //    if(mask[i] == 1)
-        //        dd++;
-        //}
-
-        solve_seq_eqns(dd, iam, bdm, sz, n, p, eps, ssfmin, ssfmax, mask, tmpd, ev, zz);
+            if(p < 0)
+                evs[i] *= -1;
+        }
     }
 }
 
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeValues_Rescale_kernel(const rocblas_int levs,
-                                     const rocblas_int blks,
-                                     const rocblas_int k,
+    stedc_mergeValues_Rescale_kernel(const rocblas_int k,
                                      const rocblas_int n,
                                      S* DD,
                                      const rocblas_stride strideD,
                                      S* EE,
                                      const rocblas_stride strideE,
                                      S* tmpzA,
-                                     S* vecsA,
+                                     S* tempgemmA,
                                      rocblas_int* splitsA,
                                      const S eps,
                                      const S ssfmin,
@@ -1664,324 +1272,195 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     // threads and groups indices
     // batch instance id
     rocblas_int bid = hipBlockIdx_y;
-    // merge sub-block id
-    rocblas_int sid = hipBlockIdx_x;
-    // thread id
-    rocblas_int tidb = hipThreadIdx_x;
-    rocblas_int tid;
+    // value id
+    rocblas_int eid = hipBlockIdx_x;
 
     // select batch instance to work with
     S* D = DD + bid * strideD;
-    S* E = EE + bid * strideE;
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
-    // container of permutations when solving the secular eqns
-    rocblas_int* pers = idd + n;
-    // sizes of the first sub-block in a merge
-    rocblas_int* szfs = pers + n;
-    // sizes of both sub-blocks in a merge
-    rocblas_int* szs = szfs + n;
-    // degrees of secular equation
-    rocblas_int* dds = szs + n;
-    // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // roots of secular equations
-    S* evs = z + n;
+    rocblas_int* nps = ptr_nps(n, splits);
+    rocblas_int* nsz = ptr_nsz(n, splits);
+    rocblas_int* ndd = ptr_ndd(n, splits);
+
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* z = ptr_cz(n, tmpz);
     // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
+    S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
+    S* etmpd = ptr_etmpd(n, tempgemm);
 
-    // tn is the number of thread-groups needed in level k of the merge
-    rocblas_int bd = 1 << k;
-    rocblas_int bdm = bd << 1;
-    rocblas_int tn = blks / bdm;
+    rocblas_int sz = nsz[eid];
+    rocblas_int p1 = nps[eid];
+    rocblas_int dd = ndd[eid];
 
-    // Work with merges on level k. A thread-group works with two leaves in the merge tree;
-    // all threads work together to solve the secular equation.
-    if(sid < tn)
+    // Re-scale vector Z to avoid bad numerics when an eigenvalue
+    // is too close to a pole
+    rocblas_int i = eid - p1;
+    if(i < dd)
     {
-        rocblas_int iam, sz, dim, p2;
-        S valf, valg;
+        S valf = 1;
+        for(int j = hipThreadIdx_x; j < dd; j += hipBlockDim_x)
+        {
+            S valg = etmpd[(p1 + j) * n + i];
+            valf *= ((p1 + i) == (p1 + j)) ? valg : valg / (D[p1 + i] - D[p1 + j]);
+        }
+        __shared__ S lds[STEDC_BDIM];
+        rocblas_int dim2 = hipBlockDim_x / 2;
 
-        // tid indexes the sub-blocks in the entire split block
-        // iam indexes the sub-blocks in the context of the merge
-        // (according to its level in the merge tree)
-        dim = hipBlockDim_x / 2;
-        iam = tidb / dim;
-        tid = sid * bdm + iam * bd;
-        p2 = ps[tid];
+        lds[hipThreadIdx_x] = valf;
+        __syncthreads();
+        while(dim2 > 0)
+        {
+            if(hipThreadIdx_x < dim2)
+            {
+                valf *= lds[hipThreadIdx_x + dim2];
+                lds[hipThreadIdx_x] = valf;
+            }
+            dim2 /= 2;
+            __syncthreads();
+        }
 
-        // Find off-diagonal element of the merge
-        // Threads with iam = 0 work with components below the merge point;
-        // threads with iam = 1 work above the merge point
-        //sz = ns[tid];
-        //for(int j = 1; j < bd; ++j)
-        //    sz += ns[tid + j];
-        sz = szfs[tid];
-        // with this, all threads involved in a merge
-        // will point to the same row of C and the same off-diag element
-        S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
-
-        // determine boundaries of what would be the new merged sub-block
-        // 'in' will be its initial position.
-        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        rocblas_int in = tid - iam * bd;
-        //sz = ns[in];
-        //for(int i = 1; i < bdm; ++i)
-        //    sz += ns[in + i];
-        sz = szs[in];
-        in = ps[in];
-
-        // 1. Organize data with non-deflated values to prepare secular equation
-        // -----------------------------------------------------------------
-        // All threads of the group participating in the merge will work together
-        // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
-        iam = tidb;
-        bdm = hipBlockDim_x;
-
-        // define shifted arrays
-        S* tmpd = temps + in * n;
-        S* ev = evs + in;
-        S* diag = D + in;
-        rocblas_int* mask = idd + in;
-        S* zz = z + in;
-        rocblas_int* per = pers + in;
-
-        // find degree of secular equation
-        rocblas_int dd = dds[in];
-        //rocblas_int dd = 0;
-        //for(int i = 0; i < sz; ++i)
-        //{
-        //    if(mask[i] == 1)
-        //        dd++;
-        //}
-
-        rescale_z(dd, iam, bdm, sz, n, per, mask, tmpd, diag, zz);
+        if(hipThreadIdx_x == 0)
+        {
+            valf = sqrt(std::abs(valf));
+            z[eid] = z[eid] < 0 ? -valf : valf;
+        }
     }
 }
 
 //--------------------------------------------------------------------------------------//
 /** STEDC_MERGEVECTORS_KERNEL prepares vectors from the secular equation for
     every pair of sub-blocks that need to be merged.
-        - Call this kernel with batch_count groups in y, and as many groups as columns would
-          be in the matrix if its size is exact multiple of the number of sub-blocks 'blks'.
+        - Call this kernel with batch_count groups in y, and n groups in x.
           Each group works with a column. Groups are size STEDC_BDIM.
         - If a group has an id larger than the actual number of columns it will do nothing. **/
 template <bool USEGEMM, typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeVectors_kernel(const rocblas_int levs,
-                              const rocblas_int blks,
-                              const rocblas_int k,
+    stedc_mergeVectors_kernel(const rocblas_int k,
                               const rocblas_int n,
-                              S* DD,
-                              const rocblas_stride strideD,
-                              S* EE,
-                              const rocblas_stride strideE,
                               S* CC,
                               const rocblas_int shiftC,
                               const rocblas_int ldc,
                               const rocblas_stride strideC,
                               S* tmpzA,
-                              S* vecsA,
+                              S* tempgemmA,
                               rocblas_int* splitsA)
 {
     // threads and groups indices
     // batch instance id
     rocblas_int bid = hipBlockIdx_y;
-    // merge sub-block id
-    rocblas_int sid = hipBlockIdx_x;
+    // eigenvalue id
+    rocblas_int eid = hipBlockIdx_x;
     // thread id
     rocblas_int tidb = hipThreadIdx_x;
     rocblas_int dim = hipBlockDim_x;
-    rocblas_int tid, vidb;
 
     // select batch instance to work with
-    S* C;
-    if(CC)
-        C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
-    S* D = DD + bid * strideD;
-    S* E = EE + bid * strideE;
+    S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
-    // container of permutations when solving the secular eqns
-    rocblas_int* pers = idd + n;
-    // sizes of the first sub-block in a merge
-    rocblas_int* szfs = pers + n;
-    // sizes of both sub-blocks in a merge
-    rocblas_int* szs = szfs + n;
-    // degrees of secular equation
-    rocblas_int* dds = szs + n;
-    // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // roots of secular equations
-    S* evs = z + n;
+    rocblas_int* nsz = ptr_nsz(n, splits);
+    rocblas_int* nps = ptr_nps(n, splits);
+    rocblas_int* ndd = ptr_ndd(n, splits);
+
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* z = ptr_cz(n, tmpz);
     // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
-    // temp values during the merges
-    S* temps = vecs + (n * n);
+    S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
+    S* vecs = ptr_vecs(n, tempgemm);
+    S* etmpd = ptr_etmpd(n, tempgemm);
+
+    // Work with merges on level k. Each thread-group works with one vector.
+    // determine boundaries of what would be the new merged sub-block
+    rocblas_int p1 = nps[eid];
+    rocblas_int sz = nsz[eid];
+    rocblas_int dd = ndd[eid];
+
+    __syncthreads();
 
     // temporary arrays in shared memory
     // used to store temp values during the different reductions
-    extern __shared__ rocblas_int lsmem[];
-    S* inrms = reinterpret_cast<S*>(lsmem);
+    __shared__ S inrms[STEDC_BDIM];
 
-    // tn is max number of vectors in each sub-block
-    rocblas_int bd = 1 << k;
-    rocblas_int bdm = bd << 1;
-    rocblas_int tn = (n - 1) / blks + 1;
+    // Prepare vectors corresponding to non-deflated values
+    S nrm;
+    S* putvec = USEGEMM ? vecs : etmpd;
 
-    // Work with merges on level k. Each thread-group works with one vector.
-    if(sid < tn * blks)
+    if(eid - p1 < dd)
     {
-        rocblas_int iam, sz, p2;
-        S valf, valg;
-
-        // tid indexes the sub-blocks in the entire split block
-        tid = sid / tn;
-        p2 = ps[tid];
-        // vidb indexes the vectors associated with each sub-block
-        vidb = sid % tn;
-        // iam indexes the sub-blocks in the context of the merge
-        // (according to its level in the merge tree)
-        iam = tid % bdm;
-
-        // determine boundaries of what would be the new merged sub-block
-        // 'in' will be its initial position
-        rocblas_int in = ps[tid - iam];
-        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        sz = ns[tid];
-        for(int i = iam; i > 0; --i)
-            sz += ns[tid - i];
-        for(int i = bdm - 1 - iam; i > 0; --i)
-            sz += ns[tid + i];
-
-        // define shifted arrays
-        S* tmpd = temps + in * n;
-        S* ev = evs + in;
-        S* diag = D + in;
-        rocblas_int* mask = idd + in;
-        S* zz = z + in;
-        rocblas_int* per = pers + in;
-
-        // find degree of secular equation
-        rocblas_int dd = 0;
-        for(int i = 0; i < sz; ++i)
+        // compute vectors of rank-1 perturbed system and their norms
+        nrm = 0;
+        for(int i = tidb; i < dd; i += dim)
         {
-            if(mask[i] == 1)
-                dd++;
+            S valf = z[p1 + i] / etmpd[i + eid * n];
+            nrm += valf * valf;
+            putvec[i + eid * n] = valf;
+        }
+
+        // reduction (for the norms)
+        inrms[tidb] = nrm;
+        for(int r = dim / 2; r > 0; r /= 2)
+        {
+            __syncthreads();
+            if(tidb < r)
+            {
+                nrm += inrms[tidb + r];
+                inrms[tidb] = nrm;
+            }
         }
         __syncthreads();
+        nrm = sqrt(inrms[0]);
+    }
 
-        // Prepare vectors corresponding to non-deflated values
-        S temp, nrm;
-        rocblas_int j = vidb;
-        bool go = (j < ns[tid]);
-        S* putvec = USEGEMM ? vecs : temps;
-
-        if(go)
+    if(USEGEMM)
+    {
+        // when using external gemms for the update, we need to
+        // put vectors in padded matrix 'etmpd'
+        // (this is to compute 'vecs = C * etmpd' using external gemm call)
+        for(int i = tidb; i < p1 + sz; i += dim)
         {
-            if(idd[p2 + j] == 1)
+            if(i >= p1 && (eid - p1) < dd && (i - p1) < dd)
             {
-                // compute vectors of rank-1 perturbed system and their norms
-                nrm = 0;
-                for(int i = tidb; i < dd; i += dim)
-                {
-                    valf = zz[i] / temps[i + (p2 + j) * n];
-                    nrm += valf * valf;
-                    putvec[i + (p2 + j) * n] = valf;
-                }
-                inrms[tidb] = nrm;
-                __syncthreads();
-
-                // reduction (for the norms)
-                for(int r = dim / 2; r > 0; r /= 2)
-                {
-                    if(tidb < r)
-                    {
-                        nrm += inrms[tidb + r];
-                        inrms[tidb] = nrm;
-                    }
-                    __syncthreads();
-                }
-                nrm = sqrt(inrms[0]);
-            }
-
-            if(USEGEMM)
-            {
-                // when using external gemms for the update, we need to
-                // put vectors in padded matrix 'temps'
-                // (this is to compute 'vecs = C * temps' using external gemm call)
-                for(int i = tidb; i < in + sz; i += dim)
-                {
-                    if(i >= in && idd[p2 + j] == 1 && idd[i] == 1)
-                    {
-                        dd = 0;
-                        for(int k = in; k < i; ++k)
-                        {
-                            if(idd[k] == 0)
-                                dd++;
-                        }
-                        temps[pers[i - dd] + in + (p2 + j) * n]
-                            = vecs[i - dd - in + (p2 + j) * n] / nrm;
-                    }
-                    else
-                        temps[i + (p2 + j) * n] = 0;
-                }
+                etmpd[i + eid * n] = vecs[i - p1 + eid * n] / nrm;
             }
             else
+                etmpd[i + eid * n] = 0;
+        }
+    }
+    else
+    {
+        // otherwise, use internal gemm-like procedure to
+        // multiply by C (row by row)
+        if(eid - p1 < dd)
+        {
+            for(int ii = 0; ii < sz; ++ii)
             {
-                // otherwise, use internal gemm-like procedure to
-                // multiply by C (row by row)
-                rocblas_int tsz = 1 << (levs - 1 - k);
-                tsz = (n - 1) / tsz + 1;
-                if(idd[p2 + j] == 1)
+                rocblas_int i = p1 + ii;
+
+                // inner products
+                S temp = 0;
+                for(int kk = tidb; kk < dd; kk += dim)
+                    temp += C[i + (p1 + kk) * ldc] * etmpd[kk + eid * n];
+
+                // reduction
+                inrms[tidb] = temp;
+                for(int r = dim / 2; r > 0; r /= 2)
                 {
-                    for(int ii = 0; ii < tsz; ++ii)
+                    __syncthreads();
+                    if(tidb < r)
                     {
-                        rocblas_int i = in + ii;
-
-                        // inner products
-                        temp = 0;
-                        if(ii < sz)
-                        {
-                            for(int kk = tidb; kk < dd; kk += dim)
-                                temp += C[i + (per[kk] + in) * ldc] * temps[kk + (p2 + j) * n];
-                        }
+                        temp += inrms[tidb + r];
                         inrms[tidb] = temp;
-                        __syncthreads();
-
-                        // reduction
-                        for(int r = dim / 2; r > 0; r /= 2)
-                        {
-                            if(ii < sz && tidb < r)
-                            {
-                                temp += inrms[tidb + r];
-                                inrms[tidb] = temp;
-                            }
-                            __syncthreads();
-                        }
-
-                        // result
-                        if(ii < sz && tidb == 0)
-                            vecs[i + (p2 + j) * n] = temp / nrm;
-                        __syncthreads();
                     }
                 }
+                __syncthreads();
+
+                // result
+                if(tidb == 0)
+                    vecs[i + eid * n] = temp / nrm;
+                __syncthreads();
             }
         }
     }
@@ -1989,15 +1468,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
 //--------------------------------------------------------------------------------------//
 /** STEDC_MERGEUPDATE_KERNEL updates vectors and values after a merge is done.
-        - Call this kernel with batch_count groups in y, and as many groups as columns would
-          be in the matrix if its size is exact multiple of the number of sub-blocks 'blks'.
-          Each group works with a column. Groups are size STEDC_BDIM.
-        - If a group has an id larger than the actual number of columns it will do nothing. **/
+        - Call this kernel with batch_count groups in y, and n groups in x.
+          Each group works with a column. Groups are size STEDC_BDIM. **/
 template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeUpdate_kernel(const rocblas_int levs,
-                             const rocblas_int blks,
-                             const rocblas_int k,
+    stedc_mergeUpdate_kernel(const rocblas_int k,
                              const rocblas_int n,
                              S* DD,
                              const rocblas_stride strideD,
@@ -2006,80 +1481,42 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                              const rocblas_int ldc,
                              const rocblas_stride strideC,
                              S* tmpzA,
-                             S* vecsA,
+                             S* tempgemmA,
                              rocblas_int* splitsA)
 {
     // threads and groups indices
     // batch instance id
     rocblas_int bid = hipBlockIdx_y;
-    // merge sub-block id
-    rocblas_int sid = hipBlockIdx_x;
-    // thread id
-    rocblas_int tidb = hipThreadIdx_x;
-    rocblas_int dim = hipBlockDim_x;
-    rocblas_int tid, vidb;
+    // eigenvalue id
+    rocblas_int eid = hipBlockIdx_x;
 
     // select batch instance to work with
-    S* C;
-    if(CC)
-        C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
+    S* C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
     S* D = DD + bid * strideD;
 
     // temporary arrays in global memory
     rocblas_int* splits = splitsA + bid * get_splits_size(n);
-    // the sub-blocks sizes
-    rocblas_int* ns = splits + n;
-    // the sub-blocks initial positions
-    rocblas_int* ps = ns + n;
-    // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = ps + n;
-    // the rank-1 modification vectors in the merges
-    S* z = tmpzA + bid * (2 * n);
-    // roots of secular equations
-    S* evs = z + n;
+    rocblas_int* ndd = ptr_ndd(n, splits);
+    rocblas_int* nsz = ptr_nsz(n, splits);
+    rocblas_int* nps = ptr_nps(n, splits);
+
+    S* tmpz = tmpzA + bid * get_tmpz_size(n);
+    S* evs = ptr_evs(n, tmpz);
     // updated eigenvectors after merges
-    S* vecs = vecsA + bid * 2 * (n * n);
+    S* tempgemm = tempgemmA + bid * get_tempgemm_size(n);
+    S* vecs = ptr_vecs(n, tempgemm);
 
-    // tn is max number of vectors in each sub-block
-    rocblas_int bd = 1 << k;
-    rocblas_int bdm = bd << 1;
-    rocblas_int tn = (n - 1) / blks + 1;
+    rocblas_int p1 = nps[eid];
+    rocblas_int sz = nsz[eid];
+    rocblas_int dd = ndd[eid];
 
-    // Work with merges on level k. Each thread-group works with one vector.
-    if(sid < tn * blks)
+    // update D and C with computed values and vectors
+    if(eid - p1 < dd)
     {
-        rocblas_int iam, sz, p2;
-        S valf, valg;
-
-        // tid indexes the sub-blocks in the entire split block
-        tid = sid / tn;
-        p2 = ps[tid];
-        // vidb indexes the vectors associated with each sub-block
-        vidb = sid % tn;
-        // iam indexes the sub-blocks in the context of the merge
-        // (according to its level in the merge tree)
-        iam = tid % bdm;
-
-        // determine boundaries of what would be the new merged sub-block
-        // 'in' will be its initial position
-        rocblas_int in = ps[tid - iam];
-        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-        sz = ns[tid];
-        for(int i = iam; i > 0; --i)
-            sz += ns[tid - i];
-        for(int i = bdm - 1 - iam; i > 0; --i)
-            sz += ns[tid + i];
-
-        // update D and C with computed values and vectors
-        rocblas_int j = vidb;
-        bool go = (j < ns[tid] && idd[p2 + j] == 1);
-        if(go)
-        {
-            if(tidb == 0)
-                D[p2 + j] = evs[p2 + j];
-            for(int i = in + tidb; i < in + sz; i += dim)
-                C[i + (p2 + j) * ldc] = vecs[i + (p2 + j) * n];
-        }
+        if(hipThreadIdx_x == 0)
+            D[eid] = evs[eid];
+        for(int i = p1 + hipThreadIdx_x; i < p1 + sz; i += hipBlockDim_x)
+            C[i + eid * ldc] = vecs[i + eid * n];
     }
 }
 
@@ -2164,6 +1601,57 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_copyC(const rocblas_in
     }
 }
 
+template <typename T, typename U1, typename U2>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_reshuffleC(const rocblas_int n,
+                                                                     U1 CCin,
+                                                                     const rocblas_int shiftCin,
+                                                                     const rocblas_int ldcin,
+                                                                     const rocblas_stride strideCin,
+                                                                     U2 CCout,
+                                                                     const rocblas_int shiftCout,
+                                                                     const rocblas_int ldcout,
+                                                                     const rocblas_stride strideCout,
+                                                                     rocblas_int* splitsA)
+{
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+    // group id
+    rocblas_int gid = hipBlockIdx_x;
+
+    rocblas_int* splits = splitsA + bid * get_splits_size(n);
+    rocblas_int* map = ptr_map(n, splits);
+
+    rocblas_int dst_row = gid;
+    rocblas_int src_row = map[gid];
+
+    T* Cin = load_ptr_batch<T>(CCin, bid, shiftCin, strideCin);
+    T* Cout = load_ptr_batch<T>(CCout, bid, shiftCout, strideCout);
+
+    T* src = Cin + ldcin * src_row;
+    T* dst = Cout + ldcout * dst_row;
+
+    constexpr int regs = 16;
+    const int chunk_width = regs * hipBlockDim_x;
+    const int n_chunks = (n - 1) / chunk_width + 1;
+    T bval[regs];
+
+    for(int chunk = 0; chunk < n_chunks; chunk++)
+    {
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < n)
+                bval[i] = src[x];
+        }
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < n)
+                dst[x] = bval[i];
+        }
+    }
+}
+
 /** STEDC_SORT sorts computed eigenvalues and eigenvectors in increasing order **/
 template <typename T, typename S, typename U1, typename U2>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int n,
@@ -2219,12 +1707,9 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
             if(x < n)
             {
-                nan += (bvalS[i] != bvalS[i]);
+                nan += std::isnan(bvalS[i]);
                 // lt - how many values are less then the current
                 // eq - how many values are equal to the current
-                // all zero deflated values have to be grouped at the end
-                // so we order any deflated value > any non-deflated value
-                // dz == 0 - current is deflated, dz[i] == 1 - other value is not deflated
                 lt += (bvalS[i] < d);
                 eq += (bvalS[i] == d && x < gid);
             }
@@ -2232,28 +1717,26 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int
     }
 
     int pos = lt + eq;
-    __shared__ int lds[STEDC_BDIM];
-    // Reduction (sum of pos across all lanes in a workgroup)
-    // on each iteration reduction is done within a subgroup of size of 2*bit
-    // by xoring corresponding bit of an address.
-    // The faster implementation should use dpp + a single trip through lds
-    // but keeping code simple for now.
-    int bit = 1;
-    while(bit < STEDC_BDIM)
+    // reduction
+    __shared__ int lpos[STEDC_BDIM];
+    lpos[hipThreadIdx_x] = pos;
+    for(int r = hipBlockDim_x / 2; r > 0; r /= 2)
     {
-        lds[hipThreadIdx_x ^ bit] = pos;
         __syncthreads();
-        pos += lds[hipThreadIdx_x];
-        __syncthreads();
-        bit *= 2;
+        if(hipThreadIdx_x < r)
+        {
+            pos += lpos[hipThreadIdx_x + r];
+            lpos[hipThreadIdx_x] = pos;
+        }
     }
+    __syncthreads();
+    pos = lpos[0];
 
     if(hipThreadIdx_x == 0)
     {
         Dout[pos] = d;
     }
 
-    __syncthreads();
     // The NAN fp value is unordered, so it is possible that with computed
     // new positions it would be silently overwriten with non NAN value.
     // Make sure we propagate NAN. It is likely to have more NANs in the output
@@ -2301,8 +1784,6 @@ inline rocblas_int stedc_num_levels(const rocblas_int n)
         levels = 0;
     else
         levels = std::ceil(std::log2(n)) - 4;
-
-    //return 3;
 
     return levels;
 }
@@ -2367,17 +1848,16 @@ void rocsolver_stedc_getMemorySize(const rocblas_evect evect,
             *size_tempvect = sizeof(S) * (n * n) * batch_count;
         else
             *size_tempvect = 0;
-        *size_tempgemm = sizeof(S) * 2 * (n * n) * batch_count;
-        if(BATCHED && !COMPLEX)
-            *size_workArr = sizeof(S*) * batch_count;
-        else
-            *size_workArr = 0;
+        *size_tempgemm = sizeof(S) * get_tempgemm_size(n) * batch_count;
+        // blocks for batched GEMM are at least 8 x 8
+        auto max_n_merges = 1 << (stedc_num_levels(n) - 1);
+        *size_workArr = sizeof(S*) * std::max(max_n_merges * 3, batch_count);
 
         // size for split blocks and sub-blocks positions
         *size_splits_map = sizeof(rocblas_int) * get_splits_size(n) * batch_count;
 
         // size for temporary diagonal and rank-1 modif vector
-        *size_tmpz = sizeof(S) * (2 * n) * batch_count;
+        *size_tmpz = sizeof(S) * get_tmpz_size(n) * batch_count;
     }
 }
 
@@ -2486,7 +1966,7 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
     else
     {
         // initialize temporary array for vector updates
-        size_t size_tempgemm = sizeof(S) * 2 * n * n * batch_count;
+        size_t size_tempgemm = sizeof(S) * get_tempgemm_size(n) * batch_count;
         HIP_CHECK(hipMemsetAsync((void*)tempgemm, 0, size_tempgemm, stream));
 
         // everything must be executed with scalars on the host
@@ -2533,86 +2013,71 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         // 2. solve phase
         //-----------------------------
         ROCSOLVER_LAUNCH_KERNEL((stedc_solve_kernel<S>), dim3(blks, batch_count), dim3(64), 0,
-                                stream, levs, blks, n, D + shiftD, strideD, E + shiftE, strideE, V,
-                                0, ldv, strideV, info, (S*)work_stack, splits, eps, ssfmin, ssfmax);
+                                stream, levs, n, D + shiftD, strideD, E + shiftE, strideE, V, 0,
+                                ldv, strideV, info, (S*)work_stack, splits, eps, ssfmin, ssfmax);
 
         // 3. merge phase
         //----------------
-        size_t lmemsize3 = sizeof(S) * STEDC_BDIM;
-        rocblas_int numgrps3 = ((n - 1) / blks + 1) * blks;
-
         // launch merge for level k
         for(rocblas_int k = 0; k < levs; ++k)
         {
-            // a. prepare secular equations
-            rocblas_int numgrps2 = 1 << (levs - 1 - k);
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_DeflateZero_kernel<S>),
-                                    dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream, levs,
-                                    blks, k, n, D + shiftD, strideD, E + shiftE, strideE, V, 0, ldv,
-                                    strideV, tmpz, tempgemm, splits, eps);
+            rocblas_int n_merges = 1 << (levs - k - 1);
+            ROCSOLVER_LAUNCH_KERNEL(stedc_update_splits, dim3(1, batch_count), dim3(STEDC_BDIM), 0,
+                                    stream, levs, k, n, splits);
 
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_Fill_kernel<S>),
-                                    dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream, levs,
-                                    blks, k, n, tmpz, tempgemm, splits);
+            // a. prepare secular equations
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_DeflateZero_kernel<S>),
+                                    dim3(n_merges, batch_count), dim3(STEDC_BDIM), 0, stream, k, n,
+                                    D + shiftD, strideD, E + shiftE, strideE, V, 0, ldv, strideV,
+                                    tmpz, splits, eps);
+
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_SortD_kernel<S>), dim3(n, batch_count),
-                                    dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
-                                    strideD, tmpz, tempgemm, splits);
+                                    dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD, strideD, tmpz,
+                                    splits);
             rocblas_int numgrps_deflate = (n - 1) / STEDC_BDIM + 1;
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_SetCandFlags_kernel<S>),
                                     dim3(numgrps_deflate, batch_count), dim3(STEDC_BDIM), 0, stream,
-                                    levs, blks, k, n, D + shiftD, strideD, tmpz, tempgemm, splits);
+                                    k, n, D + shiftD, strideD, tmpz, splits);
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_DeflateCount_kernel<S>),
                                     dim3(numgrps_deflate, batch_count), dim3(STEDC_BDIM), 0, stream,
-                                    levs, blks, k, n, D + shiftD, strideD, tmpz, tempgemm, splits);
+                                    k, n, D + shiftD, strideD, tmpz, splits);
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_DeflateApply_kernel<S>),
                                     dim3(numgrps_deflate, batch_count), dim3(STEDC_BDIM), 0, stream,
-                                    levs, blks, k, n, D + shiftD, strideD, tmpz, tempgemm, splits);
+                                    k, n, D + shiftD, strideD, tmpz, splits);
 
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeRotate_kernel<S>), dim3(n, batch_count),
-                                    dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, V, 0, ldv,
-                                    strideV, tmpz, tempgemm, splits);
+                                    dim3(STEDC_BDIM), 0, stream, k, n, V, 0, ldv, strideV, tmpz,
+                                    splits);
 
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_Organize_kernel<S>),
-                                    dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream, levs,
-                                    blks, k, n, D + shiftD, strideD, E + shiftE, strideE, V, 0, ldv,
-                                    strideV, tmpz, tempgemm, splits, eps);
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_SortDZ_kernel<S>), dim3(n, batch_count),
+                                    dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD, strideD, tmpz,
+                                    splits);
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_copyD_kernel<S>), dim3(n, batch_count),
+                                    dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD, strideD, tmpz,
+                                    tempgemm, splits);
 
-            // b. solve secular eq to find merged eigenvalues
-            rocblas_int max_n_per_merge = (n + numgrps2 - 1) / numgrps2;
+            ROCSOLVER_LAUNCH_KERNEL(stedc_copyC<S>, dim3(n, batch_count), dim3(STEDC_BDIM), 0,
+                                    stream, n, V, 0, ldv, strideV, ptr_vecs(n, tempgemm), 0, n,
+                                    get_tempgemm_size(n));
 
-            if(max_n_per_merge > STEDC_BDIM)
-            {
-                // split mergeValues into stages to run seqular eqns solver using more groups
-                ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Sort_kernel<S>),
-                                        dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream,
-                                        levs, blks, k, n, D + shiftD, strideD, E + shiftE, strideE,
-                                        tmpz, tempgemm, splits, eps, ssfmin, ssfmax);
+            ROCSOLVER_LAUNCH_KERNEL(stedc_reshuffleC<S>, dim3(n, batch_count), dim3(STEDC_BDIM), 0,
+                                    stream, n, ptr_vecs(n, tempgemm), 0, n, get_tempgemm_size(n), V,
+                                    0, ldv, strideV, splits);
 
-                rocblas_int groups_per_merge = (max_n_per_merge + STEDC_BDIM - 1) / STEDC_BDIM;
-                ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Solve_kernel<S>),
-                                        dim3(numgrps2 * groups_per_merge, batch_count),
-                                        dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
-                                        strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
-                                        ssfmin, ssfmax, groups_per_merge);
-                ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Rescale_kernel<S>),
-                                        dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream,
-                                        levs, blks, k, n, D + shiftD, strideD, E + shiftE, strideE,
-                                        tmpz, tempgemm, splits, eps, ssfmin, ssfmax);
-            }
-            else
-            {
-                // compute in one dispatch for small merges
-                ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_kernel<S>), dim3(numgrps2, batch_count),
-                                        dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
-                                        strideD, E + shiftE, strideE, tmpz, tempgemm, splits, eps,
-                                        ssfmin, ssfmax);
-            }
+            rocblas_int numgrps_solve = (n - 1) / STEDC_SOLVE_BDIM + 1;
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Solve_kernel<S>),
+                                    dim3(numgrps_solve, batch_count), dim3(STEDC_SOLVE_BDIM), 0,
+                                    stream, k, n, D + shiftD, strideD, E + shiftE, strideE, tmpz,
+                                    tempgemm, splits, eps, ssfmin, ssfmax);
+
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_Rescale_kernel<S>), dim3(n, batch_count),
+                                    dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD, strideD,
+                                    E + shiftE, strideE, tmpz, tempgemm, splits, eps, ssfmin, ssfmax);
 
             // c. find merged eigenvectors
             ROCSOLVER_LAUNCH_KERNEL((stedc_mergeVectors_kernel<STEDC_EXTERNAL_GEMM, S>),
-                                    dim3(numgrps3, batch_count), dim3(STEDC_BDIM), lmemsize3,
-                                    stream, levs, blks, k, n, D + shiftD, strideD, E + shiftE,
-                                    strideE, V, 0, ldv, strideV, tmpz, tempgemm, splits);
+                                    dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, k, n, V, 0,
+                                    ldv, strideV, tmpz, tempgemm, splits);
 
             if(STEDC_EXTERNAL_GEMM)
             {
@@ -2621,15 +2086,72 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                 // TODO: using macro STEDC_EXTERNAL_GEMM = true for now. In the future we can pass
                 // STEDC_EXTERNAL_GEMM at run time to switch between internal vector updates and
                 // external gemm based updates.
-                rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, n, n, n,
-                               &one, V, 0, ldv, strideV, tempgemm, n * n, n, 2 * n * n, &zero,
-                               tempgemm, 0, n, 2 * n * n, batch_count, workArr);
+                if(n <= 1024 || batch_count > 1)
+                {
+                    rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, n, n, n,
+                                   &one, V, 0, ldv, strideV, ptr_etmpd(n, tempgemm), 0, n,
+                                   get_tempgemm_size(n), &zero, ptr_vecs(n, tempgemm), 0, n,
+                                   get_tempgemm_size(n), batch_count, workArr);
+                }
+                else
+                {
+                    HIP_CHECK(hipMemsetAsync((void*)tempgemm, 0, n * n * sizeof(S), stream));
+
+                    if(n % n_merges == 0)
+                    {
+                        int sz = n / n_merges;
+                        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, sz,
+                                       sz, sz, &one, V, 0, ldv, sz * ldv + sz,
+                                       ptr_etmpd(n, tempgemm), 0, n, sz * n + sz, &zero,
+                                       ptr_vecs(n, tempgemm), 0, n, sz * n + sz, n_merges, workArr);
+                    }
+                    else
+                    {
+                        rocblas_int lvl = levs - k - 1;
+                        std::vector<rocblas_int> ns(n_merges);
+                        ns[0] = n;
+                        for(int i = 0; i < lvl; ++i)
+                        {
+                            for(int j = (1 << i); j > 0; --j)
+                            {
+                                auto t = ns[j - 1];
+                                ns[j * 2 - 1] = t / 2 + (t & 1);
+                                ns[j * 2 - 2] = t / 2;
+                            }
+                        }
+                        // there can only be 2 block sizes: ns[0] and ns[0]+1
+                        std::array<std::vector<rocblas_int>, 2> uniform_batch;
+                        uniform_batch[0].reserve(n_merges);
+                        uniform_batch[1].reserve(n_merges);
+                        for(rocblas_int i = 0, ps = 0; i < n_merges; ps += ns[i++])
+                            uniform_batch[ns[i] != ns[0]].push_back(ps);
+                        for(rocblas_int i = 0, nsb = ns[0]; i < 2; ++i, ++nsb)
+                        {
+                            auto& b = uniform_batch[i];
+                            auto nbb = b.size();
+                            std::vector<S*> hABC(nbb * 3);
+                            for(size_t j = 0; j < nbb; ++j)
+                            {
+                                auto ps = b[j];
+                                hABC[j + 0 * nbb] = ps + ps * ldv + V;
+                                hABC[j + 1 * nbb] = ps + ps * n + ptr_etmpd(n, tempgemm);
+                                hABC[j + 2 * nbb] = ps + ps * n + ptr_vecs(n, tempgemm);
+                            }
+                            HIP_CHECK(hipMemcpyAsync(workArr, hABC.data(), 3 * nbb * sizeof(S*),
+                                                     hipMemcpyHostToDevice, stream));
+                            rocsolver_gemm<S, rocblas_int, S* const*, S* const*, S* const*>(
+                                handle, rocblas_operation_none, rocblas_operation_none, nsb, nsb,
+                                nsb, &one, workArr, 0, ldv, 0, workArr + nbb, 0, n, 0, &zero,
+                                workArr + 2 * nbb, 0, n, 0, nbb, nullptr);
+                        }
+                    }
+                }
             }
 
             // d. update level
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeUpdate_kernel<S>), dim3(numgrps3, batch_count),
-                                    dim3(STEDC_BDIM), 0, stream, levs, blks, k, n, D + shiftD,
-                                    strideD, V, 0, ldv, strideV, tmpz, tempgemm, splits);
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeUpdate_kernel<S>), dim3(n, batch_count),
+                                    dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD, strideD, V, 0,
+                                    ldv, strideV, tmpz, tempgemm, splits);
         }
 
         // 4. update and sort

--- a/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -37,796 +37,58 @@
 #include "rocauxiliary_sterf.hpp"
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
-#include "rocsolver_run_specialized_kernels.hpp"
 
 #include <algorithm>
 
 ROCSOLVER_BEGIN_NAMESPACE
 
 #define STEDC_BDIM 512 // Number of threads per thread-block used in main stedc kernels
-#define MAXITERS 50 // Max number of iterations for root finding method
 
 // TODO: using macro STEDC_EXTERNAL_GEMM = true for now. In the future we can pass
 // STEDC_EXTERNAL_GEMM at run time to switch between internal vector updates and
 // external gemm-based updates.
 #define STEDC_EXTERNAL_GEMM true
 
-typedef enum rocsolver_stedc_mode_
-{
-    rocsolver_stedc_mode_qr,
-    rocsolver_stedc_mode_jacobi,
-    rocsolver_stedc_mode_bisection
-} rocsolver_stedc_mode;
-
-template <rocsolver_stedc_mode MODE>
-__host__ __device__ inline rocblas_int stedc_num_levels(const rocblas_int n);
-
-/***************** Device auxiliary functions ******************************************/
-/**************************************************************************************/
-
-//--------------------------------------------------------------------------------------//
-/** SEQ_EVAL evaluates the secular equation at a given point. It accumulates the
-    corrections to the elements in D so that distance to poles are computed
-   accurately **/
-template <typename S>
-__device__ void seq_eval(const rocblas_int type,
-                         const rocblas_int k,
-                         const rocblas_int dd,
-                         S* D,
-                         const S* z,
-                         const S p,
-                         const S cor,
-                         S* pt_fx,
-                         S* pt_fdx,
-                         S* pt_gx,
-                         S* pt_gdx,
-                         S* pt_hx,
-                         S* pt_hdx,
-                         S* pt_er,
-                         bool modif)
-{
-    S er, fx, gx, hx, fdx, gdx, hdx, zz, tmp;
-    rocblas_int gout, hout;
-
-    // prepare computations
-    // if type = 0: evaluate secular equation
-    if(type == 0)
-    {
-        gout = k + 1;
-        hout = k;
-    }
-    // if type = 1: evaluate secular equation without the k-th pole
-    else if(type == 1)
-    {
-        if(modif)
-        {
-            tmp = D[k] - cor;
-            D[k] = tmp;
-        }
-        gout = k;
-        hout = k;
-    }
-    // if type = 2: evaluate secular equation without the k-th and (k+1)-th poles
-    else if(type == 2)
-    {
-        if(modif)
-        {
-            tmp = D[k] - cor;
-            D[k] = tmp;
-            tmp = D[k + 1] - cor;
-            D[k + 1] = tmp;
-        }
-        gout = k;
-        hout = k + 1;
-    }
-    else
-    {
-        // unexpected value for type, something is wrong
-        assert(false);
-    }
-
-    // computations
-    gx = 0;
-    gdx = 0;
-    er = 0;
-    for(int i = 0; i < gout; ++i)
-    {
-        tmp = D[i] - cor;
-        if(modif)
-            D[i] = tmp;
-        zz = z[i];
-        tmp = zz / tmp;
-        gx += zz * tmp;
-        gdx += tmp * tmp;
-        er += gx;
-    }
-    er = abs(er);
-
-    hx = 0;
-    hdx = 0;
-    for(int i = dd - 1; i > hout; --i)
-    {
-        tmp = D[i] - cor;
-        if(modif)
-            D[i] = tmp;
-        zz = z[i];
-        tmp = zz / tmp;
-        hx += zz * tmp;
-        hdx += tmp * tmp;
-        er += hx;
-    }
-
-    fx = p + gx + hx;
-    fdx = gdx + hdx;
-
-    // return results
-    *pt_fx = fx;
-    *pt_fdx = fdx;
-    *pt_gx = gx;
-    *pt_gdx = gdx;
-    *pt_hx = hx;
-    *pt_hdx = hdx;
-    *pt_er = er;
-}
-
-//--------------------------------------------------------------------------------------//
-/** SEQ_SOLVE solves secular equation at point k (i.e. computes kth eigenvalue
-   that is within an internal interval). We use rational interpolation and fixed
-   weights method between the 2 poles of the interval. (TODO: In the future, we
-   could consider using 3 poles for those cases that may need it to reduce the
-   number of required iterations to converge. The performance improvements are
-   expected to be marginal, though) **/
-template <typename S>
-__device__ rocblas_int seq_solve(const rocblas_int dd,
-                                 S* D,
-                                 const S* z,
-                                 const S p,
-                                 rocblas_int k,
-                                 S* ev,
-                                 const S tol,
-                                 const S ssfmin,
-                                 const S ssfmax)
-{
-    bool converged = false;
-    bool up, fixed;
-    S lowb, uppb, aa, bb, cc, x;
-    S nx, er, fx, fdx, gx, gdx, hx, hdx, oldfx;
-    S tau, eta;
-    S dk, dk1, ddk, ddk1;
-    rocblas_int kk;
-    rocblas_int k1 = k + 1;
-
-    // initialize
-    dk = D[k];
-    dk1 = D[k1];
-    x = (dk + dk1) / 2; // midpoint of interval
-    tau = (dk1 - dk);
-    S pinv = 1 / p;
-
-    // find bounds and initial guess; translate origin
-    seq_eval(2, k, dd, D, z, pinv, x, &cc, &fdx, &gx, &gdx, &hx, &hdx, &er, false);
-    gdx = z[k] * z[k];
-    hdx = z[k1] * z[k1];
-    fx = cc + 2 * (hdx - gdx) / tau;
-    if(fx > 0)
-    {
-        // if the secular eq at the midpoint is positive, the root is in between
-        // D[k] and the midpoint take D[k] as the origin, i.e. x = D[k] + tau with
-        // tau in (0, uppb)
-        lowb = 0;
-        uppb = tau / 2;
-        up = true;
-        kk = k; // origin remains the same
-        aa = cc * tau + gdx + hdx;
-        bb = gdx * tau;
-        eta = sqrt(abs(aa * aa - 4 * bb * cc));
-        if(aa > 0)
-            tau = 2 * bb / (aa + eta);
-        else
-            tau = (aa - eta) / (2 * cc);
-        x = dk + tau; // initial guess
-    }
-    else
-    {
-        // otherwise, the root is in between the midpoint and D[k+1]
-        // take D[k+1] as the origin, i.e. x = D[k+1] + tau with tau in (lowb, 0)
-        lowb = -tau / 2;
-        uppb = 0;
-        up = false;
-        kk = k + 1; // translate the origin
-        aa = cc * tau - gdx - hdx;
-        bb = hdx * tau;
-        eta = sqrt(abs(aa * aa + 4 * bb * cc));
-        if(aa < 0)
-            tau = 2 * bb / (aa - eta);
-        else
-            tau = -(aa + eta) / (2 * cc);
-        x = dk1 + tau; // initial guess
-    }
-
-    // evaluate secular eq and get input values to calculate step correction
-    seq_eval(0, kk, dd, D, z, pinv, (up ? dk : dk1), &fx, &fdx, &gx, &gdx, &hx, &hdx, &er, true);
-    seq_eval(1, kk, dd, D, z, pinv, tau, &fx, &fdx, &gx, &gdx, &hx, &hdx, &er, true);
-    bb = z[kk];
-    aa = bb / D[kk];
-    fdx += aa * aa;
-    bb *= aa;
-    fx += bb;
-
-    // calculate tolerance er for convergence test
-    er += 8 * (hx - gx) + 2 * pinv + 3 * abs(bb) + abs(tau) * fdx;
-
-    // if the value of secular eq is small enough, no point to continue;
-    // converged!!!
-    if(abs(fx) <= tol * er)
-        converged = true;
-
-    // otherwise...
-    else
-    {
-        // update bounds
-        lowb = (fx <= 0) ? std::max(lowb, tau) : lowb;
-        uppb = (fx > 0) ? std::min(uppb, tau) : uppb;
-
-        // calculate first step correction with fixed weight method
-        ddk = D[k];
-        ddk1 = D[k1];
-        if(up)
-            cc = fx - ddk1 * fdx - (dk - dk1) * z[k] * z[k] / ddk / ddk;
-        else
-            cc = fx - ddk * fdx - (dk1 - dk) * z[k1] * z[k1] / ddk1 / ddk1;
-        aa = (ddk + ddk1) * fx - ddk * ddk1 * fdx;
-        bb = ddk * ddk1 * fx;
-        if(cc == 0)
-        {
-            if(aa == 0)
-            {
-                if(up)
-                    aa = z[k] * z[k] + ddk1 * ddk1 * (gdx + hdx);
-                else
-                    aa = z[k1] * z[k1] + ddk * ddk * (gdx + hdx);
-            }
-            eta = bb / aa;
-        }
-        else
-        {
-            eta = sqrt(abs(aa * aa - 4 * bb * cc));
-            if(aa <= 0)
-                eta = (aa - eta) / (2 * cc);
-            else
-                eta = (2 * bb) / (aa + eta);
-        }
-
-        // verify that the correction eta will get x closer to the root
-        // i.e. eta*fx should be negative. If not the case, take a Newton step
-        // instead
-        if(fx * eta >= 0)
-            eta = -fx / fdx;
-
-        // now verify that applying the correction won't get the process out of
-        // bounds if that is the case, bisect the interval instead
-        if(tau + eta > uppb || tau + eta < lowb)
-        {
-            if(fx < 0)
-                eta = (uppb - tau) / 2;
-            else
-                eta = (lowb - tau) / 2;
-        }
-
-        // take the step
-        tau += eta;
-        x = (up ? dk : dk1) + tau;
-
-        // evaluate secular eq and get input values to calculate step correction
-        oldfx = fx;
-        seq_eval(1, kk, dd, D, z, pinv, eta, &fx, &fdx, &gx, &gdx, &hx, &hdx, &er, true);
-        bb = z[kk];
-        aa = bb / D[kk];
-        fdx += aa * aa;
-        bb *= aa;
-        fx += bb;
-
-        // calculate tolerance er for convergence test
-        er += 8 * (hx - gx) + 2 * pinv + 3 * abs(bb) + abs(tau) * fdx;
-
-        // from now on, further step corrections will be calculated either with
-        // fixed weights method or with normal interpolation depending on the value
-        // of boolean fixed
-        cc = up ? -1 : 1;
-        fixed = (cc * fx) > (abs(oldfx) / 10);
-
-        // MAIN ITERATION LOOP
-        // ==============================================
-        for(int i = 1; i < MAXITERS; ++i)
-        {
-            // if the value of secular eq is small enough, no point to continue;
-            // converged!!!
-            if(abs(fx) <= tol * er)
-            {
-                converged = true;
-                break;
-            }
-
-            // update bounds
-            lowb = (fx <= 0) ? std::max(lowb, tau) : lowb;
-            uppb = (fx > 0) ? std::min(uppb, tau) : uppb;
-
-            // calculate next step correction with either fixed weight method or
-            // simple interpolation
-            ddk = D[k];
-            ddk1 = D[k1];
-            if(fixed)
-            {
-                if(up)
-                    cc = fx - ddk1 * fdx - (dk - dk1) * z[k] * z[k] / ddk / ddk;
-                else
-                    cc = fx - ddk * fdx - (dk1 - dk) * z[k1] * z[k1] / ddk1 / ddk1;
-            }
-            else
-            {
-                if(up)
-                    gdx += aa * aa;
-                else
-                    hdx += aa * aa;
-                cc = fx - ddk * gdx - ddk1 * hdx;
-            }
-            aa = (ddk + ddk1) * fx - ddk * ddk1 * fdx;
-            bb = ddk * ddk1 * fx;
-            if(cc == 0)
-            {
-                if(aa == 0)
-                {
-                    if(fixed)
-                    {
-                        if(up)
-                            aa = z[k] * z[k] + ddk1 * ddk1 * (gdx + hdx);
-                        else
-                            aa = z[k1] * z[k1] + ddk * ddk * (gdx + hdx);
-                    }
-                    else
-                        aa = ddk * ddk * gdx + ddk1 * ddk1 * hdx;
-                }
-                eta = bb / aa;
-            }
-            else
-            {
-                eta = sqrt(abs(aa * aa - 4 * bb * cc));
-                if(aa <= 0)
-                    eta = (aa - eta) / (2 * cc);
-                else
-                    eta = (2 * bb) / (aa + eta);
-            }
-
-            // verify that the correction eta will get x closer to the root
-            // i.e. eta*fx should be negative. If not the case, take a Newton step
-            // instead
-            if(fx * eta >= 0)
-                eta = -fx / fdx;
-
-            // now verify that applying the correction won't get the process out of
-            // bounds if that is the case, bisect the interval instead
-            if(tau + eta > uppb || tau + eta < lowb)
-            {
-                if(fx < 0)
-                    eta = (uppb - tau) / 2;
-                else
-                    eta = (lowb - tau) / 2;
-            }
-
-            // take the step
-            tau += eta;
-            x = (up ? dk : dk1) + tau;
-
-            // evaluate secular eq and get input values to calculate step correction
-            oldfx = fx;
-            seq_eval(1, kk, dd, D, z, pinv, eta, &fx, &fdx, &gx, &gdx, &hx, &hdx, &er, true);
-            bb = z[kk];
-            aa = bb / D[kk];
-            fdx += aa * aa;
-            bb *= aa;
-            fx += bb;
-
-            // calculate tolerance er for convergence test
-            er += 8 * (hx - gx) + 2 * pinv + 3 * abs(bb) + abs(tau) * fdx;
-
-            // update boolean fixed if necessary
-            if(fx * oldfx > 0 && abs(fx) > abs(oldfx) / 10)
-                fixed = !fixed;
-        }
-    }
-
-    *ev = x;
-    return converged ? 0 : 1;
-}
-
-//--------------------------------------------------------------------------------------//
-/** SEQ_SOLVE_EXT solves secular equation at point n (i.e. computes last
-   eigenvalue). We use rational interpolation and fixed weights method between
-   the (n-1)th and nth poles. (TODO: In the future, we could consider using 3
-   poles for those cases that may need it to reduce the number of required
-   iterations to converge. The performance improvements are expected to be
-   marginal, though) **/
-template <typename S>
-__device__ rocblas_int seq_solve_ext(const rocblas_int dd,
-                                     S* D,
-                                     const S* z,
-                                     const S p,
-                                     S* ev,
-                                     const S tol,
-                                     const S ssfmin,
-                                     const S ssfmax)
-{
-    bool converged = false;
-    S lowb, uppb, aa, bb, cc, x;
-    S er, fx, fdx, gx, gdx, hx, hdx;
-    S tau, eta;
-    S dk, dkm1, ddk, ddkm1;
-    rocblas_int k = dd - 1;
-    rocblas_int km1 = dd - 2;
-
-    // initialize
-    dk = D[k];
-    dkm1 = D[km1];
-    x = dk + p / 2;
-    S pinv = 1 / p;
-
-    // find bounds and initial guess
-    seq_eval(2, km1, dd, D, z, pinv, x, &cc, &fdx, &gx, &gdx, &hx, &hdx, &er, false);
-    gdx = z[km1] * z[km1];
-    hdx = z[k] * z[k];
-    fx = cc + gdx / (dkm1 - x) - 2 * hdx * pinv;
-    if(fx > 0)
-    {
-        // if the secular eq at the midpoint is positive, the root is in between
-        // D[k] and the midpoint take D[k] as the origin, i.e. x = D[k] + tau with
-        // tau in (0, uppb)
-        lowb = 0;
-        uppb = p / 2;
-        tau = dk - dkm1;
-        aa = -cc * tau + gdx + hdx;
-        bb = hdx * tau;
-        eta = sqrt(aa * aa + 4 * bb * cc);
-        if(aa < 0)
-            tau = 2 * bb / (eta - aa);
-        else
-            tau = (aa + eta) / (2 * cc);
-    }
-    else
-    {
-        // otherwise, the root is in between the midpoint and D[k+1]
-        // take D[k+1] as the origin, i.e. x = D[k+1] + tau with tau in (lowb, 0)
-        lowb = p / 2;
-        uppb = p;
-        eta = gdx / (dk - dkm1 + p) + hdx / p;
-        if(cc <= eta)
-            tau = p;
-        else
-        {
-            tau = dk - dkm1;
-            aa = -cc * tau + gdx + hdx;
-            bb = hdx * tau;
-            eta = sqrt(aa * aa + 4 * bb * cc);
-            if(aa < 0)
-                tau = 2 * bb / (eta - aa);
-            else
-                tau = (aa + eta) / (2 * cc);
-        }
-    }
-    x = dk + tau; // initial guess
-
-    // evaluate secular eq and get input values to calculate step correction
-    seq_eval(0, km1, dd, D, z, pinv, dk, &fx, &fdx, &gx, &gdx, &hx, &hdx, &er, true);
-    seq_eval(0, km1, dd, D, z, pinv, tau, &fx, &fdx, &gx, &gdx, &hx, &hdx, &er, true);
-
-    // calculate tolerance er for convergence test
-    er += abs(tau) * (hdx + gdx) - 8 * (hx + gx) - hx + pinv;
-
-    // if the value of secular eq is small enough, no point to continue;
-    // converged!!!
-    if(abs(fx) <= tol * er)
-        converged = true;
-
-    // otherwise...
-    else
-    {
-        // update bounds
-        lowb = (fx <= 0) ? std::max(lowb, tau) : lowb;
-        uppb = (fx > 0) ? std::min(uppb, tau) : uppb;
-
-        // calculate first step correction with fixed weight method
-        ddk = D[k];
-        ddkm1 = D[km1];
-        cc = abs(fx - ddkm1 * gdx - ddk * hdx);
-        aa = (ddk + ddkm1) * fx - ddk * ddkm1 * (gdx + hdx);
-        bb = ddk * ddkm1 * fx;
-        if(cc == 0)
-        {
-            eta = uppb - tau;
-        }
-        else
-        {
-            eta = sqrt(abs(aa * aa - 4 * bb * cc));
-            if(aa >= 0)
-                eta = (aa + eta) / (2 * cc);
-            else
-                eta = (2 * bb) / (aa - eta);
-        }
-
-        // verify that the correction eta will get x closer to the root
-        // i.e. eta*fx should be negative. If not the case, take a Newton step
-        // instead
-        if(fx * eta > 0)
-            eta = -fx / (gdx + hdx);
-
-        // now verify that applying the correction won't get the process out of
-        // bounds if that is the case, bisect the interval instead
-        if(tau + eta > uppb || tau + eta < lowb)
-        {
-            if(fx < 0)
-                eta = (uppb - tau) / 2;
-            else
-                eta = (lowb - tau) / 2;
-        }
-
-        // take the step
-        tau += eta;
-        x = dk + tau;
-
-        // evaluate secular eq and get input values to calculate step correction
-        seq_eval(0, km1, dd, D, z, pinv, eta, &fx, &fdx, &gx, &gdx, &hx, &hdx, &er, true);
-
-        // calculate tolerance er for convergence test
-        er += abs(tau) * (hdx + gdx) - 8 * (hx + gx) - hx + pinv;
-
-        // MAIN ITERATION LOOP
-        // ==============================================
-        for(int i = 1; i < MAXITERS; ++i)
-        {
-            // if the value of secular eq is small enough, no point to continue;
-            // converged!!!
-            if(abs(fx) <= tol * er)
-            {
-                converged = true;
-                break;
-            }
-
-            // update bounds
-            lowb = (fx <= 0) ? std::max(lowb, tau) : lowb;
-            uppb = (fx > 0) ? std::min(uppb, tau) : uppb;
-
-            // calculate step correction
-            ddk = D[k];
-            ddkm1 = D[km1];
-            cc = fx - ddkm1 * gdx - ddk * hdx;
-            aa = (ddk + ddkm1) * fx - ddk * ddkm1 * (gdx + hdx);
-            bb = ddk * ddkm1 * fx;
-            eta = sqrt(abs(aa * aa - 4 * bb * cc));
-            if(aa >= 0)
-                eta = (aa + eta) / (2 * cc);
-            else
-                eta = (2 * bb) / (aa - eta);
-
-            // verify that the correction eta will get x closer to the root
-            // i.e. eta*fx should be negative. If not the case, take a Newton step
-            // instead
-            if(fx * eta > 0)
-                eta = -fx / (gdx + hdx);
-
-            // now verify that applying the correction won't get the process out of
-            // bounds if that is the case, bisect the interval instead
-            if(tau + eta > uppb || tau + eta < lowb)
-            {
-                if(fx < 0)
-                    eta = (uppb - tau) / 2;
-                else
-                    eta = (lowb - tau) / 2;
-            }
-
-            // take the step
-            tau += eta;
-            x = dk + tau;
-
-            // evaluate secular eq and get input values to calculate step correction
-            seq_eval(0, km1, dd, D, z, pinv, eta, &fx, &fdx, &gx, &gdx, &hx, &hdx, &er, true);
-
-            // calculate tolerance er for convergence test
-            er += abs(tau) * (hdx + gdx) - 8 * (hx + gx) - hx + pinv;
-        }
-    }
-
-    *ev = x;
-    return converged ? 0 : 1;
-}
-
-//--------------------------------------------------------------------------------------//
-/** STEDC_NUM_LEVELS returns the ideal number of times/levels in which a matrix
-   (or split block) will be divided during the divide phase of divide & conquer
-   algorithm. i.e. number of sub-blocks = 2^levels **/
-template <>
-__host__ __device__ inline rocblas_int stedc_num_levels<rocsolver_stedc_mode_qr>(const rocblas_int n)
-{
-    rocblas_int levels = 0;
-    // return the max number of levels such that the sub-blocks are at least of
-    // size 1 (i.e. 2^levels <= n), and there are no more than 256 sub-blocks
-    // (i.e. 2^levels <= 256)
-    if(n <= 2)
-        return levels;
-
-    if(n <= 4)
-    {
-        levels = 1;
-    }
-    else if(n <= 32)
-    {
-        levels = 2;
-    }
-    else if(n <= 232)
-    {
-        levels = 4;
-    }
-    else
-    {
-        if(n <= 1946)
-        {
-            if(n <= 1692)
-            {
-                if(n <= 295)
-                {
-                    levels = 5;
-                }
-                else
-                {
-                    levels = 7;
-                }
-            }
-            else
-            {
-                levels = 7;
-            }
-        }
-        else
-        {
-            levels = 8;
-        }
-    }
-
-    return levels;
-}
 
 /*************** Main kernels *********************************************************/
 /**************************************************************************************/
 
 //--------------------------------------------------------------------------------------//
-/** STEDC_SPLIT finds independent blocks (split-blocks) in the tridiagonal
-   matrix given by D and E. The independent blocks can then be solved in
-    parallel by the DC algorithm.
-        - Call this kernel with batch_count single-threaded groups in x **/
-template <typename S>
-ROCSOLVER_KERNEL void stedc_split(const rocblas_int n,
-                                  S* DD,
-                                  const rocblas_stride strideD,
-                                  S* EE,
-                                  const rocblas_stride strideE,
-                                  rocblas_int* splitsA,
-                                  const S eps)
-{
-    rocblas_int bid = hipBlockIdx_x;
-
-    // select batch instance
-    S* D = DD + (bid * strideD);
-    S* E = EE + (bid * strideE);
-    rocblas_int* splits = splitsA + bid * (5 * n + 2);
-
-    rocblas_int k = 0; // position where the last block starts
-    S tol; // tolerance. If an element of E is <= tol we have an independent
-        // block
-    rocblas_int bs; // size of an independent block
-    rocblas_int nb = 1; // number of blocks
-    splits[0] = 0; // positions where each block begings
-
-    // main loop
-    while(k < n)
-    {
-        bs = 1;
-        for(rocblas_int j = k; j < n - 1; ++j)
-        {
-            tol = eps * sqrt(abs(D[j])) * sqrt(abs(D[j + 1]));
-            if(abs(E[j]) < tol)
-            {
-                // Split next independent block
-                // save its location in matrix
-                splits[nb] = j + 1;
-                nb++;
-                break;
-            }
-            bs++;
-        }
-        k += bs;
-    }
-    splits[nb] = n;
-    splits[n + 1] = nb; // also save the number of split blocks
-}
-
-//--------------------------------------------------------------------------------------//
 /** STEDC_DIVIDE_KERNEL implements the divide phase of the DC algorithm. It
-   divides each split-block into a number of sub-blocks.
-        - Call this kernel with batch_count groups in x. Groups are of size
-   STEDC_BDIM.
-        - If there are actually more split-blocks than STEDC_BDIM, some threads
-   will work with more than one split-block sequentially. **/
-template <rocsolver_stedc_mode MODE, typename S>
-ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_divide_kernel(const rocblas_int n,
+    divides the input matrix into a 'blks' sub-blocks.
+        - This kernel is to be called with as many groups in x as needed to cover all
+        the batch_count problems. Each thread will work with a matrix in the batch. 
+        - Size of groups is set to STEDC_BDIM. **/
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_divide_kernel(const rocblas_int levs,
+                                                                        const rocblas_int blks,
+                                                                        const rocblas_int n,
                                                                         S* DD,
                                                                         const rocblas_stride strideD,
                                                                         S* EE,
                                                                         const rocblas_stride strideE,
+                                                                        const rocblas_int batch_count,
                                                                         rocblas_int* splitsA)
 {
     // threads and groups indices
-    /* --------------------------------------------------- */
-    // batch instance id
-    rocblas_int bid = hipBlockIdx_x;
-    // split-block id
-    rocblas_int sid = hipThreadIdx_x;
-    /* --------------------------------------------------- */
+    rocblas_int bid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
 
-    // select batch instance to work with
-    /* --------------------------------------------------- */
-    S* D = DD + bid * strideD;
-    S* E = EE + bid * strideE;
-    /* --------------------------------------------------- */
-
-    // temporary arrays in global memory
-    /* --------------------------------------------------- */
-    // contains the beginning of split blocks
-    rocblas_int* splits = splitsA + bid * (5 * n + 2);
-    // the sub-blocks sizes
-    rocblas_int* nsA = splits + n + 2;
-    // the sub-blocks initial positions
-    rocblas_int* psA = nsA + n;
-    /* --------------------------------------------------- */
-
-    // local variables
-    /* --------------------------------------------------- */
-    // total number of split blocks
-    rocblas_int nb = splits[n + 1];
-    // size of split block
-    rocblas_int bs;
-    // beginning of split block
-    rocblas_int p1;
-    // beginning of sub-block
-    rocblas_int p2;
-    // number of sub-blocks
-    rocblas_int blks;
-    // number of level of division
-    rocblas_int levs;
-    // other aux variables
-    S p;
-    rocblas_int *ns, *ps;
-    /* --------------------------------------------------- */
-
-    // work with STEDC_BDIM split blocks in parallel
-    /* --------------------------------------------------- */
-    for(int kb = sid; kb < nb; kb += STEDC_BDIM)
+    // for each matrix in the batch
+    if(bid < batch_count)
     {
-        // Select current split block
-        p1 = splits[kb];
-        p2 = splits[kb + 1];
-        bs = p2 - p1;
-        ns = nsA + p1;
-        ps = psA + p1;
+        // select batch instance to work with
+        S* D = DD + bid * strideD;
+        S* E = EE + bid * strideE;
 
-        // determine ideal number of sub-blocks in split-block
-        levs = stedc_num_levels<MODE>(bs);
-        blks = 1 << levs;
-
-        // 1. DIVIDE PHASE
-        /* ----------------------------------------------------------------- */
-        // (artificially divide split-block into blks sub-blocks
-        // find initial positions of each sub-blocks)
+        // temporary arrays in global memory
+        rocblas_int* splits = splitsA + bid * (5 * n + 2);
+        // the sub-blocks sizes
+        rocblas_int* ns = splits + n + 2;
+        // the sub-blocks initial positions
+        rocblas_int* ps = ns + n;
 
         // find sizes of sub-blocks
-        ns[0] = bs;
+        ns[0] = n;
         rocblas_int t, t2;
         for(int i = 0; i < levs; ++i)
         {
@@ -839,8 +101,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_divide_kernel(const ro
             }
         }
 
-        // find beginning of sub-blocks and update D elements
-        p2 = p1;
+        // find beginning of sub-blocks and update elements in D
+        rocblas_int p2 = 0;
         ps[0] = p2;
         for(int i = 1; i < blks; ++i)
         {
@@ -848,25 +110,23 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_divide_kernel(const ro
             ps[i] = p2;
 
             // perform sub-block division
-            p = E[p2 - 1];
+            S p = E[p2 - 1];
             D[p2] -= p;
             D[p2 - 1] -= p;
         }
     }
 }
 
+
 //--------------------------------------------------------------------------------------//
 /** STEDC_SOLVE_KERNEL implements the solver phase of the DC algorithm to
-        compute the eigenvalues/eigenvectors of the different sub-blocks of each
-   split-block. A matrix in the batch could have many split-blocks, and each
-   split-block could be divided in a maximum of nn sub-blocks.
-        - Call this kernel with batch_count groups in z, STEDC_NUM_SPLIT_BLKS
-   groups in y. Groups are single-thread.
-        - STEDC_NUM_SPLIT_BLKS is fixed (is the number of split-blocks that will
-   be analysed in parallel). If there are actually more split-blocks, some
-   groups will work with more than one split-block sequentially. **/
+   compute the eigenvalues/eigenvectors of the 'blks' different sub-blocks of a matrix.
+        - Call this kernel with batch_count groups in y, and 'blks' groups in x. 
+          Groups are single-thread **/
 template <typename S>
-ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_solve_kernel(const rocblas_int n,
+ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_solve_kernel(const rocblas_int levs,
+                                                                       const rocblas_int blks,
+                                                                       const rocblas_int n,
                                                                        S* DD,
                                                                        const rocblas_stride strideD,
                                                                        S* EE,
@@ -883,108 +143,54 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_solve_kernel(const roc
                                                                        const S ssfmax)
 {
     // threads and groups indices
-    /* --------------------------------------------------- */
     // batch instance id
-    rocblas_int bid = hipBlockIdx_z;
-    // split-block id
-    rocblas_int sid = hipBlockIdx_y;
+    rocblas_int bid = hipBlockIdx_y;
     // sub-block id
-    rocblas_int tid = hipBlockIdx_x;
+    rocblas_int sid = hipBlockIdx_x;
     // thread index
     rocblas_int tidb = hipThreadIdx_x;
     rocblas_int tidb_inc = hipBlockDim_x;
-    /* --------------------------------------------------- */
 
     // select batch instance to work with
-    /* --------------------------------------------------- */
     S* C;
     if(CC)
         C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
     S* D = DD + bid * strideD;
     S* E = EE + bid * strideE;
     rocblas_int* info = iinfo + bid;
-    /* --------------------------------------------------- */
 
     // temporary arrays in global memory
-    /* --------------------------------------------------- */
-    // contains the beginning of split blocks
     rocblas_int* splits = splitsA + bid * (5 * n + 2);
     // the sub-blocks sizes
-    rocblas_int* nsA = splits + n + 2;
+    rocblas_int* ns = splits + n + 2;
     // the sub-blocks initial positions
-    rocblas_int* psA = nsA + n;
+    rocblas_int* ps = ns + n;
     // workspace for solvers
     S* W = WA + bid * (2 * n);
-    /* --------------------------------------------------- */
 
-    // local variables
-    /* --------------------------------------------------- */
-    // total number of split blocks
-    rocblas_int nb = splits[n + 1];
-    // size of split block
-    rocblas_int bs;
-    // size of sub block
-    rocblas_int sbs;
-    // beginning of split block
-    rocblas_int p1;
-    // beginning of sub-block
-    rocblas_int p2;
-    // number of sub-blocks
-    rocblas_int blks;
-    // number of level of division
-    rocblas_int levs;
-    // other aux variables
-    S p;
-    rocblas_int *ns, *ps;
-    /* --------------------------------------------------- */
-
-    // work with STEDC_NUM_SPLIT_BLKS split blocks in parallel
-    /* --------------------------------------------------- */
-    for(int kb = sid; kb < nb; kb += STEDC_NUM_SPLIT_BLKS)
+    // Solve the blks sub-blocks in parallel (using classic QR iteration).
+    if(sid < blks)
     {
-        // Select current split block
-        p1 = splits[kb];
-        p2 = splits[kb + 1];
-        bs = p2 - p1;
-        ns = nsA + p1;
-        ps = psA + p1;
+        rocblas_int sbs = ns[sid];  // size of sub-block
+        rocblas_int p2 = ps[sid];   // start position of sub-block
 
-        // determine ideal number of sub-blocks
-        levs = stedc_num_levels<rocsolver_stedc_mode_qr>(bs);
-        blks = 1 << levs;
-
-        // 2. SOLVE PHASE
-        /* ----------------------------------------------------------------- */
-        // Solve the blks sub-blocks in parallel.
-
-        if(tid < blks)
-        {
-            sbs = ns[tid];
-            p2 = ps[tid];
-
-            run_steqr(tidb, tidb_inc, sbs, D + p2, E + p2, C + p2 + p2 * ldc, ldc, info, W + p2 * 2,
-                      30 * bs, eps, ssfmin, ssfmax, false);
-            __syncthreads();
-        }
+        run_steqr(tidb, tidb_inc, sbs, D + p2, E + p2, C + p2 + p2 * ldc, ldc, info, W + p2 * 2,
+                  30 * sbs, eps, ssfmin, ssfmax, false);
     }
 }
 
+
 //--------------------------------------------------------------------------------------//
 /** STEDC_MERGEPREPARE_KERNEL performs deflation and prepares the secular equation for
-    every pair of sub-blocks that need to be merged in a split block. A matrix in the batch
-    could have many split-blocks, and each split-block could be divided in a maximum of nn sub-blocks.
-        - Call this kernel with batch_count groups in z, STEDC_NUM_SPLIT_BLKS groups in y,
-          and as many groups as half of the unmerged sub-blocks in current level. Each group works
-          with a merge. Groups are size STEDC_BDIM.
-        - STEDC_NUM_SPLIT_BLKS is fixed (is the number of split-blocks that will
-          be analysed in parallel). If there are actually more split-blocks, some
-          groups will work with more than one split-block sequentially.
-        - An upper bound for the number of sub-blocks (nn) can be estimated from
-          the size n. If a group has an id larger than half the actual number of unmerged sub-blocks
-          in the level, it will do nothing. **/
-template <rocsolver_stedc_mode MODE, typename S>
+    every pair of sub-blocks that need to be merged. 
+        - Call this kernel with batch_count groups in y, and as many groups as half of the 
+          unmerged sub-blocks in current level in x. Each group works with a merge of a pair
+          of sub-blocks. Groups are size STEDC_BDIM **/
+template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergePrepare_kernel(const rocblas_int k,
+    stedc_mergePrepare_kernel(const rocblas_int levs,
+                              const rocblas_int blks,
+                              const rocblas_int k,
                               const rocblas_int n,
                               S* DD,
                               const rocblas_stride strideD,
@@ -1000,37 +206,29 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                               const S eps)
 {
     // threads and groups indices
-    /* --------------------------------------------------- */
     // batch instance id
-    rocblas_int bid = hipBlockIdx_z;
-    // split block id
-    rocblas_int sid = hipBlockIdx_y;
+    rocblas_int bid = hipBlockIdx_y;
     // merge sub-block id
-    rocblas_int mid = hipBlockIdx_x;
+    rocblas_int sid = hipBlockIdx_x;
     // thread id
     rocblas_int tidb = hipThreadIdx_x;
     rocblas_int tid, tx;
-    /* --------------------------------------------------- */
 
     // select batch instance to work with
-    /* --------------------------------------------------- */
     S* C;
     if(CC)
         C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
     S* D = DD + bid * strideD;
     S* E = EE + bid * strideE;
-    /* --------------------------------------------------- */
 
     // temporary arrays in global memory
-    /* --------------------------------------------------- */
-    // contains the beginning of split blocks
     rocblas_int* splits = splitsA + bid * (5 * n + 2);
     // the sub-blocks sizes
-    rocblas_int* nsA = splits + n + 2;
+    rocblas_int* ns = splits + n + 2;
     // the sub-blocks initial positions
-    rocblas_int* psA = nsA + n;
+    rocblas_int* ps = ns + n;
     // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = psA + n;
+    rocblas_int* idd = ps + n;
     // container of permutations when solving the secular eqns
     rocblas_int* pers = idd + n;
     // the rank-1 modification vectors in the merges
@@ -1041,269 +239,219 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* vecs = vecsA + bid * 2 * (n * n);
     // temp values during the merges
     S* temps = vecs + (n * n);
-    /* --------------------------------------------------- */
 
     // temporary arrays in shared memory
-    /* --------------------------------------------------- */
-    extern __shared__ rocblas_int lsmem[];
     // used to store temp values during the different reductions
+    extern __shared__ rocblas_int lsmem[];
     S* inrmsd = reinterpret_cast<S*>(lsmem);
     S* inrmsz = inrmsd + hipBlockDim_x;
-    /* --------------------------------------------------- */
 
-    // local variables
-    /* --------------------------------------------------- */
-    // total number of split blocks
-    rocblas_int nb = splits[n + 1];
-    // size of split block
-    rocblas_int bs;
-    // beginning of split block
-    rocblas_int p1;
-    // beginning of sub-block
-    rocblas_int p2;
-    // number of sub-blocks
-    rocblas_int blks;
-    rocblas_int tn;
-    // number of level of division
-    rocblas_int levs;
-    // other aux variables
-    S p;
-    rocblas_int *ns, *ps;
-    /* --------------------------------------------------- */
+    // tn is the number of thread-groups needed in level k of the merge
+    rocblas_int bd = 1 << k;
+    rocblas_int bdm = bd << 1;
+    rocblas_int tn = blks / bdm;
 
-    // work with STEDC_NUM_SPLIT_BLKS split blocks in parallel
-    /* --------------------------------------------------- */
-    for(int kb = sid; kb < nb; kb += STEDC_NUM_SPLIT_BLKS)
+    // Work with merges on level k. A thread-group works with two leaves in the merge tree.
+    if(sid < tn)
     {
+        rocblas_int iam, sz, dim, dim2, p2;
+
+        // tid indexes the sub-blocks in the entire matrix
+        // iam indexes the sub-blocks in the context of the merge
+        // (according to its level in the merge tree)
+        dim = hipBlockDim_x / 2;
+        iam = tidb / dim;
+        tx = tidb % dim;
+        tid = sid * bdm + iam * bd;
+        p2 = ps[tid];
+
+        // 1. find rank-1 modification components (z and p) for this merge
+        // ----------------------------------------------------------------
+        // Threads with iam = 0 work with components below the merge point;
+        // threads with iam = 1 work above the merge point
+        sz = ns[tid];
+        for(int j = 1; j < bd; ++j)
+            sz += ns[tid + j];
+        // with this, all threads involved in a merge
+        // will point to the same row of C and the same off-diag element
+        S* ptz = (iam == 0) ? C + p2 - 1 + sz : C + p2;
+        S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
+
+        // copy elements of z
+        for(int j = tx; j < sz; j += dim)
+            z[p2 + j] = ptz[(p2 + j) * ldc] / sqrt(2);
+
+
+        // 2. calculate deflation tolerance
+        // ----------------------------------------------------------------
+        // compute maximum of diagonal and z in each merge block
+        S valf, valg, maxd, maxz;
+        maxd = 0;
+        maxz = 0;
+        for(int i = tx; i < sz; i += dim)
+        {
+            valf = std::abs(D[p2 + i]);
+            valg = std::abs(z[p2 + i]);
+            maxd = valf > maxd ? valf : maxd;
+            maxz = valg > maxz ? valg : maxz;
+        }
+        inrmsd[tidb] = maxd;
+        inrmsz[tidb] = maxz;
         __syncthreads();
 
-        // Select current split block
-        p1 = splits[kb];
-        p2 = splits[kb + 1];
-        bs = p2 - p1;
-        ns = nsA + p1;
-        ps = psA + p1;
-
-        // determine ideal number of sub-blocks
-        // tn is the number of thread-groups needed
-        levs = stedc_num_levels<MODE>(bs);
-        blks = levs - 1 - k;
-        tn = (blks < 0) ? 0 : 1 << blks;
-
-        // 3. MERGE PHASE
-        /* ----------------------------------------------------------------- */
-        // Work with merges on level k. A thread-group works with two leaves in the merge tree.
-        if(mid < tn)
+        dim2 = dim;
+        while(dim2 > 0)
         {
-            rocblas_int iam, sz, bdm, dim, dim2;
-            S* ptz;
-            rocblas_int bd = 1 << k;
-            bdm = bd << 1;
-            dim = hipBlockDim_x / 2;
-
-            // tid indexes the sub-blocks in the entire split block
-            // iam indexes the sub-blocks in the context of the merge
-            // (according to its level in the merge tree)
-            iam = tidb / dim;
-            tx = tidb % dim;
-            tid = mid * bdm + iam * bd;
-            p2 = ps[tid];
-
-            // 3a. find rank-1 modification components (z and p) for this merge
-            /* ----------------------------------------------------------------- */
-            // Threads with iam = 0 work with components below the merge point;
-            // threads with iam = 1 work above the merge point
-            sz = ns[tid];
-            for(int j = 1; j < bd; ++j)
-                sz += ns[tid + j];
-            // with this, all threads involved in a merge
-            // will point to the same row of C and the same off-diag element
-            ptz = (iam == 0) ? C + p2 - 1 + sz : C + p2;
-            p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
-
-            // copy elements of z
-            for(int j = tx; j < sz; j += dim)
-                z[p2 + j] = ptz[(p2 + j) * ldc] / sqrt(2);
-            /* ----------------------------------------------------------------- */
-
-            // 3b. calculate deflation tolerance
-            /* ----------------------------------------------------------------- */
-            // compute maximum of diagonal and z in each merge block
-            S valf, valg, maxd, maxz;
-            maxd = 0;
-            maxz = 0;
-            for(int i = tx; i < sz; i += dim)
+            if(tidb < dim2)
             {
-                valf = std::abs(D[p2 + i]);
-                valg = std::abs(z[p2 + i]);
+                valf = inrmsd[tidb + dim2];
+                valg = inrmsz[tidb + dim2];
                 maxd = valf > maxd ? valf : maxd;
                 maxz = valg > maxz ? valg : maxz;
+                inrmsd[tidb] = maxd;
+                inrmsz[tidb] = maxz;
             }
-            inrmsd[tidb] = maxd;
-            inrmsz[tidb] = maxz;
+            dim2 /= 2;
             __syncthreads();
+        }
 
-            dim2 = dim;
-            while(dim2 > 0)
+        // tol should be  8 * eps * (max diagonal or z element participating in merge)
+        maxd = inrmsd[0];
+        maxz = inrmsz[0];
+        maxd = maxz > maxd ? maxz : maxd;
+        S tol = 8 * eps * maxd;
+
+
+        // 3. deflate eigenvalues
+        // ----------------------------------------------------------------
+        // determine boundaries of what would be the new merged sub-block
+        // 'in' will be its initial position.
+        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
+        rocblas_int in = tid - iam * bd;
+        sz = ns[in];
+        for(int i = 1; i < bdm; ++i)
+            sz += ns[in + i];
+        in = ps[in];
+
+        // first deflate zero components
+        S f, g, c, s, rr;
+        for(int i = tidb; i < sz; i += hipBlockDim_x)
+        {
+            tx = in + i;
+            g = z[tx];
+            if(abs(p * g) <= tol)
+                // deflated ev because component in z is zero
+                idd[tx] = 0;
+            else
+                idd[tx] = 1;
+        }
+        __syncthreads();
+
+        // now deflate repeated values
+        rocblas_int sz_even, sz_half, base, top, com;
+        sz_even = (sz % 2 == 1) ? sz + 1 : sz;
+        sz_half = sz_even / 2;
+
+        // the number of rounds needed is sz_even - 1
+        for(int r = 0; r < sz_even - 1; ++r)
+        {
+            // in each round threads analyze pairs of values in parallel
+            // sz_half pairs are needed
+            for(int i = tidb; i < sz_half; i += hipBlockDim_x)
             {
-                if(tidb < dim2)
+                // determine pair of values (base, top)
+                com = 2 * (i - r);
+                base = (i == 0)             ? 0
+                    : (r < i)               ? com
+                    : (r > i - 1 + sz_half) ? 2 * (sz_even - 1) + com
+                                            : 1 - com;
+
+                com = 2 * (i + r);
+                top = (r < sz_half - i)     ? 1 + com
+                    : (r > sz_even - 2 - i) ? 3 - 2 * sz_even + com
+                                            : 2 * (sz_even - 1) - com;
+
+                if(base > top)
                 {
-                    valf = inrmsd[tidb + dim2];
-                    valg = inrmsz[tidb + dim2];
-                    maxd = valf > maxd ? valf : maxd;
-                    maxz = valg > maxz ? valg : maxz;
-                    inrmsd[tidb] = maxd;
-                    inrmsz[tidb] = maxz;
+                    com = base;
+                    base = top;
+                    top = com;
                 }
-                dim2 /= 2;
-                __syncthreads();
-            }
 
-            // tol should be  8 * eps * (max diagonal or z element participating in
-            // merge)
-            maxd = inrmsd[0];
-            maxz = inrmsz[0];
-            maxd = maxz > maxd ? maxz : maxd;
-
-            S tol = 8 * eps * maxd;
-            /* ----------------------------------------------------------------- */
-
-            // 3c. deflate eigenvalues
-            /* ----------------------------------------------------------------- */
-            // determine boundaries of what would be the new merged sub-block
-            // 'in' will be its initial position.
-            // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-            rocblas_int in = tid - iam * bd;
-            sz = ns[in];
-            for(int i = 1; i < bdm; ++i)
-                sz += ns[in + i];
-            in = ps[in];
-
-            // first deflate zero components
-            S f, g, c, s, rr;
-            for(int i = tidb; i < sz; i += hipBlockDim_x)
-            {
-                tx = in + i;
-                g = z[tx];
-                if(abs(p * g) <= tol)
-                    // deflated ev because component in z is zero
-                    idd[tx] = 0;
-                else
-                    idd[tx] = 1;
-            }
-            __syncthreads();
-
-            // now deflate repeated values
-            rocblas_int sz_even, sz_half, base, top, com;
-            sz_even = (sz % 2 == 1) ? sz + 1 : sz;
-            sz_half = sz_even / 2;
-
-            // the number of rounds needed is sz_even - 1
-            for(int r = 0; r < sz_even - 1; ++r)
-            {
-                // in each round threads analyze pairs of values in parallel
-                // sz_half pairs are needed
-                for(int i = tidb; i < sz_half; i += hipBlockDim_x)
+                // compare values and deflate if needed
+                base += in;
+                top += in;
+                if(idd[base] == 1 && idd[top] == 1 && top < sz + in)
                 {
-                    // determine pair of values (base, top)
-                    com = 2 * (i - r);
-                    base = (i == 0)             ? 0
-                        : (r < i)               ? com
-                        : (r > i - 1 + sz_half) ? 2 * (sz_even - 1) + com
-                                                : 1 - com;
-
-                    com = 2 * (i + r);
-                    top = (r < sz_half - i)     ? 1 + com
-                        : (r > sz_even - 2 - i) ? 3 - 2 * sz_even + com
-                                                : 2 * (sz_even - 1) - com;
-
-                    if(base > top)
+                    if(abs(D[base] - D[top]) <= tol)
                     {
-                        com = base;
-                        base = top;
-                        top = com;
-                    }
-
-                    // compare values and deflate if needed
-                    base += in;
-                    top += in;
-                    if(idd[base] == 1 && idd[top] == 1 && top < sz + in)
-                    {
-                        if(abs(D[base] - D[top]) <= tol)
+                        // deflated ev because it is repeated
+                        idd[top] = 0;
+                        // rotation to eliminate component in z
+                        g = z[top];
+                        f = z[base];
+                        lartg(f, g, c, s, rr);
+                        z[base] = rr;
+                        z[top] = 0;
+                        // update C with the rotation
+                        for(int ii = 0; ii < n; ++ii)
                         {
-                            // deflated ev because it is repeated
-                            idd[top] = 0;
-                            // rotation to eliminate component in z
-                            g = z[top];
-                            f = z[base];
-                            lartg(f, g, c, s, rr);
-                            z[base] = rr;
-                            z[top] = 0;
-                            // update C with the rotation
-                            for(int ii = 0; ii < n; ++ii)
-                            {
-                                valf = C[ii + base * ldc];
-                                valg = C[ii + top * ldc];
-                                C[ii + base * ldc] = valf * c - valg * s;
-                                C[ii + top * ldc] = valf * s + valg * c;
-                            }
+                            valf = C[ii + base * ldc];
+                            valg = C[ii + top * ldc];
+                            C[ii + base * ldc] = valf * c - valg * s;
+                            C[ii + top * ldc] = valf * s + valg * c;
                         }
                     }
-                    __syncthreads();
                 }
+                __syncthreads();
             }
-            /* ----------------------------------------------------------------- */
+        }
 
-            // 3d.1. Organize data with non-deflated values to prepare secular equation
-            /* ----------------------------------------------------------------- */
-            // define shifted arrays
-            S* tmpd = temps + in * n;
-            S* diag = D + in;
-            rocblas_int* mask = idd + in;
-            S* zz = z + in;
-            rocblas_int* per = pers + in;
-            S* ev = evs + in;
 
-            // find degree and components of secular equation
-            // tmpd contains the non-deflated diagonal elements (ie. poles of the
-            // secular eqn) zz contains the corresponding non-zero elements of the
-            // rank-1 modif vector
-            rocblas_int dd = 0;
-            for(int i = 0; i < sz; ++i)
+        // 4. Organize data with non-deflated values to prepare secular equation
+        // ------------------------------------------------------------------------ 
+        // define shifted arrays
+        S* tmpd = temps + in * n;
+        S* diag = D + in;
+        rocblas_int* mask = idd + in;
+        S* zz = z + in;
+        rocblas_int* per = pers + in;
+        S* ev = evs + in;
+
+        // find degree and components of secular equation
+        // tmpd contains the non-deflated diagonal elements (ie. poles of the
+        // secular eqn) zz contains the corresponding non-zero elements of the
+        // rank-1 modif vector
+        rocblas_int dd = 0;
+        for(int i = 0; i < sz; ++i)
+        {
+            if(mask[i] == 1)
             {
-                if(mask[i] == 1)
+                if(tidb == 0)
                 {
-                    if(tidb == 0)
-                    {
-                        per[dd] = i;
-                        tmpd[dd] = p < 0 ? -diag[i] : diag[i];
-                        if(dd != i)
-                            zz[dd] = zz[i];
-                    }
-                    dd++;
+                    per[dd] = i;
+                    tmpd[dd] = p < 0 ? -diag[i] : diag[i];
+                    if(dd != i)
+                        zz[dd] = zz[i];
                 }
+                dd++;
             }
-            /* ----------------------------------------------------------------- */
         }
     }
 }
 
+
 //--------------------------------------------------------------------------------------//
-/** STEDC_MERGEVALUES_KERNEL solves the secular equation for
-    every pair of sub-blocks that need to be merged in a split block. A matrix in the batch
-    could have many split-blocks, and each split-block could be divided in a maximum of nn sub-blocks.
-        - Call this kernel with batch_count groups in z, STEDC_NUM_SPLIT_BLKS groups in y,
-          and as many groups as half of the unmerged sub-blocks in current level. Each group works
-          with a merge. Groups are size STEDC_BDIM.
-        - STEDC_NUM_SPLIT_BLKS is fixed (is the number of split-blocks that will
-          be analysed in parallel). If there are actually more split-blocks, some
-          groups will work with more than one split-block sequentially.
-        - An upper bound for the number of sub-blocks (nn) can be estimated from
-          the size n. If a group has an id larger than half the actual number of unmerged sub-blocks
-          in the level, it will do nothing. **/
-template <rocsolver_stedc_mode MODE, typename S>
+/** STEDC_MERGEVALUES_KERNEL solves the secular equation for every pair of sub-blocks 
+    that need to be merged. 
+        - Call this kernel with batch_count groups in y, and as many groups as half of the 
+          unmerged sub-blocks in current level in x. Each group works with a merge of a pair
+          of sub-blocks. Groups are size STEDC_BDIM **/
+template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeValues_kernel(const rocblas_int k,
+    stedc_mergeValues_kernel(const rocblas_int levs,
+                             const rocblas_int blks,
+                             const rocblas_int k,
                              const rocblas_int n,
                              S* DD,
                              const rocblas_stride strideD,
@@ -1317,34 +465,26 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                              const S ssfmax)
 {
     // threads and groups indices
-    /* --------------------------------------------------- */
     // batch instance id
-    rocblas_int bid = hipBlockIdx_z;
-    // split block id
-    rocblas_int sid = hipBlockIdx_y;
+    rocblas_int bid = hipBlockIdx_y;
     // merge sub-block id
-    rocblas_int mid = hipBlockIdx_x;
+    rocblas_int sid = hipBlockIdx_x;
     // thread id
     rocblas_int tidb = hipThreadIdx_x;
     rocblas_int tid;
-    /* --------------------------------------------------- */
 
     // select batch instance to work with
-    /* --------------------------------------------------- */
     S* D = DD + bid * strideD;
     S* E = EE + bid * strideE;
-    /* --------------------------------------------------- */
 
     // temporary arrays in global memory
-    /* --------------------------------------------------- */
-    // contains the beginning of split blocks
     rocblas_int* splits = splitsA + bid * (5 * n + 2);
     // the sub-blocks sizes
-    rocblas_int* nsA = splits + n + 2;
+    rocblas_int* ns = splits + n + 2;
     // the sub-blocks initial positions
-    rocblas_int* psA = nsA + n;
+    rocblas_int* ps = ns + n;
     // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = psA + n;
+    rocblas_int* idd = ps + n;
     // container of permutations when solving the secular eqns
     rocblas_int* pers = idd + n;
     // the rank-1 modification vectors in the merges
@@ -1355,230 +495,182 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* vecs = vecsA + bid * 2 * (n * n);
     // temp values during the merges
     S* temps = vecs + (n * n);
-    /* --------------------------------------------------- */
 
-    // local variables
-    /* --------------------------------------------------- */
-    // total number of split blocks
-    rocblas_int nb = splits[n + 1];
-    // size of split block
-    rocblas_int bs;
-    // beginning of split block
-    rocblas_int p1;
-    // beginning of sub-block
-    rocblas_int p2;
-    // number of sub-blocks
-    rocblas_int blks;
-    rocblas_int tn;
-    // number of level of division
-    rocblas_int levs;
-    // other aux variables
-    S p;
-    rocblas_int *ns, *ps;
-    /* --------------------------------------------------- */
+    // tn is the number of thread-groups needed in level k of the merge
+    rocblas_int bd = 1 << k;
+    rocblas_int bdm = bd << 1;
+    rocblas_int tn = blks / bdm;
 
-    // work with STEDC_NUM_SPLIT_BLKS split blocks in parallel
-    /* --------------------------------------------------- */
-    for(int kb = sid; kb < nb; kb += STEDC_NUM_SPLIT_BLKS)
+    // Work with merges on level k. A thread-group works with two leaves in the merge tree;
+    // all threads work together to solve the secular equation.
+    if(sid < tn)
     {
+        rocblas_int iam, sz, dim, p2;
+        S valf, valg;
+
+        // tid indexes the sub-blocks in the entire split block
+        // iam indexes the sub-blocks in the context of the merge
+        // (according to its level in the merge tree)
+        dim = hipBlockDim_x / 2;
+        iam = tidb / dim;
+        tid = sid * bdm + iam * bd;
+        p2 = ps[tid];
+
+        // Find off-diagonal element of the merge
+        // Threads with iam = 0 work with components below the merge point;
+        // threads with iam = 1 work above the merge point
+        sz = ns[tid];
+        for(int j = 1; j < bd; ++j)
+            sz += ns[tid + j];
+        // with this, all threads involved in a merge
+        // will point to the same row of C and the same off-diag element
+        S p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
+
+        // determine boundaries of what would be the new merged sub-block
+        // 'in' will be its initial position.
+        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
+        rocblas_int in = tid - iam * bd;
+        sz = ns[in];
+        for(int i = 1; i < bdm; ++i)
+            sz += ns[in + i];
+        in = ps[in];
+
+
+        // 1. Organize data with non-deflated values to prepare secular equation
+        // ----------------------------------------------------------------- 
+        // All threads of the group participating in the merge will work together
+        // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
+        iam = tidb;
+        bdm = hipBlockDim_x;
+
+        // define shifted arrays
+        S* tmpd = temps + in * n;
+        S* ev = evs + in;
+        S* diag = D + in;
+        rocblas_int* mask = idd + in;
+        S* zz = z + in;
+        rocblas_int* per = pers + in;
+
+        // find degree of secular equation
+        rocblas_int dd = 0;
+        for(int i = 0; i < sz; ++i)
+        {
+            if(mask[i] == 1)
+                dd++;
+        }
+
+        // Order the elements in tmpd and zz using a simple parallel selection/bubble sort.
+        // This will allow us to find initial intervals for eigenvalue guesses
+        for(int i = 0; i < dd; i++)
+        {
+            for(int j = 2 * iam + i % 2; j < dd - 1; j += 2 * bdm)
+            {
+                if(tmpd[j] > tmpd[j + 1])
+                {
+                    swap(tmpd[j], tmpd[j + 1]);
+                    swap(zz[j], zz[j + 1]);
+                    swap(per[j], per[j + 1]);
+                }
+            }
+            __syncthreads();
+        }
+
+        // make dd copies of the non-deflated ordered diagonal elements
+        // (i.e. the poles of the secular eqn) so that the distances to the
+        // eigenvalues (D - lambda_i) are updated while computing each eigenvalue.
+        // This will prevent collapses and division by zero when an eigenvalue
+        // is too close to a pole.
+        for(int i = iam; i < dd; i += bdm)
+        {
+            for(int j = i + n; j < i + sz * n; j += n)
+                tmpd[j] = tmpd[i];
+        }
+
+        // finally copy over all diagonal elements in ev. ev will be overwritten
+        // by the new computed eigenvalues of the merged block
+        for(int i = iam; i < sz; i += bdm)
+            ev[i] = diag[i];
         __syncthreads();
 
-        // Select current split block
-        p1 = splits[kb];
-        p2 = splits[kb + 1];
-        bs = p2 - p1;
-        ns = nsA + p1;
-        ps = psA + p1;
 
-        // determine ideal number of sub-blocks
-        // tn is the number of thread-groups needed
-        levs = stedc_num_levels<MODE>(bs);
-        blks = levs - 1 - k;
-        tn = (blks < 0) ? 0 : 1 << blks;
-        blks = 1 << levs;
-
-        // 3. MERGE PHASE
-        /* ----------------------------------------------------------------- */
-        // Work with merges on level k. A thread-group works with two leaves in the merge tree;
-        // all threads work together to solve the secular equation.
-        if(mid < tn)
+        // 2. Solve secular eqns, i.e. find the dd zeros
+        // corresponding to non-deflated new eigenvalues of the merged block
+        // ----------------------------------------------------------------- 
+        // each thread will find a different zero in parallel
+        S a, b;
+        for(int j = iam; j < sz; j += bdm)
         {
-            rocblas_int iam, sz, bdm, dim;
-            S valf, valg;
-            rocblas_int bd = 1 << k;
-            bdm = bd << 1;
-            dim = hipBlockDim_x / 2;
-
-            // tid indexes the sub-blocks in the entire split block
-            // iam indexes the sub-blocks in the context of the merge
-            // (according to its level in the merge tree)
-            iam = tidb / dim;
-            tid = mid * bdm + iam * bd;
-            p2 = ps[tid];
-
-            // Find off-diagonal element of the merge
-            // Threads with iam = 0 work with components below the merge point;
-            // threads with iam = 1 work above the merge point
-            sz = ns[tid];
-            for(int j = 1; j < bd; ++j)
-                sz += ns[tid + j];
-            // with this, all threads involved in a merge
-            // will point to the same row of C and the same off-diag element
-            p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
-
-            // determine boundaries of what would be the new merged sub-block
-            // 'in' will be its initial position.
-            // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-            rocblas_int in = tid - iam * bd;
-            sz = ns[in];
-            for(int i = 1; i < bdm; ++i)
-                sz += ns[in + i];
-            in = ps[in];
-
-            // 3d.2. Organize data with non-deflated values to prepare secular equation
-            /* ----------------------------------------------------------------- */
-            rocblas_int tsz = 1 << (levs - 1 - k);
-            tsz = (bs - 1) / tsz + 1;
-
-            // All threads of the group participating in the merge will work together
-            // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
-            iam = tidb;
-            bdm = hipBlockDim_x;
-
-            // define shifted arrays
-            S* tmpd = temps + in * n;
-            S* ev = evs + in;
-            S* diag = D + in;
-            rocblas_int* mask = idd + in;
-            S* zz = z + in;
-            rocblas_int* per = pers + in;
-
-            // find degree of secular equation
-            rocblas_int dd = 0;
-            for(int i = 0; i < sz; ++i)
+            if(mask[j] == 1)
             {
-                if(mask[i] == 1)
-                    dd++;
-            }
-
-            // Order the elements in tmpd and zz using a simple parallel selection/bubble sort.
-            // This will allow us to find initial intervals for eigenvalue guesses
-            for(int i = 0; i < dd; i++)
-            {
-                for(int j = 2 * iam + i % 2; j < dd - 1; j += 2 * bdm)
+                // find position in the ordered array
+                valf = p < 0 ? -ev[j] : ev[j];
+                int count = dd, cc = 0;
+                while(count > 0)
                 {
-                    if(tmpd[j] > tmpd[j + 1])
+                    auto step = count / 2;
+                    auto it = cc + step;
+                    if(tmpd[it + j * n] < valf)
                     {
-                        swap(tmpd[j], tmpd[j + 1]);
-                        swap(zz[j], zz[j + 1]);
-                        swap(per[j], per[j + 1]);
+                        cc = ++it;
+                        count -= step + 1;
                     }
+                    else
+                        count = step;
                 }
-                __syncthreads();
+
+                // computed zero will overwrite 'ev' at the corresponding position.
+                // 'tmpd' will be updated with the distances D - lambda_i.
+                // deflated values are not changed.
+                rocblas_int linfo;
+
+#if defined(ROCSOLVER_USE_REFERENCE_SECULAR_EQUATIONS_SOLVER)
+                linfo = slaed4(dd, cc, tmpd + j * n, zz, std::abs(p), ev[j]);
+#else
+                if(cc == dd - 1)
+                    linfo = seq_solve_ext(dd, tmpd + j * n, zz, (p < 0 ? -p : p), ev + j, eps,
+                                          ssfmin, ssfmax);
+                else
+                    linfo = seq_solve(dd, tmpd + j * n, zz, (p < 0 ? -p : p), cc, ev + j, eps,
+                                      ssfmin, ssfmax);
+#endif
+                if(p < 0)
+                    ev[j] *= -1;
             }
+        }
+        __syncthreads();
 
-            // make dd copies of the non-deflated ordered diagonal elements
-            // (i.e. the poles of the secular eqn) so that the distances to the
-            // eigenvalues (D - lambda_i) are updated while computing each eigenvalue.
-            // This will prevent collapses and division by zero when an eigenvalue
-            // is too close to a pole.
-            for(int i = iam; i < dd; i += bdm)
-            {
-                for(int j = i + n; j < i + sz * n; j += n)
-                    tmpd[j] = tmpd[i];
-            }
-
-            // finally copy over all diagonal elements in ev. ev will be overwritten
-            // by the new computed eigenvalues of the merged block
-            for(int i = iam; i < sz; i += bdm)
-                ev[i] = diag[i];
-            __syncthreads();
-            /* ----------------------------------------------------------------- */
-
-            // 3e. Solve secular eqns, i.e. find the dd zeros
-            // corresponding to non-deflated new eigenvalues of the merged block
-            /* ----------------------------------------------------------------- */
-            // each thread will find a different zero in parallel
-            S a, b;
-            for(int j = iam; j < sz; j += bdm)
+        // Re-scale vector Z to avoid bad numerics when an eigenvalue
+        // is too close to a pole
+        for(int i = iam; i < dd; i += bdm)
+        {
+            valf = 1;
+            for(int j = 0; j < sz; ++j)
             {
                 if(mask[j] == 1)
                 {
-                    // find position in the ordered array
-                    valf = p < 0 ? -ev[j] : ev[j];
-                    int count = dd, cc = 0;
-                    while(count > 0)
-                    {
-                        auto step = count / 2;
-                        auto it = cc + step;
-                        if(tmpd[it + j * n] < valf)
-                        {
-                            cc = ++it;
-                            count -= step + 1;
-                        }
-                        else
-                            count = step;
-                    }
-
-                    // computed zero will overwrite 'ev' at the corresponding position.
-                    // 'tmpd' will be updated with the distances D - lambda_i.
-                    // deflated values are not changed.
-                    rocblas_int linfo;
-
-#if defined(ROCSOLVER_USE_REFERENCE_SECULAR_EQUATIONS_SOLVER)
-                    linfo = slaed4(dd, cc, tmpd + j * n, zz, std::abs(p), ev[j]);
-#else
-                    if(cc == dd - 1)
-                        linfo = seq_solve_ext(dd, tmpd + j * n, zz, (p < 0 ? -p : p), ev + j, eps,
-                                              ssfmin, ssfmax);
-                    else
-                        linfo = seq_solve(dd, tmpd + j * n, zz, (p < 0 ? -p : p), cc, ev + j, eps,
-                                          ssfmin, ssfmax);
-#endif
-
-                    if(p < 0)
-                        ev[j] *= -1;
+                    valg = tmpd[i + j * n];
+                    valf *= (per[i] == j) ? valg : valg / (diag[per[i]] - diag[j]);
                 }
             }
-            __syncthreads();
-
-            // Re-scale vector Z to avoid bad numerics when an eigenvalue
-            // is too close to a pole
-            for(int i = iam; i < dd; i += bdm)
-            {
-                valf = 1;
-                for(int j = 0; j < sz; ++j)
-                {
-                    if(mask[j] == 1)
-                    {
-                        valg = tmpd[i + j * n];
-                        valf *= (per[i] == j) ? valg : valg / (diag[per[i]] - diag[j]);
-                    }
-                }
-                valf = sqrt(std::abs(valf));
-                zz[i] = zz[i] < 0 ? -valf : valf;
-            }
-            /* ----------------------------------------------------------------- */
+            valf = sqrt(std::abs(valf));
+            zz[i] = zz[i] < 0 ? -valf : valf;
         }
     }
 }
 
+
 //--------------------------------------------------------------------------------------//
 /** STEDC_MERGEVECTORS_KERNEL prepares vectors from the secular equation for
-    every pair of sub-blocks that need to be merged in a split block. A matrix in the batch
-    could have many split-blocks, and each split-block could be divided in a maximum of nn sub-blocks.
-        - Call this kernel with batch_count groups in z, STEDC_NUM_SPLIT_BLKS groups in y,
-          and as many groups as columns would be in the matrix if its size is exact multiple of nn.
+    every pair of sub-blocks that need to be merged.
+        - Call this kernel with batch_count groups in y, and as many groups as columns would 
+          be in the matrix if its size is exact multiple of the number of sub-blocks 'blks'.
           Each group works with a column. Groups are size STEDC_BDIM.
-        - STEDC_NUM_SPLIT_BLKS is fixed (is the number of split-blocks that will
-          be analysed in parallel). If there are actually more split-blocks, some
-          groups will work with more than one split-block sequentially.
-        - An upper bound for the number of sub-blocks (nn) can be estimated from
-          the size n. If a group has an id larger than the actual number of columns n,
-          it will do nothing. **/
-template <rocsolver_stedc_mode MODE, bool USEGEMM, typename S>
+        - If a group has an id larger than the actual number of columns it will do nothing. **/
+template <bool USEGEMM, typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeVectors_kernel(const rocblas_int k,
+    stedc_mergeVectors_kernel(const rocblas_int levs,
+                              const rocblas_int blks,
+                              const rocblas_int k,
                               const rocblas_int n,
                               S* DD,
                               const rocblas_stride strideD,
@@ -1593,38 +685,30 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                               rocblas_int* splitsA)
 {
     // threads and groups indices
-    /* --------------------------------------------------- */
     // batch instance id
-    rocblas_int bid = hipBlockIdx_z;
-    // split block id
-    rocblas_int sid = hipBlockIdx_y;
+    rocblas_int bid = hipBlockIdx_y;
     // merge sub-block id
-    rocblas_int mid = hipBlockIdx_x;
+    rocblas_int sid = hipBlockIdx_x;
     // thread id
     rocblas_int tidb = hipThreadIdx_x;
     rocblas_int dim = hipBlockDim_x;
     rocblas_int tid, vidb;
-    /* --------------------------------------------------- */
 
     // select batch instance to work with
-    /* --------------------------------------------------- */
     S* C;
     if(CC)
         C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
     S* D = DD + bid * strideD;
     S* E = EE + bid * strideE;
-    /* --------------------------------------------------- */
 
     // temporary arrays in global memory
-    /* --------------------------------------------------- */
-    // contains the beginning of split blocks
     rocblas_int* splits = splitsA + bid * (5 * n + 2);
     // the sub-blocks sizes
-    rocblas_int* nsA = splits + n + 2;
+    rocblas_int* ns = splits + n + 2;
     // the sub-blocks initial positions
-    rocblas_int* psA = nsA + n;
+    rocblas_int* ps = ns + n;
     // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = psA + n;
+    rocblas_int* idd = ps + n;
     // container of permutations when solving the secular eqns
     rocblas_int* pers = idd + n;
     // the rank-1 modification vectors in the merges
@@ -1635,199 +719,153 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     S* vecs = vecsA + bid * 2 * (n * n);
     // temp values during the merges
     S* temps = vecs + (n * n);
-    /* --------------------------------------------------- */
 
     // temporary arrays in shared memory
-    /* --------------------------------------------------- */
-    extern __shared__ rocblas_int lsmem[];
     // used to store temp values during the different reductions
+    extern __shared__ rocblas_int lsmem[];
     S* inrms = reinterpret_cast<S*>(lsmem);
-    /* --------------------------------------------------- */
 
-    // local variables
-    /* --------------------------------------------------- */
-    // total number of split blocks
-    rocblas_int nb = splits[n + 1];
-    // size of split block
-    rocblas_int bs;
-    // beginning of split block
-    rocblas_int p1;
-    // beginning of sub-block
-    rocblas_int p2;
-    // number of sub-blocks
-    rocblas_int blks;
-    // number of level of division
-    rocblas_int levs;
-    // other aux variables
-    rocblas_int tn;
-    S p;
-    rocblas_int *ns, *ps;
-    /* --------------------------------------------------- */
+    // tn is max number of vectors in each sub-block
+    rocblas_int bd = 1 << k;
+    rocblas_int bdm = bd << 1;
+    rocblas_int tn = (n - 1) / blks + 1;
 
-    // work with STEDC_NUM_SPLIT_BLKS split blocks in parallel
-    /* --------------------------------------------------- */
-    for(int kb = sid; kb < nb; kb += STEDC_NUM_SPLIT_BLKS)
+    // Work with merges on level k. Each thread-group works with one vector.
+    if(sid < tn * blks)
     {
+        rocblas_int iam, sz, p2;
+        S valf, valg;
+
+        // tid indexes the sub-blocks in the entire split block
+        tid = sid / tn;
+        p2 = ps[tid];
+        // vidb indexes the vectors associated with each sub-block
+        vidb = sid % tn;
+        // iam indexes the sub-blocks in the context of the merge
+        // (according to its level in the merge tree)
+        iam = tid % bdm;
+
+        // determine boundaries of what would be the new merged sub-block
+        // 'in' will be its initial position
+        rocblas_int in = ps[tid - iam];
+        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
+        sz = ns[tid];
+        for(int i = iam; i > 0; --i)
+            sz += ns[tid - i];
+        for(int i = bdm - 1 - iam; i > 0; --i)
+            sz += ns[tid + i];
+
+        // define shifted arrays
+        S* tmpd = temps + in * n;
+        S* ev = evs + in;
+        S* diag = D + in;
+        rocblas_int* mask = idd + in;
+        S* zz = z + in;
+        rocblas_int* per = pers + in;
+
+        // find degree of secular equation
+        rocblas_int dd = 0;
+        for(int i = 0; i < sz; ++i)
+        {
+            if(mask[i] == 1)
+                dd++;
+        }
         __syncthreads();
 
-        // Select current split block
-        p1 = splits[kb];
-        p2 = splits[kb + 1];
-        bs = p2 - p1;
-        ns = nsA + p1;
-        ps = psA + p1;
 
-        // determine ideal number of sub-blocks
-        levs = stedc_num_levels<MODE>(bs);
-        blks = 1 << levs;
+        // Prepare vectors corresponding to non-deflated values
+        S temp, nrm;
+        rocblas_int j = vidb;
+        bool go = (j < ns[tid]);
+        S* putvec = USEGEMM ? vecs : temps;
 
-        // tn is max number of vectors in each sub-block
-        tn = (bs - 1) / blks + 1;
-
-        // 3. MERGE PHASE
-        /* ----------------------------------------------------------------- */
-        // Work with merges on level k. Each thread-group works with one vector.
-        if(mid < tn * blks && k < levs)
+        if(go)
         {
-            rocblas_int iam, sz, bdm;
-            S* ptz;
-            S valf, valg;
-            rocblas_int bd = 1 << k;
-            bdm = bd << 1;
-
-            // tid indexes the sub-blocks in the entire split block
-            tid = mid / tn;
-            p2 = ps[tid];
-            // vidb indexes the vectors associated with each sub-block
-            vidb = mid % tn;
-            // iam indexes the sub-blocks in the context of the merge
-            // (according to its level in the merge tree)
-            iam = tid % bdm;
-
-            // determine boundaries of what would be the new merged sub-block
-            // 'in' will be its initial position
-            rocblas_int in = ps[tid - iam];
-            // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-            sz = ns[tid];
-            for(int i = iam; i > 0; --i)
-                sz += ns[tid - i];
-            for(int i = bdm - 1 - iam; i > 0; --i)
-                sz += ns[tid + i];
-
-            // final number of merged sub-blocks
-            rocblas_int tsz = 1 << (levs - 1 - k);
-            tsz = (bs - 1) / tsz + 1;
-
-            // define shifted arrays
-            S* tmpd = temps + in * n;
-            S* ev = evs + in;
-            S* diag = D + in;
-            rocblas_int* mask = idd + in;
-            S* zz = z + in;
-            rocblas_int* per = pers + in;
-
-            // find degree of secular equation
-            rocblas_int dd = 0;
-            for(int i = 0; i < sz; ++i)
+            if(idd[p2 + j] == 1)
             {
-                if(mask[i] == 1)
-                    dd++;
+                // compute vectors of rank-1 perturbed system and their norms
+                nrm = 0;
+                for(int i = tidb; i < dd; i += dim)
+                {
+                    valf = zz[i] / temps[i + (p2 + j) * n];
+                    nrm += valf * valf;
+                    putvec[i + (p2 + j) * n] = valf;
+                }
+                inrms[tidb] = nrm;
+                __syncthreads();
+
+                // reduction (for the norms)
+                for(int r = dim / 2; r > 0; r /= 2)
+                {
+                    if(tidb < r)
+                    {
+                        nrm += inrms[tidb + r];
+                        inrms[tidb] = nrm;
+                    }
+                    __syncthreads();
+                }
+                nrm = sqrt(inrms[0]);
             }
-            __syncthreads();
 
-            // 3f. Prepare vectors corresponding to non-deflated values
-            /* ----------------------------------------------------------------- */
-            S temp, nrm;
-            rocblas_int j = vidb;
-            bool go = (j < ns[tid]);
-            S* putvec = USEGEMM ? vecs : temps;
-
-            if(go)
+            if(USEGEMM)
             {
+                // when using external gemms for the update, we need to
+                // put vectors in padded matrix 'temps'
+                // (this is to compute 'vecs = C * temps' using external gemm call)
+                for(int i = tidb; i < in + sz; i += dim)
+                {
+                    if(i >= in && idd[p2 + j] == 1 && idd[i] == 1)
+                    {
+                        dd = 0;
+                        for(int k = in; k < i; ++k)
+                        {
+                            if(idd[k] == 0)
+                                dd++;
+                        }
+                        temps[pers[i - dd] + in + (p2 + j) * n]
+                            = vecs[i - dd - in + (p2 + j) * n] / nrm;
+                    }
+                    else
+                        temps[i + (p2 + j) * n] = 0;
+                }
+            }
+            else
+            {
+                // otherwise, use internal gemm-like procedure to
+                // multiply by C (row by row)
+                rocblas_int tsz = 1 << (levs - 1 - k);
+                tsz = (n - 1) / tsz + 1;
                 if(idd[p2 + j] == 1)
                 {
-                    // compute vectors of rank-1 perturbed system and their norms
-                    nrm = 0;
-                    for(int i = tidb; i < dd; i += dim)
+                    for(int ii = 0; ii < tsz; ++ii)
                     {
-                        valf = zz[i] / temps[i + (p2 + j) * n];
-                        nrm += valf * valf;
-                        putvec[i + (p2 + j) * n] = valf;
-                    }
-                    inrms[tidb] = nrm;
-                    __syncthreads();
+                        rocblas_int i = in + ii;
 
-                    // reduction (for the norms)
-                    for(int r = dim / 2; r > 0; r /= 2)
-                    {
-                        if(tidb < r)
+                        // inner products
+                        temp = 0;
+                        if(ii < sz)
                         {
-                            nrm += inrms[tidb + r];
-                            inrms[tidb] = nrm;
+                            for(int kk = tidb; kk < dd; kk += dim)
+                                temp += C[i + (per[kk] + in) * ldc] * temps[kk + (p2 + j) * n];
                         }
+                        inrms[tidb] = temp;
                         __syncthreads();
-                    }
-                    nrm = sqrt(inrms[0]);
-                }
 
-                if(USEGEMM)
-                {
-                    // when using external gemms for the update, we need to
-                    // put vectors in padded matrix 'temps'
-                    // (this is to compute 'vecs = C * temps' using external gemm call)
-                    for(int i = tidb; i < in + sz; i += dim)
-                    {
-                        if(i >= in && idd[p2 + j] == 1 && idd[i] == 1)
+                        // reduction
+                        for(int r = dim / 2; r > 0; r /= 2)
                         {
-                            dd = 0;
-                            for(int k = in; k < i; ++k)
+                            if(ii < sz && tidb < r)
                             {
-                                if(idd[k] == 0)
-                                    dd++;
+                                temp += inrms[tidb + r];
+                                inrms[tidb] = temp;
                             }
-                            temps[pers[i - dd] + in + (p2 + j) * n]
-                                = vecs[i - dd - in + (p2 + j) * n] / nrm;
-                        }
-                        else
-                            temps[i + (p2 + j) * n] = 0;
-                    }
-                }
-                else
-                {
-                    // otherwise, use internal gemm-like procedure to
-                    // multiply by C (row by row)
-                    if(idd[p2 + j] == 1)
-                    {
-                        for(int ii = 0; ii < tsz; ++ii)
-                        {
-                            rocblas_int i = in + ii;
-
-                            // inner products
-                            temp = 0;
-                            if(ii < sz)
-                            {
-                                for(int kk = tidb; kk < dd; kk += dim)
-                                    temp += C[i + (per[kk] + in) * ldc] * temps[kk + (p2 + j) * n];
-                            }
-                            inrms[tidb] = temp;
-                            __syncthreads();
-
-                            // reduction
-                            for(int r = dim / 2; r > 0; r /= 2)
-                            {
-                                if(ii < sz && tidb < r)
-                                {
-                                    temp += inrms[tidb + r];
-                                    inrms[tidb] = temp;
-                                }
-                                __syncthreads();
-                            }
-
-                            // result
-                            if(ii < sz && tidb == 0)
-                                vecs[i + (p2 + j) * n] = temp / nrm;
                             __syncthreads();
                         }
+
+                        // result
+                        if(ii < sz && tidb == 0)
+                            vecs[i + (p2 + j) * n] = temp / nrm;
+                        __syncthreads();
                     }
                 }
             }
@@ -1835,21 +873,18 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     }
 }
 
+
 //--------------------------------------------------------------------------------------//
-/** STEDC_MERGEUPDATE_KERNEL updates vectors after merges are done. A matrix in the batch
-    could have many split-blocks, and each split-block could be divided in a maximum of nn sub-blocks.
-        - Call this kernel with batch_count groups in z, STEDC_NUM_SPLIT_BLKS groups in y,
-          and as many groups as columns would be in the matrix if its size is exact multiple of nn.
+/** STEDC_MERGEUPDATE_KERNEL updates vectors and values after a merge is done. 
+        - Call this kernel with batch_count groups in y, and as many groups as columns would 
+          be in the matrix if its size is exact multiple of the number of sub-blocks 'blks'.
           Each group works with a column. Groups are size STEDC_BDIM.
-        - STEDC_NUM_SPLIT_BLKS is fixed (is the number of split-blocks that will
-          be analysed in parallel). If there are actually more split-blocks, some
-          groups will work with more than one split-block sequentially.
-        - An upper bound for the number of sub-blocks (nn) can be estimated from
-          the size n. If a group has an id larger than the actual number of columns n,
-          it will do nothing. **/
-template <rocsolver_stedc_mode MODE, typename S>
+        - If a group has an id larger than the actual number of columns it will do nothing. **/
+template <typename S>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
-    stedc_mergeUpdate_kernel(const rocblas_int k,
+    stedc_mergeUpdate_kernel(const rocblas_int levs,
+                             const rocblas_int blks,
+                             const rocblas_int k,
                              const rocblas_int n,
                              S* DD,
                              const rocblas_stride strideD,
@@ -1862,137 +897,79 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
                              rocblas_int* splitsA)
 {
     // threads and groups indices
-    /* --------------------------------------------------- */
     // batch instance id
-    rocblas_int bid = hipBlockIdx_z;
-    // split block id
-    rocblas_int sid = hipBlockIdx_y;
+    rocblas_int bid = hipBlockIdx_y;
     // merge sub-block id
-    rocblas_int mid = hipBlockIdx_x;
+    rocblas_int sid = hipBlockIdx_x;
     // thread id
     rocblas_int tidb = hipThreadIdx_x;
     rocblas_int dim = hipBlockDim_x;
     rocblas_int tid, vidb;
-    /* --------------------------------------------------- */
 
     // select batch instance to work with
-    /* --------------------------------------------------- */
     S* C;
     if(CC)
         C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
     S* D = DD + bid * strideD;
-    /* --------------------------------------------------- */
 
     // temporary arrays in global memory
-    /* --------------------------------------------------- */
-    // contains the beginning of split blocks
     rocblas_int* splits = splitsA + bid * (5 * n + 2);
     // the sub-blocks sizes
-    rocblas_int* nsA = splits + n + 2;
+    rocblas_int* ns = splits + n + 2;
     // the sub-blocks initial positions
-    rocblas_int* psA = nsA + n;
+    rocblas_int* ps = ns + n;
     // if idd[i] = 0, the value in position i has been deflated
-    rocblas_int* idd = psA + n;
+    rocblas_int* idd = ps + n;
     // the rank-1 modification vectors in the merges
     S* z = tmpzA + bid * (2 * n);
     // roots of secular equations
     S* evs = z + n;
     // updated eigenvectors after merges
     S* vecs = vecsA + bid * 2 * (n * n);
-    /* --------------------------------------------------- */
 
-    // temporary arrays in shared memory
-    /* --------------------------------------------------- */
-    extern __shared__ rocblas_int lsmem[];
-    // used to store temp values during the different reductions
-    S* inrms = reinterpret_cast<S*>(lsmem);
-    /* --------------------------------------------------- */
+    // tn is max number of vectors in each sub-block
+    rocblas_int bd = 1 << k;
+    rocblas_int bdm = bd << 1;
+    rocblas_int tn = (n - 1) / blks + 1;
 
-    // local variables
-    /* --------------------------------------------------- */
-    // total number of split blocks
-    rocblas_int nb = splits[n + 1];
-    // size of split block
-    rocblas_int bs;
-    // beginning of split block
-    rocblas_int p1;
-    // beginning of sub-block
-    rocblas_int p2;
-    // number of sub-blocks
-    rocblas_int blks;
-    // number of level of division
-    rocblas_int levs;
-    // other aux variables
-    rocblas_int tn;
-    S p;
-    rocblas_int *ns, *ps;
-    /* --------------------------------------------------- */
-
-    // work with STEDC_NUM_SPLIT_BLKS split blocks in parallel
-    /* --------------------------------------------------- */
-    for(int kb = sid; kb < nb; kb += STEDC_NUM_SPLIT_BLKS)
+    // Work with merges on level k. Each thread-group works with one vector.
+    if(sid < tn * blks)
     {
-        __syncthreads();
+        rocblas_int iam, sz, p2;
+        S valf, valg;
 
-        // Select current split block
-        p1 = splits[kb];
-        p2 = splits[kb + 1];
-        bs = p2 - p1;
-        ns = nsA + p1;
-        ps = psA + p1;
+        // tid indexes the sub-blocks in the entire split block
+        tid = sid / tn;
+        p2 = ps[tid];
+        // vidb indexes the vectors associated with each sub-block
+        vidb = sid % tn;
+        // iam indexes the sub-blocks in the context of the merge
+        // (according to its level in the merge tree)
+        iam = tid % bdm;
 
-        // determine ideal number of sub-blocks
-        levs = stedc_num_levels<MODE>(bs);
-        blks = 1 << levs;
+        // determine boundaries of what would be the new merged sub-block
+        // 'in' will be its initial position
+        rocblas_int in = ps[tid - iam];
+        // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
+        sz = ns[tid];
+        for(int i = iam; i > 0; --i)
+            sz += ns[tid - i];
+        for(int i = bdm - 1 - iam; i > 0; --i)
+            sz += ns[tid + i];
 
-        // tn is max number of vectors in each sub-block
-        tn = (bs - 1) / blks + 1;
-
-        // 3. MERGE PHASE
-        /* ----------------------------------------------------------------- */
-        // Work with merges on level k. Each thread-group works with one vector.
-        if(mid < tn * blks && k < levs)
+        // update D and C with computed values and vectors
+        rocblas_int j = vidb;
+        bool go = (j < ns[tid] && idd[p2 + j] == 1);
+        if(go)
         {
-            rocblas_int iam, sz, bdm;
-            S* ptz;
-            S valf, valg;
-            rocblas_int bd = 1 << k;
-            bdm = bd << 1;
-
-            // tid indexes the sub-blocks in the entire split block
-            tid = mid / tn;
-            p2 = ps[tid];
-            // vidb indexes the vectors associated with each sub-block
-            vidb = mid % tn;
-            // iam indexes the sub-blocks in the context of the merge
-            // (according to its level in the merge tree)
-            iam = tid % bdm;
-
-            // determine boundaries of what would be the new merged sub-block
-            // 'in' will be its initial position
-            rocblas_int in = ps[tid - iam];
-            // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
-            sz = ns[tid];
-            for(int i = iam; i > 0; --i)
-                sz += ns[tid - i];
-            for(int i = bdm - 1 - iam; i > 0; --i)
-                sz += ns[tid + i];
-
-            // 3g. update D and C with computed values and vectors
-            /* ----------------------------------------------------------------- */
-            rocblas_int j = vidb;
-            bool go = (j < ns[tid] && idd[p2 + j] == 1);
-            if(go)
-            {
-                if(tidb == 0)
-                    D[p2 + j] = evs[p2 + j];
-                for(int i = in + tidb; i < in + sz; i += dim)
-                    C[i + (p2 + j) * ldc] = vecs[i + (p2 + j) * n];
-            }
-            /* ----------------------------------------------------------------- */
+            if(tidb == 0)
+                D[p2 + j] = evs[p2 + j];
+            for(int i = in + tidb; i < in + sz; i += dim)
+                C[i + (p2 + j) * ldc] = vecs[i + (p2 + j) * n];
         }
     }
 }
+
 
 /** STEDC_SORT sorts computed eigenvalues and eigenvectors in increasing order **/
 template <typename T, typename S, typename U>
@@ -2048,106 +1025,24 @@ ROCSOLVER_KERNEL void __launch_bounds__(BS1) stedc_sort(const rocblas_int n,
     }
 }
 
+
 /******************* Host functions *********************************************/
 /*******************************************************************************/
 
 //--------------------------------------------------------------------------------------//
-/** This local gemm adapts rocblas_gemm to multiply complex*real, and
-    overwrite result: A = A*B **/
-template <bool BATCHED,
-          bool STRIDED,
-          typename T,
-          typename S,
-          typename U,
-          std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
-void local_gemm(rocblas_handle handle,
-                const rocblas_int n,
-                U A,
-                const rocblas_int shiftA,
-                const rocblas_int lda,
-                const rocblas_stride strideA,
-                S* B,
-                S* temp,
-                S* work,
-                const rocblas_int shiftV,
-                const rocblas_int ldv,
-                const rocblas_stride strideV,
-                const rocblas_int batch_count,
-                S** workArr)
+/** STEDC_NUM_LEVELS returns the ideal number of times/levels in which a matrix
+    will be divided during the divide phase of divide & conquer algorithm 
+    i.e. number of sub-blocks = 2^levels **/
+inline rocblas_int stedc_num_levels(const rocblas_int n)
 {
-    S one = 1.0;
-    S zero = 0.0;
+    rocblas_int levels;
 
-    // Execute A*B -> temp -> A
-    // temp = A*B
-    rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, n, n, n, &one, A, shiftA,
-                   lda, strideA, B, shiftV, ldv, strideV, &zero, temp, shiftV, ldv, strideV,
-                   batch_count, workArr);
+    if(n <= 16)
+        levels = 0;
+    else
+        levels = std::ceil(std::log2(n)) - 4;
 
-    // A = temp
-    hipStream_t stream;
-    rocblas_get_stream(handle, &stream);
-    rocblas_int blocks = (n - 1) / BS2 + 1;
-    ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(blocks, blocks, batch_count), dim3(BS2, BS2), 0,
-                            stream, copymat_from_buffer, n, n, A, shiftA, lda, strideA, temp);
-}
-
-template <bool BATCHED,
-          bool STRIDED,
-          typename T,
-          typename S,
-          typename U,
-          std::enable_if_t<rocblas_is_complex<T>, int> = 0>
-void local_gemm(rocblas_handle handle,
-                const rocblas_int n,
-                U A,
-                const rocblas_int shiftA,
-                const rocblas_int lda,
-                const rocblas_stride strideA,
-                S* B,
-                S* temp,
-                S* work,
-                const rocblas_int shiftV,
-                const rocblas_int ldv,
-                const rocblas_stride strideV,
-                const rocblas_int batch_count,
-                S** workArr)
-{
-    S one = 1.0;
-    S zero = 0.0;
-
-    // Execute A -> work; work*B -> temp -> A
-
-    // work = real(A)
-    hipStream_t stream;
-    rocblas_get_stream(handle, &stream);
-    rocblas_int blocks = (n - 1) / BS2 + 1;
-    ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, S, true>), dim3(blocks, blocks, batch_count), dim3(BS2, BS2),
-                            0, stream, copymat_to_buffer, n, n, A, shiftA, lda, strideA, work);
-
-    // temp = work*B
-    rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, n, n, n, &one, work,
-                   shiftV, ldv, strideV, B, shiftV, ldv, strideV, &zero, temp, shiftV, ldv, strideV,
-                   batch_count, workArr);
-
-    // real(A) = temp
-    ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, S, true>), dim3(blocks, blocks, batch_count), dim3(BS2, BS2),
-                            0, stream, copymat_from_buffer, n, n, A, shiftA, lda, strideA, temp);
-
-    // work = imag(A)
-    ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, S, false>), dim3(blocks, blocks, batch_count),
-                            dim3(BS2, BS2), 0, stream, copymat_to_buffer, n, n, A, shiftA, lda,
-                            strideA, work);
-
-    // temp = work*B
-    rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, n, n, n, &one, work,
-                   shiftV, ldv, strideV, B, shiftV, ldv, strideV, &zero, temp, shiftV, ldv, strideV,
-                   batch_count, workArr);
-
-    // imag(A) = temp
-    ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, S, false>), dim3(blocks, blocks, batch_count),
-                            dim3(BS2, BS2), 0, stream, copymat_from_buffer, n, n, A, shiftA, lda,
-                            strideA, temp);
+    return levels;
 }
 
 //--------------------------------------------------------------------------------------//
@@ -2345,11 +1240,10 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         S ssfmax = S(1.0) / ssfmin;
         ssfmin = sqrt(ssfmin) / (eps * eps);
         ssfmax = sqrt(ssfmax) / S(3.0);
-        rocblas_int blocksn = (n - 1) / BS2 + 1;
 
-        // find max number of sub-blocks to consider during the divide phase
-        rocblas_int maxlevs = stedc_num_levels<rocsolver_stedc_mode_qr>(n);
-        rocblas_int maxblks = 1 << maxlevs;
+        // find number of sub-blocks 
+        rocblas_int levs = stedc_num_levels(n);
+        rocblas_int blks = 1 << levs;
 
         // initialize identity matrix in V
         // if evect is tridiagonal we can store V directly in C
@@ -2363,60 +1257,54 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             ldv = (rocblas_int)(sizeof(T) / sizeof(S)) * ldc;
             strideV = (rocblas_int)(sizeof(T) / sizeof(S)) * strideC;
         }
-        ROCSOLVER_LAUNCH_KERNEL(init_ident<S>, dim3(blocksn, blocksn, batch_count), dim3(BS2, BS2),
+        rocblas_int groupsn = (n - 1) / BS2 + 1;
+        ROCSOLVER_LAUNCH_KERNEL(init_ident<S>, dim3(groupsn, groupsn, batch_count), dim3(BS2, BS2),
                                 0, stream, n, n, V, 0, ldv, strideV);
-
-        // find independent split blocks in matrix
-        ROCSOLVER_LAUNCH_KERNEL(stedc_split, dim3(batch_count), dim3(1), 0, stream, n, D + shiftD,
-                                strideD, E + shiftE, strideE, splits_map, eps);
 
         // 1. divide phase
         //-----------------------------
-        ROCSOLVER_LAUNCH_KERNEL((stedc_divide_kernel<rocsolver_stedc_mode_qr, S>),
-                                dim3(batch_count), dim3(STEDC_BDIM), 0, stream, n, D + shiftD,
-                                strideD, E + shiftE, strideE, splits);
+        rocblas_int groups = (batch_count - 1) / STEDC_BDIM + 1;
+        ROCSOLVER_LAUNCH_KERNEL((stedc_divide_kernel<S>),
+                                dim3(groups), dim3(STEDC_BDIM), 0, stream, levs, blks, n, D + shiftD,
+                                strideD, E + shiftE, strideE, batch_count, splits);
 
         // 2. solve phase
         //-----------------------------
         ROCSOLVER_LAUNCH_KERNEL((stedc_solve_kernel<S>),
-                                dim3(maxblks, STEDC_NUM_SPLIT_BLKS, batch_count), dim3(1), 0,
-                                stream, n, D + shiftD, strideD, E + shiftE, strideE, V, 0, ldv,
-                                strideV, info, (S*)work_stack, splits, eps, ssfmin, ssfmax);
+                                dim3(blks, batch_count), dim3(64), 0, stream, levs, blks, 
+                                n, D + shiftD, strideD, E + shiftE, strideE, 
+                                V, 0, ldv, strideV, info, (S*)work_stack, splits, 
+                                eps, ssfmin, ssfmax);
 
         // 3. merge phase
         //----------------
         size_t lmemsize1 = sizeof(S) * 2 * STEDC_BDIM;
         size_t lmemsize3 = sizeof(S) * STEDC_BDIM;
-        rocblas_int numgrps3 = ((n - 1) / maxblks + 1) * maxblks;
+        rocblas_int numgrps3 = ((n - 1) / blks + 1) * blks;
 
         // launch merge for level k
-        // TODO: using max number of levels for now. Kernels return immediately when surpassing
-        // the actual number of levels in the split block. We should explore if synchronizing
-        // to copy back the actual number of levels makes any difference.
-        // TODO: the code computing the context of the level (first part of each kernel) could be
-        // reused.
-        for(rocblas_int k = 0; k < maxlevs; ++k)
+        for(rocblas_int k = 0; k < levs; ++k)
         {
             // a. prepare secular equations
-            rocblas_int numgrps2 = 1 << (maxlevs - 1 - k);
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_kernel<rocsolver_stedc_mode_qr, S>),
-                                    dim3(numgrps2, STEDC_NUM_SPLIT_BLKS, batch_count),
-                                    dim3(STEDC_BDIM), lmemsize1, stream, k, n, D + shiftD, strideD,
+            rocblas_int numgrps2 = 1 << (levs - 1 - k);
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_kernel<S>),
+                                    dim3(numgrps2, batch_count), dim3(STEDC_BDIM), lmemsize1, stream, 
+                                    levs, blks, k, n, D + shiftD, strideD,
                                     E + shiftE, strideE, V, 0, ldv, strideV, tmpz, tempgemm, splits,
                                     eps);
 
-            // b. solve to find merged eigen values
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_kernel<rocsolver_stedc_mode_qr, S>),
-                                    dim3(numgrps2, STEDC_NUM_SPLIT_BLKS, batch_count),
-                                    dim3(STEDC_BDIM), 0, stream, k, n, D + shiftD, strideD,
+            // b. solve secular eq to find merged eigenvalues
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_kernel<S>),
+                                    dim3(numgrps2, batch_count), dim3(STEDC_BDIM), 0, stream, 
+                                    levs, blks, k, n, D + shiftD, strideD,
                                     E + shiftE, strideE, tmpz, tempgemm, splits, eps, ssfmin, ssfmax);
 
-            // c. find merged eigen vectors
+            // c. find merged eigenvectors
             ROCSOLVER_LAUNCH_KERNEL(
-                (stedc_mergeVectors_kernel<rocsolver_stedc_mode_qr, STEDC_EXTERNAL_GEMM, S>),
-                dim3(numgrps3, STEDC_NUM_SPLIT_BLKS, batch_count), dim3(STEDC_BDIM), lmemsize3,
-                stream, k, n, D + shiftD, strideD, E + shiftE, strideE, V, 0, ldv, strideV, tmpz,
-                tempgemm, splits);
+                (stedc_mergeVectors_kernel<STEDC_EXTERNAL_GEMM, S>),
+                dim3(numgrps3, batch_count), dim3(STEDC_BDIM), lmemsize3, stream, 
+                levs, blks, k, n, D + shiftD, strideD, E + shiftE, strideE, V, 0, ldv, strideV, 
+                tmpz, tempgemm, splits);
 
             if(STEDC_EXTERNAL_GEMM)
             {
@@ -2431,9 +1319,9 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
             }
 
             // d. update level
-            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeUpdate_kernel<rocsolver_stedc_mode_qr, S>),
-                                    dim3(numgrps3, STEDC_NUM_SPLIT_BLKS, batch_count),
-                                    dim3(STEDC_BDIM), lmemsize3, stream, k, n, D + shiftD, strideD,
+            ROCSOLVER_LAUNCH_KERNEL((stedc_mergeUpdate_kernel<S>),
+                                    dim3(numgrps3, batch_count), dim3(STEDC_BDIM), 0, stream, 
+                                    levs, blks, k, n, D + shiftD, strideD,
                                     V, 0, ldv, strideV, tmpz, tempgemm, splits);
         }
 
@@ -2450,22 +1338,21 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
         {
             // V is stored in C but is of type S; need to convert to type T
             // tempgemm = V
-            ROCSOLVER_LAUNCH_KERNEL(copy_mat<S>, dim3(blocksn, blocksn, batch_count), dim3(BS2, BS2),
+            ROCSOLVER_LAUNCH_KERNEL(copy_mat<S>, dim3(groupsn, groupsn, batch_count), dim3(BS2, BS2),
                                     0, stream, copymat_to_buffer, n, n, V, 0, ldv, strideV, tempgemm);
 
             // imag(C) = zeros
-            ROCSOLVER_LAUNCH_KERNEL(set_zero<T>, dim3(blocksn, blocksn, batch_count),
+            ROCSOLVER_LAUNCH_KERNEL(set_zero<T>, dim3(groupsn, groupsn, batch_count),
                                     dim3(BS2, BS2), 0, stream, n, n, C, shiftC, ldc, strideC);
 
             // real(C) = tempgemm
-            ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, S, true>), dim3(blocksn, blocksn, batch_count),
+            ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, S, true>), dim3(groupsn, groupsn, batch_count),
                                     dim3(BS2, BS2), 0, stream, copymat_from_buffer, n, n, C, shiftC,
                                     ldc, strideC, tempgemm);
         }
 
         // finally sort eigenvalues and eigenvectors
-        auto const nblocks = batch_count;
-        ROCSOLVER_LAUNCH_KERNEL((stedc_sort<T>), dim3(1, 1, nblocks), dim3(BS1), 0, stream, n,
+        ROCSOLVER_LAUNCH_KERNEL((stedc_sort<T>), dim3(1, 1, batch_count), dim3(BS1), 0, stream, n,
                                 D + shiftD, strideD, C, shiftC, ldc, strideC, batch_count,
                                 splits_map);
 

--- a/library/src/auxiliary/rocauxiliary_stedcj.cpp
+++ b/library/src/auxiliary/rocauxiliary_stedcj.cpp
@@ -52,7 +52,7 @@ rocblas_status rocsolver_stedcj_impl(rocblas_handle handle,
         return rocblas_status_invalid_handle;
 
     // argument checking
-    rocblas_status st = rocsolver_stedc_argCheck(handle, evect, n, D, E, C, ldc, info);
+    rocblas_status st = rocsolver_stedcj_argCheck(handle, evect, n, D, E, C, ldc, info);
     if(st != rocblas_status_continue)
         return st;
 

--- a/library/src/auxiliary/rocauxiliary_stedcj.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedcj.hpp
@@ -1,5 +1,5 @@
 /************************************************************************
- * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,12 +31,12 @@
 
 #include "lapack/roclapack_syevj_heevj.hpp"
 #include "lapack_device_functions.hpp"
-#include "rocauxiliary_stedc.hpp"
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
 
 ROCSOLVER_BEGIN_NAMESPACE
 
+#define STEDCJ_BDIM 512 // Number of threads per thread-block used in main stedc kernels
 #define MAXSWEEPS 20 // Max number of sweeps for Jacobi solver (when used)
 
 // TODO: using macro STEDCJ_EXTERNAL_GEMM = false for now. We can enable the use of
@@ -47,12 +47,10 @@ ROCSOLVER_BEGIN_NAMESPACE
 /**************************************************************************************/
 
 //--------------------------------------------------------------------------------------//
-/** STEDC_NUM_LEVELS returns the ideal number of times/levels in which a matrix
+/** STEDCJ_NUM_LEVELS returns the ideal number of times/levels in which a matrix
    (or split block) will be divided during the divide phase of divide & conquer
    algorithm. i.e. number of sub-blocks = 2^levels **/
-template <>
-__host__ __device__ inline rocblas_int
-    stedc_num_levels<rocsolver_stedc_mode_jacobi>(const rocblas_int n)
+__host__ __device__ inline rocblas_int stedcj_num_levels(const rocblas_int n)
 {
     rocblas_int levels = 0;
     // return the max number of levels such that the sub-blocks are at least of
@@ -133,12 +131,172 @@ __device__ inline void de2tridiag(const int numt,
 /**************************************************************************************/
 
 //--------------------------------------------------------------------------------------//
-/** STEDC_SOLVE_KERNEL implements the solver phase of the DC algorithm to
+/** STEDCJ_SPLIT finds independent blocks (split-blocks) in the tridiagonal
+   matrix given by D and E. The independent blocks can then be solved in
+    parallel by the DC algorithm.
+        - Call this kernel with batch_count single-threaded groups in x **/
+template <typename S>
+ROCSOLVER_KERNEL void stedcj_split(const rocblas_int n,
+                                   S* DD,
+                                   const rocblas_stride strideD,
+                                   S* EE,
+                                   const rocblas_stride strideE,
+                                   rocblas_int* splitsA,
+                                   const S eps)
+{
+    rocblas_int bid = hipBlockIdx_x;
+
+    // select batch instance
+    S* D = DD + (bid * strideD);
+    S* E = EE + (bid * strideE);
+    rocblas_int* splits = splitsA + bid * (5 * n + 2);
+
+    rocblas_int k = 0; // position where the last block starts
+    S tol; // tolerance. If an element of E is <= tol we have an independent
+        // block
+    rocblas_int bs; // size of an independent block
+    rocblas_int nb = 1; // number of blocks
+    splits[0] = 0; // positions where each block begings
+
+    // main loop
+    while(k < n)
+    {
+        bs = 1;
+        for(rocblas_int j = k; j < n - 1; ++j)
+        {
+            tol = eps * sqrt(abs(D[j])) * sqrt(abs(D[j + 1]));
+            if(abs(E[j]) < tol)
+            {
+                // Split next independent block
+                // save its location in matrix
+                splits[nb] = j + 1;
+                nb++;
+                break;
+            }
+            bs++;
+        }
+        k += bs;
+    }
+    splits[nb] = n;
+    splits[n + 1] = nb; // also save the number of split blocks
+}
+
+//--------------------------------------------------------------------------------------//
+/** STEDCJ_DIVIDE_KERNEL implements the divide phase of the DC algorithm. It
+   divides each split-block into a number of sub-blocks.
+        - Call this kernel with batch_count groups in x. Groups are of size
+   STEDCJ_BDIM.
+        - If there are actually more split-blocks than STEDCJ_BDIM, some threads
+   will work with more than one split-block sequentially. **/
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDCJ_BDIM)
+    stedcj_divide_kernel(const rocblas_int n,
+                         S* DD,
+                         const rocblas_stride strideD,
+                         S* EE,
+                         const rocblas_stride strideE,
+                         rocblas_int* splitsA)
+{
+    // threads and groups indices
+    /* --------------------------------------------------- */
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_x;
+    // split-block id
+    rocblas_int sid = hipThreadIdx_x;
+    /* --------------------------------------------------- */
+
+    // select batch instance to work with
+    /* --------------------------------------------------- */
+    S* D = DD + bid * strideD;
+    S* E = EE + bid * strideE;
+    /* --------------------------------------------------- */
+
+    // temporary arrays in global memory
+    /* --------------------------------------------------- */
+    // contains the beginning of split blocks
+    rocblas_int* splits = splitsA + bid * (5 * n + 2);
+    // the sub-blocks sizes
+    rocblas_int* nsA = splits + n + 2;
+    // the sub-blocks initial positions
+    rocblas_int* psA = nsA + n;
+    /* --------------------------------------------------- */
+
+    // local variables
+    /* --------------------------------------------------- */
+    // total number of split blocks
+    rocblas_int nb = splits[n + 1];
+    // size of split block
+    rocblas_int bs;
+    // beginning of split block
+    rocblas_int p1;
+    // beginning of sub-block
+    rocblas_int p2;
+    // number of sub-blocks
+    rocblas_int blks;
+    // number of level of division
+    rocblas_int levs;
+    // other aux variables
+    S p;
+    rocblas_int *ns, *ps;
+    /* --------------------------------------------------- */
+
+    // work with STEDCJ_BDIM split blocks in parallel
+    /* --------------------------------------------------- */
+    for(int kb = sid; kb < nb; kb += STEDCJ_BDIM)
+    {
+        // Select current split block
+        p1 = splits[kb];
+        p2 = splits[kb + 1];
+        bs = p2 - p1;
+        ns = nsA + p1;
+        ps = psA + p1;
+
+        // determine ideal number of sub-blocks in split-block
+        levs = stedcj_num_levels(bs);
+        blks = 1 << levs;
+
+        // 1. DIVIDE PHASE
+        /* ----------------------------------------------------------------- */
+        // (artificially divide split-block into blks sub-blocks
+        // find initial positions of each sub-blocks)
+
+        // find sizes of sub-blocks
+        ns[0] = bs;
+        rocblas_int t, t2;
+        for(int i = 0; i < levs; ++i)
+        {
+            for(int j = (1 << i); j > 0; --j)
+            {
+                t = ns[j - 1];
+                t2 = t / 2;
+                ns[j * 2 - 1] = (2 * t2 < t) ? t2 + 1 : t2;
+                ns[j * 2 - 2] = t2;
+            }
+        }
+
+        // find beginning of sub-blocks and update D elements
+        p2 = p1;
+        ps[0] = p2;
+        for(int i = 1; i < blks; ++i)
+        {
+            p2 += ns[i - 1];
+            ps[i] = p2;
+
+            // perform sub-block division
+            p = E[p2 - 1];
+            D[p2] -= p;
+            D[p2 - 1] -= p;
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+/** STEDCJ_SOLVE_KERNEL implements the solver phase of the DC algorithm to
         compute the eigenvalues/eigenvectors of the different sub-blocks of each
    split-block. A matrix in the batch could have many split-blocks, and each
    split-block could be divided in a maximum of nn sub-blocks.
         - Call this kernel with batch_count groups in z, STEDC_NUM_SPLIT_BLKS
-   groups in y and nn groups in x. Groups are size STEDC_BDIM.
+   groups in y and nn groups in x. Groups are size STEDCJ_BDIM.
         - STEDC_NUM_SPLIT_BLKS is fixed (is the number of split-blocks that will
    be analysed in parallel). If there are actually more split-blocks, some
    groups will work with more than one split-block sequentially.
@@ -146,7 +304,7 @@ __device__ inline void de2tridiag(const int numt,
    the size n. If a group has an id larger than the actual number of sub-blocks
    in a split-block, it will do nothing. **/
 template <typename S>
-ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+ROCSOLVER_KERNEL void __launch_bounds__(STEDCJ_BDIM)
     stedcj_solve_kernel(const rocblas_int n,
                         S* DD,
                         const rocblas_stride strideD,
@@ -237,7 +395,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
         ps = psA + p1;
 
         // determine ideal number of sub-blocks
-        levs = stedc_num_levels<rocsolver_stedc_mode_jacobi>(bs);
+        levs = stedcj_num_levels(bs);
         blks = 1 << levs;
 
         // 2. SOLVE PHASE
@@ -250,7 +408,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             p2 = ps[tid];
 
             // transform D and E into full upper tridiag matrix and copy to C
-            de2tridiag(STEDC_BDIM, tidb, sbs, D + p2, E + p2, C + p2 + p2 * ldc, ldc);
+            de2tridiag(STEDCJ_BDIM, tidb, sbs, D + p2, E + p2, C + p2 + p2 * ldc, ldc);
 
             // set work space
             S* W_Acpy = W;
@@ -267,7 +425,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
 
             // re-arrange threads in 2D array
             rocblas_int ddx, ddy;
-            syevj_get_dims(sbs, STEDC_BDIM, &ddx, &ddy);
+            syevj_get_dims(sbs, STEDCJ_BDIM, &ddx, &ddy);
             rocblas_int tix = tidb % ddx;
             rocblas_int tiy = tidb / ddx;
             __syncthreads();
@@ -282,8 +440,1123 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     }
 }
 
+//--------------------------------------------------------------------------------------//
+/** STEDCJ_MERGEPREPARE_KERNEL performs deflation and prepares the secular equation for
+    every pair of sub-blocks that need to be merged in a split block. A matrix in the batch
+    could have many split-blocks, and each split-block could be divided in a maximum of nn sub-blocks.
+        - Call this kernel with batch_count groups in z, STEDC_NUM_SPLIT_BLKS groups in y,
+          and as many groups as half of the unmerged sub-blocks in current level. Each group works
+          with a merge. Groups are size STEDCJ_BDIM.
+        - STEDC_NUM_SPLIT_BLKS is fixed (is the number of split-blocks that will
+          be analysed in parallel). If there are actually more split-blocks, some
+          groups will work with more than one split-block sequentially.
+        - An upper bound for the number of sub-blocks (nn) can be estimated from
+          the size n. If a group has an id larger than half the actual number of unmerged sub-blocks
+          in the level, it will do nothing. **/
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDCJ_BDIM)
+    stedcj_mergePrepare_kernel(const rocblas_int k,
+                               const rocblas_int n,
+                               S* DD,
+                               const rocblas_stride strideD,
+                               S* EE,
+                               const rocblas_stride strideE,
+                               S* CC,
+                               const rocblas_int shiftC,
+                               const rocblas_int ldc,
+                               const rocblas_stride strideC,
+                               S* tmpzA,
+                               S* vecsA,
+                               rocblas_int* splitsA,
+                               const S eps)
+{
+    // threads and groups indices
+    /* --------------------------------------------------- */
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_z;
+    // split block id
+    rocblas_int sid = hipBlockIdx_y;
+    // merge sub-block id
+    rocblas_int mid = hipBlockIdx_x;
+    // thread id
+    rocblas_int tidb = hipThreadIdx_x;
+    rocblas_int tid, tx;
+    /* --------------------------------------------------- */
+
+    // select batch instance to work with
+    /* --------------------------------------------------- */
+    S* C;
+    if(CC)
+        C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
+    S* D = DD + bid * strideD;
+    S* E = EE + bid * strideE;
+    /* --------------------------------------------------- */
+
+    // temporary arrays in global memory
+    /* --------------------------------------------------- */
+    // contains the beginning of split blocks
+    rocblas_int* splits = splitsA + bid * (5 * n + 2);
+    // the sub-blocks sizes
+    rocblas_int* nsA = splits + n + 2;
+    // the sub-blocks initial positions
+    rocblas_int* psA = nsA + n;
+    // if idd[i] = 0, the value in position i has been deflated
+    rocblas_int* idd = psA + n;
+    // container of permutations when solving the secular eqns
+    rocblas_int* pers = idd + n;
+    // the rank-1 modification vectors in the merges
+    S* z = tmpzA + bid * (2 * n);
+    // roots of secular equations
+    S* evs = z + n;
+    // updated eigenvectors after merges
+    S* vecs = vecsA + bid * 2 * (n * n);
+    // temp values during the merges
+    S* temps = vecs + (n * n);
+    /* --------------------------------------------------- */
+
+    // temporary arrays in shared memory
+    /* --------------------------------------------------- */
+    extern __shared__ rocblas_int lsmem[];
+    // used to store temp values during the different reductions
+    S* inrmsd = reinterpret_cast<S*>(lsmem);
+    S* inrmsz = inrmsd + hipBlockDim_x;
+    /* --------------------------------------------------- */
+
+    // local variables
+    /* --------------------------------------------------- */
+    // total number of split blocks
+    rocblas_int nb = splits[n + 1];
+    // size of split block
+    rocblas_int bs;
+    // beginning of split block
+    rocblas_int p1;
+    // beginning of sub-block
+    rocblas_int p2;
+    // number of sub-blocks
+    rocblas_int blks;
+    rocblas_int tn;
+    // number of level of division
+    rocblas_int levs;
+    // other aux variables
+    S p;
+    rocblas_int *ns, *ps;
+    /* --------------------------------------------------- */
+
+    // work with STEDC_NUM_SPLIT_BLKS split blocks in parallel
+    /* --------------------------------------------------- */
+    for(int kb = sid; kb < nb; kb += STEDC_NUM_SPLIT_BLKS)
+    {
+        __syncthreads();
+
+        // Select current split block
+        p1 = splits[kb];
+        p2 = splits[kb + 1];
+        bs = p2 - p1;
+        ns = nsA + p1;
+        ps = psA + p1;
+
+        // determine ideal number of sub-blocks
+        // tn is the number of thread-groups needed
+        levs = stedcj_num_levels(bs);
+        blks = levs - 1 - k;
+        tn = (blks < 0) ? 0 : 1 << blks;
+
+        // 3. MERGE PHASE
+        /* ----------------------------------------------------------------- */
+        // Work with merges on level k. A thread-group works with two leaves in the merge tree.
+        if(mid < tn)
+        {
+            rocblas_int iam, sz, bdm, dim, dim2;
+            S* ptz;
+            rocblas_int bd = 1 << k;
+            bdm = bd << 1;
+            dim = hipBlockDim_x / 2;
+
+            // tid indexes the sub-blocks in the entire split block
+            // iam indexes the sub-blocks in the context of the merge
+            // (according to its level in the merge tree)
+            iam = tidb / dim;
+            tx = tidb % dim;
+            tid = mid * bdm + iam * bd;
+            p2 = ps[tid];
+
+            // 3a. find rank-1 modification components (z and p) for this merge
+            /* ----------------------------------------------------------------- */
+            // Threads with iam = 0 work with components below the merge point;
+            // threads with iam = 1 work above the merge point
+            sz = ns[tid];
+            for(int j = 1; j < bd; ++j)
+                sz += ns[tid + j];
+            // with this, all threads involved in a merge
+            // will point to the same row of C and the same off-diag element
+            ptz = (iam == 0) ? C + p2 - 1 + sz : C + p2;
+            p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
+
+            // copy elements of z
+            for(int j = tx; j < sz; j += dim)
+                z[p2 + j] = ptz[(p2 + j) * ldc] / sqrt(2);
+            /* ----------------------------------------------------------------- */
+
+            // 3b. calculate deflation tolerance
+            /* ----------------------------------------------------------------- */
+            // compute maximum of diagonal and z in each merge block
+            S valf, valg, maxd, maxz;
+            maxd = 0;
+            maxz = 0;
+            for(int i = tx; i < sz; i += dim)
+            {
+                valf = std::abs(D[p2 + i]);
+                valg = std::abs(z[p2 + i]);
+                maxd = valf > maxd ? valf : maxd;
+                maxz = valg > maxz ? valg : maxz;
+            }
+            inrmsd[tidb] = maxd;
+            inrmsz[tidb] = maxz;
+            __syncthreads();
+
+            dim2 = dim;
+            while(dim2 > 0)
+            {
+                if(tidb < dim2)
+                {
+                    valf = inrmsd[tidb + dim2];
+                    valg = inrmsz[tidb + dim2];
+                    maxd = valf > maxd ? valf : maxd;
+                    maxz = valg > maxz ? valg : maxz;
+                    inrmsd[tidb] = maxd;
+                    inrmsz[tidb] = maxz;
+                }
+                dim2 /= 2;
+                __syncthreads();
+            }
+
+            // tol should be  8 * eps * (max diagonal or z element participating in
+            // merge)
+            maxd = inrmsd[0];
+            maxz = inrmsz[0];
+            maxd = maxz > maxd ? maxz : maxd;
+
+            S tol = 8 * eps * maxd;
+            /* ----------------------------------------------------------------- */
+
+            // 3c. deflate eigenvalues
+            /* ----------------------------------------------------------------- */
+            // determine boundaries of what would be the new merged sub-block
+            // 'in' will be its initial position.
+            // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
+            rocblas_int in = tid - iam * bd;
+            sz = ns[in];
+            for(int i = 1; i < bdm; ++i)
+                sz += ns[in + i];
+            in = ps[in];
+
+            // first deflate zero components
+            S f, g, c, s, rr;
+            for(int i = tidb; i < sz; i += hipBlockDim_x)
+            {
+                tx = in + i;
+                g = z[tx];
+                if(abs(p * g) <= tol)
+                    // deflated ev because component in z is zero
+                    idd[tx] = 0;
+                else
+                    idd[tx] = 1;
+            }
+            __syncthreads();
+
+            // now deflate repeated values
+            rocblas_int sz_even, sz_half, base, top, com;
+            sz_even = (sz % 2 == 1) ? sz + 1 : sz;
+            sz_half = sz_even / 2;
+
+            // the number of rounds needed is sz_even - 1
+            for(int r = 0; r < sz_even - 1; ++r)
+            {
+                // in each round threads analyze pairs of values in parallel
+                // sz_half pairs are needed
+                for(int i = tidb; i < sz_half; i += hipBlockDim_x)
+                {
+                    // determine pair of values (base, top)
+                    com = 2 * (i - r);
+                    base = (i == 0)             ? 0
+                        : (r < i)               ? com
+                        : (r > i - 1 + sz_half) ? 2 * (sz_even - 1) + com
+                                                : 1 - com;
+
+                    com = 2 * (i + r);
+                    top = (r < sz_half - i)     ? 1 + com
+                        : (r > sz_even - 2 - i) ? 3 - 2 * sz_even + com
+                                                : 2 * (sz_even - 1) - com;
+
+                    if(base > top)
+                    {
+                        com = base;
+                        base = top;
+                        top = com;
+                    }
+
+                    // compare values and deflate if needed
+                    base += in;
+                    top += in;
+                    if(idd[base] == 1 && idd[top] == 1 && top < sz + in)
+                    {
+                        if(abs(D[base] - D[top]) <= tol)
+                        {
+                            // deflated ev because it is repeated
+                            idd[top] = 0;
+                            // rotation to eliminate component in z
+                            g = z[top];
+                            f = z[base];
+                            lartg(f, g, c, s, rr);
+                            z[base] = rr;
+                            z[top] = 0;
+                            // update C with the rotation
+                            for(int ii = 0; ii < n; ++ii)
+                            {
+                                valf = C[ii + base * ldc];
+                                valg = C[ii + top * ldc];
+                                C[ii + base * ldc] = valf * c - valg * s;
+                                C[ii + top * ldc] = valf * s + valg * c;
+                            }
+                        }
+                    }
+                    __syncthreads();
+                }
+            }
+            /* ----------------------------------------------------------------- */
+
+            // 3d.1. Organize data with non-deflated values to prepare secular equation
+            /* ----------------------------------------------------------------- */
+            // define shifted arrays
+            S* tmpd = temps + in * n;
+            S* diag = D + in;
+            rocblas_int* mask = idd + in;
+            S* zz = z + in;
+            rocblas_int* per = pers + in;
+            S* ev = evs + in;
+
+            // find degree and components of secular equation
+            // tmpd contains the non-deflated diagonal elements (ie. poles of the
+            // secular eqn) zz contains the corresponding non-zero elements of the
+            // rank-1 modif vector
+            rocblas_int dd = 0;
+            for(int i = 0; i < sz; ++i)
+            {
+                if(mask[i] == 1)
+                {
+                    if(tidb == 0)
+                    {
+                        per[dd] = i;
+                        tmpd[dd] = p < 0 ? -diag[i] : diag[i];
+                        if(dd != i)
+                            zz[dd] = zz[i];
+                    }
+                    dd++;
+                }
+            }
+            /* ----------------------------------------------------------------- */
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+/** STEDCJ_MERGEVALUES_KERNEL solves the secular equation for
+    every pair of sub-blocks that need to be merged in a split block. A matrix in the batch
+    could have many split-blocks, and each split-block could be divided in a maximum of nn sub-blocks.
+        - Call this kernel with batch_count groups in z, STEDC_NUM_SPLIT_BLKS groups in y,
+          and as many groups as half of the unmerged sub-blocks in current level. Each group works
+          with a merge. Groups are size STEDCJ_BDIM.
+        - STEDC_NUM_SPLIT_BLKS is fixed (is the number of split-blocks that will
+          be analysed in parallel). If there are actually more split-blocks, some
+          groups will work with more than one split-block sequentially.
+        - An upper bound for the number of sub-blocks (nn) can be estimated from
+          the size n. If a group has an id larger than half the actual number of unmerged sub-blocks
+          in the level, it will do nothing. **/
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDCJ_BDIM)
+    stedcj_mergeValues_kernel(const rocblas_int k,
+                              const rocblas_int n,
+                              S* DD,
+                              const rocblas_stride strideD,
+                              S* EE,
+                              const rocblas_stride strideE,
+                              S* tmpzA,
+                              S* vecsA,
+                              rocblas_int* splitsA,
+                              const S eps,
+                              const S ssfmin,
+                              const S ssfmax)
+{
+    // threads and groups indices
+    /* --------------------------------------------------- */
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_z;
+    // split block id
+    rocblas_int sid = hipBlockIdx_y;
+    // merge sub-block id
+    rocblas_int mid = hipBlockIdx_x;
+    // thread id
+    rocblas_int tidb = hipThreadIdx_x;
+    rocblas_int tid;
+    /* --------------------------------------------------- */
+
+    // select batch instance to work with
+    /* --------------------------------------------------- */
+    S* D = DD + bid * strideD;
+    S* E = EE + bid * strideE;
+    /* --------------------------------------------------- */
+
+    // temporary arrays in global memory
+    /* --------------------------------------------------- */
+    // contains the beginning of split blocks
+    rocblas_int* splits = splitsA + bid * (5 * n + 2);
+    // the sub-blocks sizes
+    rocblas_int* nsA = splits + n + 2;
+    // the sub-blocks initial positions
+    rocblas_int* psA = nsA + n;
+    // if idd[i] = 0, the value in position i has been deflated
+    rocblas_int* idd = psA + n;
+    // container of permutations when solving the secular eqns
+    rocblas_int* pers = idd + n;
+    // the rank-1 modification vectors in the merges
+    S* z = tmpzA + bid * (2 * n);
+    // roots of secular equations
+    S* evs = z + n;
+    // updated eigenvectors after merges
+    S* vecs = vecsA + bid * 2 * (n * n);
+    // temp values during the merges
+    S* temps = vecs + (n * n);
+    /* --------------------------------------------------- */
+
+    // local variables
+    /* --------------------------------------------------- */
+    // total number of split blocks
+    rocblas_int nb = splits[n + 1];
+    // size of split block
+    rocblas_int bs;
+    // beginning of split block
+    rocblas_int p1;
+    // beginning of sub-block
+    rocblas_int p2;
+    // number of sub-blocks
+    rocblas_int blks;
+    rocblas_int tn;
+    // number of level of division
+    rocblas_int levs;
+    // other aux variables
+    S p;
+    rocblas_int *ns, *ps;
+    /* --------------------------------------------------- */
+
+    // work with STEDC_NUM_SPLIT_BLKS split blocks in parallel
+    /* --------------------------------------------------- */
+    for(int kb = sid; kb < nb; kb += STEDC_NUM_SPLIT_BLKS)
+    {
+        __syncthreads();
+
+        // Select current split block
+        p1 = splits[kb];
+        p2 = splits[kb + 1];
+        bs = p2 - p1;
+        ns = nsA + p1;
+        ps = psA + p1;
+
+        // determine ideal number of sub-blocks
+        // tn is the number of thread-groups needed
+        levs = stedcj_num_levels(bs);
+        blks = levs - 1 - k;
+        tn = (blks < 0) ? 0 : 1 << blks;
+        blks = 1 << levs;
+
+        // 3. MERGE PHASE
+        /* ----------------------------------------------------------------- */
+        // Work with merges on level k. A thread-group works with two leaves in the merge tree;
+        // all threads work together to solve the secular equation.
+        if(mid < tn)
+        {
+            rocblas_int iam, sz, bdm, dim;
+            S valf, valg;
+            rocblas_int bd = 1 << k;
+            bdm = bd << 1;
+            dim = hipBlockDim_x / 2;
+
+            // tid indexes the sub-blocks in the entire split block
+            // iam indexes the sub-blocks in the context of the merge
+            // (according to its level in the merge tree)
+            iam = tidb / dim;
+            tid = mid * bdm + iam * bd;
+            p2 = ps[tid];
+
+            // Find off-diagonal element of the merge
+            // Threads with iam = 0 work with components below the merge point;
+            // threads with iam = 1 work above the merge point
+            sz = ns[tid];
+            for(int j = 1; j < bd; ++j)
+                sz += ns[tid + j];
+            // with this, all threads involved in a merge
+            // will point to the same row of C and the same off-diag element
+            p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
+
+            // determine boundaries of what would be the new merged sub-block
+            // 'in' will be its initial position.
+            // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
+            rocblas_int in = tid - iam * bd;
+            sz = ns[in];
+            for(int i = 1; i < bdm; ++i)
+                sz += ns[in + i];
+            in = ps[in];
+
+            // 3d.2. Organize data with non-deflated values to prepare secular equation
+            /* ----------------------------------------------------------------- */
+            rocblas_int tsz = 1 << (levs - 1 - k);
+            tsz = (bs - 1) / tsz + 1;
+
+            // All threads of the group participating in the merge will work together
+            // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
+            iam = tidb;
+            bdm = hipBlockDim_x;
+
+            // define shifted arrays
+            S* tmpd = temps + in * n;
+            S* ev = evs + in;
+            S* diag = D + in;
+            rocblas_int* mask = idd + in;
+            S* zz = z + in;
+            rocblas_int* per = pers + in;
+
+            // find degree of secular equation
+            rocblas_int dd = 0;
+            for(int i = 0; i < sz; ++i)
+            {
+                if(mask[i] == 1)
+                    dd++;
+            }
+
+            // Order the elements in tmpd and zz using a simple parallel selection/bubble sort.
+            // This will allow us to find initial intervals for eigenvalue guesses
+            for(int i = 0; i < dd; i++)
+            {
+                for(int j = 2 * iam + i % 2; j < dd - 1; j += 2 * bdm)
+                {
+                    if(tmpd[j] > tmpd[j + 1])
+                    {
+                        swap(tmpd[j], tmpd[j + 1]);
+                        swap(zz[j], zz[j + 1]);
+                        swap(per[j], per[j + 1]);
+                    }
+                }
+                __syncthreads();
+            }
+
+            // make dd copies of the non-deflated ordered diagonal elements
+            // (i.e. the poles of the secular eqn) so that the distances to the
+            // eigenvalues (D - lambda_i) are updated while computing each eigenvalue.
+            // This will prevent collapses and division by zero when an eigenvalue
+            // is too close to a pole.
+            for(int i = iam; i < dd; i += bdm)
+            {
+                for(int j = i + n; j < i + sz * n; j += n)
+                    tmpd[j] = tmpd[i];
+            }
+
+            // finally copy over all diagonal elements in ev. ev will be overwritten
+            // by the new computed eigenvalues of the merged block
+            for(int i = iam; i < sz; i += bdm)
+                ev[i] = diag[i];
+            __syncthreads();
+            /* ----------------------------------------------------------------- */
+
+            // 3e. Solve secular eqns, i.e. find the dd zeros
+            // corresponding to non-deflated new eigenvalues of the merged block
+            /* ----------------------------------------------------------------- */
+            // each thread will find a different zero in parallel
+            S a, b;
+            for(int j = iam; j < sz; j += bdm)
+            {
+                if(mask[j] == 1)
+                {
+                    // find position in the ordered array
+                    valf = p < 0 ? -ev[j] : ev[j];
+                    int count = dd, cc = 0;
+                    while(count > 0)
+                    {
+                        auto step = count / 2;
+                        auto it = cc + step;
+                        if(tmpd[it + j * n] < valf)
+                        {
+                            cc = ++it;
+                            count -= step + 1;
+                        }
+                        else
+                            count = step;
+                    }
+
+                    // computed zero will overwrite 'ev' at the corresponding position.
+                    // 'tmpd' will be updated with the distances D - lambda_i.
+                    // deflated values are not changed.
+                    rocblas_int linfo;
+
+#if defined(ROCSOLVER_USE_REFERENCE_SECULAR_EQUATIONS_SOLVER)
+                    linfo = slaed4(dd, cc, tmpd + j * n, zz, std::abs(p), ev[j]);
+#else
+                    if(cc == dd - 1)
+                        linfo = seq_solve_ext(dd, tmpd + j * n, zz, (p < 0 ? -p : p), ev + j, eps,
+                                              ssfmin, ssfmax);
+                    else
+                        linfo = seq_solve(dd, tmpd + j * n, zz, (p < 0 ? -p : p), cc, ev + j, eps,
+                                          ssfmin, ssfmax);
+#endif
+
+                    if(p < 0)
+                        ev[j] *= -1;
+                }
+            }
+            __syncthreads();
+
+            // Re-scale vector Z to avoid bad numerics when an eigenvalue
+            // is too close to a pole
+            for(int i = iam; i < dd; i += bdm)
+            {
+                valf = 1;
+                for(int j = 0; j < sz; ++j)
+                {
+                    if(mask[j] == 1)
+                    {
+                        valg = tmpd[i + j * n];
+                        valf *= (per[i] == j) ? valg : valg / (diag[per[i]] - diag[j]);
+                    }
+                }
+                valf = sqrt(std::abs(valf));
+                zz[i] = zz[i] < 0 ? -valf : valf;
+            }
+            /* ----------------------------------------------------------------- */
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+/** STEDCJ_MERGEVECTORS_KERNEL prepares vectors from the secular equation for
+    every pair of sub-blocks that need to be merged in a split block. A matrix in the batch
+    could have many split-blocks, and each split-block could be divided in a maximum of nn sub-blocks.
+        - Call this kernel with batch_count groups in z, STEDC_NUM_SPLIT_BLKS groups in y,
+          and as many groups as columns would be in the matrix if its size is exact multiple of nn.
+          Each group works with a column. Groups are size STEDCJ_BDIM.
+        - STEDC_NUM_SPLIT_BLKS is fixed (is the number of split-blocks that will
+          be analysed in parallel). If there are actually more split-blocks, some
+          groups will work with more than one split-block sequentially.
+        - An upper bound for the number of sub-blocks (nn) can be estimated from
+          the size n. If a group has an id larger than the actual number of columns n,
+          it will do nothing. **/
+template <bool USEGEMM, typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDCJ_BDIM)
+    stedcj_mergeVectors_kernel(const rocblas_int k,
+                               const rocblas_int n,
+                               S* DD,
+                               const rocblas_stride strideD,
+                               S* EE,
+                               const rocblas_stride strideE,
+                               S* CC,
+                               const rocblas_int shiftC,
+                               const rocblas_int ldc,
+                               const rocblas_stride strideC,
+                               S* tmpzA,
+                               S* vecsA,
+                               rocblas_int* splitsA)
+{
+    // threads and groups indices
+    /* --------------------------------------------------- */
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_z;
+    // split block id
+    rocblas_int sid = hipBlockIdx_y;
+    // merge sub-block id
+    rocblas_int mid = hipBlockIdx_x;
+    // thread id
+    rocblas_int tidb = hipThreadIdx_x;
+    rocblas_int dim = hipBlockDim_x;
+    rocblas_int tid, vidb;
+    /* --------------------------------------------------- */
+
+    // select batch instance to work with
+    /* --------------------------------------------------- */
+    S* C;
+    if(CC)
+        C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
+    S* D = DD + bid * strideD;
+    S* E = EE + bid * strideE;
+    /* --------------------------------------------------- */
+
+    // temporary arrays in global memory
+    /* --------------------------------------------------- */
+    // contains the beginning of split blocks
+    rocblas_int* splits = splitsA + bid * (5 * n + 2);
+    // the sub-blocks sizes
+    rocblas_int* nsA = splits + n + 2;
+    // the sub-blocks initial positions
+    rocblas_int* psA = nsA + n;
+    // if idd[i] = 0, the value in position i has been deflated
+    rocblas_int* idd = psA + n;
+    // container of permutations when solving the secular eqns
+    rocblas_int* pers = idd + n;
+    // the rank-1 modification vectors in the merges
+    S* z = tmpzA + bid * (2 * n);
+    // roots of secular equations
+    S* evs = z + n;
+    // updated eigenvectors after merges
+    S* vecs = vecsA + bid * 2 * (n * n);
+    // temp values during the merges
+    S* temps = vecs + (n * n);
+    /* --------------------------------------------------- */
+
+    // temporary arrays in shared memory
+    /* --------------------------------------------------- */
+    extern __shared__ rocblas_int lsmem[];
+    // used to store temp values during the different reductions
+    S* inrms = reinterpret_cast<S*>(lsmem);
+    /* --------------------------------------------------- */
+
+    // local variables
+    /* --------------------------------------------------- */
+    // total number of split blocks
+    rocblas_int nb = splits[n + 1];
+    // size of split block
+    rocblas_int bs;
+    // beginning of split block
+    rocblas_int p1;
+    // beginning of sub-block
+    rocblas_int p2;
+    // number of sub-blocks
+    rocblas_int blks;
+    // number of level of division
+    rocblas_int levs;
+    // other aux variables
+    rocblas_int tn;
+    S p;
+    rocblas_int *ns, *ps;
+    /* --------------------------------------------------- */
+
+    // work with STEDC_NUM_SPLIT_BLKS split blocks in parallel
+    /* --------------------------------------------------- */
+    for(int kb = sid; kb < nb; kb += STEDC_NUM_SPLIT_BLKS)
+    {
+        __syncthreads();
+
+        // Select current split block
+        p1 = splits[kb];
+        p2 = splits[kb + 1];
+        bs = p2 - p1;
+        ns = nsA + p1;
+        ps = psA + p1;
+
+        // determine ideal number of sub-blocks
+        levs = stedcj_num_levels(bs);
+        blks = 1 << levs;
+
+        // tn is max number of vectors in each sub-block
+        tn = (bs - 1) / blks + 1;
+
+        // 3. MERGE PHASE
+        /* ----------------------------------------------------------------- */
+        // Work with merges on level k. Each thread-group works with one vector.
+        if(mid < tn * blks && k < levs)
+        {
+            rocblas_int iam, sz, bdm;
+            S* ptz;
+            S valf, valg;
+            rocblas_int bd = 1 << k;
+            bdm = bd << 1;
+
+            // tid indexes the sub-blocks in the entire split block
+            tid = mid / tn;
+            p2 = ps[tid];
+            // vidb indexes the vectors associated with each sub-block
+            vidb = mid % tn;
+            // iam indexes the sub-blocks in the context of the merge
+            // (according to its level in the merge tree)
+            iam = tid % bdm;
+
+            // determine boundaries of what would be the new merged sub-block
+            // 'in' will be its initial position
+            rocblas_int in = ps[tid - iam];
+            // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
+            sz = ns[tid];
+            for(int i = iam; i > 0; --i)
+                sz += ns[tid - i];
+            for(int i = bdm - 1 - iam; i > 0; --i)
+                sz += ns[tid + i];
+
+            // final number of merged sub-blocks
+            rocblas_int tsz = 1 << (levs - 1 - k);
+            tsz = (bs - 1) / tsz + 1;
+
+            // define shifted arrays
+            S* tmpd = temps + in * n;
+            S* ev = evs + in;
+            S* diag = D + in;
+            rocblas_int* mask = idd + in;
+            S* zz = z + in;
+            rocblas_int* per = pers + in;
+
+            // find degree of secular equation
+            rocblas_int dd = 0;
+            for(int i = 0; i < sz; ++i)
+            {
+                if(mask[i] == 1)
+                    dd++;
+            }
+            __syncthreads();
+
+            // 3f. Prepare vectors corresponding to non-deflated values
+            /* ----------------------------------------------------------------- */
+            S temp, nrm;
+            rocblas_int j = vidb;
+            bool go = (j < ns[tid]);
+            S* putvec = USEGEMM ? vecs : temps;
+
+            if(go)
+            {
+                if(idd[p2 + j] == 1)
+                {
+                    // compute vectors of rank-1 perturbed system and their norms
+                    nrm = 0;
+                    for(int i = tidb; i < dd; i += dim)
+                    {
+                        valf = zz[i] / temps[i + (p2 + j) * n];
+                        nrm += valf * valf;
+                        putvec[i + (p2 + j) * n] = valf;
+                    }
+                    inrms[tidb] = nrm;
+                    __syncthreads();
+
+                    // reduction (for the norms)
+                    for(int r = dim / 2; r > 0; r /= 2)
+                    {
+                        if(tidb < r)
+                        {
+                            nrm += inrms[tidb + r];
+                            inrms[tidb] = nrm;
+                        }
+                        __syncthreads();
+                    }
+                    nrm = sqrt(inrms[0]);
+                }
+
+                if(USEGEMM)
+                {
+                    // when using external gemms for the update, we need to
+                    // put vectors in padded matrix 'temps'
+                    // (this is to compute 'vecs = C * temps' using external gemm call)
+                    for(int i = tidb; i < in + sz; i += dim)
+                    {
+                        if(i >= in && idd[p2 + j] == 1 && idd[i] == 1)
+                        {
+                            dd = 0;
+                            for(int k = in; k < i; ++k)
+                            {
+                                if(idd[k] == 0)
+                                    dd++;
+                            }
+                            temps[pers[i - dd] + in + (p2 + j) * n]
+                                = vecs[i - dd - in + (p2 + j) * n] / nrm;
+                        }
+                        else
+                            temps[i + (p2 + j) * n] = 0;
+                    }
+                }
+                else
+                {
+                    // otherwise, use internal gemm-like procedure to
+                    // multiply by C (row by row)
+                    if(idd[p2 + j] == 1)
+                    {
+                        for(int ii = 0; ii < tsz; ++ii)
+                        {
+                            rocblas_int i = in + ii;
+
+                            // inner products
+                            temp = 0;
+                            if(ii < sz)
+                            {
+                                for(int kk = tidb; kk < dd; kk += dim)
+                                    temp += C[i + (per[kk] + in) * ldc] * temps[kk + (p2 + j) * n];
+                            }
+                            inrms[tidb] = temp;
+                            __syncthreads();
+
+                            // reduction
+                            for(int r = dim / 2; r > 0; r /= 2)
+                            {
+                                if(ii < sz && tidb < r)
+                                {
+                                    temp += inrms[tidb + r];
+                                    inrms[tidb] = temp;
+                                }
+                                __syncthreads();
+                            }
+
+                            // result
+                            if(ii < sz && tidb == 0)
+                                vecs[i + (p2 + j) * n] = temp / nrm;
+                            __syncthreads();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+/** STEDCJ_MERGEUPDATE_KERNEL updates vectors after merges are done. A matrix in the batch
+    could have many split-blocks, and each split-block could be divided in a maximum of nn sub-blocks.
+        - Call this kernel with batch_count groups in z, STEDC_NUM_SPLIT_BLKS groups in y,
+          and as many groups as columns would be in the matrix if its size is exact multiple of nn.
+          Each group works with a column. Groups are size STEDCJ_BDIM.
+        - STEDC_NUM_SPLIT_BLKS is fixed (is the number of split-blocks that will
+          be analysed in parallel). If there are actually more split-blocks, some
+          groups will work with more than one split-block sequentially.
+        - An upper bound for the number of sub-blocks (nn) can be estimated from
+          the size n. If a group has an id larger than the actual number of columns n,
+          it will do nothing. **/
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDCJ_BDIM)
+    stedcj_mergeUpdate_kernel(const rocblas_int k,
+                              const rocblas_int n,
+                              S* DD,
+                              const rocblas_stride strideD,
+                              S* CC,
+                              const rocblas_int shiftC,
+                              const rocblas_int ldc,
+                              const rocblas_stride strideC,
+                              S* tmpzA,
+                              S* vecsA,
+                              rocblas_int* splitsA)
+{
+    // threads and groups indices
+    /* --------------------------------------------------- */
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_z;
+    // split block id
+    rocblas_int sid = hipBlockIdx_y;
+    // merge sub-block id
+    rocblas_int mid = hipBlockIdx_x;
+    // thread id
+    rocblas_int tidb = hipThreadIdx_x;
+    rocblas_int dim = hipBlockDim_x;
+    rocblas_int tid, vidb;
+    /* --------------------------------------------------- */
+
+    // select batch instance to work with
+    /* --------------------------------------------------- */
+    S* C;
+    if(CC)
+        C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
+    S* D = DD + bid * strideD;
+    /* --------------------------------------------------- */
+
+    // temporary arrays in global memory
+    /* --------------------------------------------------- */
+    // contains the beginning of split blocks
+    rocblas_int* splits = splitsA + bid * (5 * n + 2);
+    // the sub-blocks sizes
+    rocblas_int* nsA = splits + n + 2;
+    // the sub-blocks initial positions
+    rocblas_int* psA = nsA + n;
+    // if idd[i] = 0, the value in position i has been deflated
+    rocblas_int* idd = psA + n;
+    // the rank-1 modification vectors in the merges
+    S* z = tmpzA + bid * (2 * n);
+    // roots of secular equations
+    S* evs = z + n;
+    // updated eigenvectors after merges
+    S* vecs = vecsA + bid * 2 * (n * n);
+    /* --------------------------------------------------- */
+
+    // temporary arrays in shared memory
+    /* --------------------------------------------------- */
+    extern __shared__ rocblas_int lsmem[];
+    // used to store temp values during the different reductions
+    S* inrms = reinterpret_cast<S*>(lsmem);
+    /* --------------------------------------------------- */
+
+    // local variables
+    /* --------------------------------------------------- */
+    // total number of split blocks
+    rocblas_int nb = splits[n + 1];
+    // size of split block
+    rocblas_int bs;
+    // beginning of split block
+    rocblas_int p1;
+    // beginning of sub-block
+    rocblas_int p2;
+    // number of sub-blocks
+    rocblas_int blks;
+    // number of level of division
+    rocblas_int levs;
+    // other aux variables
+    rocblas_int tn;
+    S p;
+    rocblas_int *ns, *ps;
+    /* --------------------------------------------------- */
+
+    // work with STEDC_NUM_SPLIT_BLKS split blocks in parallel
+    /* --------------------------------------------------- */
+    for(int kb = sid; kb < nb; kb += STEDC_NUM_SPLIT_BLKS)
+    {
+        __syncthreads();
+
+        // Select current split block
+        p1 = splits[kb];
+        p2 = splits[kb + 1];
+        bs = p2 - p1;
+        ns = nsA + p1;
+        ps = psA + p1;
+
+        // determine ideal number of sub-blocks
+        levs = stedcj_num_levels(bs);
+        blks = 1 << levs;
+
+        // tn is max number of vectors in each sub-block
+        tn = (bs - 1) / blks + 1;
+
+        // 3. MERGE PHASE
+        /* ----------------------------------------------------------------- */
+        // Work with merges on level k. Each thread-group works with one vector.
+        if(mid < tn * blks && k < levs)
+        {
+            rocblas_int iam, sz, bdm;
+            S* ptz;
+            S valf, valg;
+            rocblas_int bd = 1 << k;
+            bdm = bd << 1;
+
+            // tid indexes the sub-blocks in the entire split block
+            tid = mid / tn;
+            p2 = ps[tid];
+            // vidb indexes the vectors associated with each sub-block
+            vidb = mid % tn;
+            // iam indexes the sub-blocks in the context of the merge
+            // (according to its level in the merge tree)
+            iam = tid % bdm;
+
+            // determine boundaries of what would be the new merged sub-block
+            // 'in' will be its initial position
+            rocblas_int in = ps[tid - iam];
+            // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
+            sz = ns[tid];
+            for(int i = iam; i > 0; --i)
+                sz += ns[tid - i];
+            for(int i = bdm - 1 - iam; i > 0; --i)
+                sz += ns[tid + i];
+
+            // 3g. update D and C with computed values and vectors
+            /* ----------------------------------------------------------------- */
+            rocblas_int j = vidb;
+            bool go = (j < ns[tid] && idd[p2 + j] == 1);
+            if(go)
+            {
+                if(tidb == 0)
+                    D[p2 + j] = evs[p2 + j];
+                for(int i = in + tidb; i < in + sz; i += dim)
+                    C[i + (p2 + j) * ldc] = vecs[i + (p2 + j) * n];
+            }
+            /* ----------------------------------------------------------------- */
+        }
+    }
+}
+
+/** STEDCJ_SORT sorts computed eigenvalues and eigenvectors in increasing order **/
+template <typename T, typename S, typename U>
+ROCSOLVER_KERNEL void __launch_bounds__(BS1) stedcj_sort(const rocblas_int n,
+                                                         S* DD,
+                                                         const rocblas_stride strideD,
+                                                         U CC,
+                                                         const rocblas_int shiftC,
+                                                         const rocblas_int ldc,
+                                                         const rocblas_stride strideC,
+                                                         const rocblas_int batch_count,
+                                                         rocblas_int* work,
+                                                         rocblas_int* nev = nullptr)
+{
+    // -----------------------------------
+    // use z-grid dimension as batch index
+    // -----------------------------------
+    rocblas_int bid_start = hipBlockIdx_z;
+    rocblas_int bid_inc = hipGridDim_z;
+
+    int tid = hipThreadIdx_x;
+
+    rocblas_int* const map = work + bid_start * ((int64_t)n);
+
+    for(auto bid = bid_start; bid < batch_count; bid += bid_inc)
+    {
+        // ---------------------------------------------
+        // select batch instance to work with
+        // (avoiding arithmetics with possible nullptrs)
+        // ---------------------------------------------
+        T* C = nullptr;
+        if(CC)
+            C = load_ptr_batch<T>(CC, bid, shiftC, strideC);
+        S* D = DD + (bid * strideD);
+        rocblas_int nn;
+        if(nev)
+            nn = nev[bid];
+        else
+            nn = n;
+
+        bool constexpr use_shell_sort = true;
+
+        __syncthreads();
+
+        if(use_shell_sort)
+            shell_sort(nn, D, map);
+        else
+            selection_sort(nn, D, map);
+        __syncthreads();
+
+        permute_swap(n, C, ldc, map, nn);
+        __syncthreads();
+    }
+}
+
 /******************* Host functions *********************************************/
 /*******************************************************************************/
+
+//--------------------------------------------------------------------------------------//
+/** This helper check argument correctness for stedc API **/
+template <typename T, typename S>
+rocblas_status rocsolver_stedcj_argCheck(rocblas_handle handle,
+                                         const rocblas_evect evect,
+                                         const rocblas_int n,
+                                         S D,
+                                         S E,
+                                         T C,
+                                         const rocblas_int ldc,
+                                         rocblas_int* info)
+{
+    // order is important for unit tests:
+
+    // 1. invalid/non-supported values
+    if(evect != rocblas_evect_none && evect != rocblas_evect_tridiagonal
+       && evect != rocblas_evect_original)
+        return rocblas_status_invalid_value;
+
+    // 2. invalid size
+    if(n < 0)
+        return rocblas_status_invalid_size;
+    if(evect != rocblas_evect_none && ldc < n)
+        return rocblas_status_invalid_size;
+
+    // skip pointer check if querying memory size
+    if(rocblas_is_device_memory_size_query(handle))
+        return rocblas_status_continue;
+
+    // 3. invalid pointers
+    if((n && !D) || (n > 1 && !E) || (evect != rocblas_evect_none && n && !C) || !info)
+        return rocblas_status_invalid_pointer;
+
+    return rocblas_status_continue;
+}
 
 //--------------------------------------------------------------------------------------//
 /** This helper calculates required workspace size **/
@@ -407,31 +1680,31 @@ rocblas_status rocsolver_stedcj_template(rocblas_handle handle,
                             stream, n, n, tempvect, 0, ldt, strideT);
 
     // find max number of sub-blocks to consider during the divide phase
-    rocblas_int maxlevs = stedc_num_levels<rocsolver_stedc_mode_jacobi>(n);
+    rocblas_int maxlevs = stedcj_num_levels(n);
     rocblas_int maxblks = 1 << maxlevs;
 
     // find independent split blocks in matrix
-    ROCSOLVER_LAUNCH_KERNEL(stedc_split, dim3(batch_count), dim3(1), 0, stream, n, D, strideD, E,
+    ROCSOLVER_LAUNCH_KERNEL(stedcj_split, dim3(batch_count), dim3(1), 0, stream, n, D, strideD, E,
                             strideE, splits_map, eps);
 
     // 1. divide phase
     //-----------------------------
-    ROCSOLVER_LAUNCH_KERNEL((stedc_divide_kernel<rocsolver_stedc_mode_jacobi, S>), dim3(batch_count),
-                            dim3(STEDC_BDIM), 0, stream, n, D, strideD, E, strideE, splits_map);
+    ROCSOLVER_LAUNCH_KERNEL((stedcj_divide_kernel<S>), dim3(batch_count), dim3(STEDCJ_BDIM), 0,
+                            stream, n, D, strideD, E, strideE, splits_map);
 
     // 2. solve phase
     //-----------------------------
     size_t lmemsize = (n + n % 2) * (sizeof(rocblas_int) + sizeof(S));
 
     ROCSOLVER_LAUNCH_KERNEL((stedcj_solve_kernel<S>),
-                            dim3(maxblks, STEDC_NUM_SPLIT_BLKS, batch_count), dim3(STEDC_BDIM),
+                            dim3(maxblks, STEDC_NUM_SPLIT_BLKS, batch_count), dim3(STEDCJ_BDIM),
                             lmemsize, stream, n, D, strideD, E, strideE, tempvect, 0, ldt, strideT,
                             info, static_cast<S*>(work_stack), splits_map, eps, ssfmin, ssfmax);
 
     // 3. merge phase
     //----------------
-    size_t lmemsize1 = sizeof(S) * 2 * STEDC_BDIM;
-    size_t lmemsize3 = sizeof(S) * STEDC_BDIM;
+    size_t lmemsize1 = sizeof(S) * 2 * STEDCJ_BDIM;
+    size_t lmemsize3 = sizeof(S) * STEDCJ_BDIM;
     rocblas_int numgrps3 = ((n - 1) / maxblks + 1) * maxblks;
 
     // launch merge for level k
@@ -442,28 +1715,28 @@ rocblas_status rocsolver_stedcj_template(rocblas_handle handle,
     {
         // a. prepare secular equations
         rocblas_int numgrps2 = 1 << (maxlevs - 1 - k);
-        ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_kernel<rocsolver_stedc_mode_jacobi, S>),
-                                dim3(numgrps2, STEDC_NUM_SPLIT_BLKS, batch_count), dim3(STEDC_BDIM),
-                                lmemsize1, stream, k, n, D, strideD, E, strideE, tempvect, 0, ldt,
-                                strideT, tmpz, tempgemm, splits_map, eps);
+        ROCSOLVER_LAUNCH_KERNEL((stedcj_mergePrepare_kernel<S>),
+                                dim3(numgrps2, STEDC_NUM_SPLIT_BLKS, batch_count),
+                                dim3(STEDCJ_BDIM), lmemsize1, stream, k, n, D, strideD, E, strideE,
+                                tempvect, 0, ldt, strideT, tmpz, tempgemm, splits_map, eps);
 
         // b. solve to find merged eigen values
-        ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_kernel<rocsolver_stedc_mode_jacobi, S>),
-                                dim3(numgrps2, STEDC_NUM_SPLIT_BLKS, batch_count), dim3(STEDC_BDIM),
-                                0, stream, k, n, D, strideD, E, strideE, tmpz, tempgemm, splits_map,
-                                eps, ssfmin, ssfmax);
+        ROCSOLVER_LAUNCH_KERNEL((stedcj_mergeValues_kernel<S>),
+                                dim3(numgrps2, STEDC_NUM_SPLIT_BLKS, batch_count),
+                                dim3(STEDCJ_BDIM), 0, stream, k, n, D, strideD, E, strideE, tmpz,
+                                tempgemm, splits_map, eps, ssfmin, ssfmax);
 
         // c. find merged eigen vectors
-        ROCSOLVER_LAUNCH_KERNEL(
-            (stedc_mergeVectors_kernel<rocsolver_stedc_mode_jacobi, STEDCJ_EXTERNAL_GEMM, S>),
-            dim3(numgrps3, STEDC_NUM_SPLIT_BLKS, batch_count), dim3(STEDC_BDIM), lmemsize3, stream,
-            k, n, D, strideD, E, strideE, tempvect, 0, ldt, strideT, tmpz, tempgemm, splits_map);
+        ROCSOLVER_LAUNCH_KERNEL((stedcj_mergeVectors_kernel<STEDCJ_EXTERNAL_GEMM, S>),
+                                dim3(numgrps3, STEDC_NUM_SPLIT_BLKS, batch_count),
+                                dim3(STEDCJ_BDIM), lmemsize3, stream, k, n, D, strideD, E, strideE,
+                                tempvect, 0, ldt, strideT, tmpz, tempgemm, splits_map);
 
         // c. update level
-        ROCSOLVER_LAUNCH_KERNEL((stedc_mergeUpdate_kernel<rocsolver_stedc_mode_jacobi, S>),
-                                dim3(numgrps3, STEDC_NUM_SPLIT_BLKS, batch_count), dim3(STEDC_BDIM),
-                                lmemsize3, stream, k, n, D, strideD, tempvect, 0, ldt, strideT,
-                                tmpz, tempgemm, splits_map);
+        ROCSOLVER_LAUNCH_KERNEL((stedcj_mergeUpdate_kernel<S>),
+                                dim3(numgrps3, STEDC_NUM_SPLIT_BLKS, batch_count),
+                                dim3(STEDCJ_BDIM), lmemsize3, stream, k, n, D, strideD, tempvect, 0,
+                                ldt, strideT, tmpz, tempgemm, splits_map);
     }
 
     // 4. update and sort
@@ -473,7 +1746,7 @@ rocblas_status rocsolver_stedcj_template(rocblas_handle handle,
                                     static_cast<S*>(work_stack), 0, ldt, strideT, batch_count,
                                     workArr);
 
-    ROCSOLVER_LAUNCH_KERNEL((stedc_sort<T>), dim3(1, 1, batch_count), dim3(BS1), 0, stream, n, D,
+    ROCSOLVER_LAUNCH_KERNEL((stedcj_sort<T>), dim3(1, 1, batch_count), dim3(BS1), 0, stream, n, D,
                             strideD, C, shiftC, ldc, strideC, batch_count, splits_map);
 
     return rocblas_status_success;

--- a/library/src/auxiliary/rocauxiliary_stedcx.hpp
+++ b/library/src/auxiliary/rocauxiliary_stedcx.hpp
@@ -29,12 +29,14 @@
 
 #include "auxiliary/rocauxiliary_stebz.hpp"
 #include "auxiliary/rocauxiliary_stein.hpp"
+#include "auxiliary/rocauxiliary_steqr.hpp"
 #include "lapack_device_functions.hpp"
-#include "rocauxiliary_stedc.hpp"
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
 
 ROCSOLVER_BEGIN_NAMESPACE
+
+#define STEDCX_BDIM 512 // Number of threads per thread-block used in main stedc kernels
 
 // TODO: using macro STEDCX_EXTERNAL_GEMM = false for now. We can enable the use of
 // external gemm updates once the development is completed for stedc.
@@ -44,12 +46,10 @@ ROCSOLVER_BEGIN_NAMESPACE
 /**************************************************************************************/
 
 //--------------------------------------------------------------------------------------//
-/** STEDC_NUM_LEVELS returns the ideal number of times/levels in which a matrix (or split block)
+/** STEDCX_NUM_LEVELS returns the ideal number of times/levels in which a matrix (or split block)
     will be divided during the divide phase of divide & conquer algorithm.
     i.e. number of sub-blocks = 2^levels **/
-template <>
-__host__ __device__ inline rocblas_int
-    stedc_num_levels<rocsolver_stedc_mode_bisection>(const rocblas_int n)
+__host__ __device__ inline rocblas_int stedcx_num_levels(const rocblas_int n)
 {
     rocblas_int levels = 0;
     // return the max number of levels such that the sub-blocks are at least of size 1
@@ -197,9 +197,233 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEBZ_SPLIT_THDS)
 }
 
 //--------------------------------------------------------------------------------------//
+/** STEDCX_DIVIDE_KERNEL implements the divide phase of the DC algorithm. It
+   divides each split-block into a number of sub-blocks.
+        - Call this kernel with batch_count groups in x. Groups are of size
+   STEDCX_BDIM.
+        - If there are actually more split-blocks than STEDCX_BDIM, some threads
+   will work with more than one split-block sequentially. **/
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDCX_BDIM)
+    stedcx_divide_kernel(const rocblas_int n,
+                         S* DD,
+                         const rocblas_stride strideD,
+                         S* EE,
+                         const rocblas_stride strideE,
+                         rocblas_int* splitsA)
+{
+    // threads and groups indices
+    /* --------------------------------------------------- */
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_x;
+    // split-block id
+    rocblas_int sid = hipThreadIdx_x;
+    /* --------------------------------------------------- */
+
+    // select batch instance to work with
+    /* --------------------------------------------------- */
+    S* D = DD + bid * strideD;
+    S* E = EE + bid * strideE;
+    /* --------------------------------------------------- */
+
+    // temporary arrays in global memory
+    /* --------------------------------------------------- */
+    // contains the beginning of split blocks
+    rocblas_int* splits = splitsA + bid * (5 * n + 2);
+    // the sub-blocks sizes
+    rocblas_int* nsA = splits + n + 2;
+    // the sub-blocks initial positions
+    rocblas_int* psA = nsA + n;
+    /* --------------------------------------------------- */
+
+    // local variables
+    /* --------------------------------------------------- */
+    // total number of split blocks
+    rocblas_int nb = splits[n + 1];
+    // size of split block
+    rocblas_int bs;
+    // beginning of split block
+    rocblas_int p1;
+    // beginning of sub-block
+    rocblas_int p2;
+    // number of sub-blocks
+    rocblas_int blks;
+    // number of level of division
+    rocblas_int levs;
+    // other aux variables
+    S p;
+    rocblas_int *ns, *ps;
+    /* --------------------------------------------------- */
+
+    // work with STEDCX_BDIM split blocks in parallel
+    /* --------------------------------------------------- */
+    for(int kb = sid; kb < nb; kb += STEDCX_BDIM)
+    {
+        // Select current split block
+        p1 = splits[kb];
+        p2 = splits[kb + 1];
+        bs = p2 - p1;
+        ns = nsA + p1;
+        ps = psA + p1;
+
+        // determine ideal number of sub-blocks in split-block
+        levs = stedcx_num_levels(bs);
+        blks = 1 << levs;
+
+        // 1. DIVIDE PHASE
+        /* ----------------------------------------------------------------- */
+        // (artificially divide split-block into blks sub-blocks
+        // find initial positions of each sub-blocks)
+
+        // find sizes of sub-blocks
+        ns[0] = bs;
+        rocblas_int t, t2;
+        for(int i = 0; i < levs; ++i)
+        {
+            for(int j = (1 << i); j > 0; --j)
+            {
+                t = ns[j - 1];
+                t2 = t / 2;
+                ns[j * 2 - 1] = (2 * t2 < t) ? t2 + 1 : t2;
+                ns[j * 2 - 2] = t2;
+            }
+        }
+
+        // find beginning of sub-blocks and update D elements
+        p2 = p1;
+        ps[0] = p2;
+        for(int i = 1; i < blks; ++i)
+        {
+            p2 += ns[i - 1];
+            ps[i] = p2;
+
+            // perform sub-block division
+            p = E[p2 - 1];
+            D[p2] -= p;
+            D[p2 - 1] -= p;
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+/** STEDCX_SOLVE_KERNEL implements the solver phase of the DC algorithm to
+        compute the eigenvalues/eigenvectors of the different sub-blocks of each
+   split-block. A matrix in the batch could have many split-blocks, and each
+   split-block could be divided in a maximum of nn sub-blocks.
+        - Call this kernel with batch_count groups in z, STEDC_NUM_SPLIT_BLKS
+   groups in y. Groups are single-thread.
+        - STEDC_NUM_SPLIT_BLKS is fixed (is the number of split-blocks that will
+   be analysed in parallel). If there are actually more split-blocks, some
+   groups will work with more than one split-block sequentially. **/
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDCX_BDIM)
+    stedcx_solve_kernel(const rocblas_int n,
+                        S* DD,
+                        const rocblas_stride strideD,
+                        S* EE,
+                        const rocblas_stride strideE,
+                        S* CC,
+                        const rocblas_int shiftC,
+                        const rocblas_int ldc,
+                        const rocblas_stride strideC,
+                        rocblas_int* iinfo,
+                        S* WA,
+                        rocblas_int* splitsA,
+                        const S eps,
+                        const S ssfmin,
+                        const S ssfmax)
+{
+    // threads and groups indices
+    /* --------------------------------------------------- */
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_z;
+    // split-block id
+    rocblas_int sid = hipBlockIdx_y;
+    // sub-block id
+    rocblas_int tid = hipBlockIdx_x;
+    // thread index
+    rocblas_int tidb = hipThreadIdx_x;
+    rocblas_int tidb_inc = hipBlockDim_x;
+    /* --------------------------------------------------- */
+
+    // select batch instance to work with
+    /* --------------------------------------------------- */
+    S* C;
+    if(CC)
+        C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
+    S* D = DD + bid * strideD;
+    S* E = EE + bid * strideE;
+    rocblas_int* info = iinfo + bid;
+    /* --------------------------------------------------- */
+
+    // temporary arrays in global memory
+    /* --------------------------------------------------- */
+    // contains the beginning of split blocks
+    rocblas_int* splits = splitsA + bid * (5 * n + 2);
+    // the sub-blocks sizes
+    rocblas_int* nsA = splits + n + 2;
+    // the sub-blocks initial positions
+    rocblas_int* psA = nsA + n;
+    // workspace for solvers
+    S* W = WA + bid * (2 * n);
+    /* --------------------------------------------------- */
+
+    // local variables
+    /* --------------------------------------------------- */
+    // total number of split blocks
+    rocblas_int nb = splits[n + 1];
+    // size of split block
+    rocblas_int bs;
+    // size of sub block
+    rocblas_int sbs;
+    // beginning of split block
+    rocblas_int p1;
+    // beginning of sub-block
+    rocblas_int p2;
+    // number of sub-blocks
+    rocblas_int blks;
+    // number of level of division
+    rocblas_int levs;
+    // other aux variables
+    S p;
+    rocblas_int *ns, *ps;
+    /* --------------------------------------------------- */
+
+    // work with STEDC_NUM_SPLIT_BLKS split blocks in parallel
+    /* --------------------------------------------------- */
+    for(int kb = sid; kb < nb; kb += STEDC_NUM_SPLIT_BLKS)
+    {
+        // Select current split block
+        p1 = splits[kb];
+        p2 = splits[kb + 1];
+        bs = p2 - p1;
+        ns = nsA + p1;
+        ps = psA + p1;
+
+        // determine ideal number of sub-blocks
+        levs = stedcx_num_levels(bs);
+        blks = 1 << levs;
+
+        // 2. SOLVE PHASE
+        /* ----------------------------------------------------------------- */
+        // Solve the blks sub-blocks in parallel.
+
+        if(tid < blks)
+        {
+            sbs = ns[tid];
+            p2 = ps[tid];
+
+            run_steqr(tidb, tidb_inc, sbs, D + p2, E + p2, C + p2 + p2 * ldc, ldc, info, W + p2 * 2,
+                      30 * bs, eps, ssfmin, ssfmax, false);
+            __syncthreads();
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------//
 /** STEDCX_SYNTHESIS_KERNEL synthesizes the results of the partial decomposition **/
 template <typename S>
-ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
+ROCSOLVER_KERNEL void __launch_bounds__(STEDCX_BDIM)
     stedcx_synthesis_kernel(const rocblas_erange range,
                             const rocblas_int n,
                             const rocblas_int il,
@@ -333,6 +557,1085 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
             }
             nn++;
         }
+        __syncthreads();
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+/** STEDCX_MERGEPREPARE_KERNEL performs deflation and prepares the secular equation for
+    every pair of sub-blocks that need to be merged in a split block. A matrix in the batch
+    could have many split-blocks, and each split-block could be divided in a maximum of nn sub-blocks.
+        - Call this kernel with batch_count groups in z, STEDC_NUM_SPLIT_BLKS groups in y,
+          and as many groups as half of the unmerged sub-blocks in current level. Each group works
+          with a merge. Groups are size STEDCX_BDIM.
+        - STEDC_NUM_SPLIT_BLKS is fixed (is the number of split-blocks that will
+          be analysed in parallel). If there are actually more split-blocks, some
+          groups will work with more than one split-block sequentially.
+        - An upper bound for the number of sub-blocks (nn) can be estimated from
+          the size n. If a group has an id larger than half the actual number of unmerged sub-blocks
+          in the level, it will do nothing. **/
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDCX_BDIM)
+    stedcx_mergePrepare_kernel(const rocblas_int k,
+                               const rocblas_int n,
+                               S* DD,
+                               const rocblas_stride strideD,
+                               S* EE,
+                               const rocblas_stride strideE,
+                               S* CC,
+                               const rocblas_int shiftC,
+                               const rocblas_int ldc,
+                               const rocblas_stride strideC,
+                               S* tmpzA,
+                               S* vecsA,
+                               rocblas_int* splitsA,
+                               const S eps)
+{
+    // threads and groups indices
+    /* --------------------------------------------------- */
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_z;
+    // split block id
+    rocblas_int sid = hipBlockIdx_y;
+    // merge sub-block id
+    rocblas_int mid = hipBlockIdx_x;
+    // thread id
+    rocblas_int tidb = hipThreadIdx_x;
+    rocblas_int tid, tx;
+    /* --------------------------------------------------- */
+
+    // select batch instance to work with
+    /* --------------------------------------------------- */
+    S* C;
+    if(CC)
+        C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
+    S* D = DD + bid * strideD;
+    S* E = EE + bid * strideE;
+    /* --------------------------------------------------- */
+
+    // temporary arrays in global memory
+    /* --------------------------------------------------- */
+    // contains the beginning of split blocks
+    rocblas_int* splits = splitsA + bid * (5 * n + 2);
+    // the sub-blocks sizes
+    rocblas_int* nsA = splits + n + 2;
+    // the sub-blocks initial positions
+    rocblas_int* psA = nsA + n;
+    // if idd[i] = 0, the value in position i has been deflated
+    rocblas_int* idd = psA + n;
+    // container of permutations when solving the secular eqns
+    rocblas_int* pers = idd + n;
+    // the rank-1 modification vectors in the merges
+    S* z = tmpzA + bid * (2 * n);
+    // roots of secular equations
+    S* evs = z + n;
+    // updated eigenvectors after merges
+    S* vecs = vecsA + bid * 2 * (n * n);
+    // temp values during the merges
+    S* temps = vecs + (n * n);
+    /* --------------------------------------------------- */
+
+    // temporary arrays in shared memory
+    /* --------------------------------------------------- */
+    extern __shared__ rocblas_int lsmem[];
+    // used to store temp values during the different reductions
+    S* inrmsd = reinterpret_cast<S*>(lsmem);
+    S* inrmsz = inrmsd + hipBlockDim_x;
+    /* --------------------------------------------------- */
+
+    // local variables
+    /* --------------------------------------------------- */
+    // total number of split blocks
+    rocblas_int nb = splits[n + 1];
+    // size of split block
+    rocblas_int bs;
+    // beginning of split block
+    rocblas_int p1;
+    // beginning of sub-block
+    rocblas_int p2;
+    // number of sub-blocks
+    rocblas_int blks;
+    rocblas_int tn;
+    // number of level of division
+    rocblas_int levs;
+    // other aux variables
+    S p;
+    rocblas_int *ns, *ps;
+    /* --------------------------------------------------- */
+
+    // work with STEDC_NUM_SPLIT_BLKS split blocks in parallel
+    /* --------------------------------------------------- */
+    for(int kb = sid; kb < nb; kb += STEDC_NUM_SPLIT_BLKS)
+    {
+        __syncthreads();
+
+        // Select current split block
+        p1 = splits[kb];
+        p2 = splits[kb + 1];
+        bs = p2 - p1;
+        ns = nsA + p1;
+        ps = psA + p1;
+
+        // determine ideal number of sub-blocks
+        // tn is the number of thread-groups needed
+        levs = stedcx_num_levels(bs);
+        blks = levs - 1 - k;
+        tn = (blks < 0) ? 0 : 1 << blks;
+
+        // 3. MERGE PHASE
+        /* ----------------------------------------------------------------- */
+        // Work with merges on level k. A thread-group works with two leaves in the merge tree.
+        if(mid < tn)
+        {
+            rocblas_int iam, sz, bdm, dim, dim2;
+            S* ptz;
+            rocblas_int bd = 1 << k;
+            bdm = bd << 1;
+            dim = hipBlockDim_x / 2;
+
+            // tid indexes the sub-blocks in the entire split block
+            // iam indexes the sub-blocks in the context of the merge
+            // (according to its level in the merge tree)
+            iam = tidb / dim;
+            tx = tidb % dim;
+            tid = mid * bdm + iam * bd;
+            p2 = ps[tid];
+
+            // 3a. find rank-1 modification components (z and p) for this merge
+            /* ----------------------------------------------------------------- */
+            // Threads with iam = 0 work with components below the merge point;
+            // threads with iam = 1 work above the merge point
+            sz = ns[tid];
+            for(int j = 1; j < bd; ++j)
+                sz += ns[tid + j];
+            // with this, all threads involved in a merge
+            // will point to the same row of C and the same off-diag element
+            ptz = (iam == 0) ? C + p2 - 1 + sz : C + p2;
+            p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
+
+            // copy elements of z
+            for(int j = tx; j < sz; j += dim)
+                z[p2 + j] = ptz[(p2 + j) * ldc] / sqrt(2);
+            /* ----------------------------------------------------------------- */
+
+            // 3b. calculate deflation tolerance
+            /* ----------------------------------------------------------------- */
+            // compute maximum of diagonal and z in each merge block
+            S valf, valg, maxd, maxz;
+            maxd = 0;
+            maxz = 0;
+            for(int i = tx; i < sz; i += dim)
+            {
+                valf = std::abs(D[p2 + i]);
+                valg = std::abs(z[p2 + i]);
+                maxd = valf > maxd ? valf : maxd;
+                maxz = valg > maxz ? valg : maxz;
+            }
+            inrmsd[tidb] = maxd;
+            inrmsz[tidb] = maxz;
+            __syncthreads();
+
+            dim2 = dim;
+            while(dim2 > 0)
+            {
+                if(tidb < dim2)
+                {
+                    valf = inrmsd[tidb + dim2];
+                    valg = inrmsz[tidb + dim2];
+                    maxd = valf > maxd ? valf : maxd;
+                    maxz = valg > maxz ? valg : maxz;
+                    inrmsd[tidb] = maxd;
+                    inrmsz[tidb] = maxz;
+                }
+                dim2 /= 2;
+                __syncthreads();
+            }
+
+            // tol should be  8 * eps * (max diagonal or z element participating in
+            // merge)
+            maxd = inrmsd[0];
+            maxz = inrmsz[0];
+            maxd = maxz > maxd ? maxz : maxd;
+
+            S tol = 8 * eps * maxd;
+            /* ----------------------------------------------------------------- */
+
+            // 3c. deflate eigenvalues
+            /* ----------------------------------------------------------------- */
+            // determine boundaries of what would be the new merged sub-block
+            // 'in' will be its initial position.
+            // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
+            rocblas_int in = tid - iam * bd;
+            sz = ns[in];
+            for(int i = 1; i < bdm; ++i)
+                sz += ns[in + i];
+            in = ps[in];
+
+            // first deflate zero components
+            S f, g, c, s, rr;
+            for(int i = tidb; i < sz; i += hipBlockDim_x)
+            {
+                tx = in + i;
+                g = z[tx];
+                if(abs(p * g) <= tol)
+                    // deflated ev because component in z is zero
+                    idd[tx] = 0;
+                else
+                    idd[tx] = 1;
+            }
+            __syncthreads();
+
+            // now deflate repeated values
+            rocblas_int sz_even, sz_half, base, top, com;
+            sz_even = (sz % 2 == 1) ? sz + 1 : sz;
+            sz_half = sz_even / 2;
+
+            // the number of rounds needed is sz_even - 1
+            for(int r = 0; r < sz_even - 1; ++r)
+            {
+                // in each round threads analyze pairs of values in parallel
+                // sz_half pairs are needed
+                for(int i = tidb; i < sz_half; i += hipBlockDim_x)
+                {
+                    // determine pair of values (base, top)
+                    com = 2 * (i - r);
+                    base = (i == 0)             ? 0
+                        : (r < i)               ? com
+                        : (r > i - 1 + sz_half) ? 2 * (sz_even - 1) + com
+                                                : 1 - com;
+
+                    com = 2 * (i + r);
+                    top = (r < sz_half - i)     ? 1 + com
+                        : (r > sz_even - 2 - i) ? 3 - 2 * sz_even + com
+                                                : 2 * (sz_even - 1) - com;
+
+                    if(base > top)
+                    {
+                        com = base;
+                        base = top;
+                        top = com;
+                    }
+
+                    // compare values and deflate if needed
+                    base += in;
+                    top += in;
+                    if(idd[base] == 1 && idd[top] == 1 && top < sz + in)
+                    {
+                        if(abs(D[base] - D[top]) <= tol)
+                        {
+                            // deflated ev because it is repeated
+                            idd[top] = 0;
+                            // rotation to eliminate component in z
+                            g = z[top];
+                            f = z[base];
+                            lartg(f, g, c, s, rr);
+                            z[base] = rr;
+                            z[top] = 0;
+                            // update C with the rotation
+                            for(int ii = 0; ii < n; ++ii)
+                            {
+                                valf = C[ii + base * ldc];
+                                valg = C[ii + top * ldc];
+                                C[ii + base * ldc] = valf * c - valg * s;
+                                C[ii + top * ldc] = valf * s + valg * c;
+                            }
+                        }
+                    }
+                    __syncthreads();
+                }
+            }
+            /* ----------------------------------------------------------------- */
+
+            // 3d.1. Organize data with non-deflated values to prepare secular equation
+            /* ----------------------------------------------------------------- */
+            // define shifted arrays
+            S* tmpd = temps + in * n;
+            S* diag = D + in;
+            rocblas_int* mask = idd + in;
+            S* zz = z + in;
+            rocblas_int* per = pers + in;
+            S* ev = evs + in;
+
+            // find degree and components of secular equation
+            // tmpd contains the non-deflated diagonal elements (ie. poles of the
+            // secular eqn) zz contains the corresponding non-zero elements of the
+            // rank-1 modif vector
+            rocblas_int dd = 0;
+            for(int i = 0; i < sz; ++i)
+            {
+                if(mask[i] == 1)
+                {
+                    if(tidb == 0)
+                    {
+                        per[dd] = i;
+                        tmpd[dd] = p < 0 ? -diag[i] : diag[i];
+                        if(dd != i)
+                            zz[dd] = zz[i];
+                    }
+                    dd++;
+                }
+            }
+            /* ----------------------------------------------------------------- */
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+/** STEDCX_MERGEVALUES_KERNEL solves the secular equation for
+    every pair of sub-blocks that need to be merged in a split block. A matrix in the batch
+    could have many split-blocks, and each split-block could be divided in a maximum of nn sub-blocks.
+        - Call this kernel with batch_count groups in z, STEDC_NUM_SPLIT_BLKS groups in y,
+          and as many groups as half of the unmerged sub-blocks in current level. Each group works
+          with a merge. Groups are size STEDCX_BDIM.
+        - STEDC_NUM_SPLIT_BLKS is fixed (is the number of split-blocks that will
+          be analysed in parallel). If there are actually more split-blocks, some
+          groups will work with more than one split-block sequentially.
+        - An upper bound for the number of sub-blocks (nn) can be estimated from
+          the size n. If a group has an id larger than half the actual number of unmerged sub-blocks
+          in the level, it will do nothing. **/
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDCX_BDIM)
+    stedcx_mergeValues_kernel(const rocblas_int k,
+                              const rocblas_int n,
+                              S* DD,
+                              const rocblas_stride strideD,
+                              S* EE,
+                              const rocblas_stride strideE,
+                              S* tmpzA,
+                              S* vecsA,
+                              rocblas_int* splitsA,
+                              const S eps,
+                              const S ssfmin,
+                              const S ssfmax)
+{
+    // threads and groups indices
+    /* --------------------------------------------------- */
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_z;
+    // split block id
+    rocblas_int sid = hipBlockIdx_y;
+    // merge sub-block id
+    rocblas_int mid = hipBlockIdx_x;
+    // thread id
+    rocblas_int tidb = hipThreadIdx_x;
+    rocblas_int tid;
+    /* --------------------------------------------------- */
+
+    // select batch instance to work with
+    /* --------------------------------------------------- */
+    S* D = DD + bid * strideD;
+    S* E = EE + bid * strideE;
+    /* --------------------------------------------------- */
+
+    // temporary arrays in global memory
+    /* --------------------------------------------------- */
+    // contains the beginning of split blocks
+    rocblas_int* splits = splitsA + bid * (5 * n + 2);
+    // the sub-blocks sizes
+    rocblas_int* nsA = splits + n + 2;
+    // the sub-blocks initial positions
+    rocblas_int* psA = nsA + n;
+    // if idd[i] = 0, the value in position i has been deflated
+    rocblas_int* idd = psA + n;
+    // container of permutations when solving the secular eqns
+    rocblas_int* pers = idd + n;
+    // the rank-1 modification vectors in the merges
+    S* z = tmpzA + bid * (2 * n);
+    // roots of secular equations
+    S* evs = z + n;
+    // updated eigenvectors after merges
+    S* vecs = vecsA + bid * 2 * (n * n);
+    // temp values during the merges
+    S* temps = vecs + (n * n);
+    /* --------------------------------------------------- */
+
+    // local variables
+    /* --------------------------------------------------- */
+    // total number of split blocks
+    rocblas_int nb = splits[n + 1];
+    // size of split block
+    rocblas_int bs;
+    // beginning of split block
+    rocblas_int p1;
+    // beginning of sub-block
+    rocblas_int p2;
+    // number of sub-blocks
+    rocblas_int blks;
+    rocblas_int tn;
+    // number of level of division
+    rocblas_int levs;
+    // other aux variables
+    S p;
+    rocblas_int *ns, *ps;
+    /* --------------------------------------------------- */
+
+    // work with STEDC_NUM_SPLIT_BLKS split blocks in parallel
+    /* --------------------------------------------------- */
+    for(int kb = sid; kb < nb; kb += STEDC_NUM_SPLIT_BLKS)
+    {
+        __syncthreads();
+
+        // Select current split block
+        p1 = splits[kb];
+        p2 = splits[kb + 1];
+        bs = p2 - p1;
+        ns = nsA + p1;
+        ps = psA + p1;
+
+        // determine ideal number of sub-blocks
+        // tn is the number of thread-groups needed
+        levs = stedcx_num_levels(bs);
+        blks = levs - 1 - k;
+        tn = (blks < 0) ? 0 : 1 << blks;
+        blks = 1 << levs;
+
+        // 3. MERGE PHASE
+        /* ----------------------------------------------------------------- */
+        // Work with merges on level k. A thread-group works with two leaves in the merge tree;
+        // all threads work together to solve the secular equation.
+        if(mid < tn)
+        {
+            rocblas_int iam, sz, bdm, dim;
+            S valf, valg;
+            rocblas_int bd = 1 << k;
+            bdm = bd << 1;
+            dim = hipBlockDim_x / 2;
+
+            // tid indexes the sub-blocks in the entire split block
+            // iam indexes the sub-blocks in the context of the merge
+            // (according to its level in the merge tree)
+            iam = tidb / dim;
+            tid = mid * bdm + iam * bd;
+            p2 = ps[tid];
+
+            // Find off-diagonal element of the merge
+            // Threads with iam = 0 work with components below the merge point;
+            // threads with iam = 1 work above the merge point
+            sz = ns[tid];
+            for(int j = 1; j < bd; ++j)
+                sz += ns[tid + j];
+            // with this, all threads involved in a merge
+            // will point to the same row of C and the same off-diag element
+            p = (iam == 0) ? 2 * E[p2 - 1 + sz] : 2 * E[p2 - 1];
+
+            // determine boundaries of what would be the new merged sub-block
+            // 'in' will be its initial position.
+            // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
+            rocblas_int in = tid - iam * bd;
+            sz = ns[in];
+            for(int i = 1; i < bdm; ++i)
+                sz += ns[in + i];
+            in = ps[in];
+
+            // 3d.2. Organize data with non-deflated values to prepare secular equation
+            /* ----------------------------------------------------------------- */
+            rocblas_int tsz = 1 << (levs - 1 - k);
+            tsz = (bs - 1) / tsz + 1;
+
+            // All threads of the group participating in the merge will work together
+            // to solve the correspondinbg secular eqn. Now 'iam' indexes those threads
+            iam = tidb;
+            bdm = hipBlockDim_x;
+
+            // define shifted arrays
+            S* tmpd = temps + in * n;
+            S* ev = evs + in;
+            S* diag = D + in;
+            rocblas_int* mask = idd + in;
+            S* zz = z + in;
+            rocblas_int* per = pers + in;
+
+            // find degree of secular equation
+            rocblas_int dd = 0;
+            for(int i = 0; i < sz; ++i)
+            {
+                if(mask[i] == 1)
+                    dd++;
+            }
+
+            // Order the elements in tmpd and zz using a simple parallel selection/bubble sort.
+            // This will allow us to find initial intervals for eigenvalue guesses
+            for(int i = 0; i < dd; i++)
+            {
+                for(int j = 2 * iam + i % 2; j < dd - 1; j += 2 * bdm)
+                {
+                    if(tmpd[j] > tmpd[j + 1])
+                    {
+                        swap(tmpd[j], tmpd[j + 1]);
+                        swap(zz[j], zz[j + 1]);
+                        swap(per[j], per[j + 1]);
+                    }
+                }
+                __syncthreads();
+            }
+
+            // make dd copies of the non-deflated ordered diagonal elements
+            // (i.e. the poles of the secular eqn) so that the distances to the
+            // eigenvalues (D - lambda_i) are updated while computing each eigenvalue.
+            // This will prevent collapses and division by zero when an eigenvalue
+            // is too close to a pole.
+            for(int i = iam; i < dd; i += bdm)
+            {
+                for(int j = i + n; j < i + sz * n; j += n)
+                    tmpd[j] = tmpd[i];
+            }
+
+            // finally copy over all diagonal elements in ev. ev will be overwritten
+            // by the new computed eigenvalues of the merged block
+            for(int i = iam; i < sz; i += bdm)
+                ev[i] = diag[i];
+            __syncthreads();
+            /* ----------------------------------------------------------------- */
+
+            // 3e. Solve secular eqns, i.e. find the dd zeros
+            // corresponding to non-deflated new eigenvalues of the merged block
+            /* ----------------------------------------------------------------- */
+            // each thread will find a different zero in parallel
+            S a, b;
+            for(int j = iam; j < sz; j += bdm)
+            {
+                if(mask[j] == 1)
+                {
+                    // find position in the ordered array
+                    valf = p < 0 ? -ev[j] : ev[j];
+                    int count = dd, cc = 0;
+                    while(count > 0)
+                    {
+                        auto step = count / 2;
+                        auto it = cc + step;
+                        if(tmpd[it + j * n] < valf)
+                        {
+                            cc = ++it;
+                            count -= step + 1;
+                        }
+                        else
+                            count = step;
+                    }
+
+                    // computed zero will overwrite 'ev' at the corresponding position.
+                    // 'tmpd' will be updated with the distances D - lambda_i.
+                    // deflated values are not changed.
+                    rocblas_int linfo;
+
+#if defined(ROCSOLVER_USE_REFERENCE_SECULAR_EQUATIONS_SOLVER)
+                    linfo = slaed4(dd, cc, tmpd + j * n, zz, std::abs(p), ev[j]);
+#else
+                    if(cc == dd - 1)
+                        linfo = seq_solve_ext(dd, tmpd + j * n, zz, (p < 0 ? -p : p), ev + j, eps,
+                                              ssfmin, ssfmax);
+                    else
+                        linfo = seq_solve(dd, tmpd + j * n, zz, (p < 0 ? -p : p), cc, ev + j, eps,
+                                          ssfmin, ssfmax);
+#endif
+
+                    if(p < 0)
+                        ev[j] *= -1;
+                }
+            }
+            __syncthreads();
+
+            // Re-scale vector Z to avoid bad numerics when an eigenvalue
+            // is too close to a pole
+            for(int i = iam; i < dd; i += bdm)
+            {
+                valf = 1;
+                for(int j = 0; j < sz; ++j)
+                {
+                    if(mask[j] == 1)
+                    {
+                        valg = tmpd[i + j * n];
+                        valf *= (per[i] == j) ? valg : valg / (diag[per[i]] - diag[j]);
+                    }
+                }
+                valf = sqrt(std::abs(valf));
+                zz[i] = zz[i] < 0 ? -valf : valf;
+            }
+            /* ----------------------------------------------------------------- */
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+/** STEDCX_MERGEVECTORS_KERNEL prepares vectors from the secular equation for
+    every pair of sub-blocks that need to be merged in a split block. A matrix in the batch
+    could have many split-blocks, and each split-block could be divided in a maximum of nn sub-blocks.
+        - Call this kernel with batch_count groups in z, STEDC_NUM_SPLIT_BLKS groups in y,
+          and as many groups as columns would be in the matrix if its size is exact multiple of nn.
+          Each group works with a column. Groups are size STEDCX_BDIM.
+        - STEDC_NUM_SPLIT_BLKS is fixed (is the number of split-blocks that will
+          be analysed in parallel). If there are actually more split-blocks, some
+          groups will work with more than one split-block sequentially.
+        - An upper bound for the number of sub-blocks (nn) can be estimated from
+          the size n. If a group has an id larger than the actual number of columns n,
+          it will do nothing. **/
+template <bool USEGEMM, typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDCX_BDIM)
+    stedcx_mergeVectors_kernel(const rocblas_int k,
+                               const rocblas_int n,
+                               S* DD,
+                               const rocblas_stride strideD,
+                               S* EE,
+                               const rocblas_stride strideE,
+                               S* CC,
+                               const rocblas_int shiftC,
+                               const rocblas_int ldc,
+                               const rocblas_stride strideC,
+                               S* tmpzA,
+                               S* vecsA,
+                               rocblas_int* splitsA)
+{
+    // threads and groups indices
+    /* --------------------------------------------------- */
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_z;
+    // split block id
+    rocblas_int sid = hipBlockIdx_y;
+    // merge sub-block id
+    rocblas_int mid = hipBlockIdx_x;
+    // thread id
+    rocblas_int tidb = hipThreadIdx_x;
+    rocblas_int dim = hipBlockDim_x;
+    rocblas_int tid, vidb;
+    /* --------------------------------------------------- */
+
+    // select batch instance to work with
+    /* --------------------------------------------------- */
+    S* C;
+    if(CC)
+        C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
+    S* D = DD + bid * strideD;
+    S* E = EE + bid * strideE;
+    /* --------------------------------------------------- */
+
+    // temporary arrays in global memory
+    /* --------------------------------------------------- */
+    // contains the beginning of split blocks
+    rocblas_int* splits = splitsA + bid * (5 * n + 2);
+    // the sub-blocks sizes
+    rocblas_int* nsA = splits + n + 2;
+    // the sub-blocks initial positions
+    rocblas_int* psA = nsA + n;
+    // if idd[i] = 0, the value in position i has been deflated
+    rocblas_int* idd = psA + n;
+    // container of permutations when solving the secular eqns
+    rocblas_int* pers = idd + n;
+    // the rank-1 modification vectors in the merges
+    S* z = tmpzA + bid * (2 * n);
+    // roots of secular equations
+    S* evs = z + n;
+    // updated eigenvectors after merges
+    S* vecs = vecsA + bid * 2 * (n * n);
+    // temp values during the merges
+    S* temps = vecs + (n * n);
+    /* --------------------------------------------------- */
+
+    // temporary arrays in shared memory
+    /* --------------------------------------------------- */
+    extern __shared__ rocblas_int lsmem[];
+    // used to store temp values during the different reductions
+    S* inrms = reinterpret_cast<S*>(lsmem);
+    /* --------------------------------------------------- */
+
+    // local variables
+    /* --------------------------------------------------- */
+    // total number of split blocks
+    rocblas_int nb = splits[n + 1];
+    // size of split block
+    rocblas_int bs;
+    // beginning of split block
+    rocblas_int p1;
+    // beginning of sub-block
+    rocblas_int p2;
+    // number of sub-blocks
+    rocblas_int blks;
+    // number of level of division
+    rocblas_int levs;
+    // other aux variables
+    rocblas_int tn;
+    S p;
+    rocblas_int *ns, *ps;
+    /* --------------------------------------------------- */
+
+    // work with STEDC_NUM_SPLIT_BLKS split blocks in parallel
+    /* --------------------------------------------------- */
+    for(int kb = sid; kb < nb; kb += STEDC_NUM_SPLIT_BLKS)
+    {
+        __syncthreads();
+
+        // Select current split block
+        p1 = splits[kb];
+        p2 = splits[kb + 1];
+        bs = p2 - p1;
+        ns = nsA + p1;
+        ps = psA + p1;
+
+        // determine ideal number of sub-blocks
+        levs = stedcx_num_levels(bs);
+        blks = 1 << levs;
+
+        // tn is max number of vectors in each sub-block
+        tn = (bs - 1) / blks + 1;
+
+        // 3. MERGE PHASE
+        /* ----------------------------------------------------------------- */
+        // Work with merges on level k. Each thread-group works with one vector.
+        if(mid < tn * blks && k < levs)
+        {
+            rocblas_int iam, sz, bdm;
+            S* ptz;
+            S valf, valg;
+            rocblas_int bd = 1 << k;
+            bdm = bd << 1;
+
+            // tid indexes the sub-blocks in the entire split block
+            tid = mid / tn;
+            p2 = ps[tid];
+            // vidb indexes the vectors associated with each sub-block
+            vidb = mid % tn;
+            // iam indexes the sub-blocks in the context of the merge
+            // (according to its level in the merge tree)
+            iam = tid % bdm;
+
+            // determine boundaries of what would be the new merged sub-block
+            // 'in' will be its initial position
+            rocblas_int in = ps[tid - iam];
+            // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
+            sz = ns[tid];
+            for(int i = iam; i > 0; --i)
+                sz += ns[tid - i];
+            for(int i = bdm - 1 - iam; i > 0; --i)
+                sz += ns[tid + i];
+
+            // final number of merged sub-blocks
+            rocblas_int tsz = 1 << (levs - 1 - k);
+            tsz = (bs - 1) / tsz + 1;
+
+            // define shifted arrays
+            S* tmpd = temps + in * n;
+            S* ev = evs + in;
+            S* diag = D + in;
+            rocblas_int* mask = idd + in;
+            S* zz = z + in;
+            rocblas_int* per = pers + in;
+
+            // find degree of secular equation
+            rocblas_int dd = 0;
+            for(int i = 0; i < sz; ++i)
+            {
+                if(mask[i] == 1)
+                    dd++;
+            }
+            __syncthreads();
+
+            // 3f. Prepare vectors corresponding to non-deflated values
+            /* ----------------------------------------------------------------- */
+            S temp, nrm;
+            rocblas_int j = vidb;
+            bool go = (j < ns[tid]);
+            S* putvec = USEGEMM ? vecs : temps;
+
+            if(go)
+            {
+                if(idd[p2 + j] == 1)
+                {
+                    // compute vectors of rank-1 perturbed system and their norms
+                    nrm = 0;
+                    for(int i = tidb; i < dd; i += dim)
+                    {
+                        valf = zz[i] / temps[i + (p2 + j) * n];
+                        nrm += valf * valf;
+                        putvec[i + (p2 + j) * n] = valf;
+                    }
+                    inrms[tidb] = nrm;
+                    __syncthreads();
+
+                    // reduction (for the norms)
+                    for(int r = dim / 2; r > 0; r /= 2)
+                    {
+                        if(tidb < r)
+                        {
+                            nrm += inrms[tidb + r];
+                            inrms[tidb] = nrm;
+                        }
+                        __syncthreads();
+                    }
+                    nrm = sqrt(inrms[0]);
+                }
+
+                if(USEGEMM)
+                {
+                    // when using external gemms for the update, we need to
+                    // put vectors in padded matrix 'temps'
+                    // (this is to compute 'vecs = C * temps' using external gemm call)
+                    for(int i = tidb; i < in + sz; i += dim)
+                    {
+                        if(i >= in && idd[p2 + j] == 1 && idd[i] == 1)
+                        {
+                            dd = 0;
+                            for(int k = in; k < i; ++k)
+                            {
+                                if(idd[k] == 0)
+                                    dd++;
+                            }
+                            temps[pers[i - dd] + in + (p2 + j) * n]
+                                = vecs[i - dd - in + (p2 + j) * n] / nrm;
+                        }
+                        else
+                            temps[i + (p2 + j) * n] = 0;
+                    }
+                }
+                else
+                {
+                    // otherwise, use internal gemm-like procedure to
+                    // multiply by C (row by row)
+                    if(idd[p2 + j] == 1)
+                    {
+                        for(int ii = 0; ii < tsz; ++ii)
+                        {
+                            rocblas_int i = in + ii;
+
+                            // inner products
+                            temp = 0;
+                            if(ii < sz)
+                            {
+                                for(int kk = tidb; kk < dd; kk += dim)
+                                    temp += C[i + (per[kk] + in) * ldc] * temps[kk + (p2 + j) * n];
+                            }
+                            inrms[tidb] = temp;
+                            __syncthreads();
+
+                            // reduction
+                            for(int r = dim / 2; r > 0; r /= 2)
+                            {
+                                if(ii < sz && tidb < r)
+                                {
+                                    temp += inrms[tidb + r];
+                                    inrms[tidb] = temp;
+                                }
+                                __syncthreads();
+                            }
+
+                            // result
+                            if(ii < sz && tidb == 0)
+                                vecs[i + (p2 + j) * n] = temp / nrm;
+                            __syncthreads();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+/** STEDCX_MERGEUPDATE_KERNEL updates vectors after merges are done. A matrix in the batch
+    could have many split-blocks, and each split-block could be divided in a maximum of nn sub-blocks.
+        - Call this kernel with batch_count groups in z, STEDC_NUM_SPLIT_BLKS groups in y,
+          and as many groups as columns would be in the matrix if its size is exact multiple of nn.
+          Each group works with a column. Groups are size STEDCX_BDIM.
+        - STEDC_NUM_SPLIT_BLKS is fixed (is the number of split-blocks that will
+          be analysed in parallel). If there are actually more split-blocks, some
+          groups will work with more than one split-block sequentially.
+        - An upper bound for the number of sub-blocks (nn) can be estimated from
+          the size n. If a group has an id larger than the actual number of columns n,
+          it will do nothing. **/
+template <typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(STEDCX_BDIM)
+    stedcx_mergeUpdate_kernel(const rocblas_int k,
+                              const rocblas_int n,
+                              S* DD,
+                              const rocblas_stride strideD,
+                              S* CC,
+                              const rocblas_int shiftC,
+                              const rocblas_int ldc,
+                              const rocblas_stride strideC,
+                              S* tmpzA,
+                              S* vecsA,
+                              rocblas_int* splitsA)
+{
+    // threads and groups indices
+    /* --------------------------------------------------- */
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_z;
+    // split block id
+    rocblas_int sid = hipBlockIdx_y;
+    // merge sub-block id
+    rocblas_int mid = hipBlockIdx_x;
+    // thread id
+    rocblas_int tidb = hipThreadIdx_x;
+    rocblas_int dim = hipBlockDim_x;
+    rocblas_int tid, vidb;
+    /* --------------------------------------------------- */
+
+    // select batch instance to work with
+    /* --------------------------------------------------- */
+    S* C;
+    if(CC)
+        C = load_ptr_batch<S>(CC, bid, shiftC, strideC);
+    S* D = DD + bid * strideD;
+    /* --------------------------------------------------- */
+
+    // temporary arrays in global memory
+    /* --------------------------------------------------- */
+    // contains the beginning of split blocks
+    rocblas_int* splits = splitsA + bid * (5 * n + 2);
+    // the sub-blocks sizes
+    rocblas_int* nsA = splits + n + 2;
+    // the sub-blocks initial positions
+    rocblas_int* psA = nsA + n;
+    // if idd[i] = 0, the value in position i has been deflated
+    rocblas_int* idd = psA + n;
+    // the rank-1 modification vectors in the merges
+    S* z = tmpzA + bid * (2 * n);
+    // roots of secular equations
+    S* evs = z + n;
+    // updated eigenvectors after merges
+    S* vecs = vecsA + bid * 2 * (n * n);
+    /* --------------------------------------------------- */
+
+    // temporary arrays in shared memory
+    /* --------------------------------------------------- */
+    extern __shared__ rocblas_int lsmem[];
+    // used to store temp values during the different reductions
+    S* inrms = reinterpret_cast<S*>(lsmem);
+    /* --------------------------------------------------- */
+
+    // local variables
+    /* --------------------------------------------------- */
+    // total number of split blocks
+    rocblas_int nb = splits[n + 1];
+    // size of split block
+    rocblas_int bs;
+    // beginning of split block
+    rocblas_int p1;
+    // beginning of sub-block
+    rocblas_int p2;
+    // number of sub-blocks
+    rocblas_int blks;
+    // number of level of division
+    rocblas_int levs;
+    // other aux variables
+    rocblas_int tn;
+    S p;
+    rocblas_int *ns, *ps;
+    /* --------------------------------------------------- */
+
+    // work with STEDC_NUM_SPLIT_BLKS split blocks in parallel
+    /* --------------------------------------------------- */
+    for(int kb = sid; kb < nb; kb += STEDC_NUM_SPLIT_BLKS)
+    {
+        __syncthreads();
+
+        // Select current split block
+        p1 = splits[kb];
+        p2 = splits[kb + 1];
+        bs = p2 - p1;
+        ns = nsA + p1;
+        ps = psA + p1;
+
+        // determine ideal number of sub-blocks
+        levs = stedcx_num_levels(bs);
+        blks = 1 << levs;
+
+        // tn is max number of vectors in each sub-block
+        tn = (bs - 1) / blks + 1;
+
+        // 3. MERGE PHASE
+        /* ----------------------------------------------------------------- */
+        // Work with merges on level k. Each thread-group works with one vector.
+        if(mid < tn * blks && k < levs)
+        {
+            rocblas_int iam, sz, bdm;
+            S* ptz;
+            S valf, valg;
+            rocblas_int bd = 1 << k;
+            bdm = bd << 1;
+
+            // tid indexes the sub-blocks in the entire split block
+            tid = mid / tn;
+            p2 = ps[tid];
+            // vidb indexes the vectors associated with each sub-block
+            vidb = mid % tn;
+            // iam indexes the sub-blocks in the context of the merge
+            // (according to its level in the merge tree)
+            iam = tid % bdm;
+
+            // determine boundaries of what would be the new merged sub-block
+            // 'in' will be its initial position
+            rocblas_int in = ps[tid - iam];
+            // 'sz' will be its size (i.e. the sum of the sizes of all merging sub-blocks)
+            sz = ns[tid];
+            for(int i = iam; i > 0; --i)
+                sz += ns[tid - i];
+            for(int i = bdm - 1 - iam; i > 0; --i)
+                sz += ns[tid + i];
+
+            // 3g. update D and C with computed values and vectors
+            /* ----------------------------------------------------------------- */
+            rocblas_int j = vidb;
+            bool go = (j < ns[tid] && idd[p2 + j] == 1);
+            if(go)
+            {
+                if(tidb == 0)
+                    D[p2 + j] = evs[p2 + j];
+                for(int i = in + tidb; i < in + sz; i += dim)
+                    C[i + (p2 + j) * ldc] = vecs[i + (p2 + j) * n];
+            }
+            /* ----------------------------------------------------------------- */
+        }
+    }
+}
+
+/** STEDCX_SORT sorts computed eigenvalues and eigenvectors in increasing order **/
+template <typename T, typename S, typename U>
+ROCSOLVER_KERNEL void __launch_bounds__(BS1) stedcx_sort(const rocblas_int n,
+                                                         S* DD,
+                                                         const rocblas_stride strideD,
+                                                         U CC,
+                                                         const rocblas_int shiftC,
+                                                         const rocblas_int ldc,
+                                                         const rocblas_stride strideC,
+                                                         const rocblas_int batch_count,
+                                                         rocblas_int* work,
+                                                         rocblas_int* nev = nullptr)
+{
+    // -----------------------------------
+    // use z-grid dimension as batch index
+    // -----------------------------------
+    rocblas_int bid_start = hipBlockIdx_z;
+    rocblas_int bid_inc = hipGridDim_z;
+
+    int tid = hipThreadIdx_x;
+
+    rocblas_int* const map = work + bid_start * ((int64_t)n);
+
+    for(auto bid = bid_start; bid < batch_count; bid += bid_inc)
+    {
+        // ---------------------------------------------
+        // select batch instance to work with
+        // (avoiding arithmetics with possible nullptrs)
+        // ---------------------------------------------
+        T* C = nullptr;
+        if(CC)
+            C = load_ptr_batch<T>(CC, bid, shiftC, strideC);
+        S* D = DD + (bid * strideD);
+        rocblas_int nn;
+        if(nev)
+            nn = nev[bid];
+        else
+            nn = n;
+
+        bool constexpr use_shell_sort = true;
+
+        __syncthreads();
+
+        if(use_shell_sort)
+            shell_sort(nn, D, map);
+        else
+            selection_sort(nn, D, map);
+        __syncthreads();
+
+        permute_swap(n, C, ldc, map, nn);
         __syncthreads();
     }
 }
@@ -530,7 +1833,7 @@ rocblas_status rocsolver_stedcx_template(rocblas_handle handle,
                             stream, n, n, tempvect, 0, ldt, strideT);
 
     // find max number of sub-blocks to consider during the divide phase
-    rocblas_int maxlevs = stedc_num_levels<rocsolver_stedc_mode_bisection>(n);
+    rocblas_int maxlevs = stedcx_num_levels(n);
     rocblas_int maxblks = 1 << maxlevs;
 
     // find independent split blocks in matrix and prepare range for partial decomposition
@@ -540,20 +1843,20 @@ rocblas_status rocsolver_stedcx_template(rocblas_handle handle,
 
     // 1. divide phase
     //-----------------------------
-    ROCSOLVER_LAUNCH_KERNEL((stedc_divide_kernel<rocsolver_stedc_mode_bisection, S>),
-                            dim3(batch_count), dim3(STEDC_BDIM), 0, stream, n, D, strideD, E,
-                            strideE, splits);
+    ROCSOLVER_LAUNCH_KERNEL((stedcx_divide_kernel<S>), dim3(batch_count), dim3(STEDCX_BDIM), 0,
+                            stream, n, D, strideD, E, strideE, splits);
 
     // 2. solve phase
     //-----------------------------
-    ROCSOLVER_LAUNCH_KERNEL((stedc_solve_kernel<S>), dim3(maxblks, STEDC_NUM_SPLIT_BLKS, batch_count),
-                            dim3(1), 0, stream, n, D, strideD, E, strideE, tempvect, 0, ldt,
-                            strideT, info, work_steqr, splits, eps, ssfmin, ssfmax);
+    ROCSOLVER_LAUNCH_KERNEL((stedcx_solve_kernel<S>),
+                            dim3(maxblks, STEDC_NUM_SPLIT_BLKS, batch_count), dim3(1), 0, stream, n,
+                            D, strideD, E, strideE, tempvect, 0, ldt, strideT, info, work_steqr,
+                            splits, eps, ssfmin, ssfmax);
 
     // 3. merge phase
     //----------------
-    size_t lmemsize1 = sizeof(S) * 2 * STEDC_BDIM;
-    size_t lmemsize3 = sizeof(S) * STEDC_BDIM;
+    size_t lmemsize1 = sizeof(S) * 2 * STEDCX_BDIM;
+    size_t lmemsize3 = sizeof(S) * STEDCX_BDIM;
     rocblas_int numgrps3 = ((n - 1) / maxblks + 1) * maxblks;
 
     // launch merge for level k
@@ -570,34 +1873,34 @@ rocblas_status rocsolver_stedcx_template(rocblas_handle handle,
 
         // a. prepare secular equations
         rocblas_int numgrps2 = 1 << (maxlevs - 1 - k);
-        ROCSOLVER_LAUNCH_KERNEL((stedc_mergePrepare_kernel<rocsolver_stedc_mode_bisection, S>),
-                                dim3(numgrps2, STEDC_NUM_SPLIT_BLKS, batch_count), dim3(STEDC_BDIM),
-                                lmemsize1, stream, k, n, D, strideD, E, strideE, tempvect, 0, ldt,
-                                strideT, tmpz, tempgemm, splits, eps);
+        ROCSOLVER_LAUNCH_KERNEL((stedcx_mergePrepare_kernel<S>),
+                                dim3(numgrps2, STEDC_NUM_SPLIT_BLKS, batch_count),
+                                dim3(STEDCX_BDIM), lmemsize1, stream, k, n, D, strideD, E, strideE,
+                                tempvect, 0, ldt, strideT, tmpz, tempgemm, splits, eps);
 
         // b. solve to find merged eigen values
-        ROCSOLVER_LAUNCH_KERNEL((stedc_mergeValues_kernel<rocsolver_stedc_mode_bisection, S>),
-                                dim3(numgrps2, STEDC_NUM_SPLIT_BLKS, batch_count), dim3(STEDC_BDIM),
-                                0, stream, k, n, D, strideD, E, strideE, tmpz, tempgemm, splits,
-                                eps, ssfmin, ssfmax);
+        ROCSOLVER_LAUNCH_KERNEL((stedcx_mergeValues_kernel<S>),
+                                dim3(numgrps2, STEDC_NUM_SPLIT_BLKS, batch_count),
+                                dim3(STEDCX_BDIM), 0, stream, k, n, D, strideD, E, strideE, tmpz,
+                                tempgemm, splits, eps, ssfmin, ssfmax);
 
         // c. find merged eigen vectors
-        ROCSOLVER_LAUNCH_KERNEL(
-            (stedc_mergeVectors_kernel<rocsolver_stedc_mode_bisection, STEDCX_EXTERNAL_GEMM, S>),
-            dim3(numgrps3, STEDC_NUM_SPLIT_BLKS, batch_count), dim3(STEDC_BDIM), lmemsize3, stream,
-            k, n, D, strideD, E, strideE, tempvect, 0, ldt, strideT, tmpz, tempgemm, splits);
+        ROCSOLVER_LAUNCH_KERNEL((stedcx_mergeVectors_kernel<STEDCX_EXTERNAL_GEMM, S>),
+                                dim3(numgrps3, STEDC_NUM_SPLIT_BLKS, batch_count),
+                                dim3(STEDCX_BDIM), lmemsize3, stream, k, n, D, strideD, E, strideE,
+                                tempvect, 0, ldt, strideT, tmpz, tempgemm, splits);
 
         // d. update level
-        ROCSOLVER_LAUNCH_KERNEL((stedc_mergeUpdate_kernel<rocsolver_stedc_mode_bisection, S>),
-                                dim3(numgrps3, STEDC_NUM_SPLIT_BLKS, batch_count), dim3(STEDC_BDIM),
-                                lmemsize3, stream, k, n, D, strideD, tempvect, 0, ldt, strideT,
-                                tmpz, tempgemm, splits);
+        ROCSOLVER_LAUNCH_KERNEL((stedcx_mergeUpdate_kernel<S>),
+                                dim3(numgrps3, STEDC_NUM_SPLIT_BLKS, batch_count),
+                                dim3(STEDCX_BDIM), lmemsize3, stream, k, n, D, strideD, tempvect, 0,
+                                ldt, strideT, tmpz, tempgemm, splits);
     }
 
     // 4. update and sort
     //----------------------
     // Synthesize the results from all the split blocks
-    ROCSOLVER_LAUNCH_KERNEL(stedcx_synthesis_kernel, dim3(1, batch_count), dim3(STEDC_BDIM), 0,
+    ROCSOLVER_LAUNCH_KERNEL(stedcx_synthesis_kernel, dim3(1, batch_count), dim3(STEDCX_BDIM), 0,
                             stream, erange, n, il, iu, D, strideD, nev, W, strideW, tempvect, ldt,
                             strideT, batch_count, splits, work_stack, eps);
 
@@ -606,7 +1909,7 @@ rocblas_status rocsolver_stedcx_template(rocblas_handle handle,
                                     work_stack, 0, ldt, strideT, batch_count, workArr);
 
     // sort eigenvalues and eigenvectors
-    ROCSOLVER_LAUNCH_KERNEL((stedc_sort<T>), dim3(1, 1, batch_count), dim3(BS1), 0, stream, n, W,
+    ROCSOLVER_LAUNCH_KERNEL((stedcx_sort<T>), dim3(1, 1, batch_count), dim3(BS1), 0, stream, n, W,
                             strideW, C, shiftC, ldc, strideC, batch_count, splits, nev);
 
     return rocblas_status_success;

--- a/library/src/auxiliary/rocauxiliary_steqr.hpp
+++ b/library/src/auxiliary/rocauxiliary_steqr.hpp
@@ -829,15 +829,11 @@ rocblas_status rocsolver_steqr_template(rocblas_handle handle,
         }
         else
         {
-            int device;
-            HIP_CHECK(hipGetDevice(&device));
-            hipDeviceProp_t deviceProperties;
-            HIP_CHECK(hipGetDeviceProperties(&deviceProperties, device));
+            const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
 
-            ROCSOLVER_LAUNCH_KERNEL((steqr_kernel<T>), dim3(1, batch_count),
-                                    dim3(deviceProperties.warpSize), 0, stream, n, D + shiftD,
-                                    strideD, E + shiftE, strideE, C, shiftC, ldc, strideC, info,
-                                    (S*)work_stack, 30 * n, eps, ssfmin, ssfmax);
+            ROCSOLVER_LAUNCH_KERNEL((steqr_kernel<T>), dim3(1, batch_count), dim3(props->warpSize),
+                                    0, stream, n, D + shiftD, strideD, E + shiftE, strideE, C, shiftC,
+                                    ldc, strideC, info, (S*)work_stack, 30 * n, eps, ssfmin, ssfmax);
         }
     }
 

--- a/library/src/include/ideal_sizes.hpp
+++ b/library/src/include/ideal_sizes.hpp
@@ -242,6 +242,10 @@
 #define xxTRD_xxTD2_SWITCHSIZE 256
 #endif
 
+#ifndef xxTD2_SSKER_MAX_N
+#define xxTD2_SSKER_MAX_N 192
+#endif
+
 /***************** sygs2/sygst and hegs2/hegst ********************************
 *******************************************************************************/
 /*! \brief Determines the size of the leading block that is reduced to standard form at each step

--- a/library/src/include/lapack_device_functions.hpp
+++ b/library/src/include/lapack_device_functions.hpp
@@ -30,6 +30,8 @@
 #include "lib_device_helpers.hpp"
 #include "lib_macros.hpp"
 #include "rocsolver/rocsolver.h"
+#include "rocsolver_logger.hpp"
+#include "rocsolver_run_specialized_kernels.hpp"
 
 ROCSOLVER_BEGIN_NAMESPACE
 
@@ -2410,6 +2412,679 @@ __device__ I slaed4(I n,
     }
 
     return info;
+}
+
+#define MAXITERS 50 // Max number of iterations for root finding method
+
+/** SEQ_EVAL evaluates the secular equation at a given point. It accumulates the
+    corrections to the elements in D so that distance to poles are computed
+   accurately **/
+template <typename S>
+__device__ void seq_eval(const rocblas_int type,
+                         const rocblas_int k,
+                         const rocblas_int dd,
+                         S* D,
+                         const S* z,
+                         const S p,
+                         const S cor,
+                         S* pt_fx,
+                         S* pt_fdx,
+                         S* pt_gx,
+                         S* pt_gdx,
+                         S* pt_hx,
+                         S* pt_hdx,
+                         S* pt_er,
+                         bool modif)
+{
+    S er, fx, gx, hx, fdx, gdx, hdx, zz, tmp;
+    rocblas_int gout, hout;
+
+    // prepare computations
+    // if type = 0: evaluate secular equation
+    if(type == 0)
+    {
+        gout = k + 1;
+        hout = k;
+    }
+    // if type = 1: evaluate secular equation without the k-th pole
+    else if(type == 1)
+    {
+        if(modif)
+        {
+            tmp = D[k] - cor;
+            D[k] = tmp;
+        }
+        gout = k;
+        hout = k;
+    }
+    // if type = 2: evaluate secular equation without the k-th and (k+1)-th poles
+    else if(type == 2)
+    {
+        if(modif)
+        {
+            tmp = D[k] - cor;
+            D[k] = tmp;
+            tmp = D[k + 1] - cor;
+            D[k + 1] = tmp;
+        }
+        gout = k;
+        hout = k + 1;
+    }
+    else
+    {
+        // unexpected value for type, something is wrong
+        assert(false);
+    }
+
+    // computations
+    gx = 0;
+    gdx = 0;
+    er = 0;
+    for(int i = 0; i < gout; ++i)
+    {
+        tmp = D[i] - cor;
+        if(modif)
+            D[i] = tmp;
+        zz = z[i];
+        tmp = zz / tmp;
+        gx += zz * tmp;
+        gdx += tmp * tmp;
+        er += gx;
+    }
+    er = abs(er);
+
+    hx = 0;
+    hdx = 0;
+    for(int i = dd - 1; i > hout; --i)
+    {
+        tmp = D[i] - cor;
+        if(modif)
+            D[i] = tmp;
+        zz = z[i];
+        tmp = zz / tmp;
+        hx += zz * tmp;
+        hdx += tmp * tmp;
+        er += hx;
+    }
+
+    fx = p + gx + hx;
+    fdx = gdx + hdx;
+
+    // return results
+    *pt_fx = fx;
+    *pt_fdx = fdx;
+    *pt_gx = gx;
+    *pt_gdx = gdx;
+    *pt_hx = hx;
+    *pt_hdx = hdx;
+    *pt_er = er;
+}
+
+//--------------------------------------------------------------------------------------//
+/** SEQ_SOLVE solves secular equation at point k (i.e. computes kth eigenvalue
+   that is within an internal interval). We use rational interpolation and fixed
+   weights method between the 2 poles of the interval. (TODO: In the future, we
+   could consider using 3 poles for those cases that may need it to reduce the
+   number of required iterations to converge. The performance improvements are
+   expected to be marginal, though) **/
+template <typename S>
+__device__ rocblas_int seq_solve(const rocblas_int dd,
+                                 S* D,
+                                 const S* z,
+                                 const S p,
+                                 rocblas_int k,
+                                 S* ev,
+                                 const S tol,
+                                 const S ssfmin,
+                                 const S ssfmax)
+{
+    bool converged = false;
+    bool up, fixed;
+    S lowb, uppb, aa, bb, cc, x;
+    S nx, er, fx, fdx, gx, gdx, hx, hdx, oldfx;
+    S tau, eta;
+    S dk, dk1, ddk, ddk1;
+    rocblas_int kk;
+    rocblas_int k1 = k + 1;
+
+    // initialize
+    dk = D[k];
+    dk1 = D[k1];
+    x = (dk + dk1) / 2; // midpoint of interval
+    tau = (dk1 - dk);
+    S pinv = 1 / p;
+
+    // find bounds and initial guess; translate origin
+    seq_eval(2, k, dd, D, z, pinv, x, &cc, &fdx, &gx, &gdx, &hx, &hdx, &er, false);
+    gdx = z[k] * z[k];
+    hdx = z[k1] * z[k1];
+    fx = cc + 2 * (hdx - gdx) / tau;
+    if(fx > 0)
+    {
+        // if the secular eq at the midpoint is positive, the root is in between
+        // D[k] and the midpoint take D[k] as the origin, i.e. x = D[k] + tau with
+        // tau in (0, uppb)
+        lowb = 0;
+        uppb = tau / 2;
+        up = true;
+        kk = k; // origin remains the same
+        aa = cc * tau + gdx + hdx;
+        bb = gdx * tau;
+        eta = sqrt(abs(aa * aa - 4 * bb * cc));
+        if(aa > 0)
+            tau = 2 * bb / (aa + eta);
+        else
+            tau = (aa - eta) / (2 * cc);
+        x = dk + tau; // initial guess
+    }
+    else
+    {
+        // otherwise, the root is in between the midpoint and D[k+1]
+        // take D[k+1] as the origin, i.e. x = D[k+1] + tau with tau in (lowb, 0)
+        lowb = -tau / 2;
+        uppb = 0;
+        up = false;
+        kk = k + 1; // translate the origin
+        aa = cc * tau - gdx - hdx;
+        bb = hdx * tau;
+        eta = sqrt(abs(aa * aa + 4 * bb * cc));
+        if(aa < 0)
+            tau = 2 * bb / (aa - eta);
+        else
+            tau = -(aa + eta) / (2 * cc);
+        x = dk1 + tau; // initial guess
+    }
+
+    // evaluate secular eq and get input values to calculate step correction
+    seq_eval(0, kk, dd, D, z, pinv, (up ? dk : dk1), &fx, &fdx, &gx, &gdx, &hx, &hdx, &er, true);
+    seq_eval(1, kk, dd, D, z, pinv, tau, &fx, &fdx, &gx, &gdx, &hx, &hdx, &er, true);
+    bb = z[kk];
+    aa = bb / D[kk];
+    fdx += aa * aa;
+    bb *= aa;
+    fx += bb;
+
+    // calculate tolerance er for convergence test
+    er += 8 * (hx - gx) + 2 * pinv + 3 * abs(bb) + abs(tau) * fdx;
+
+    // if the value of secular eq is small enough, no point to continue;
+    // converged!!!
+    if(abs(fx) <= tol * er)
+        converged = true;
+
+    // otherwise...
+    else
+    {
+        // update bounds
+        lowb = (fx <= 0) ? std::max(lowb, tau) : lowb;
+        uppb = (fx > 0) ? std::min(uppb, tau) : uppb;
+
+        // calculate first step correction with fixed weight method
+        ddk = D[k];
+        ddk1 = D[k1];
+        if(up)
+            cc = fx - ddk1 * fdx - (dk - dk1) * z[k] * z[k] / ddk / ddk;
+        else
+            cc = fx - ddk * fdx - (dk1 - dk) * z[k1] * z[k1] / ddk1 / ddk1;
+        aa = (ddk + ddk1) * fx - ddk * ddk1 * fdx;
+        bb = ddk * ddk1 * fx;
+        if(cc == 0)
+        {
+            if(aa == 0)
+            {
+                if(up)
+                    aa = z[k] * z[k] + ddk1 * ddk1 * (gdx + hdx);
+                else
+                    aa = z[k1] * z[k1] + ddk * ddk * (gdx + hdx);
+            }
+            eta = bb / aa;
+        }
+        else
+        {
+            eta = sqrt(abs(aa * aa - 4 * bb * cc));
+            if(aa <= 0)
+                eta = (aa - eta) / (2 * cc);
+            else
+                eta = (2 * bb) / (aa + eta);
+        }
+
+        // verify that the correction eta will get x closer to the root
+        // i.e. eta*fx should be negative. If not the case, take a Newton step
+        // instead
+        if(fx * eta >= 0)
+            eta = -fx / fdx;
+
+        // now verify that applying the correction won't get the process out of
+        // bounds if that is the case, bisect the interval instead
+        if(tau + eta > uppb || tau + eta < lowb)
+        {
+            if(fx < 0)
+                eta = (uppb - tau) / 2;
+            else
+                eta = (lowb - tau) / 2;
+        }
+
+        // take the step
+        tau += eta;
+        x = (up ? dk : dk1) + tau;
+
+        // evaluate secular eq and get input values to calculate step correction
+        oldfx = fx;
+        seq_eval(1, kk, dd, D, z, pinv, eta, &fx, &fdx, &gx, &gdx, &hx, &hdx, &er, true);
+        bb = z[kk];
+        aa = bb / D[kk];
+        fdx += aa * aa;
+        bb *= aa;
+        fx += bb;
+
+        // calculate tolerance er for convergence test
+        er += 8 * (hx - gx) + 2 * pinv + 3 * abs(bb) + abs(tau) * fdx;
+
+        // from now on, further step corrections will be calculated either with
+        // fixed weights method or with normal interpolation depending on the value
+        // of boolean fixed
+        cc = up ? -1 : 1;
+        fixed = (cc * fx) > (abs(oldfx) / 10);
+
+        // MAIN ITERATION LOOP
+        // ==============================================
+        for(int i = 1; i < MAXITERS; ++i)
+        {
+            // if the value of secular eq is small enough, no point to continue;
+            // converged!!!
+            if(abs(fx) <= tol * er)
+            {
+                converged = true;
+                break;
+            }
+
+            // update bounds
+            lowb = (fx <= 0) ? std::max(lowb, tau) : lowb;
+            uppb = (fx > 0) ? std::min(uppb, tau) : uppb;
+
+            // calculate next step correction with either fixed weight method or
+            // simple interpolation
+            ddk = D[k];
+            ddk1 = D[k1];
+            if(fixed)
+            {
+                if(up)
+                    cc = fx - ddk1 * fdx - (dk - dk1) * z[k] * z[k] / ddk / ddk;
+                else
+                    cc = fx - ddk * fdx - (dk1 - dk) * z[k1] * z[k1] / ddk1 / ddk1;
+            }
+            else
+            {
+                if(up)
+                    gdx += aa * aa;
+                else
+                    hdx += aa * aa;
+                cc = fx - ddk * gdx - ddk1 * hdx;
+            }
+            aa = (ddk + ddk1) * fx - ddk * ddk1 * fdx;
+            bb = ddk * ddk1 * fx;
+            if(cc == 0)
+            {
+                if(aa == 0)
+                {
+                    if(fixed)
+                    {
+                        if(up)
+                            aa = z[k] * z[k] + ddk1 * ddk1 * (gdx + hdx);
+                        else
+                            aa = z[k1] * z[k1] + ddk * ddk * (gdx + hdx);
+                    }
+                    else
+                        aa = ddk * ddk * gdx + ddk1 * ddk1 * hdx;
+                }
+                eta = bb / aa;
+            }
+            else
+            {
+                eta = sqrt(abs(aa * aa - 4 * bb * cc));
+                if(aa <= 0)
+                    eta = (aa - eta) / (2 * cc);
+                else
+                    eta = (2 * bb) / (aa + eta);
+            }
+
+            // verify that the correction eta will get x closer to the root
+            // i.e. eta*fx should be negative. If not the case, take a Newton step
+            // instead
+            if(fx * eta >= 0)
+                eta = -fx / fdx;
+
+            // now verify that applying the correction won't get the process out of
+            // bounds if that is the case, bisect the interval instead
+            if(tau + eta > uppb || tau + eta < lowb)
+            {
+                if(fx < 0)
+                    eta = (uppb - tau) / 2;
+                else
+                    eta = (lowb - tau) / 2;
+            }
+
+            // take the step
+            tau += eta;
+            x = (up ? dk : dk1) + tau;
+
+            // evaluate secular eq and get input values to calculate step correction
+            oldfx = fx;
+            seq_eval(1, kk, dd, D, z, pinv, eta, &fx, &fdx, &gx, &gdx, &hx, &hdx, &er, true);
+            bb = z[kk];
+            aa = bb / D[kk];
+            fdx += aa * aa;
+            bb *= aa;
+            fx += bb;
+
+            // calculate tolerance er for convergence test
+            er += 8 * (hx - gx) + 2 * pinv + 3 * abs(bb) + abs(tau) * fdx;
+
+            // update boolean fixed if necessary
+            if(fx * oldfx > 0 && abs(fx) > abs(oldfx) / 10)
+                fixed = !fixed;
+        }
+    }
+
+    *ev = x;
+    return converged ? 0 : 1;
+}
+
+//--------------------------------------------------------------------------------------//
+/** SEQ_SOLVE_EXT solves secular equation at point n (i.e. computes last
+   eigenvalue). We use rational interpolation and fixed weights method between
+   the (n-1)th and nth poles. (TODO: In the future, we could consider using 3
+   poles for those cases that may need it to reduce the number of required
+   iterations to converge. The performance improvements are expected to be
+   marginal, though) **/
+template <typename S>
+__device__ rocblas_int seq_solve_ext(const rocblas_int dd,
+                                     S* D,
+                                     const S* z,
+                                     const S p,
+                                     S* ev,
+                                     const S tol,
+                                     const S ssfmin,
+                                     const S ssfmax)
+{
+    bool converged = false;
+    S lowb, uppb, aa, bb, cc, x;
+    S er, fx, fdx, gx, gdx, hx, hdx;
+    S tau, eta;
+    S dk, dkm1, ddk, ddkm1;
+    rocblas_int k = dd - 1;
+    rocblas_int km1 = dd - 2;
+
+    // initialize
+    dk = D[k];
+    dkm1 = D[km1];
+    x = dk + p / 2;
+    S pinv = 1 / p;
+
+    // find bounds and initial guess
+    seq_eval(2, km1, dd, D, z, pinv, x, &cc, &fdx, &gx, &gdx, &hx, &hdx, &er, false);
+    gdx = z[km1] * z[km1];
+    hdx = z[k] * z[k];
+    fx = cc + gdx / (dkm1 - x) - 2 * hdx * pinv;
+    if(fx > 0)
+    {
+        // if the secular eq at the midpoint is positive, the root is in between
+        // D[k] and the midpoint take D[k] as the origin, i.e. x = D[k] + tau with
+        // tau in (0, uppb)
+        lowb = 0;
+        uppb = p / 2;
+        tau = dk - dkm1;
+        aa = -cc * tau + gdx + hdx;
+        bb = hdx * tau;
+        eta = sqrt(aa * aa + 4 * bb * cc);
+        if(aa < 0)
+            tau = 2 * bb / (eta - aa);
+        else
+            tau = (aa + eta) / (2 * cc);
+    }
+    else
+    {
+        // otherwise, the root is in between the midpoint and D[k+1]
+        // take D[k+1] as the origin, i.e. x = D[k+1] + tau with tau in (lowb, 0)
+        lowb = p / 2;
+        uppb = p;
+        eta = gdx / (dk - dkm1 + p) + hdx / p;
+        if(cc <= eta)
+            tau = p;
+        else
+        {
+            tau = dk - dkm1;
+            aa = -cc * tau + gdx + hdx;
+            bb = hdx * tau;
+            eta = sqrt(aa * aa + 4 * bb * cc);
+            if(aa < 0)
+                tau = 2 * bb / (eta - aa);
+            else
+                tau = (aa + eta) / (2 * cc);
+        }
+    }
+    x = dk + tau; // initial guess
+
+    // evaluate secular eq and get input values to calculate step correction
+    seq_eval(0, km1, dd, D, z, pinv, dk, &fx, &fdx, &gx, &gdx, &hx, &hdx, &er, true);
+    seq_eval(0, km1, dd, D, z, pinv, tau, &fx, &fdx, &gx, &gdx, &hx, &hdx, &er, true);
+
+    // calculate tolerance er for convergence test
+    er += abs(tau) * (hdx + gdx) - 8 * (hx + gx) - hx + pinv;
+
+    // if the value of secular eq is small enough, no point to continue;
+    // converged!!!
+    if(abs(fx) <= tol * er)
+        converged = true;
+
+    // otherwise...
+    else
+    {
+        // update bounds
+        lowb = (fx <= 0) ? std::max(lowb, tau) : lowb;
+        uppb = (fx > 0) ? std::min(uppb, tau) : uppb;
+
+        // calculate first step correction with fixed weight method
+        ddk = D[k];
+        ddkm1 = D[km1];
+        cc = abs(fx - ddkm1 * gdx - ddk * hdx);
+        aa = (ddk + ddkm1) * fx - ddk * ddkm1 * (gdx + hdx);
+        bb = ddk * ddkm1 * fx;
+        if(cc == 0)
+        {
+            eta = uppb - tau;
+        }
+        else
+        {
+            eta = sqrt(abs(aa * aa - 4 * bb * cc));
+            if(aa >= 0)
+                eta = (aa + eta) / (2 * cc);
+            else
+                eta = (2 * bb) / (aa - eta);
+        }
+
+        // verify that the correction eta will get x closer to the root
+        // i.e. eta*fx should be negative. If not the case, take a Newton step
+        // instead
+        if(fx * eta > 0)
+            eta = -fx / (gdx + hdx);
+
+        // now verify that applying the correction won't get the process out of
+        // bounds if that is the case, bisect the interval instead
+        if(tau + eta > uppb || tau + eta < lowb)
+        {
+            if(fx < 0)
+                eta = (uppb - tau) / 2;
+            else
+                eta = (lowb - tau) / 2;
+        }
+
+        // take the step
+        tau += eta;
+        x = dk + tau;
+
+        // evaluate secular eq and get input values to calculate step correction
+        seq_eval(0, km1, dd, D, z, pinv, eta, &fx, &fdx, &gx, &gdx, &hx, &hdx, &er, true);
+
+        // calculate tolerance er for convergence test
+        er += abs(tau) * (hdx + gdx) - 8 * (hx + gx) - hx + pinv;
+
+        // MAIN ITERATION LOOP
+        // ==============================================
+        for(int i = 1; i < MAXITERS; ++i)
+        {
+            // if the value of secular eq is small enough, no point to continue;
+            // converged!!!
+            if(abs(fx) <= tol * er)
+            {
+                converged = true;
+                break;
+            }
+
+            // update bounds
+            lowb = (fx <= 0) ? std::max(lowb, tau) : lowb;
+            uppb = (fx > 0) ? std::min(uppb, tau) : uppb;
+
+            // calculate step correction
+            ddk = D[k];
+            ddkm1 = D[km1];
+            cc = fx - ddkm1 * gdx - ddk * hdx;
+            aa = (ddk + ddkm1) * fx - ddk * ddkm1 * (gdx + hdx);
+            bb = ddk * ddkm1 * fx;
+            eta = sqrt(abs(aa * aa - 4 * bb * cc));
+            if(aa >= 0)
+                eta = (aa + eta) / (2 * cc);
+            else
+                eta = (2 * bb) / (aa - eta);
+
+            // verify that the correction eta will get x closer to the root
+            // i.e. eta*fx should be negative. If not the case, take a Newton step
+            // instead
+            if(fx * eta > 0)
+                eta = -fx / (gdx + hdx);
+
+            // now verify that applying the correction won't get the process out of
+            // bounds if that is the case, bisect the interval instead
+            if(tau + eta > uppb || tau + eta < lowb)
+            {
+                if(fx < 0)
+                    eta = (uppb - tau) / 2;
+                else
+                    eta = (lowb - tau) / 2;
+            }
+
+            // take the step
+            tau += eta;
+            x = dk + tau;
+
+            // evaluate secular eq and get input values to calculate step correction
+            seq_eval(0, km1, dd, D, z, pinv, eta, &fx, &fdx, &gx, &gdx, &hx, &hdx, &er, true);
+
+            // calculate tolerance er for convergence test
+            er += abs(tau) * (hdx + gdx) - 8 * (hx + gx) - hx + pinv;
+        }
+    }
+
+    *ev = x;
+    return converged ? 0 : 1;
+}
+
+/** This local gemm adapts rocblas_gemm to multiply complex*real, and
+    overwrite result: A = A*B **/
+template <bool BATCHED,
+          bool STRIDED,
+          typename T,
+          typename S,
+          typename U,
+          std::enable_if_t<!rocblas_is_complex<T>, int> = 0>
+void local_gemm(rocblas_handle handle,
+                const rocblas_int n,
+                U A,
+                const rocblas_int shiftA,
+                const rocblas_int lda,
+                const rocblas_stride strideA,
+                S* B,
+                S* temp,
+                S* work,
+                const rocblas_int shiftV,
+                const rocblas_int ldv,
+                const rocblas_stride strideV,
+                const rocblas_int batch_count,
+                S** workArr)
+{
+    S one = 1.0;
+    S zero = 0.0;
+
+    // Execute A*B -> temp -> A
+    // temp = A*B
+    rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, n, n, n, &one, A, shiftA,
+                   lda, strideA, B, shiftV, ldv, strideV, &zero, temp, shiftV, ldv, strideV,
+                   batch_count, workArr);
+
+    // A = temp
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+    rocblas_int blocks = (n - 1) / BS2 + 1;
+    ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(blocks, blocks, batch_count), dim3(BS2, BS2), 0,
+                            stream, copymat_from_buffer, n, n, A, shiftA, lda, strideA, temp);
+}
+
+template <bool BATCHED,
+          bool STRIDED,
+          typename T,
+          typename S,
+          typename U,
+          std::enable_if_t<rocblas_is_complex<T>, int> = 0>
+void local_gemm(rocblas_handle handle,
+                const rocblas_int n,
+                U A,
+                const rocblas_int shiftA,
+                const rocblas_int lda,
+                const rocblas_stride strideA,
+                S* B,
+                S* temp,
+                S* work,
+                const rocblas_int shiftV,
+                const rocblas_int ldv,
+                const rocblas_stride strideV,
+                const rocblas_int batch_count,
+                S** workArr)
+{
+    S one = 1.0;
+    S zero = 0.0;
+
+    // Execute A -> work; work*B -> temp -> A
+
+    // work = real(A)
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+    rocblas_int blocks = (n - 1) / BS2 + 1;
+    ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, S, true>), dim3(blocks, blocks, batch_count), dim3(BS2, BS2),
+                            0, stream, copymat_to_buffer, n, n, A, shiftA, lda, strideA, work);
+
+    // temp = work*B
+    rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, n, n, n, &one, work,
+                   shiftV, ldv, strideV, B, shiftV, ldv, strideV, &zero, temp, shiftV, ldv, strideV,
+                   batch_count, workArr);
+
+    // real(A) = temp
+    ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, S, true>), dim3(blocks, blocks, batch_count), dim3(BS2, BS2),
+                            0, stream, copymat_from_buffer, n, n, A, shiftA, lda, strideA, temp);
+
+    // work = imag(A)
+    ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, S, false>), dim3(blocks, blocks, batch_count),
+                            dim3(BS2, BS2), 0, stream, copymat_to_buffer, n, n, A, shiftA, lda,
+                            strideA, work);
+
+    // temp = work*B
+    rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, n, n, n, &one, work,
+                   shiftV, ldv, strideV, B, shiftV, ldv, strideV, &zero, temp, shiftV, ldv, strideV,
+                   batch_count, workArr);
+
+    // imag(A) = temp
+    ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, S, false>), dim3(blocks, blocks, batch_count),
+                            dim3(BS2, BS2), 0, stream, copymat_from_buffer, n, n, A, shiftA, lda,
+                            strideA, temp);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/library/src/include/lib_device_helpers.hpp
+++ b/library/src/include/lib_device_helpers.hpp
@@ -27,6 +27,8 @@
 
 #pragma once
 
+#include <cassert>
+
 #include <hip/hip_runtime.h>
 
 #include "ideal_sizes.hpp"

--- a/library/src/lapack/roclapack_geqr2.hpp
+++ b/library/src/lapack/roclapack_geqr2.hpp
@@ -40,6 +40,131 @@
 
 ROCSOLVER_BEGIN_NAMESPACE
 
+template <int MAX_THDS, typename T, typename I, typename S, typename U>
+ROCSOLVER_KERNEL void __launch_bounds__(MAX_THDS) geqr2_kernel_small(const I m,
+                                                                     const I n,
+                                                                     U AA,
+                                                                     const rocblas_stride shiftA,
+                                                                     const I lda,
+                                                                     const rocblas_stride strideA,
+                                                                     S* diagA,
+                                                                     const rocblas_stride strideD,
+                                                                     T* tauA,
+                                                                     const rocblas_stride strideP)
+{
+    I bid = blockIdx.z;
+    I tid = threadIdx.x;
+
+    // select batch instance
+    T* A = load_ptr_batch<T>(AA, bid, shiftA, strideA);
+    S* diag = load_ptr_batch<S>(diagA, bid, 0, strideD);
+    T* tau = load_ptr_batch<T>(tauA, bid, 0, strideP);
+
+    // shared variables
+    extern __shared__ double lmem[];
+    T* a = reinterpret_cast<T*>(lmem);
+    T* w = reinterpret_cast<T*>(a + m * n);
+    T* tmptau = reinterpret_cast<T*>(w + n);
+    T* sval = reinterpret_cast<T*>(tmptau + 1);
+
+    T* x;
+
+    I dim = std::min(m, n); // total number of pivots
+
+    // load A to lds
+    for(I i = tid % (MAX_THDS / 2); i < m; i += (MAX_THDS / 2))
+    {
+        const auto tidy = tid / (MAX_THDS / 2);
+        for(I j = tidy; j < n; j += 2)
+        {
+            a[i + j * m] = A[i + j * lda];
+        }
+    }
+
+    __syncthreads();
+
+    // main loop running forwards (for each column)
+    for(rocblas_int j = 0; j < dim; ++j)
+    {
+        I mm = m - j;
+        I nn = n - j;
+
+        // ----- 1. generate Householder reflector to annihilate A(j+1:m-1,j) -----
+        // load A(j:m-1,j) into x
+        x = a + j + j * m;
+
+        // larfg
+        T norm2 = 0;
+        for(I i = tid; i < mm - 1; i += MAX_THDS)
+            norm2 += x[i + 1] * conj(x[i + 1]);
+
+        // reduce squared entries to find squared norm of x
+        norm2 += shift_left(norm2, 1);
+        norm2 += shift_left(norm2, 2);
+        norm2 += shift_left(norm2, 4);
+        norm2 += shift_left(norm2, 8);
+        norm2 += shift_left(norm2, 16);
+        if(warpSize > 32)
+            norm2 += shift_left(norm2, 32);
+        if(tid % warpSize == 0)
+            sval[tid / warpSize] = norm2;
+        __syncthreads();
+        if(tid == 0)
+        {
+            for(I k = 1; k < MAX_THDS / warpSize; k++)
+                norm2 += sval[k];
+
+            // set tau, beta, and put scaling factor into sval[0]
+            run_set_taubeta<T>(tmptau, &norm2, x, diag + j);
+
+            tau[j] = tmptau[0];
+            sval[0] = norm2;
+
+            tmptau[0] = conj(tmptau[0]);
+        }
+        __syncthreads();
+
+        // scale x by scaling factor
+        for(I i = tid; i < mm - 1; i += MAX_THDS)
+            x[i + 1] *= sval[0];
+        __syncthreads();
+
+        // ----- 2. compute w = tau'*v'*A -----
+        // gemv
+        for(I i = tid; i < nn - 1; i += MAX_THDS)
+        {
+            T temp = 0;
+            T* Atmp = a + j + j * m;
+            for(I jj = 0; jj < mm; jj++)
+                temp += Atmp[jj + (i + 1) * m] * conj(x[jj]);
+            w[i] = tmptau[0] * temp;
+        }
+        __syncthreads();
+
+        // ----- 3. apply the Householder reflector to A as a rank-1 update: A = A - v*w -----
+        // ger
+        for(I i = tid; i < mm; i += MAX_THDS)
+        {
+            T* Atmp = a + j + j * m;
+            for(I jj = 0; jj < nn - 1; jj++)
+            {
+                Atmp[i + (jj + 1) * m] = Atmp[i + (jj + 1) * m] - x[i] * w[jj];
+            }
+        }
+        __syncthreads();
+    }
+
+    // write lds back to A
+    for(I i = tid % (MAX_THDS / 2); i < m; i += (MAX_THDS / 2))
+    {
+        const auto tidy = tid / (MAX_THDS / 2);
+        for(I j = tidy; j < n; j += 2)
+        {
+            A[i + j * lda] = a[i + j * m];
+        }
+    }
+}
+
 template <bool BATCHED, typename T, typename I>
 void rocsolver_geqr2_getMemorySize(const I m,
                                    const I n,
@@ -129,10 +254,27 @@ rocblas_status rocsolver_geqr2_template(rocblas_handle handle,
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
 
-    I dim = std::min(m, n); // total number of pivots
+    // get device prop
+    int device;
+    HIP_CHECK(hipGetDevice(&device));
+    hipDeviceProp_t props;
+    HIP_CHECK(hipGetDeviceProperties(&props, device));
 
+    I dim = std::min(m, n); // total number of pivots
     for(I j = 0; j < dim; ++j)
     {
+        I mm = m - j;
+        I nn = n - j;
+
+        const size_t lmemsize = ((256 / props.warpSize) + mm + nn + 1 + mm * nn) * sizeof(T);
+        if(lmemsize <= props.sharedMemPerBlock && nn == mm)
+        {
+            ROCSOLVER_LAUNCH_KERNEL((geqr2_kernel_small<256, T>), dim3(1, 1, batch_count), dim3(256),
+                                    lmemsize, stream, mm, nn, A, shiftA + idx2D(j, j, lda), lda,
+                                    strideA, (S*)diag + j, dim, ipiv + j, strideP);
+            break;
+        }
+
         // generate Householder reflector to work on column j
         rocsolver_larfg_template<T>(handle, m - j, A, shiftA + idx2D(j, j, lda), (S*)diag, j, dim,
                                     A, shiftA + idx2D(std::min(j + 1, m - 1), j, lda), (I)1, strideA,

--- a/library/src/lapack/roclapack_geqr2.hpp
+++ b/library/src/lapack/roclapack_geqr2.hpp
@@ -255,10 +255,7 @@ rocblas_status rocsolver_geqr2_template(rocblas_handle handle,
     rocblas_get_stream(handle, &stream);
 
     // get device prop
-    int device;
-    HIP_CHECK(hipGetDevice(&device));
-    hipDeviceProp_t props;
-    HIP_CHECK(hipGetDeviceProperties(&props, device));
+    const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
 
     I dim = std::min(m, n); // total number of pivots
     for(I j = 0; j < dim; ++j)
@@ -266,8 +263,8 @@ rocblas_status rocsolver_geqr2_template(rocblas_handle handle,
         I mm = m - j;
         I nn = n - j;
 
-        const size_t lmemsize = ((256 / props.warpSize) + mm + nn + 1 + mm * nn) * sizeof(T);
-        if(lmemsize <= props.sharedMemPerBlock && nn == mm)
+        const size_t lmemsize = ((256 / props->warpSize) + mm + nn + 1 + mm * nn) * sizeof(T);
+        if(lmemsize <= props->sharedMemPerBlock && nn == mm)
         {
             ROCSOLVER_LAUNCH_KERNEL((geqr2_kernel_small<256, T>), dim3(1, 1, batch_count), dim3(256),
                                     lmemsize, stream, mm, nn, A, shiftA + idx2D(j, j, lda), lda,

--- a/library/src/lapack/roclapack_geqrf.cpp
+++ b/library/src/lapack/roclapack_geqrf.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -55,39 +55,46 @@ rocblas_status
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of arrays of pointers (for batched cases) and re-usable workspace
-    size_t size_work_workArr, size_workArr;
+    bool optim_mem;
+    size_t size_work_workArr_work1, size_work2, size_work3, size_work4, size_workArr;
     // extra requirements for calling GEQR2 and to store temporary triangular factor
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GEQR2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_geqrf_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
-                                            &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr);
+    rocsolver_geqrf_getMemorySize<false, false, T>(
+        m, n, batch_count, &size_scalars, &size_work_workArr_work1, &size_work2, &size_work3,
+        &size_work4, &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_workArr,
-                                                      size_Abyx_norms_trfact, size_diag_tmptr,
-                                                      size_workArr);
+        return rocblas_set_optimal_device_memory_size(
+            handle, size_scalars, size_work_workArr_work1, size_work2, size_work3, size_work4,
+            size_Abyx_norms_trfact, size_diag_tmptr, size_workArr);
 
     // memory workspace allocation
-    void *scalars, *work_workArr, *Abyx_norms_trfact, *diag_tmptr, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms_trfact,
-                              size_diag_tmptr, size_workArr);
+    void *scalars, *work_workArr_work1, *work2, *work3, *work4, *Abyx_norms_trfact, *diag_tmptr,
+        *workArr;
+    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr_work1, size_work2, size_work3,
+                              size_work4, size_Abyx_norms_trfact, size_diag_tmptr, size_workArr);
 
     if(!mem)
         return rocblas_status_memory_error;
 
     scalars = mem[0];
-    work_workArr = mem[1];
-    Abyx_norms_trfact = mem[2];
-    diag_tmptr = mem[3];
-    workArr = mem[4];
+    work_workArr_work1 = mem[1];
+    work2 = mem[2];
+    work3 = mem[3];
+    work4 = mem[4];
+    Abyx_norms_trfact = mem[5];
+    diag_tmptr = mem[6];
+    workArr = mem[7];
     if(size_scalars > 0)
         init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_geqrf_template<false, false, T>(
         handle, m, n, A, shiftA, lda, strideA, ipiv, stridep, batch_count, (T*)scalars,
-        work_workArr, (T*)Abyx_norms_trfact, (T*)diag_tmptr, (T**)workArr);
+        work_workArr_work1, work2, work3, work4, (T*)Abyx_norms_trfact, (T*)diag_tmptr,
+        (T**)workArr, optim_mem);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/library/src/lapack/roclapack_geqrf.hpp
+++ b/library/src/lapack/roclapack_geqrf.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     November 2019
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -171,6 +171,157 @@ rocblas_status rocsolver_geqrf_template(rocblas_handle handle,
         rocsolver_geqr2_template<T>(handle, m - j, n - j, A, shiftA + idx2D(j, j, lda), lda,
                                     strideA, (ipiv + j), strideP, batch_count, scalars,
                                     work_workArr, Abyx_norms_trfact, diag_tmptr);
+
+    return rocblas_status_success;
+}
+
+template <bool BATCHED, bool STRIDED, typename T, typename I>
+void rocsolver_geqrf_getMemorySize(const I m,
+                                   const I n,
+                                   const I batch_count,
+                                   size_t* size_scalars,
+                                   size_t* size_work_workArr_work1,
+                                   size_t* size_work2,
+                                   size_t* size_work3,
+                                   size_t* size_work4,
+                                   size_t* size_Abyx_norms_trfact,
+                                   size_t* size_diag_tmptr,
+                                   size_t* size_workArr,
+                                   bool* optim_mem)
+{
+    *size_scalars = 0;
+    *size_work_workArr_work1 = 0;
+    *size_Abyx_norms_trfact = 0;
+    *size_diag_tmptr = 0;
+    *size_workArr = 0;
+    *size_work2 = 0;
+    *size_work3 = 0;
+    *size_work4 = 0;
+    *optim_mem = true;
+
+    // if quick return no workspace needed
+    if(m == 0 || n == 0 || batch_count == 0)
+    {
+        return;
+    }
+
+    if(m <= GEQxF_GEQx2_SWITCHSIZE || n <= GEQxF_GEQx2_SWITCHSIZE)
+    {
+        // requirements for a single GEQR2 call
+        rocsolver_geqr2_getMemorySize<BATCHED, T>(m, n, batch_count, size_scalars,
+                                                  size_work_workArr_work1, size_Abyx_norms_trfact,
+                                                  size_diag_tmptr);
+        *size_workArr = 0;
+    }
+    else
+    {
+        size_t w1, w2, unused, s1, s2;
+        I jb = GEQxF_BLOCKSIZE;
+
+        // size to store the temporary triangular factor
+        *size_Abyx_norms_trfact = sizeof(T) * jb * jb * batch_count;
+
+        // requirements for calling GEQR2 with sub blocks
+        rocsolver_geqr2_getMemorySize<BATCHED, T>(m, jb, batch_count, size_scalars, &w1, &s2, &s1);
+        *size_Abyx_norms_trfact = std::max(s2, *size_Abyx_norms_trfact);
+
+        // requirements for calling LARFT
+        rocsolver_larft_inverse_getMemorySize<BATCHED, T>(m, jb, batch_count, &w2, size_workArr);
+        *size_work_workArr_work1 = std::max(w1, w2);
+
+        // requirements for calling LARFB
+        rocsolver_larfb_inverse_getMemorySize<BATCHED, STRIDED, T>(
+            rocblas_side_left, rocblas_operation_conjugate_transpose, m, n - jb, jb, batch_count,
+            &s2, &w2, size_work2, size_work3, size_work4, &unused, optim_mem);
+        *size_work_workArr_work1 = std::max(w2, *size_work_workArr_work1);
+
+        *size_diag_tmptr = std::max(s1, s2);
+
+        // size of workArr is double to accommodate
+        // LARFB's TRMM calls in the batched case
+        if(BATCHED)
+            *size_workArr *= 2;
+    }
+}
+
+template <bool BATCHED, bool STRIDED, typename T, typename I, typename U>
+rocblas_status rocsolver_geqrf_template(rocblas_handle handle,
+                                        const I m,
+                                        const I n,
+                                        U A,
+                                        const rocblas_stride shiftA,
+                                        const I lda,
+                                        const rocblas_stride strideA,
+                                        T* ipiv,
+                                        const rocblas_stride strideP,
+                                        const I batch_count,
+                                        T* scalars,
+                                        void* work_workArr_work1,
+                                        void* work2,
+                                        void* work3,
+                                        void* work4,
+                                        T* Abyx_norms_trfact,
+                                        T* diag_tmptr,
+                                        T** workArr,
+                                        bool optim_mem)
+{
+    ROCSOLVER_ENTER("geqrf", "m:", m, "n:", n, "shiftA:", shiftA, "lda:", lda, "bc:", batch_count);
+
+    // quick return
+    if(m == 0 || n == 0 || batch_count == 0)
+        return rocblas_status_success;
+
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    // if the matrix is small, use the unblocked (BLAS-levelII) variant of the
+    // algorithm
+    if(m <= GEQxF_GEQx2_SWITCHSIZE || n <= GEQxF_GEQx2_SWITCHSIZE)
+    {
+        rocsolver_geqr2_template<T>(handle, m, n, A, shiftA, lda, strideA, ipiv, strideP, batch_count,
+                                    scalars, work_workArr_work1, Abyx_norms_trfact, diag_tmptr);
+        return rocblas_status_success;
+    }
+
+    I dim = std::min(m, n); // total number of pivots
+    I jb, j = 0;
+
+    I nb = GEQxF_BLOCKSIZE;
+    I ldw = GEQxF_BLOCKSIZE;
+    rocblas_stride strideW = rocblas_stride(ldw) * ldw;
+
+    while(j < dim - GEQxF_GEQx2_SWITCHSIZE)
+    {
+        // Factor diagonal and subdiagonal blocks
+        jb = std::min(dim - j, nb); // number of columns in the block
+        rocsolver_geqr2_template<T>(handle, m - j, jb, A, shiftA + idx2D(j, j, lda), lda, strideA,
+                                    (ipiv + j), strideP, batch_count, scalars, work_workArr_work1,
+                                    Abyx_norms_trfact, diag_tmptr);
+
+        // apply transformation to the rest of the matrix
+        if(j + jb < n)
+        {
+            // compute block reflector
+            rocsolver_larft_inverse_template<T>(
+                handle, rocblas_forward_direction, rocblas_column_wise, m - j, jb, A,
+                shiftA + idx2D(j, j, lda), lda, strideA, (ipiv + j), strideP, Abyx_norms_trfact,
+                ldw, strideW, batch_count, (T*)work_workArr_work1, workArr);
+
+            rocsolver_larfb_inverse_template<BATCHED, STRIDED, T>(
+                handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                rocblas_forward_direction, rocblas_column_wise, m - j, n - j - jb, jb, A,
+                shiftA + idx2D(j, j, lda), lda, strideA, Abyx_norms_trfact, 0, ldw, strideW, A,
+                shiftA + idx2D(j, j + jb, lda), lda, strideA, batch_count, diag_tmptr,
+                work_workArr_work1, work2, work3, work4, workArr, optim_mem);
+        }
+        j += nb;
+    }
+
+    // factor last block
+    if(j < dim)
+        rocsolver_geqr2_template<T>(handle, m - j, n - j, A, shiftA + idx2D(j, j, lda), lda,
+                                    strideA, (ipiv + j), strideP, batch_count, scalars,
+                                    work_workArr_work1, Abyx_norms_trfact, diag_tmptr);
 
     return rocblas_status_success;
 }

--- a/library/src/lapack/roclapack_geqrf_batched.cpp
+++ b/library/src/lapack/roclapack_geqrf_batched.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -60,39 +60,46 @@ rocblas_status rocsolver_geqrf_batched_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of arrays of pointers (for batched cases) and re-usable workspace
-    size_t size_work_workArr, size_workArr;
+    bool optim_mem;
+    size_t size_work_workArr_work1, size_work2, size_work3, size_work4, size_workArr;
     // extra requirements for calling GEQR2 and to store temporary triangular factor
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GEQR2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_geqrf_getMemorySize<true, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
-                                           &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr);
+    rocsolver_geqrf_getMemorySize<true, false, T>(
+        m, n, batch_count, &size_scalars, &size_work_workArr_work1, &size_work2, &size_work3,
+        &size_work4, &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_workArr,
-                                                      size_Abyx_norms_trfact, size_diag_tmptr,
-                                                      size_workArr);
+        return rocblas_set_optimal_device_memory_size(
+            handle, size_scalars, size_work_workArr_work1, size_work2, size_work3, size_work4,
+            size_Abyx_norms_trfact, size_diag_tmptr, size_workArr);
 
     // memory workspace allocation
-    void *scalars, *work_workArr, *Abyx_norms_trfact, *diag_tmptr, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms_trfact,
-                              size_diag_tmptr, size_workArr);
+    void *scalars, *work_workArr_work1, *work2, *work3, *work4, *Abyx_norms_trfact, *diag_tmptr,
+        *workArr;
+    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr_work1, size_work2, size_work3,
+                              size_work4, size_Abyx_norms_trfact, size_diag_tmptr, size_workArr);
 
     if(!mem)
         return rocblas_status_memory_error;
 
     scalars = mem[0];
-    work_workArr = mem[1];
-    Abyx_norms_trfact = mem[2];
-    diag_tmptr = mem[3];
-    workArr = mem[4];
+    work_workArr_work1 = mem[1];
+    work2 = mem[2];
+    work3 = mem[3];
+    work4 = mem[4];
+    Abyx_norms_trfact = mem[5];
+    diag_tmptr = mem[6];
+    workArr = mem[7];
     if(size_scalars > 0)
         init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_geqrf_template<true, false, T>(
         handle, m, n, A, shiftA, lda, strideA, ipiv, stridep, batch_count, (T*)scalars,
-        work_workArr, (T*)Abyx_norms_trfact, (T*)diag_tmptr, (T**)workArr);
+        work_workArr_work1, work2, work3, work4, (T*)Abyx_norms_trfact, (T*)diag_tmptr,
+        (T**)workArr, optim_mem);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/library/src/lapack/roclapack_geqrf_ptr_batched.cpp
+++ b/library/src/lapack/roclapack_geqrf_ptr_batched.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -78,43 +78,51 @@ rocblas_status rocsolver_geqrf_ptr_batched_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of arrays of pointers (for batched cases) and re-usable workspace
-    size_t size_work_workArr, size_workArr;
+    bool optim_mem;
+    size_t size_work_workArr_work1, size_work2, size_work3, size_work4, size_workArr;
     // extra requirements for calling GEQR2 and to store temporary triangular factor
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GEQR2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_geqrf_getMemorySize<true, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
-                                           &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr);
+    rocsolver_geqrf_getMemorySize<true, false, T>(
+        m, n, batch_count, &size_scalars, &size_work_workArr_work1, &size_work2, &size_work3,
+        &size_work4, &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr, &optim_mem);
 
     // this is to mamange tau as a simple array ipiv
     size_t size_ipiv = sizeof(T) * strideP * batch_count;
 
     if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_workArr,
-                                                      size_Abyx_norms_trfact, size_diag_tmptr,
-                                                      size_workArr, size_ipiv);
+        return rocblas_set_optimal_device_memory_size(
+            handle, size_scalars, size_work_workArr_work1, size_work2, size_work3, size_work4,
+            size_Abyx_norms_trfact, size_diag_tmptr, size_workArr, size_ipiv);
 
     // memory workspace allocation
-    void *scalars, *work_workArr, *Abyx_norms_trfact, *diag_tmptr, *workArr, *ipiv;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms_trfact,
-                              size_diag_tmptr, size_workArr, size_ipiv);
+    void *scalars, *work_workArr_work1, *work2, *work3, *work4, *Abyx_norms_trfact, *diag_tmptr,
+        *workArr, *ipiv;
+    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr_work1, size_work2, size_work3,
+                              size_work4, size_Abyx_norms_trfact, size_diag_tmptr, size_workArr,
+                              size_ipiv);
 
     if(!mem)
         return rocblas_status_memory_error;
 
     scalars = mem[0];
-    work_workArr = mem[1];
-    Abyx_norms_trfact = mem[2];
-    diag_tmptr = mem[3];
-    workArr = mem[4];
-    ipiv = mem[5];
+    work_workArr_work1 = mem[1];
+    work2 = mem[2];
+    work3 = mem[3];
+    work4 = mem[4];
+    Abyx_norms_trfact = mem[5];
+    diag_tmptr = mem[6];
+    workArr = mem[7];
+    ipiv = mem[8];
     if(size_scalars > 0)
         init_scalars(handle, (T*)scalars);
 
     // execution
     rocblas_status status = rocsolver_geqrf_template<true, false, T>(
         handle, m, n, A, shiftA, lda, strideA, (T*)ipiv, strideP, batch_count, (T*)scalars,
-        work_workArr, (T*)Abyx_norms_trfact, (T*)diag_tmptr, (T**)workArr);
+        work_workArr_work1, work2, work3, work4, (T*)Abyx_norms_trfact, (T*)diag_tmptr,
+        (T**)workArr, optim_mem);
 
     // copy ipiv into tau
     if(size_ipiv > 0)

--- a/library/src/lapack/roclapack_geqrf_strided_batched.cpp
+++ b/library/src/lapack/roclapack_geqrf_strided_batched.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -58,39 +58,46 @@ rocblas_status rocsolver_geqrf_strided_batched_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of arrays of pointers (for batched cases) and re-usable workspace
-    size_t size_work_workArr, size_workArr;
+    bool optim_mem;
+    size_t size_work_workArr_work1, size_work2, size_work3, size_work4, size_workArr;
     // extra requirements for calling GEQR2 and to store temporary triangular factor
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GEQR2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_geqrf_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
-                                            &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr);
+    rocsolver_geqrf_getMemorySize<false, true, T>(
+        m, n, batch_count, &size_scalars, &size_work_workArr_work1, &size_work2, &size_work3,
+        &size_work4, &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_workArr,
-                                                      size_Abyx_norms_trfact, size_diag_tmptr,
-                                                      size_workArr);
+        return rocblas_set_optimal_device_memory_size(
+            handle, size_scalars, size_work_workArr_work1, size_work2, size_work3, size_work4,
+            size_Abyx_norms_trfact, size_diag_tmptr, size_workArr);
 
     // memory workspace allocation
-    void *scalars, *work_workArr, *Abyx_norms_trfact, *diag_tmptr, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms_trfact,
-                              size_diag_tmptr, size_workArr);
+    void *scalars, *work_workArr_work1, *work2, *work3, *work4, *Abyx_norms_trfact, *diag_tmptr,
+        *workArr;
+    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr_work1, size_work2, size_work3,
+                              size_work4, size_Abyx_norms_trfact, size_diag_tmptr, size_workArr);
 
     if(!mem)
         return rocblas_status_memory_error;
 
     scalars = mem[0];
-    work_workArr = mem[1];
-    Abyx_norms_trfact = mem[2];
-    diag_tmptr = mem[3];
-    workArr = mem[4];
+    work_workArr_work1 = mem[1];
+    work2 = mem[2];
+    work3 = mem[3];
+    work4 = mem[4];
+    Abyx_norms_trfact = mem[5];
+    diag_tmptr = mem[6];
+    workArr = mem[7];
     if(size_scalars > 0)
         init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_geqrf_template<false, true, T>(
         handle, m, n, A, shiftA, lda, strideA, ipiv, stridep, batch_count, (T*)scalars,
-        work_workArr, (T*)Abyx_norms_trfact, (T*)diag_tmptr, (T**)workArr);
+        work_workArr_work1, work2, work3, work4, (T*)Abyx_norms_trfact, (T*)diag_tmptr,
+        (T**)workArr, optim_mem);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/library/src/lapack/roclapack_gesdd.hpp
+++ b/library/src/lapack/roclapack_gesdd.hpp
@@ -388,10 +388,7 @@ rocblas_status rocsolver_gesdd_template(rocblas_handle handle,
     T one = T(1);
     T zero = T(0);
 
-    rocblas_int device_id;
-    HIP_CHECK(hipGetDevice(&device_id));
-    hipDeviceProp_t properties;
-    HIP_CHECK(hipGetDeviceProperties(&properties, device_id));
+    const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
 
     // The general idea is as follows: Given a m by n (m >= n) matrix A, we
     // compute the eigendecomposition of A^*A with Divide-and-Conquer to obtain
@@ -440,8 +437,8 @@ rocblas_status rocsolver_gesdd_template(rocblas_handle handle,
                                                     (T*)work3, (T*)work4, (T**)workArr);
 
         rocblas_int blocks = (n - 1) / BS1 + 1;
-        blocks = std::min(blocks, properties.maxGridSize[0]);
-        auto bc = std::min(batch_count, properties.maxGridSize[1]);
+        blocks = std::min(blocks, props->maxGridSize[0]);
+        auto bc = std::min(batch_count, props->maxGridSize[1]);
         ROCSOLVER_LAUNCH_KERNEL(gesdd_flip_signs<T>, dim3(blocks, bc, 1), dim3(BS1, 1, 1), 0,
                                 stream, n, S, strideS, U_gemm, ldu_gemm, strideU_gemm, V_gemm,
                                 ldv_gemm, strideV_gemm, batch_count);
@@ -492,8 +489,8 @@ rocblas_status rocsolver_gesdd_template(rocblas_handle handle,
                                                     (T*)work3, (T*)work4, (T**)workArr);
 
         rocblas_int blocks = (m - 1) / BS1 + 1;
-        blocks = std::min(blocks, properties.maxGridSize[0]);
-        auto bc = std::min(batch_count, properties.maxGridSize[1]);
+        blocks = std::min(blocks, props->maxGridSize[0]);
+        auto bc = std::min(batch_count, props->maxGridSize[1]);
         ROCSOLVER_LAUNCH_KERNEL(gesdd_flip_signs<T>, dim3(blocks, bc, 1), dim3(BS1, 1, 1), 0,
                                 stream, m, S, strideS, V_gemm, ldv_gemm, strideV_gemm, U_gemm,
                                 ldu_gemm, strideU_gemm, batch_count);

--- a/library/src/lapack/roclapack_syevd_heevd.cpp
+++ b/library/src/lapack/roclapack_syevd_heevd.cpp
@@ -38,12 +38,14 @@ rocblas_status rocsolver_syevd_heevd_impl(rocblas_handle handle,
     rocblas_int batch_count = 1;
 
     // memory workspace sizes:
+    bool optim_mem;
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspaces
     size_t size_work1;
     size_t size_work2;
     size_t size_work3;
+    size_t size_work4;
     size_t size_tmptau_W;
     // extra space for call stedc
     size_t size_splits, size_tmpz;
@@ -52,19 +54,19 @@ rocblas_status rocsolver_syevd_heevd_impl(rocblas_handle handle,
     // size for temporary householder scalars
     size_t size_tau;
 
-    rocsolver_syevd_heevd_getMemorySize<false, T, S>(
+    rocsolver_syevd_heevd_getMemorySize<false, false, T, S>(
         handle, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
-        &size_tmpz, &size_splits, &size_tmptau_W, &size_tau, &size_workArr);
+        &size_work4, &size_tmpz, &size_splits, &size_tmptau_W, &size_tau, &size_workArr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
-                                                      size_work3, size_tmpz, size_splits,
+                                                      size_work3, size_work4, size_tmpz, size_splits,
                                                       size_tmptau_W, size_tau, size_workArr);
 
     // memory workspace allocation
-    void *scalars, *work1, *work2, *work3, *tmpz, *splits, *tmptau_W, *tau, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work1, size_work2, size_work3, size_tmpz,
-                              size_splits, size_tmptau_W, size_tau, size_workArr);
+    void *scalars, *work1, *work2, *work3, *work4, *tmpz, *splits, *tmptau_W, *tau, *workArr;
+    rocblas_device_malloc mem(handle, size_scalars, size_work1, size_work2, size_work3, size_work4,
+                              size_tmpz, size_splits, size_tmptau_W, size_tau, size_workArr);
 
     if(!mem)
         return rocblas_status_memory_error;
@@ -73,19 +75,20 @@ rocblas_status rocsolver_syevd_heevd_impl(rocblas_handle handle,
     work1 = mem[1];
     work2 = mem[2];
     work3 = mem[3];
-    tmpz = mem[4];
-    splits = mem[5];
-    tmptau_W = mem[6];
-    tau = mem[7];
-    workArr = mem[8];
+    work4 = mem[4];
+    tmpz = mem[5];
+    splits = mem[6];
+    tmptau_W = mem[7];
+    tau = mem[8];
+    workArr = mem[9];
     if(size_scalars > 0)
         init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_syevd_heevd_template<false, false, T>(
         handle, evect, uplo, n, A, shiftA, lda, strideA, D, strideD, E, strideE, info, batch_count,
-        (T*)scalars, work1, work2, work3, (S*)tmpz, (rocblas_int*)splits, (T*)tmptau_W, (T*)tau,
-        (T**)workArr);
+        (T*)scalars, work1, work2, work3, work4, (S*)tmpz, (rocblas_int*)splits, (T*)tmptau_W,
+        (T*)tau, (T**)workArr, optim_mem);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/library/src/lapack/roclapack_syevd_heevd.hpp
+++ b/library/src/lapack/roclapack_syevd_heevd.hpp
@@ -90,8 +90,9 @@ void rocsolver_syevd_heevd_getMemorySize(rocblas_handle handle,
     if(alg_mode != rocsolver_alg_mode_hybrid || evect == rocblas_evect_original)
     {
         // extra requirements for computing eigenvalues and vectors (stedc)
-        rocsolver_stedc_getMemorySize<BATCHED, T, S>(rocblas_evect_tridiagonal, n, batch_count, &w31,
-                                                     &w22, &w12, size_tmpz, size_splits, &unused);
+        rocsolver_stedc_getMemorySize<BATCHED, T, S>(rocblas_evect_tridiagonal, n, batch_count,
+                                                     &w31, &w22, &w12, size_tmpz, size_splits,
+                                                     size_workArr);
     }
     else
     {
@@ -120,9 +121,7 @@ void rocsolver_syevd_heevd_getMemorySize(rocblas_handle handle,
 
     // size of array of pointers to workspace
     if(BATCHED)
-        *size_workArr = 2 * sizeof(T*) * batch_count;
-    else
-        *size_workArr = 0;
+        *size_workArr = std::max(*size_workArr, 2 * sizeof(T*) * batch_count);
 }
 
 template <bool BATCHED, bool STRIDED, typename T, typename S>
@@ -180,7 +179,7 @@ void rocsolver_syevd_heevd_getMemorySize(rocblas_handle handle,
     {
         // extra requirements for computing eigenvalues and vectors (stedc)
         rocsolver_stedc_getMemorySize<BATCHED, T, S>(rocblas_evect_tridiagonal, n, batch_count,
-                                                     &w31, &w22, &w12, &z1, &s1, &unused);
+                                                     &w31, &w22, &w12, &z1, &s1, size_workArr);
     }
 
     if(evect == rocblas_evect_original)
@@ -207,9 +206,7 @@ void rocsolver_syevd_heevd_getMemorySize(rocblas_handle handle,
 
     // size of array of pointers to workspace
     if(BATCHED)
-        *size_workArr = 2 * sizeof(T*) * batch_count;
-    else
-        *size_workArr = 0;
+        *size_workArr = std::max(*size_workArr, 2 * sizeof(T*) * batch_count);
 }
 
 template <bool BATCHED, bool STRIDED, typename T, typename S, typename W>

--- a/library/src/lapack/roclapack_syevd_heevd.hpp
+++ b/library/src/lapack/roclapack_syevd_heevd.hpp
@@ -125,6 +125,93 @@ void rocsolver_syevd_heevd_getMemorySize(rocblas_handle handle,
         *size_workArr = 0;
 }
 
+template <bool BATCHED, bool STRIDED, typename T, typename S>
+void rocsolver_syevd_heevd_getMemorySize(rocblas_handle handle,
+                                         const rocblas_evect evect,
+                                         const rocblas_fill uplo,
+                                         const rocblas_int n,
+                                         const rocblas_int batch_count,
+                                         size_t* size_scalars,
+                                         size_t* size_work1,
+                                         size_t* size_work2,
+                                         size_t* size_work3,
+                                         size_t* size_work4,
+                                         size_t* size_tmpz,
+                                         size_t* size_splits,
+                                         size_t* size_tmptau_W,
+                                         size_t* size_tau,
+                                         size_t* size_workArr,
+                                         bool* optim_mem)
+{
+    *size_scalars = 0;
+    *size_work1 = 0;
+    *size_work2 = 0;
+    *size_work3 = 0;
+    *size_work4 = 0;
+    *size_tmptau_W = 0;
+    *size_tau = 0;
+    *size_workArr = 0;
+    *size_splits = 0;
+    *size_tmpz = 0;
+    *optim_mem = true;
+
+    // if quick return, set workspace to zero
+    if(n <= 1 || batch_count == 0)
+    {
+        return;
+    }
+
+    rocsolver_alg_mode alg_mode;
+    rocsolver_get_alg_mode(handle, rocsolver_function_sterf, &alg_mode);
+
+    size_t unused;
+    size_t w11 = 0, w12 = 0, w13 = 0;
+    size_t w21 = 0, w22 = 0, w23 = 0;
+    size_t w31 = 0, w32 = 0;
+    size_t t1 = 0, t2 = 0;
+    size_t s1 = 0, s2 = 0;
+    size_t z1 = 0, z2 = 0;
+
+    // requirements for tridiagonalization (sytrd/hetrd)
+    rocsolver_sytrd_hetrd_getMemorySize<BATCHED, T>(n, batch_count, size_scalars, &w11, &w21, &t1,
+                                                    &unused, false);
+
+    if(alg_mode != rocsolver_alg_mode_hybrid || evect == rocblas_evect_original)
+    {
+        // extra requirements for computing eigenvalues and vectors (stedc)
+        rocsolver_stedc_getMemorySize<BATCHED, T, S>(rocblas_evect_tridiagonal, n, batch_count,
+                                                     &w31, &w22, &w12, &z1, &s1, &unused);
+    }
+
+    if(evect == rocblas_evect_original)
+    {
+        // extra requirements for ormtr/unmtr
+        rocsolver_ormtr_unmtr_getMemorySize<BATCHED, STRIDED, T>(
+            rocblas_side_left, uplo, rocblas_operation_none, n, n, batch_count, &unused, &w23, &z2,
+            &s2, size_work4, &w13, &w32, &unused, optim_mem);
+    }
+
+    // size of array for temporary matrix products
+    t2 = sizeof(T) * n * n * batch_count;
+
+    // get max values
+    *size_work1 = std::max({w11, w12, w13});
+    *size_work2 = std::max({w21, w22, w23});
+    *size_work3 = std::max(w31, w32);
+    *size_tmptau_W = std::max(t1, t2);
+    *size_splits = std::max(s1, s2);
+    *size_tmpz = std::max(z1, z2);
+
+    // size of array for temporary householder scalars
+    *size_tau = sizeof(T) * n * batch_count;
+
+    // size of array of pointers to workspace
+    if(BATCHED)
+        *size_workArr = 2 * sizeof(T*) * batch_count;
+    else
+        *size_workArr = 0;
+}
+
 template <bool BATCHED, bool STRIDED, typename T, typename S, typename W>
 rocblas_status rocsolver_syevd_heevd_template(rocblas_handle handle,
                                               const rocblas_evect evect,
@@ -243,6 +330,108 @@ rocblas_status rocsolver_syevd_heevd_template(rocblas_handle handle,
                 handle, rocblas_side_left, uplo, rocblas_operation_none, n, n, A, shiftA, lda,
                 strideA, tau, n, tmptau_W, 0, ldw, strideW, batch_count, scalars, (T*)work2,
                 (T*)work1, (T*)work3, workArr);
+
+            // copy matrix product into A
+            const rocblas_int copyblocks = (n - 1) / BS2 + 1;
+            ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(copyblocks, copyblocks, batch_count),
+                                    dim3(BS2, BS2), 0, stream, n, n, tmptau_W, 0, ldw, strideW, A,
+                                    shiftA, lda, strideA);
+        }
+    }
+
+    return rocblas_status_success;
+}
+
+template <bool BATCHED, bool STRIDED, typename T, typename S, typename W>
+rocblas_status rocsolver_syevd_heevd_template(rocblas_handle handle,
+                                              const rocblas_evect evect,
+                                              const rocblas_fill uplo,
+                                              const rocblas_int n,
+                                              W A,
+                                              const rocblas_int shiftA,
+                                              const rocblas_int lda,
+                                              const rocblas_stride strideA,
+                                              S* D,
+                                              const rocblas_stride strideD,
+                                              S* E,
+                                              const rocblas_stride strideE,
+                                              rocblas_int* info,
+                                              const rocblas_int batch_count,
+                                              T* scalars,
+                                              void* work1,
+                                              void* work2,
+                                              void* work3,
+                                              void* work4,
+                                              S* tmpz,
+                                              rocblas_int* splits,
+                                              T* tmptau_W,
+                                              T* tau,
+                                              T** workArr,
+                                              bool optim_mem)
+{
+    ROCSOLVER_ENTER("syevd_heevd", "evect:", evect, "uplo:", uplo, "n:", n, "shiftA:", shiftA,
+                    "lda:", lda, "bc:", batch_count);
+
+    // quick return
+    if(batch_count == 0)
+        return rocblas_status_success;
+
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    rocsolver_alg_mode sterf_mode;
+    ROCBLAS_CHECK(rocsolver_get_alg_mode(handle, rocsolver_function_sterf, &sterf_mode));
+
+    rocblas_int blocksReset = (batch_count - 1) / BS1 + 1;
+    dim3 gridReset(blocksReset, 1, 1);
+    dim3 threads(BS1, 1, 1);
+
+    // info = 0
+    ROCSOLVER_LAUNCH_KERNEL(reset_info, gridReset, threads, 0, stream, info, batch_count, 0);
+
+    // quick return
+    if(n == 0)
+        return rocblas_status_success;
+
+    // quick return for n = 1 (scalar case)
+    if(n == 1)
+    {
+        ROCSOLVER_LAUNCH_KERNEL(scalar_case<T>, gridReset, threads, 0, stream, evect, A, strideA, D,
+                                strideD, batch_count);
+        return rocblas_status_success;
+    }
+
+    // TODO: Scale the matrix
+
+    // reduce A to tridiagonal form
+    rocsolver_sytrd_hetrd_template<BATCHED>(handle, uplo, n, A, shiftA, lda, strideA, D, strideD, E,
+                                            strideE, tau, n, batch_count, scalars, (T*)work1,
+                                            (T*)work2, tmptau_W, workArr, false);
+
+    if(sterf_mode == rocsolver_alg_mode_hybrid && evect != rocblas_evect_original)
+    {
+        // only in hybrid mode, compute eigenvalues using sterf
+        rocsolver_sterf_template<S>(handle, n, D, 0, strideD, E, 0, strideE, info, batch_count,
+                                    (rocblas_int*)work1);
+    }
+    else
+    {
+        // for performance reasons, we use stedc to compute eigenvalues even if the eigenvectors are ignored
+        constexpr bool ISBATCHED = BATCHED || STRIDED;
+        const rocblas_int ldw = n;
+        const rocblas_stride strideW = n * n;
+
+        rocsolver_stedc_template<false, ISBATCHED, T>(
+            handle, rocblas_evect_tridiagonal, n, D, 0, strideD, E, 0, strideE, tmptau_W, 0, ldw,
+            strideW, info, batch_count, work3, (S*)work2, (S*)work1, tmpz, splits, (S**)workArr);
+
+        // update the eigenvectors (if applicable)
+        if(evect == rocblas_evect_original)
+        {
+            rocsolver_ormtr_unmtr_template<BATCHED, STRIDED>(
+                handle, rocblas_side_left, uplo, rocblas_operation_none, n, n, A, shiftA, lda,
+                strideA, tau, n, tmptau_W, 0, ldw, strideW, batch_count, scalars, (T*)work2, tmpz,
+                splits, work4, (T*)work1, (T*)work3, workArr, optim_mem);
 
             // copy matrix product into A
             const rocblas_int copyblocks = (n - 1) / BS2 + 1;

--- a/library/src/lapack/roclapack_syevd_heevd.hpp
+++ b/library/src/lapack/roclapack_syevd_heevd.hpp
@@ -397,7 +397,8 @@ rocblas_status rocsolver_syevd_heevd_template(rocblas_handle handle,
 
         rocsolver_syevd_heevd_getMemorySize<BATCHED, STRIDED, T, S>(
             handle, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2,
-            &size_work3, &size_work4, &size_tmpz, &size_splits, &size_tmptau_W, &size_tau, &size_workArr, &optim_mem);
+            &size_work3, &size_work4, &size_tmpz, &size_splits, &size_tmptau_W, &size_tau,
+            &size_workArr, &optim_mem);
 
         // Memory in `scalars` has already been initialized at this point
         HIP_CHECK(hipMemsetAsync((void*)work1, 0, size_work1, stream));

--- a/library/src/lapack/roclapack_syevd_heevd.hpp
+++ b/library/src/lapack/roclapack_syevd_heevd.hpp
@@ -378,6 +378,38 @@ rocblas_status rocsolver_syevd_heevd_template(rocblas_handle handle,
 
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
+    {
+        // memory workspace sizes:
+        // size for constants in rocblas calls
+        size_t size_scalars;
+        // size of reusable workspaces
+        size_t size_work1;
+        size_t size_work2;
+        size_t size_work3;
+        size_t size_work4;
+        size_t size_tmptau_W;
+        // extra space for stedc call
+        size_t size_splits, size_tmpz;
+        // size of array of pointers (only for batched case)
+        size_t size_workArr;
+        // size for temporary householder scalars
+        size_t size_tau;
+
+        rocsolver_syevd_heevd_getMemorySize<BATCHED, STRIDED, T, S>(
+            handle, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2,
+            &size_work3, &size_work4, &size_tmpz, &size_splits, &size_tmptau_W, &size_tau, &size_workArr, &optim_mem);
+
+        // Memory in `scalars` has already been initialized at this point
+        HIP_CHECK(hipMemsetAsync((void*)work1, 0, size_work1, stream));
+        HIP_CHECK(hipMemsetAsync((void*)work2, 0, size_work2, stream));
+        HIP_CHECK(hipMemsetAsync((void*)work3, 0, size_work3, stream));
+        HIP_CHECK(hipMemsetAsync((void*)work4, 0, size_work4, stream));
+        HIP_CHECK(hipMemsetAsync((void*)tmpz, 0, size_tmpz, stream));
+        HIP_CHECK(hipMemsetAsync((void*)splits, 0, size_splits, stream));
+        HIP_CHECK(hipMemsetAsync((void*)tmptau_W, 0, size_tmptau_W, stream));
+        HIP_CHECK(hipMemsetAsync((void*)tau, 0, size_tau, stream));
+        HIP_CHECK(hipMemsetAsync((void*)workArr, 0, size_workArr, stream));
+    }
 
     rocsolver_alg_mode sterf_mode;
     ROCBLAS_CHECK(rocsolver_get_alg_mode(handle, rocsolver_function_sterf, &sterf_mode));

--- a/library/src/lapack/roclapack_syevd_heevd_batched.cpp
+++ b/library/src/lapack/roclapack_syevd_heevd_batched.cpp
@@ -63,12 +63,14 @@ rocblas_status rocsolver_syevd_heevd_batched_impl(rocblas_handle handle,
     rocblas_stride strideA = 0;
 
     // memory workspace sizes:
+    bool optim_mem;
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspaces
     size_t size_work1;
     size_t size_work2;
     size_t size_work3;
+    size_t size_work4;
     size_t size_tmptau_W;
     // extra space for call stedc
     size_t size_splits, size_tmpz;
@@ -77,19 +79,19 @@ rocblas_status rocsolver_syevd_heevd_batched_impl(rocblas_handle handle,
     // size for temporary householder scalars
     size_t size_tau;
 
-    rocsolver_syevd_heevd_getMemorySize<true, T, S>(
+    rocsolver_syevd_heevd_getMemorySize<true, false, T, S>(
         handle, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
-        &size_tmpz, &size_splits, &size_tmptau_W, &size_tau, &size_workArr);
+        &size_work4, &size_tmpz, &size_splits, &size_tmptau_W, &size_tau, &size_workArr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
-                                                      size_work3, size_tmpz, size_splits,
+                                                      size_work3, size_work4, size_tmpz, size_splits,
                                                       size_tmptau_W, size_tau, size_workArr);
 
     // memory workspace allocation
-    void *scalars, *work1, *work2, *work3, *tmpz, *splits, *tmptau_W, *tau, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work1, size_work2, size_work3, size_tmpz,
-                              size_splits, size_tmptau_W, size_tau, size_workArr);
+    void *scalars, *work1, *work2, *work3, *work4, *tmpz, *splits, *tmptau_W, *tau, *workArr;
+    rocblas_device_malloc mem(handle, size_scalars, size_work1, size_work2, size_work3, size_work4,
+                              size_tmpz, size_splits, size_tmptau_W, size_tau, size_workArr);
 
     if(!mem)
         return rocblas_status_memory_error;
@@ -98,19 +100,20 @@ rocblas_status rocsolver_syevd_heevd_batched_impl(rocblas_handle handle,
     work1 = mem[1];
     work2 = mem[2];
     work3 = mem[3];
-    tmpz = mem[4];
-    splits = mem[5];
-    tmptau_W = mem[6];
-    tau = mem[7];
-    workArr = mem[8];
+    work4 = mem[4];
+    tmpz = mem[5];
+    splits = mem[6];
+    tmptau_W = mem[7];
+    tau = mem[8];
+    workArr = mem[9];
     if(size_scalars > 0)
         init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_syevd_heevd_template<true, false, T>(
         handle, evect, uplo, n, A, shiftA, lda, strideA, D, strideD, E, strideE, info, batch_count,
-        (T*)scalars, work1, work2, work3, (S*)tmpz, (rocblas_int*)splits, (T*)tmptau_W, (T*)tau,
-        (T**)workArr);
+        (T*)scalars, work1, work2, work3, work4, (S*)tmpz, (rocblas_int*)splits, (T*)tmptau_W,
+        (T*)tau, (T**)workArr, optim_mem);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/library/src/lapack/roclapack_syevd_heevd_strided_batched.cpp
+++ b/library/src/lapack/roclapack_syevd_heevd_strided_batched.cpp
@@ -62,12 +62,14 @@ rocblas_status rocsolver_syevd_heevd_strided_batched_impl(rocblas_handle handle,
     rocblas_int shiftA = 0;
 
     // memory workspace sizes:
+    bool optim_mem;
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspaces
     size_t size_work1;
     size_t size_work2;
     size_t size_work3;
+    size_t size_work4;
     size_t size_tmptau_W;
     // extra space for call stedc
     size_t size_splits, size_tmpz;
@@ -76,19 +78,19 @@ rocblas_status rocsolver_syevd_heevd_strided_batched_impl(rocblas_handle handle,
     // size for temporary householder scalars
     size_t size_tau;
 
-    rocsolver_syevd_heevd_getMemorySize<false, T, S>(
+    rocsolver_syevd_heevd_getMemorySize<false, true, T, S>(
         handle, evect, uplo, n, batch_count, &size_scalars, &size_work1, &size_work2, &size_work3,
-        &size_tmpz, &size_splits, &size_tmptau_W, &size_tau, &size_workArr);
+        &size_work4, &size_tmpz, &size_splits, &size_tmptau_W, &size_tau, &size_workArr, &optim_mem);
 
     if(rocblas_is_device_memory_size_query(handle))
         return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work1, size_work2,
-                                                      size_work3, size_tmpz, size_splits,
+                                                      size_work3, size_work4, size_tmpz, size_splits,
                                                       size_tmptau_W, size_tau, size_workArr);
 
     // memory workspace allocation
-    void *scalars, *work1, *work2, *work3, *tmpz, *splits, *tmptau_W, *tau, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work1, size_work2, size_work3, size_tmpz,
-                              size_splits, size_tmptau_W, size_tau, size_workArr);
+    void *scalars, *work1, *work2, *work3, *work4, *tmpz, *splits, *tmptau_W, *tau, *workArr;
+    rocblas_device_malloc mem(handle, size_scalars, size_work1, size_work2, size_work3, size_work4,
+                              size_tmpz, size_splits, size_tmptau_W, size_tau, size_workArr);
 
     if(!mem)
         return rocblas_status_memory_error;
@@ -97,19 +99,20 @@ rocblas_status rocsolver_syevd_heevd_strided_batched_impl(rocblas_handle handle,
     work1 = mem[1];
     work2 = mem[2];
     work3 = mem[3];
-    tmpz = mem[4];
-    splits = mem[5];
-    tmptau_W = mem[6];
-    tau = mem[7];
-    workArr = mem[8];
+    work4 = mem[4];
+    tmpz = mem[5];
+    splits = mem[6];
+    tmptau_W = mem[7];
+    tau = mem[8];
+    workArr = mem[9];
     if(size_scalars > 0)
         init_scalars(handle, (T*)scalars);
 
     // execution
     return rocsolver_syevd_heevd_template<false, true, T>(
         handle, evect, uplo, n, A, shiftA, lda, strideA, D, strideD, E, strideE, info, batch_count,
-        (T*)scalars, work1, work2, work3, (S*)tmpz, (rocblas_int*)splits, (T*)tmptau_W, (T*)tau,
-        (T**)workArr);
+        (T*)scalars, work1, work2, work3, work4, (S*)tmpz, (rocblas_int*)splits, (T*)tmptau_W,
+        (T*)tau, (T**)workArr, optim_mem);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/library/src/lapack/roclapack_sytd2_hetd2.hpp
+++ b/library/src/lapack/roclapack_sytd2_hetd2.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,10 +33,349 @@
 #pragma once
 
 #include "auxiliary/rocauxiliary_larfg.hpp"
+#include "auxiliary/rocauxiliary_latrd.hpp"
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
 
 ROCSOLVER_BEGIN_NAMESPACE
+
+template <int MAX_THDS, typename T, typename I, typename S, typename U>
+ROCSOLVER_KERNEL void __launch_bounds__(MAX_THDS)
+    sytd2_lower_kernel_small(const I n,
+                             U AA,
+                             const rocblas_stride shiftA,
+                             const I lda,
+                             const rocblas_stride strideA,
+                             S* DD,
+                             const rocblas_stride strideD,
+                             S* EE,
+                             const rocblas_stride strideE,
+                             T* tauA,
+                             const rocblas_stride strideP)
+{
+    I bid = blockIdx.z;
+    I tid = threadIdx.x;
+
+    // select batch instance
+    T* A = load_ptr_batch<T>(AA, bid, shiftA, strideA);
+    S* D = load_ptr_batch<S>(DD, bid, 0, strideD);
+    S* E = load_ptr_batch<S>(EE, bid, 0, strideE);
+    T* tau = load_ptr_batch<T>(tauA, bid, 0, strideP);
+
+    // shared variables
+    extern __shared__ double lmem[];
+    T* tmptau = reinterpret_cast<T*>(lmem);
+    T* a = reinterpret_cast<T*>(tmptau + 1);
+    T* x = reinterpret_cast<T*>(a + n * n);
+    T* w = reinterpret_cast<T*>(x + n);
+    T* sval = reinterpret_cast<T*>(w + n);
+
+    // load A to lds
+    for(I i = tid % (MAX_THDS / 2); i < n; i += (MAX_THDS / 2))
+    {
+        const auto tidy = tid / (MAX_THDS / 2);
+        for(I j = tidy; j < n; j += 2)
+        {
+            a[i + j * n] = A[i + j * lda];
+        }
+    }
+
+    __syncthreads();
+
+    for(I i = tid % (MAX_THDS / 2); i < n; i += (MAX_THDS / 2))
+    {
+        const auto tidy = tid / (MAX_THDS / 2);
+        for(I j = tidy; j < n; j += 2)
+        {
+            if(i < j)
+                a[i + j * n] = conj(a[j + i * n]);
+        }
+    }
+
+    __syncthreads();
+
+    // reduce the lower part of A
+    // main loop running forwards (for each column)
+    for(rocblas_int j = 0; j < n - 1; ++j)
+    {
+        I nn = n - j - 1;
+
+        // ----- 1. generate Householder reflector to annihilate A(j+2:n-1,j) and copy off-diagonal element to E[j] -----
+        // load A(j+1:n-1,j) into x
+        for(I i = tid; i < nn; i += MAX_THDS)
+            x[i] = a[(i + j + 1) + j * n];
+        __syncthreads();
+
+        // larfg
+        T norm2 = 0;
+        for(I i = tid; i < nn - 1; i += MAX_THDS)
+            norm2 += x[i + 1] * conj(x[i + 1]);
+
+        // reduce squared entries to find squared norm of x
+        norm2 += shift_left(norm2, 1);
+        norm2 += shift_left(norm2, 2);
+        norm2 += shift_left(norm2, 4);
+        norm2 += shift_left(norm2, 8);
+        norm2 += shift_left(norm2, 16);
+        if(warpSize > 32)
+            norm2 += shift_left(norm2, 32);
+        if(tid % warpSize == 0)
+            sval[tid / warpSize] = norm2;
+        __syncthreads();
+        if(tid == 0)
+        {
+            for(I k = 1; k < MAX_THDS / warpSize; k++)
+                norm2 += sval[k];
+
+            // set tau, beta, and put scaling factor into sval[0]
+            run_set_taubeta<T>(tmptau, &norm2, x, E + j);
+
+            tau[j] = tmptau[0];
+            sval[0] = norm2;
+        }
+        __syncthreads();
+
+        // scale x by scaling factor
+        for(I i = tid; i < nn - 1; i += MAX_THDS)
+            x[i + 1] *= sval[0];
+        __syncthreads();
+
+        // ----- 2. compute w = tau*A*v - 1/2*tau*tau*(v'*A*v)*v -----
+        // symv
+        for(I i = tid; i < nn; i += MAX_THDS)
+        {
+            T temp = 0;
+            T* Atmp = a + (j + 1) + (j + 1) * n;
+            for(I jj = 0; jj < nn; jj++)
+                temp += Atmp[i + jj * n] * x[jj];
+            w[i] = tmptau[0] * temp;
+        }
+
+        // copy x back to A(j+1:n-1,j)
+        for(I i = tid; i < nn; i += MAX_THDS)
+            a[(i + j + 1) + j * n] = x[i];
+        __syncthreads();
+
+        // dot
+        norm2 = 0;
+        for(I i = tid; i < nn; i += MAX_THDS)
+            norm2 += x[i] * conj(w[i]);
+
+        // reduce squared entries to find squared norm of x
+        norm2 += shift_left(norm2, 1);
+        norm2 += shift_left(norm2, 2);
+        norm2 += shift_left(norm2, 4);
+        norm2 += shift_left(norm2, 8);
+        norm2 += shift_left(norm2, 16);
+        if(warpSize > 32)
+            norm2 += shift_left(norm2, 32);
+        if(tid % warpSize == 0)
+            sval[tid / warpSize] = norm2;
+        __syncthreads();
+        if(tid == 0)
+        {
+            for(I k = 1; k < MAX_THDS / warpSize; k++)
+                norm2 += sval[k];
+            sval[0] = -0.5 * tmptau[0] * norm2;
+        }
+        __syncthreads();
+
+        // axpy
+        for(I i = tid; i < nn; i += MAX_THDS)
+            w[i] += sval[0] * x[i];
+        __syncthreads();
+
+        // ----- 3. apply the Householder reflector to A as a rank-2 update: A = A - v*w' - w*v' -----
+        // syr2
+        for(I i = tid; i < nn; i += MAX_THDS)
+        {
+            for(I jj = 0; jj < nn; jj++)
+            {
+                T* Atmp = a + (j + 1) + (j + 1) * n;
+                Atmp[i + jj * n] = Atmp[i + jj * n] - x[i] * conj(w[jj]) - w[i] * conj(x[jj]);
+            }
+        }
+        __syncthreads();
+    }
+
+    // write lds back to A
+    for(I i = tid % (MAX_THDS / 2); i < n; i += (MAX_THDS / 2))
+    {
+        const auto tidy = tid / (MAX_THDS / 2);
+        for(I j = tidy; j < n; j += 2)
+        {
+            if(i >= j)
+                A[i + j * lda] = a[i + j * n];
+        }
+    }
+}
+
+template <int MAX_THDS, typename T, typename I, typename S, typename U>
+ROCSOLVER_KERNEL void __launch_bounds__(MAX_THDS)
+    sytd2_upper_kernel_small(const I n,
+                             U AA,
+                             const rocblas_stride shiftA,
+                             const I lda,
+                             const rocblas_stride strideA,
+                             S* DD,
+                             const rocblas_stride strideD,
+                             S* EE,
+                             const rocblas_stride strideE,
+                             T* tauA,
+                             const rocblas_stride strideP)
+{
+    I bid = blockIdx.z;
+    I tid = threadIdx.x;
+
+    // select batch instance
+    T* A = load_ptr_batch<T>(AA, bid, shiftA, strideA);
+    S* D = load_ptr_batch<S>(DD, bid, 0, strideD);
+    S* E = load_ptr_batch<S>(EE, bid, 0, strideE);
+    T* tau = load_ptr_batch<T>(tauA, bid, 0, strideP);
+
+    // shared variables
+    extern __shared__ double lmem[];
+    T* tmptau = reinterpret_cast<T*>(lmem);
+    T* a = reinterpret_cast<T*>(tmptau + 1);
+    T* x = reinterpret_cast<T*>(a + n * n);
+    T* w = reinterpret_cast<T*>(x + n);
+    T* sval = reinterpret_cast<T*>(w + n);
+
+    // load A to lds
+    for(I i = tid % (MAX_THDS / 2); i < n; i += (MAX_THDS / 2))
+    {
+        const auto tidy = tid / (MAX_THDS / 2);
+        for(I j = tidy; j < n; j += 2)
+        {
+            a[i + j * n] = A[i + j * lda];
+        }
+    }
+
+    __syncthreads();
+
+    for(I i = tid % (MAX_THDS / 2); i < n; i += (MAX_THDS / 2))
+    {
+        const auto tidy = tid / (MAX_THDS / 2);
+        for(I j = tidy; j < n; j += 2)
+        {
+            if(i > j)
+                a[i + j * n] = conj(a[j + i * n]);
+        }
+    }
+
+    __syncthreads();
+
+    // reduce the upper part of A
+    // main loop running backwards (for each column)
+    for(rocblas_int j = n - 1; j > 0; --j)
+    {
+        I nn = j;
+
+        // ----- 1. generate Householder reflector to annihilate A(0:j-2,j) and copy off-diagonal element to E[j-1] -----
+        // load A(0:j-1,j) into x
+        for(I i = tid; i < nn; i += MAX_THDS)
+            x[i] = a[i + j * n];
+        __syncthreads();
+
+        // larfg
+        T norm2 = 0;
+        for(I i = tid; i < nn - 1; i += MAX_THDS)
+            norm2 += x[i] * conj(x[i]);
+
+        // reduce squared entries to find squared norm of x
+        norm2 += shift_left(norm2, 1);
+        norm2 += shift_left(norm2, 2);
+        norm2 += shift_left(norm2, 4);
+        norm2 += shift_left(norm2, 8);
+        norm2 += shift_left(norm2, 16);
+        if(warpSize > 32)
+            norm2 += shift_left(norm2, 32);
+        if(tid % warpSize == 0)
+            sval[tid / warpSize] = norm2;
+        __syncthreads();
+        if(tid == 0)
+        {
+            for(I k = 1; k < MAX_THDS / warpSize; k++)
+                norm2 += sval[k];
+
+            // set tau, beta, and put scaling factor into sval[0]
+            run_set_taubeta<T>(tmptau, &norm2, x + (nn - 1), E + (j - 1));
+
+            tau[j - 1] = tmptau[0];
+            sval[0] = norm2;
+        }
+        __syncthreads();
+
+        // scale x by scaling factor
+        for(I i = tid; i < nn - 1; i += MAX_THDS)
+            x[i] *= sval[0];
+        __syncthreads();
+
+        // ----- 2. compute w = tau*A*v - 1/2*tau*tau*(v'*A*v*)v -----
+        // symv
+        for(I i = tid; i < nn; i += MAX_THDS)
+        {
+            T temp = 0;
+            for(I jj = 0; jj < nn; jj++)
+                temp += a[i + jj * n] * x[jj];
+            w[i] = tmptau[0] * temp;
+        }
+
+        // copy x back to A(0:j-1,j)
+        for(I i = tid; i < nn; i += MAX_THDS)
+            a[i + j * n] = x[i];
+        __syncthreads();
+
+        // dot
+        norm2 = 0;
+        for(I i = tid; i < nn; i += MAX_THDS)
+            norm2 += x[i] * conj(w[i]);
+
+        // reduce squared entries to find squared norm of x
+        norm2 += shift_left(norm2, 1);
+        norm2 += shift_left(norm2, 2);
+        norm2 += shift_left(norm2, 4);
+        norm2 += shift_left(norm2, 8);
+        norm2 += shift_left(norm2, 16);
+        if(warpSize > 32)
+            norm2 += shift_left(norm2, 32);
+        if(tid % warpSize == 0)
+            sval[tid / warpSize] = norm2;
+        __syncthreads();
+        if(tid == 0)
+        {
+            for(I k = 1; k < MAX_THDS / warpSize; k++)
+                norm2 += sval[k];
+            sval[0] = -0.5 * tmptau[0] * norm2;
+        }
+        __syncthreads();
+
+        // axpy
+        for(I i = tid; i < nn; i += MAX_THDS)
+            w[i] += sval[0] * x[i];
+        __syncthreads();
+
+        // ----- 3. apply the Householder reflector to A as a rank-2 update: A = A - v*w' - w*v' -----
+        // syr2
+        for(I i = tid; i < nn; i += MAX_THDS)
+        {
+            for(I jj = 0; jj < nn; jj++)
+                a[i + jj * n] = a[i + jj * n] - x[i] * conj(w[jj]) - w[i] * conj(x[jj]);
+        }
+        __syncthreads();
+    }
+
+    // write lds back to A
+    for(I i = tid % (MAX_THDS / 2); i < n; i += (MAX_THDS / 2))
+    {
+        const auto tidy = tid / (MAX_THDS / 2);
+        for(I j = tidy; j < n; j += 2)
+        {
+            if(i <= j)
+                A[i + j * lda] = a[i + j * n];
+        }
+    }
+}
 
 /** set_tau kernel copies to tau the corresponding Householder scalars **/
 template <typename T>
@@ -264,49 +603,54 @@ rocblas_status rocsolver_sytd2_hetd2_template(rocblas_handle handle,
 
     rocblas_stride stridet = 1; //stride for tmptau
 
+    // get device prop
+    int device;
+    HIP_CHECK(hipGetDevice(&device));
+    hipDeviceProp_t props;
+    HIP_CHECK(hipGetDeviceProperties(&props, device));
+
     if(uplo == rocblas_fill_lower)
     {
         // reduce the lower part of A
         // main loop running forwards (for each column)
         for(rocblas_int j = 0; j < n - 1; ++j)
         {
-            // 1. generate Householder reflector to annihilate A(j+2:n-1,j)
-            rocsolver_larfg_template<T>(handle, n - 1 - j, A, shiftA + idx2D(j + 1, j, lda), A,
-                                        shiftA + idx2D(std::min(j + 2, n - 1), j, lda), 1, strideA,
-                                        tmptau, stridet, batch_count, work, norms);
+            const rocblas_int nn = n - j;
+            const size_t lmemsize = ((256 / props.warpSize) + 2 * nn + 1 + nn * nn) * sizeof(T);
+            if(lmemsize <= props.sharedMemPerBlock && nn <= xxTD2_SSKER_MAX_N)
+            {
+                ROCSOLVER_LAUNCH_KERNEL((sytd2_lower_kernel_small<256, T>), dim3(1, 1, batch_count),
+                                        dim3(256), lmemsize, stream, nn, A,
+                                        shiftA + idx2D(j, j, lda), lda, strideA, D + j, strideD,
+                                        E + j, strideE, tau + j, strideP);
 
-            // 2. copy to E(j) the corresponding off-diagonal element of A, which is set to 1
-            ROCSOLVER_LAUNCH_KERNEL(set_offdiag<T>, grid_b, threads, 0, stream, batch_count, A,
-                                    shiftA + idx2D(j + 1, j, lda), strideA, E + j, strideE);
+                break;
+            }
 
-            // 3. overwrite tau with w = tmptau*A*v - 1/2*tmptau*(tmptau*v'*A*v)*v
-            // a. compute tmptau*A*v -> tau
+            // 1. generate Householder reflector to annihilate A(j+2:n-1,j) and copy off-diagonal element to E[j]
+            rocsolver_larfg_template<T>(handle, n - 1 - j, A, shiftA + idx2D(j + 1, j, lda), E, j,
+                                        strideE, A, shiftA + idx2D(std::min(j + 2, n - 1), j, lda),
+                                        1, strideA, tmptau, stridet, batch_count, work, norms);
+
+            // 2. overwrite tau with w = tmptau*A*v - 1/2*tmptau*(tmptau*v'*A*v)*v
             rocblasCall_symv_hemv<T>(handle, uplo, n - 1 - j, tmptau, stridet, A,
                                      shiftA + idx2D(j + 1, j + 1, lda), lda, strideA, A,
                                      shiftA + idx2D(j + 1, j, lda), 1, strideA, scalars + 1, 0, tau,
                                      j, 1, strideP, batch_count, work, workArr);
 
-            // b. compute scalar tmptau*v'*A*v=tau'*v -> norms
-            rocblasCall_dot<COMPLEX, T>(handle, n - 1 - j, tau, j, 1, strideP, A,
-                                        shiftA + idx2D(j + 1, j, lda), 1, strideA, batch_count,
-                                        norms, work, workArr);
+            ROCSOLVER_LAUNCH_KERNEL((latrd_dot_scale_axpy<64, T>), dim3(1, 1, batch_count),
+                                    dim3(64, 1, 1), 0, stream, n - 1 - j, A,
+                                    shiftA + idx2D(j + 1, j, lda), strideA, tau, j, strideP, tmptau,
+                                    stridet);
 
-            // c. finally update tau as an axpy: -1/2*tmptau*norms*v + tau -> tau
-            // (TODO: rocblas_axpy is not yet ready to be used in rocsolver. When it becomes
-            //  available, we can use it instead of the scale_axpy kernel, if it provides
-            //  better performance.)
-            ROCSOLVER_LAUNCH_KERNEL(scale_axpy<T>, grid_n, threads, 0, stream, n - 1 - j, norms,
-                                    tmptau, stridet, A, shiftA + idx2D(j + 1, j, lda), strideA, tau,
-                                    j, strideP);
-
-            // 4. apply the Householder reflector to A as a rank-2 update:
+            // 3. apply the Householder reflector to A as a rank-2 update:
             // A = A - v*w' - w*v'
             rocblasCall_syr2_her2<T>(handle, uplo, n - 1 - j, scalars, A,
                                      shiftA + idx2D(j + 1, j, lda), 1, strideA, tau, j, 1, strideP,
                                      A, shiftA + idx2D(j + 1, j + 1, lda), lda, strideA,
                                      batch_count, workArr);
 
-            // 5. Save the used housedholder scalar
+            // 4. Save the used householder scalar
             ROCSOLVER_LAUNCH_KERNEL(set_tau<T>, grid_b, threads, 0, stream, batch_count, tmptau,
                                     tau + j, strideP);
         }
@@ -318,39 +662,37 @@ rocblas_status rocsolver_sytd2_hetd2_template(rocblas_handle handle,
         // main loop running backwards (for each column)
         for(rocblas_int j = n - 1; j > 0; --j)
         {
-            // 1. generate Householder reflector to annihilate A(0:j-2,j)
-            rocsolver_larfg_template<T>(handle, j, A, shiftA + idx2D(j - 1, j, lda), A,
-                                        shiftA + idx2D(0, j, lda), 1, strideA, tmptau, 1,
-                                        batch_count, work, norms);
+            const rocblas_int nn = j + 1;
+            const size_t lmemsize = ((256 / props.warpSize) + 2 * nn + 1 + nn * nn) * sizeof(T);
+            if(lmemsize <= props.sharedMemPerBlock && nn <= xxTD2_SSKER_MAX_N)
+            {
+                ROCSOLVER_LAUNCH_KERNEL((sytd2_upper_kernel_small<256, T>), dim3(1, 1, batch_count),
+                                        dim3(256), lmemsize, stream, nn, A, shiftA, lda, strideA, D,
+                                        strideD, E, strideE, tau, strideP);
+                break;
+            }
 
-            // 2. copy to E(j-1) the corresponding off-diagonal element of A, which is set to 1
-            ROCSOLVER_LAUNCH_KERNEL(set_offdiag<T>, grid_b, threads, 0, stream, batch_count, A,
-                                    shiftA + idx2D(j - 1, j, lda), strideA, E + j - 1, strideE);
+            // 1. generate Householder reflector to annihilate A(0:j-2,j) and copy off-diagonal element to E[j-1]
+            rocsolver_larfg_template<T>(handle, j, A, shiftA + idx2D(j - 1, j, lda), E, j - 1,
+                                        strideE, A, shiftA + idx2D(0, j, lda), 1, strideA, tmptau,
+                                        1, batch_count, work, norms);
 
-            // 3. overwrite tau with w = tmptau*A*v - 1/2*tmptau*tmptau*(v'*A*v*)v
-            // a. compute tmptau*A*v -> tau
+            // 2. overwrite tau with w = tmptau*A*v - 1/2*tmptau*tmptau*(v'*A*v*)v
             rocblasCall_symv_hemv<T>(handle, uplo, j, tmptau, stridet, A, shiftA, lda, strideA, A,
                                      shiftA + idx2D(0, j, lda), 1, strideA, scalars + 1, 0, tau, 0,
                                      1, strideP, batch_count, work, workArr);
 
-            // b. compute scalar tmptau*v'*A*v=tau'*v -> norms
-            rocblasCall_dot<COMPLEX, T>(handle, j, tau, 0, 1, strideP, A, shiftA + idx2D(0, j, lda),
-                                        1, strideA, batch_count, norms, work, workArr);
+            ROCSOLVER_LAUNCH_KERNEL((latrd_dot_scale_axpy<64, T>), dim3(1, 1, batch_count),
+                                    dim3(64, 1, 1), 0, stream, j, A, shiftA + idx2D(0, j, lda),
+                                    strideA, tau, 0, strideP, tmptau, stridet);
 
-            // c. finally update tau as an axpy: -1/2*tmptau*norms*v + tau -> tau
-            // (TODO: rocblas_axpy is not yet ready to be used in rocsolver. When it becomes
-            //  available, we can use it instead of the scale_axpy kernel if it provides
-            //  better performance.)
-            ROCSOLVER_LAUNCH_KERNEL(scale_axpy<T>, grid_n, threads, 0, stream, j, norms, tmptau,
-                                    stridet, A, shiftA + idx2D(0, j, lda), strideA, tau, 0, strideP);
-
-            // 4. apply the Householder reflector to A as a rank-2 update:
+            // 3. apply the Householder reflector to A as a rank-2 update:
             // A = A - v*w' - w*v'
             rocblasCall_syr2_her2<T>(handle, uplo, j, scalars, A, shiftA + idx2D(0, j, lda), 1,
                                      strideA, tau, 0, 1, strideP, A, shiftA, lda, strideA,
                                      batch_count, workArr);
 
-            // 5. Save the used housedholder scalar
+            // 4. Save the used householder scalar
             ROCSOLVER_LAUNCH_KERNEL(set_tau<T>, grid_b, threads, 0, stream, batch_count, tmptau,
                                     tau + j - 1, strideP);
         }

--- a/library/src/lapack/roclapack_sytd2_hetd2.hpp
+++ b/library/src/lapack/roclapack_sytd2_hetd2.hpp
@@ -87,6 +87,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(MAX_THDS)
         const auto tidy = tid / (MAX_THDS / 2);
         for(I j = tidy; j < n; j += 2)
         {
+            // ignore imaginary part of the diagonal
+            if(i == j)
+                a[i + j * n] = std::real(a[i + j * n]);
+            // copy lower triangle to upper triangle
             if(i < j)
                 a[i + j * n] = conj(a[j + i * n]);
         }
@@ -258,6 +262,10 @@ ROCSOLVER_KERNEL void __launch_bounds__(MAX_THDS)
         const auto tidy = tid / (MAX_THDS / 2);
         for(I j = tidy; j < n; j += 2)
         {
+            // ignore imaginary part of the diagonal
+            if(i == j)
+                a[i + j * n] = std::real(a[i + j * n]);
+            // copy upper triangle to lower triangle
             if(i > j)
                 a[i + j * n] = conj(a[j + i * n]);
         }

--- a/library/src/lapack/roclapack_sytd2_hetd2.hpp
+++ b/library/src/lapack/roclapack_sytd2_hetd2.hpp
@@ -612,10 +612,7 @@ rocblas_status rocsolver_sytd2_hetd2_template(rocblas_handle handle,
     rocblas_stride stridet = 1; //stride for tmptau
 
     // get device prop
-    int device;
-    HIP_CHECK(hipGetDevice(&device));
-    hipDeviceProp_t props;
-    HIP_CHECK(hipGetDeviceProperties(&props, device));
+    const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
 
     if(uplo == rocblas_fill_lower)
     {
@@ -624,8 +621,8 @@ rocblas_status rocsolver_sytd2_hetd2_template(rocblas_handle handle,
         for(rocblas_int j = 0; j < n - 1; ++j)
         {
             const rocblas_int nn = n - j;
-            const size_t lmemsize = ((256 / props.warpSize) + 2 * nn + 1 + nn * nn) * sizeof(T);
-            if(lmemsize <= props.sharedMemPerBlock && nn <= xxTD2_SSKER_MAX_N)
+            const size_t lmemsize = ((256 / props->warpSize) + 2 * nn + 1 + nn * nn) * sizeof(T);
+            if(lmemsize <= props->sharedMemPerBlock && nn <= xxTD2_SSKER_MAX_N)
             {
                 ROCSOLVER_LAUNCH_KERNEL((sytd2_lower_kernel_small<256, T>), dim3(1, 1, batch_count),
                                         dim3(256), lmemsize, stream, nn, A,
@@ -671,8 +668,8 @@ rocblas_status rocsolver_sytd2_hetd2_template(rocblas_handle handle,
         for(rocblas_int j = n - 1; j > 0; --j)
         {
             const rocblas_int nn = j + 1;
-            const size_t lmemsize = ((256 / props.warpSize) + 2 * nn + 1 + nn * nn) * sizeof(T);
-            if(lmemsize <= props.sharedMemPerBlock && nn <= xxTD2_SSKER_MAX_N)
+            const size_t lmemsize = ((256 / props->warpSize) + 2 * nn + 1 + nn * nn) * sizeof(T);
+            if(lmemsize <= props->sharedMemPerBlock && nn <= xxTD2_SSKER_MAX_N)
             {
                 ROCSOLVER_LAUNCH_KERNEL((sytd2_upper_kernel_small<256, T>), dim3(1, 1, batch_count),
                                         dim3(256), lmemsize, stream, nn, A, shiftA, lda, strideA, D,

--- a/library/src/lapack/roclapack_sytrd_hetrd.hpp
+++ b/library/src/lapack/roclapack_sytrd_hetrd.hpp
@@ -166,7 +166,10 @@ rocblas_status rocsolver_sytrd_hetrd_template(rocblas_handle handle,
     // everything must be executed with scalars on the device
     rocblas_pointer_mode old_mode;
     rocblas_get_pointer_mode(handle, &old_mode);
-    rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
+    rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
+
+    const T minone = T(-1);
+    const T one = T(1);
 
     rocblas_int ldw = n;
     rocblas_stride strideW = n * k;
@@ -213,12 +216,12 @@ rocblas_status rocsolver_sytrd_hetrd_template(rocblas_handle handle,
             // update trailing matrix
             // A = A - V*W' - W*V'
             rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_conjugate_transpose,
-                           n - j - k, n - j - k, k, scalars, A, shiftA + idx2D(j + k, j, lda), lda,
-                           strideA, tmptau_W, idx2D(k, 0, ldw), ldw, strideW, scalars + 2, A,
+                           n - j - k, n - j - k, k, &minone, A, shiftA + idx2D(j + k, j, lda), lda,
+                           strideA, tmptau_W, idx2D(k, 0, ldw), ldw, strideW, &one, A,
                            shiftA + idx2D(j + k, j + k, lda), lda, strideA, batch_count, workArr);
             rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_conjugate_transpose,
-                           n - j - k, n - j - k, k, scalars, tmptau_W, idx2D(k, 0, ldw), ldw,
-                           strideW, A, shiftA + idx2D(j + k, j, lda), lda, strideA, scalars + 2, A,
+                           n - j - k, n - j - k, k, &minone, tmptau_W, idx2D(k, 0, ldw), ldw,
+                           strideW, A, shiftA + idx2D(j + k, j, lda), lda, strideA, &one, A,
                            shiftA + idx2D(j + k, j + k, lda), lda, strideA, batch_count, workArr);
 
             j += k;
@@ -248,11 +251,11 @@ rocblas_status rocsolver_sytrd_hetrd_template(rocblas_handle handle,
             // update trailing matrix
             // A = A - V*W' - W*V'
             rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_conjugate_transpose, j,
-                           j, k, scalars, A, shiftA + idx2D(0, j, lda), lda, strideA, tmptau_W, 0,
-                           ldw, strideW, scalars + 2, A, shiftA, lda, strideA, batch_count, workArr);
+                           j, k, &minone, A, shiftA + idx2D(0, j, lda), lda, strideA, tmptau_W, 0,
+                           ldw, strideW, &one, A, shiftA, lda, strideA, batch_count, workArr);
             rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_conjugate_transpose, j,
-                           j, k, scalars, tmptau_W, 0, ldw, strideW, A, shiftA + idx2D(0, j, lda),
-                           lda, strideA, scalars + 2, A, shiftA, lda, strideA, batch_count, workArr);
+                           j, k, &minone, tmptau_W, 0, ldw, strideW, A, shiftA + idx2D(0, j, lda),
+                           lda, strideA, &one, A, shiftA, lda, strideA, batch_count, workArr);
 
             j -= k;
         }

--- a/library/src/specialized/roclapack_gemm_specialized_kernels.hpp
+++ b/library/src/specialized/roclapack_gemm_specialized_kernels.hpp
@@ -236,19 +236,16 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_gemm(rocblas_handle handle,
     rocblas_get_pointer_mode(handle, &pmode);
 
     // get warp size
-    int device;
-    HIP_CHECK(hipGetDevice(&device));
-    hipDeviceProp_t deviceProperties;
-    HIP_CHECK(hipGetDeviceProperties(&deviceProperties, device));
+    const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
 
-    std::string deviceArch(deviceProperties.gcnArchName);
+    std::string deviceArch(props->gcnArchName);
 
     if((deviceArch.find("gfx90a") != std::string::npos)
        || (deviceArch.find("gfx940") != std::string::npos)
        || (deviceArch.find("gfx941") != std::string::npos)
        || (deviceArch.find("gfx942") != std::string::npos))
     {
-        const auto warpSize = deviceProperties.warpSize;
+        const auto warpSize = props->warpSize;
 
         // launch specialized kernel
         const I numWarpsX = 4;


### PR DESCRIPTION
This PR cherry-picks several optimizations to the Divide-and-Conquer algorithm into ROCm 7.0.1. It also includes code to prevent the occurrence of NaNs that might appear in some corner cases.