### PR TITLE
Logging improvements

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -350,6 +350,7 @@ if(OPTIMAL)
 endif()
 
 # Asynchronous logger option
+# Note: this does not mean abolsutely asynchronous, just less synchronous
 option(ROCSOLVER_USE_ASYNC_LOGGER "Enable asynchronous HIP event-based logger (reduces GPU synchronizations)" ON)
 
 # Configure asynchronous logger compile definition

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -349,6 +349,16 @@ if(OPTIMAL)
   )
 endif()
 
+# Asynchronous logger option
+option(ROCSOLVER_USE_ASYNC_LOGGER "Enable asynchronous HIP event-based logger (reduces GPU synchronizations)" ON)
+
+# Configure asynchronous logger compile definition
+if(ROCSOLVER_USE_ASYNC_LOGGER)
+  set(ROCSOLVER_ASYNC_LOGGER_DEFINITION "ROCSOLVER_USE_ASYNC_LOGGER=1")
+else()
+  set(ROCSOLVER_ASYNC_LOGGER_DEFINITION "ROCSOLVER_USE_ASYNC_LOGGER=0")
+endif()
+
 set(auxiliaries
   common/buildinfo.cpp
   common/rocsolver_handle.cpp
@@ -492,6 +502,7 @@ target_compile_definitions(rocsolver PRIVATE
   ROCM_USE_FLOAT16
   ROCBLAS_INTERNAL_API
   ROCSOLVER_LIBRARY
+  ${ROCSOLVER_ASYNC_LOGGER_DEFINITION}
 )
 
 add_armor_flags(rocsolver "${ARMOR_LEVEL}")
@@ -541,4 +552,3 @@ rocm_export_targets(
     ${static_depends}
   NAMESPACE roc::
 )
-

--- a/library/src/auxiliary/rocauxiliary_larf.hpp
+++ b/library/src/auxiliary/rocauxiliary_larf.hpp
@@ -314,19 +314,16 @@ rocblas_status rocsolver_larf_template(rocblas_handle handle,
     }
 
     // get device prop
-    int device;
-    HIP_CHECK(hipGetDevice(&device));
-    hipDeviceProp_t props;
-    HIP_CHECK(hipGetDeviceProperties(&props, device));
+    const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
 
     // determine side
     bool leftside = (side == rocblas_side_left);
 
     static constexpr int NB = 1024;
-    const int lds_size = leftside ? (m + (NB / props.warpSize)) * sizeof(T)
-                                  : (n + (NB / props.warpSize)) * sizeof(T);
+    const int lds_size = leftside ? (m + (NB / props->warpSize)) * sizeof(T)
+                                  : (n + (NB / props->warpSize)) * sizeof(T);
 
-    if(lds_size <= props.sharedMemPerBlock)
+    if(lds_size <= props->sharedMemPerBlock)
     {
         // Launch larf kernel if tune parameters are met.
         if(leftside && (n <= 1024 || m >= 2048))

--- a/library/src/auxiliary/rocauxiliary_larf.hpp
+++ b/library/src/auxiliary/rocauxiliary_larf.hpp
@@ -314,16 +314,19 @@ rocblas_status rocsolver_larf_template(rocblas_handle handle,
     }
 
     // get device prop
-    const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
+    int device;
+    HIP_CHECK(hipGetDevice(&device));
+    hipDeviceProp_t props;
+    HIP_CHECK(hipGetDeviceProperties(&props, device));
 
     // determine side
     bool leftside = (side == rocblas_side_left);
 
     static constexpr int NB = 1024;
-    const int lds_size = leftside ? (m + (NB / props->warpSize)) * sizeof(T)
-                                  : (n + (NB / props->warpSize)) * sizeof(T);
+    const int lds_size = leftside ? (m + (NB / props.warpSize)) * sizeof(T)
+                                  : (n + (NB / props.warpSize)) * sizeof(T);
 
-    if(lds_size <= props->sharedMemPerBlock)
+    if(lds_size <= props.sharedMemPerBlock)
     {
         // Launch larf kernel if tune parameters are met.
         if(leftside && (n <= 1024 || m >= 2048))

--- a/library/src/auxiliary/rocauxiliary_larfg.hpp
+++ b/library/src/auxiliary/rocauxiliary_larfg.hpp
@@ -182,9 +182,9 @@ rocblas_status rocsolver_larfg_getMemorySize(const I n,
         // TODO: Some architectures have failures in sygvx with small-size kernels enabled, more investigation needed
         int device;
         HIP_CHECK(hipGetDevice(&device));
-        hipDeviceProp_t deviceProperties;
-        HIP_CHECK(hipGetDeviceProperties(&deviceProperties, device));
-        if(deviceProperties.warpSize >= 64)
+        hipDeviceProp_t props;
+        HIP_CHECK(hipGetDeviceProperties(&props, device));
+        if(props.warpSize >= 64)
             return rocblas_status_success;
     }
 
@@ -273,11 +273,8 @@ rocblas_status rocsolver_larfg_template(rocblas_handle handle,
     if(true)
     {
         // TODO: Some architectures have failures in sygvx with small-size kernels enabled, more investigation needed
-        int device;
-        HIP_CHECK(hipGetDevice(&device));
-        hipDeviceProp_t deviceProperties;
-        HIP_CHECK(hipGetDeviceProperties(&deviceProperties, device));
-        if(deviceProperties.warpSize >= 64)
+        const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
+        if(props->warpSize >= 64)
         {
             return larfg_run_small(handle, n, alpha, shifta, stridex, beta, shiftb, strideb, x,
                                    shiftx, incx, stridex, tau, strideP, batch_count);

--- a/library/src/auxiliary/rocauxiliary_larfg.hpp
+++ b/library/src/auxiliary/rocauxiliary_larfg.hpp
@@ -182,9 +182,9 @@ rocblas_status rocsolver_larfg_getMemorySize(const I n,
         // TODO: Some architectures have failures in sygvx with small-size kernels enabled, more investigation needed
         int device;
         HIP_CHECK(hipGetDevice(&device));
-        hipDeviceProp_t props;
-        HIP_CHECK(hipGetDeviceProperties(&props, device));
-        if(props.warpSize >= 64)
+        hipDeviceProp_t deviceProperties;
+        HIP_CHECK(hipGetDeviceProperties(&deviceProperties, device));
+        if(deviceProperties.warpSize >= 64)
             return rocblas_status_success;
     }
 
@@ -273,8 +273,11 @@ rocblas_status rocsolver_larfg_template(rocblas_handle handle,
     if(true)
     {
         // TODO: Some architectures have failures in sygvx with small-size kernels enabled, more investigation needed
-        const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
-        if(props->warpSize >= 64)
+        int device;
+        HIP_CHECK(hipGetDevice(&device));
+        hipDeviceProp_t deviceProperties;
+        HIP_CHECK(hipGetDeviceProperties(&deviceProperties, device));
+        if(deviceProperties.warpSize >= 64)
         {
             return larfg_run_small(handle, n, alpha, shifta, stridex, beta, shiftb, strideb, x,
                                    shiftx, incx, stridex, tau, strideP, batch_count);

--- a/library/src/auxiliary/rocauxiliary_larft.hpp
+++ b/library/src/auxiliary/rocauxiliary_larft.hpp
@@ -597,10 +597,7 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
     ROCSOLVER_LAUNCH_KERNEL(set_tau, dim3(blocks, batch_count), dim3(32, 1), 0, stream, k, tau,
                             strideT);
 
-    int device;
-    HIP_CHECK(hipGetDevice(&device));
-    hipDeviceProp_t props;
-    HIP_CHECK(hipGetDeviceProperties(&props, device));
+    const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
     size_t lmemsize = sizeof(T) * (k + 1) * k;
 
     rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
@@ -614,7 +611,7 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
         //      IT WILL WORK ON THE ENTIRE MATRIX/VECTOR REGARDLESS OF
         //      ZERO ENTRIES ****
 
-        if(k <= LARFT_SWITCHSIZE && lmemsize <= props.sharedMemPerBlock)
+        if(k <= LARFT_SWITCHSIZE && lmemsize <= props->sharedMemPerBlock)
         {
             ROCSOLVER_LAUNCH_KERNEL(larft_kernel_forward, dim3(1, batch_count), dim3(BS1, 1),
                                     lmemsize, stream, storev, u1_n, k, V, shiftV, ldv, strideV, tau,
@@ -668,7 +665,7 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
         //      IT WILL WORK ON THE ENTIRE MATRIX/VECTOR REGARDLESS OF
         //      ZERO ENTRIES ****
 
-        if(k <= LARFT_SWITCHSIZE && lmemsize <= props.sharedMemPerBlock)
+        if(k <= LARFT_SWITCHSIZE && lmemsize <= props->sharedMemPerBlock)
         {
             auto shiftU2 = shiftV
                 + ((storev == rocblas_column_wise) ? idx2D(u2_n, 0, ldv) : idx2D(0, u2_n, ldv));

--- a/library/src/auxiliary/rocauxiliary_larft.hpp
+++ b/library/src/auxiliary/rocauxiliary_larft.hpp
@@ -597,7 +597,10 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
     ROCSOLVER_LAUNCH_KERNEL(set_tau, dim3(blocks, batch_count), dim3(32, 1), 0, stream, k, tau,
                             strideT);
 
-    const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
+    int device;
+    HIP_CHECK(hipGetDevice(&device));
+    hipDeviceProp_t props;
+    HIP_CHECK(hipGetDeviceProperties(&props, device));
     size_t lmemsize = sizeof(T) * (k + 1) * k;
 
     rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
@@ -611,7 +614,7 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
         //      IT WILL WORK ON THE ENTIRE MATRIX/VECTOR REGARDLESS OF
         //      ZERO ENTRIES ****
 
-        if(k <= LARFT_SWITCHSIZE && lmemsize <= props->sharedMemPerBlock)
+        if(k <= LARFT_SWITCHSIZE && lmemsize <= props.sharedMemPerBlock)
         {
             ROCSOLVER_LAUNCH_KERNEL(larft_kernel_forward, dim3(1, batch_count), dim3(BS1, 1),
                                     lmemsize, stream, storev, u1_n, k, V, shiftV, ldv, strideV, tau,
@@ -665,7 +668,7 @@ rocblas_status rocsolver_larft_template(rocblas_handle handle,
         //      IT WILL WORK ON THE ENTIRE MATRIX/VECTOR REGARDLESS OF
         //      ZERO ENTRIES ****
 
-        if(k <= LARFT_SWITCHSIZE && lmemsize <= props->sharedMemPerBlock)
+        if(k <= LARFT_SWITCHSIZE && lmemsize <= props.sharedMemPerBlock)
         {
             auto shiftU2 = shiftV
                 + ((storev == rocblas_column_wise) ? idx2D(u2_n, 0, ldv) : idx2D(0, u2_n, ldv));

--- a/library/src/auxiliary/rocauxiliary_steqr.hpp
+++ b/library/src/auxiliary/rocauxiliary_steqr.hpp
@@ -829,15 +829,11 @@ rocblas_status rocsolver_steqr_template(rocblas_handle handle,
         }
         else
         {
-            int device;
-            HIP_CHECK(hipGetDevice(&device));
-            hipDeviceProp_t deviceProperties;
-            HIP_CHECK(hipGetDeviceProperties(&deviceProperties, device));
+            const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
 
-            ROCSOLVER_LAUNCH_KERNEL((steqr_kernel<T>), dim3(1, batch_count),
-                                    dim3(deviceProperties.warpSize), 0, stream, n, D + shiftD,
-                                    strideD, E + shiftE, strideE, C, shiftC, ldc, strideC, info,
-                                    (S*)work_stack, 30 * n, eps, ssfmin, ssfmax);
+            ROCSOLVER_LAUNCH_KERNEL((steqr_kernel<T>), dim3(1, batch_count), dim3(props->warpSize),
+                                    0, stream, n, D + shiftD, strideD, E + shiftE, strideE, C, shiftC,
+                                    ldc, strideC, info, (S*)work_stack, 30 * n, eps, ssfmin, ssfmax);
         }
     }
 

--- a/library/src/auxiliary/rocauxiliary_steqr.hpp
+++ b/library/src/auxiliary/rocauxiliary_steqr.hpp
@@ -829,11 +829,15 @@ rocblas_status rocsolver_steqr_template(rocblas_handle handle,
         }
         else
         {
-            const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
+            int device;
+            HIP_CHECK(hipGetDevice(&device));
+            hipDeviceProp_t deviceProperties;
+            HIP_CHECK(hipGetDeviceProperties(&deviceProperties, device));
 
-            ROCSOLVER_LAUNCH_KERNEL((steqr_kernel<T>), dim3(1, batch_count), dim3(props->warpSize),
-                                    0, stream, n, D + shiftD, strideD, E + shiftE, strideE, C, shiftC,
-                                    ldc, strideC, info, (S*)work_stack, 30 * n, eps, ssfmin, ssfmax);
+            ROCSOLVER_LAUNCH_KERNEL((steqr_kernel<T>), dim3(1, batch_count),
+                                    dim3(deviceProperties.warpSize), 0, stream, n, D + shiftD,
+                                    strideD, E + shiftE, strideE, C, shiftC, ldc, strideC, info,
+                                    (S*)work_stack, 30 * n, eps, ssfmin, ssfmax);
         }
     }
 

--- a/library/src/common/rocsolver_logger.cpp
+++ b/library/src/common/rocsolver_logger.cpp
@@ -137,7 +137,7 @@ rocsolver_log_entry rocsolver_logger::pop_log_entry(rocblas_handle handle)
 {
     // Start timing logger overhead
     double logger_start = get_time_us_no_sync();
-    
+
     std::vector<rocsolver_log_entry>& stack = call_stack[handle];
     rocsolver_log_entry result = stack.back();
 
@@ -151,7 +151,7 @@ rocsolver_log_entry rocsolver_logger::pop_log_entry(rocblas_handle handle)
     // For synchronous logger, no additional timing work needed here
 
     stack.pop_back();
-    
+
     if(stack.empty())
         call_stack.erase(handle);
 
@@ -163,7 +163,7 @@ rocsolver_log_entry rocsolver_logger::pop_log_entry(rocblas_handle handle)
     {
         // Calculate total overhead of the function being popped (own + children)
         double total_child_overhead = result.logger_overhead_us + result.child_overhead_us;
-        
+
         // Add to parent's child overhead accumulator
         stack.back().child_overhead_us += total_child_overhead + (logger_end - logger_start);
     }

--- a/library/src/common/rocsolver_logger.cpp
+++ b/library/src/common/rocsolver_logger.cpp
@@ -106,13 +106,15 @@ rocsolver_log_entry& rocsolver_logger::push_log_entry(rocblas_handle handle, std
     // HIP event-based timing: create and record a start event
     hipStream_t stream = nullptr;
     rocblas_get_stream(handle, &stream);
-    if(hipEventCreate(&result.start_evt) == hipSuccess){
-        if(hipEventRecord(result.start_evt, stream) != hipSuccess){
-            printf("BADNESS IN EVENT RECORD\n");
-        }
-    }else{
-        printf("BADNESS IN EVENT CREATE\n");
-    }
+    THROW_IF_HIP_ERROR(hipEventCreate(&result.start_evt));
+    THROW_IF_HIP_ERROR(hipEventRecord(result.start_evt, stream));
+    // if(hipEventCreate(&result.start_evt) == hipSuccess){
+    //     if(hipEventRecord(result.start_evt, stream) != hipSuccess){
+    //         printf("BADNESS IN EVENT RECORD\n");
+    //     }
+    // }else{
+    //     printf("BADNESS IN EVENT CREATE\n");
+    // }
 
     for(int i = 1; i < stack.size() - 1; i++)
         result.callers.push_back(stack[i].name);
@@ -135,14 +137,16 @@ rocsolver_log_entry rocsolver_logger::pop_log_entry(rocblas_handle handle)
     // HIP event-based timing: create and record a stop event
     hipStream_t stream = nullptr;
     rocblas_get_stream(handle, &stream);
-    if(hipEventCreate(&result.stop_evt) == hipSuccess){
+    THROW_IF_HIP_ERROR(hipEventCreate(&result.stop_evt));
+    THROW_IF_HIP_ERROR(hipEventRecord(result.stop_evt, stream));
+    // if(hipEventCreate(&result.stop_evt) == hipSuccess){
 
-        if(hipEventRecord(result.stop_evt, stream) != hipSuccess){
-            printf("BADNESS IN EVENT RECORD in pop_entry\n");
-        }
-    }else{
-        printf("BADNESS IN EVENT CREATE in pop_entry\n");
-    }
+    //     if(hipEventRecord(result.stop_evt, stream) != hipSuccess){
+    //         printf("BADNESS IN EVENT RECORD in pop_entry\n");
+    //     }
+    // }else{
+    //     printf("BADNESS IN EVENT CREATE in pop_entry\n");
+    // }
 
     stack.pop_back();
 
@@ -160,7 +164,7 @@ void rocsolver_logger::append_profile(std::string& str,
                                       rocsolver_profile_map::iterator start,
                                       rocsolver_profile_map::iterator end)
 {
-    printf("hello\n");
+    // printf("hello\n");
     for(auto it = start; it != end; ++it)
     {
         rocsolver_profile_entry& entry = it->second;
@@ -237,56 +241,60 @@ rocblas_status rocsolver_log_begin_impl()
 rocblas_status rocsolver_log_end_impl()
 {
     const std::lock_guard<std::mutex> lock(rocsolver_logger::_mutex);
-    printf("world\n");
-    printf("what the\n");
+    // printf("world\n");
+    // printf("what the\n");
 
     // if there is an active logger:
-    if(rocsolver_logger::_instance == nullptr){
-        printf("null\n");
+    if(rocsolver_logger::_instance == nullptr)
         return rocblas_status_internal_error;
-    } else{
-        printf("not null\n");
-    }
+    // if(rocsolver_logger::_instance == nullptr){
+    //     // printf("null\n");
+    //     return rocblas_status_internal_error;
+    // } else{
+    //     // printf("not null\n");
+    // }
 
     auto logger = rocsolver_logger::_instance;
 
-    // if there are pending log_exit calls:
-    if(!rocsolver_logger::_instance->call_stack.empty()){
-        printf("call stack not empty\n");
+    if(!rocsolver_logger::_instance->call_stack.empty())
         return rocblas_status_internal_error;
-    } else{
-        printf("call stack empty\n");
-    }
+    // if there are pending log_exit calls:
+    // if(!rocsolver_logger::_instance->call_stack.empty()){
+    //     printf("call stack not empty\n");
+    //     return rocblas_status_internal_error;
+    // } else{
+    //     printf("call stack empty\n");
+    // }
 
     // ONE device sync prior to time collection
     hipDeviceSynchronize();
 
     // Recursively accumulate elapsed times for all profile entries and destroy events
     logger->accumulate_times(logger->profile);
-    printf("made it out\n");
+    // printf("made it out\n");
 
-    if(logger->profile.empty()){
-        printf("empty\n");
-    } else{
-        printf("not empty\n");
-    }
+    // if(logger->profile.empty()){
+    //     printf("empty\n");
+    // } else{
+    //     printf("not empty\n");
+    // }
 
-    if(logger->layer_mode){
-        printf("not none\n");
-    } else{
-        printf("none\n");
-    }
+    // if(logger->layer_mode){
+    //     printf("not none\n");
+    // } else{
+    //     printf("none\n");
+    // }
 
-    if(logger->layer_mode & rocblas_layer_mode_log_profile){
-        printf("profile\n");
-    } else{
-        printf("not profile\n");
-    }
+    // if(logger->layer_mode & rocblas_layer_mode_log_profile){
+    //     printf("profile\n");
+    // } else{
+    //     printf("not profile\n");
+    // }
 
-    // print profile logging results
+    // // print profile logging results
     if(logger->layer_mode & rocblas_layer_mode_log_profile && !logger->profile.empty())
     {
-        printf("there\n");
+        // printf("there\n");
         std::string profile_str;
         logger->append_profile(profile_str, logger->profile.begin(), logger->profile.end());
         fmt::print(*logger->profile_os, "------- PROFILE -------\n{}\n", profile_str);
@@ -302,38 +310,41 @@ rocblas_status rocsolver_log_end_impl()
 
 void rocsolver_logger::accumulate_times(rocsolver_profile_map& m)
 {
-    printf("accumulate_times\n");
-    printf("size: %zu\n", m.size());
+    // printf("accumulate_times\n");
+    // printf("size: %zu\n", m.size());
     for(auto& kv : m)
     {
-        printf("name: %s\n", kv.second.name.c_str());
-        printf("key name: %s\n", kv.first.c_str());
-        printf("num events: %zu\n", kv.second.events.size());
-        hipError_t err;
+        // printf("name: %s\n", kv.second.name.c_str());
+        // printf("key name: %s\n", kv.first.c_str());
+        // printf("num events: %zu\n", kv.second.events.size());
+        // hipError_t err;
         rocsolver_profile_entry& entry = kv.second;
         entry.total_time = 0;
         for(auto& pair : entry.events)
         {
             float ms = 0;
-            printf("event pair\n");
-            if(!pair.first || !pair.second)
-                printf("BADNESS, NULL EVENT\n");
+            // printf("event pair\n");
+            // if(!pair.first || !pair.second)
+            //     printf("BADNESS, NULL EVENT\n");
             if(pair.first && pair.second)
-                err = hipEventElapsedTime(&ms, pair.first, pair.second);
-                printf("error: %s\n", hipGetErrorString(err));
-            if (err != hipSuccess)
-                printf("BADNESS IN ELAPSED TIME\n");
-                printf("error: %s\n", hipGetErrorString(err));
+                THROW_IF_HIP_ERROR(hipEventElapsedTime(&ms, pair.first, pair.second));
+                // err = hipEventElapsedTime(&ms, pair.first, pair.second);
+                // printf("error: %s\n", hipGetErrorString(err));
+            // if (err != hipSuccess)
+            //     printf("BADNESS IN ELAPSED TIME\n");
+            //     printf("error: %s\n", hipGetErrorString(err));
             entry.total_time += ms * 1000; // us
             // Destroy events after measurement
-            err = hipEventDestroy(pair.first);
-            if (err != hipSuccess)
-                printf("BADNESS IN EVENT DESTROY\n");
-                printf("error: %s\n", hipGetErrorString(err));
-            err = hipEventDestroy(pair.second);
-            if (err != hipSuccess)
-                printf("BADNESS IN EVENT DESTROY 2\n");
-                printf("error: %s\n", hipGetErrorString(err));
+            THROW_IF_HIP_ERROR(hipEventDestroy(pair.first));
+            // err = hipEventDestroy(pair.first);
+            // if (err != hipSuccess)
+            //     printf("BADNESS IN EVENT DESTROY\n");
+            //     printf("error: %s\n", hipGetErrorString(err));
+            THROW_IF_HIP_ERROR(hipEventDestroy(pair.second));
+            // err = hipEventDestroy(pair.second);
+            // if (err != hipSuccess)
+            //     printf("BADNESS IN EVENT DESTROY 2\n");
+            //     printf("error: %s\n", hipGetErrorString(err));
         }
         entry.events.clear();
         // Recurse

--- a/library/src/common/rocsolver_logger.cpp
+++ b/library/src/common/rocsolver_logger.cpp
@@ -97,7 +97,7 @@ rocsolver_log_entry& rocsolver_logger::push_log_entry(rocblas_handle handle, std
 {
     // Start timing logger overhead
     double logger_start = get_time_us_no_sync();
-    
+
     std::vector<rocsolver_log_entry>& stack = call_stack[handle];
     stack.push_back(rocsolver_log_entry());
 
@@ -151,13 +151,22 @@ rocsolver_log_entry rocsolver_logger::pop_log_entry(rocblas_handle handle)
     // For synchronous logger, no additional timing work needed here
 
     stack.pop_back();
-
+    
     if(stack.empty())
         call_stack.erase(handle);
 
     // End timing logger overhead and accumulate it
     double logger_end = get_time_us_no_sync();
     result.logger_overhead_us += (logger_end - logger_start);
+    // Propagate this function's total overhead to parent (if exists)
+    if(!stack.empty())
+    {
+        // Calculate total overhead of the function being popped (own + children)
+        double total_child_overhead = result.logger_overhead_us + result.child_overhead_us;
+        
+        // Add to parent's child overhead accumulator
+        stack.back().child_overhead_us += total_child_overhead + (logger_end - logger_start);
+    }
 
     return result;
 }
@@ -286,7 +295,7 @@ void rocsolver_logger::accumulate_times(rocsolver_profile_map& m)
 {
     // Start timing the overhead of this accumulate_times function
     double accumulate_start = get_time_us_no_sync();
-    
+
     for(auto& kv : m)
     {
         rocsolver_profile_entry& entry = kv.second;
@@ -302,16 +311,16 @@ void rocsolver_logger::accumulate_times(rocsolver_profile_map& m)
             THROW_IF_HIP_ERROR(hipEventDestroy(pair.second));
         }
         entry.events.clear();
-        
+
         // Subtract accumulated logger overhead from total time
         entry.total_time -= entry.total_logger_overhead;
-        
+
         // recurse on internal calls
         if(entry.internal_calls)
             accumulate_times(*entry.internal_calls);
     }
-    
-    // End timing accumulate_times overhead (this overhead is not subtracted since 
+
+    // End timing accumulate_times overhead (this overhead is not subtracted since
     // it occurs after function execution is complete)
     double accumulate_end = get_time_us_no_sync();
     // Note: We don't subtract this overhead as it happens during log_end_impl,

--- a/library/src/common/rocsolver_logger.cpp
+++ b/library/src/common/rocsolver_logger.cpp
@@ -103,6 +103,17 @@ rocsolver_log_entry& rocsolver_logger::push_log_entry(rocblas_handle handle, std
     result.level = stack.size() - 1;
     result.start_time = get_time_us_no_sync();
 
+    // HIP event-based timing: create and record a start event
+    hipStream_t stream = nullptr;
+    rocblas_get_stream(handle, &stream);
+    if(hipEventCreate(&result.start_evt) == hipSuccess){
+        if(hipEventRecord(result.start_evt, stream) != hipSuccess){
+            printf("BADNESS IN EVENT RECORD\n");
+        }
+    }else{
+        printf("BADNESS IN EVENT CREATE\n");
+    }
+
     for(int i = 1; i < stack.size() - 1; i++)
         result.callers.push_back(stack[i].name);
 
@@ -120,6 +131,19 @@ rocsolver_log_entry rocsolver_logger::pop_log_entry(rocblas_handle handle)
 {
     std::vector<rocsolver_log_entry>& stack = call_stack[handle];
     rocsolver_log_entry result = stack.back();
+
+    // HIP event-based timing: create and record a stop event
+    hipStream_t stream = nullptr;
+    rocblas_get_stream(handle, &stream);
+    if(hipEventCreate(&result.stop_evt) == hipSuccess){
+
+        if(hipEventRecord(result.stop_evt, stream) != hipSuccess){
+            printf("BADNESS IN EVENT RECORD in pop_entry\n");
+        }
+    }else{
+        printf("BADNESS IN EVENT CREATE in pop_entry\n");
+    }
+
     stack.pop_back();
 
     if(stack.empty())
@@ -136,6 +160,7 @@ void rocsolver_logger::append_profile(std::string& str,
                                       rocsolver_profile_map::iterator start,
                                       rocsolver_profile_map::iterator end)
 {
+    printf("hello\n");
     for(auto it = start; it != end; ++it)
     {
         rocsolver_profile_entry& entry = it->second;
@@ -145,13 +170,13 @@ void rocsolver_logger::append_profile(std::string& str,
         int indent = shift_width * indent_level;
 
         str += fmt::format("{: <{}}{}: Calls: {}, Total Time: {:.3f} ms", "", indent, it->first,
-                           entry.calls, entry.time * 1e-3);
+                           entry.calls, entry.total_time * 1e-3);
 
         if(entry.internal_calls)
         {
             double internal_time = 0;
             for(const auto& nested : *entry.internal_calls)
-                internal_time += nested.second.time;
+                internal_time += nested.second.total_time;
 
             str += fmt::format(" (in nested functions: {:.3f} ms)\n", internal_time * 1e-3);
 
@@ -212,20 +237,56 @@ rocblas_status rocsolver_log_begin_impl()
 rocblas_status rocsolver_log_end_impl()
 {
     const std::lock_guard<std::mutex> lock(rocsolver_logger::_mutex);
+    printf("world\n");
+    printf("what the\n");
 
     // if there is an active logger:
-    if(rocsolver_logger::_instance == nullptr)
+    if(rocsolver_logger::_instance == nullptr){
+        printf("null\n");
         return rocblas_status_internal_error;
+    } else{
+        printf("not null\n");
+    }
 
     auto logger = rocsolver_logger::_instance;
 
     // if there are pending log_exit calls:
-    if(!rocsolver_logger::_instance->call_stack.empty())
+    if(!rocsolver_logger::_instance->call_stack.empty()){
+        printf("call stack not empty\n");
         return rocblas_status_internal_error;
+    } else{
+        printf("call stack empty\n");
+    }
+
+    // ONE device sync prior to time collection
+    hipDeviceSynchronize();
+
+    // Recursively accumulate elapsed times for all profile entries and destroy events
+    logger->accumulate_times(logger->profile);
+    printf("made it out\n");
+
+    if(logger->profile.empty()){
+        printf("empty\n");
+    } else{
+        printf("not empty\n");
+    }
+
+    if(logger->layer_mode){
+        printf("not none\n");
+    } else{
+        printf("none\n");
+    }
+
+    if(logger->layer_mode & rocblas_layer_mode_log_profile){
+        printf("profile\n");
+    } else{
+        printf("not profile\n");
+    }
 
     // print profile logging results
     if(logger->layer_mode & rocblas_layer_mode_log_profile && !logger->profile.empty())
     {
+        printf("there\n");
         std::string profile_str;
         logger->append_profile(profile_str, logger->profile.begin(), logger->profile.end());
         fmt::print(*logger->profile_os, "------- PROFILE -------\n{}\n", profile_str);
@@ -237,6 +298,48 @@ rocblas_status rocsolver_log_end_impl()
     rocsolver_logger::_instance = nullptr;
 
     return rocblas_status_success;
+}
+
+void rocsolver_logger::accumulate_times(rocsolver_profile_map& m)
+{
+    printf("accumulate_times\n");
+    printf("size: %zu\n", m.size());
+    for(auto& kv : m)
+    {
+        printf("name: %s\n", kv.second.name.c_str());
+        printf("key name: %s\n", kv.first.c_str());
+        printf("num events: %zu\n", kv.second.events.size());
+        hipError_t err;
+        rocsolver_profile_entry& entry = kv.second;
+        entry.total_time = 0;
+        for(auto& pair : entry.events)
+        {
+            float ms = 0;
+            printf("event pair\n");
+            if(!pair.first || !pair.second)
+                printf("BADNESS, NULL EVENT\n");
+            if(pair.first && pair.second)
+                err = hipEventElapsedTime(&ms, pair.first, pair.second);
+                printf("error: %s\n", hipGetErrorString(err));
+            if (err != hipSuccess)
+                printf("BADNESS IN ELAPSED TIME\n");
+                printf("error: %s\n", hipGetErrorString(err));
+            entry.total_time += ms * 1000; // µs
+            // Destroy events after measurement
+            err = hipEventDestroy(pair.first);
+            if (err != hipSuccess)
+                printf("BADNESS IN EVENT DESTROY\n");
+                printf("error: %s\n", hipGetErrorString(err));
+            err = hipEventDestroy(pair.second);
+            if (err != hipSuccess)
+                printf("BADNESS IN EVENT DESTROY 2\n");
+                printf("error: %s\n", hipGetErrorString(err));
+        }
+        entry.events.clear();
+        // Recurse
+        if(entry.internal_calls)
+            accumulate_times(*entry.internal_calls);
+    }
 }
 
 rocblas_status rocsolver_log_set_layer_mode_impl(const rocblas_layer_mode_flags layer_mode)

--- a/library/src/common/rocsolver_logger.cpp
+++ b/library/src/common/rocsolver_logger.cpp
@@ -103,11 +103,16 @@ rocsolver_log_entry& rocsolver_logger::push_log_entry(rocblas_handle handle, std
     result.level = stack.size() - 1;
 
 #if ROCSOLVER_USE_ASYNC_LOGGER
+    // Track logger overhead for HIP event operations
+    double start_overhead = get_time_us_no_sync();
+    
     // HIP event-based timing: create and record a start event
     hipStream_t stream = nullptr;
     rocblas_get_stream(handle, &stream);
     THROW_IF_HIP_ERROR(hipEventCreate(&result.start_evt));
     THROW_IF_HIP_ERROR(hipEventRecord(result.start_evt, stream));
+    
+    result.logger_overhead_us = get_time_us_no_sync() - start_overhead;
 #else
     // Synchronous timing: record start time without sync
     result.start_time = get_time_us_no_sync();
@@ -132,11 +137,16 @@ rocsolver_log_entry rocsolver_logger::pop_log_entry(rocblas_handle handle)
     rocsolver_log_entry result = stack.back();
 
 #if ROCSOLVER_USE_ASYNC_LOGGER
+    // Track overhead for stop event operations
+    double start_overhead = get_time_us_no_sync();
+    
     // HIP event-based timing: create and record a stop event
     hipStream_t stream = nullptr;
     rocblas_get_stream(handle, &stream);
     THROW_IF_HIP_ERROR(hipEventCreate(&result.stop_evt));
     THROW_IF_HIP_ERROR(hipEventRecord(result.stop_evt, stream));
+    
+    result.logger_overhead_us += get_time_us_no_sync() - start_overhead;
 #endif
     // For synchronous logger, no additional timing work needed here
 
@@ -274,17 +284,44 @@ void rocsolver_logger::accumulate_times(rocsolver_profile_map& m)
     {
         rocsolver_profile_entry& entry = kv.second;
         entry.total_time = 0;
-        for(auto& pair : entry.events)
+        
+        for(size_t i = 0; i < entry.events.size(); ++i)
         {
+            auto& pair = entry.events[i];
+            double logger_overhead = entry.event_overheads[i];
+            
+            // Track overhead from HIP timing operations
+            double start_overhead = get_time_us_no_sync();
+            
             float ms = 0;
             if(pair.first && pair.second)
                 THROW_IF_HIP_ERROR(hipEventElapsedTime(&ms, pair.first, pair.second));
-            entry.total_time += ms * 1000; // us
+            
             // destroy events after measurement
             THROW_IF_HIP_ERROR(hipEventDestroy(pair.first));
             THROW_IF_HIP_ERROR(hipEventDestroy(pair.second));
+            
+            double timing_overhead = get_time_us_no_sync() - start_overhead;
+            
+            // Convert GPU time to microseconds and calculate total overhead
+            double gpu_time_us = ms * 1000.0;
+            double total_overhead = logger_overhead + timing_overhead;
+            
+            // Ensure total overhead is not greater than or equal to GPU time
+            if(total_overhead >= gpu_time_us)
+            {
+                throw std::runtime_error(fmt::format(
+                    "Logger overhead ({:.3f} us) is greater than or equal to GPU time ({:.3f} us) for function '{}'",
+                    total_overhead, gpu_time_us, kv.first));
+            }
+            
+            double corrected_time = gpu_time_us - total_overhead;
+            entry.total_time += corrected_time;
         }
+        
         entry.events.clear();
+        entry.event_overheads.clear();
+        
         // recurse on internal calls
         if(entry.internal_calls)
             accumulate_times(*entry.internal_calls);

--- a/library/src/common/rocsolver_logger.cpp
+++ b/library/src/common/rocsolver_logger.cpp
@@ -108,13 +108,6 @@ rocsolver_log_entry& rocsolver_logger::push_log_entry(rocblas_handle handle, std
     rocblas_get_stream(handle, &stream);
     THROW_IF_HIP_ERROR(hipEventCreate(&result.start_evt));
     THROW_IF_HIP_ERROR(hipEventRecord(result.start_evt, stream));
-    // if(hipEventCreate(&result.start_evt) == hipSuccess){
-    //     if(hipEventRecord(result.start_evt, stream) != hipSuccess){
-    //         printf("BADNESS IN EVENT RECORD\n");
-    //     }
-    // }else{
-    //     printf("BADNESS IN EVENT CREATE\n");
-    // }
 
     for(int i = 1; i < stack.size() - 1; i++)
         result.callers.push_back(stack[i].name);
@@ -139,14 +132,6 @@ rocsolver_log_entry rocsolver_logger::pop_log_entry(rocblas_handle handle)
     rocblas_get_stream(handle, &stream);
     THROW_IF_HIP_ERROR(hipEventCreate(&result.stop_evt));
     THROW_IF_HIP_ERROR(hipEventRecord(result.stop_evt, stream));
-    // if(hipEventCreate(&result.stop_evt) == hipSuccess){
-
-    //     if(hipEventRecord(result.stop_evt, stream) != hipSuccess){
-    //         printf("BADNESS IN EVENT RECORD in pop_entry\n");
-    //     }
-    // }else{
-    //     printf("BADNESS IN EVENT CREATE in pop_entry\n");
-    // }
 
     stack.pop_back();
 
@@ -164,7 +149,6 @@ void rocsolver_logger::append_profile(std::string& str,
                                       rocsolver_profile_map::iterator start,
                                       rocsolver_profile_map::iterator end)
 {
-    // printf("hello\n");
     for(auto it = start; it != end; ++it)
     {
         rocsolver_profile_entry& entry = it->second;
@@ -241,55 +225,22 @@ rocblas_status rocsolver_log_begin_impl()
 rocblas_status rocsolver_log_end_impl()
 {
     const std::lock_guard<std::mutex> lock(rocsolver_logger::_mutex);
-    // printf("world\n");
-    // printf("what the\n");
 
     // if there is an active logger:
     if(rocsolver_logger::_instance == nullptr)
         return rocblas_status_internal_error;
-    // if(rocsolver_logger::_instance == nullptr){
-    //     // printf("null\n");
-    //     return rocblas_status_internal_error;
-    // } else{
-    //     // printf("not null\n");
-    // }
 
     auto logger = rocsolver_logger::_instance;
 
+    // if there are pending log_exit calls:
     if(!rocsolver_logger::_instance->call_stack.empty())
         return rocblas_status_internal_error;
-    // if there are pending log_exit calls:
-    // if(!rocsolver_logger::_instance->call_stack.empty()){
-    //     printf("call stack not empty\n");
-    //     return rocblas_status_internal_error;
-    // } else{
-    //     printf("call stack empty\n");
-    // }
 
     // ONE device sync prior to time collection
     hipDeviceSynchronize();
 
     // Recursively accumulate elapsed times for all profile entries and destroy events
     logger->accumulate_times(logger->profile);
-    // printf("made it out\n");
-
-    // if(logger->profile.empty()){
-    //     printf("empty\n");
-    // } else{
-    //     printf("not empty\n");
-    // }
-
-    // if(logger->layer_mode){
-    //     printf("not none\n");
-    // } else{
-    //     printf("none\n");
-    // }
-
-    // if(logger->layer_mode & rocblas_layer_mode_log_profile){
-    //     printf("profile\n");
-    // } else{
-    //     printf("not profile\n");
-    // }
 
     // // print profile logging results
     if(logger->layer_mode & rocblas_layer_mode_log_profile && !logger->profile.empty())
@@ -310,44 +261,22 @@ rocblas_status rocsolver_log_end_impl()
 
 void rocsolver_logger::accumulate_times(rocsolver_profile_map& m)
 {
-    // printf("accumulate_times\n");
-    // printf("size: %zu\n", m.size());
     for(auto& kv : m)
     {
-        // printf("name: %s\n", kv.second.name.c_str());
-        // printf("key name: %s\n", kv.first.c_str());
-        // printf("num events: %zu\n", kv.second.events.size());
-        // hipError_t err;
         rocsolver_profile_entry& entry = kv.second;
         entry.total_time = 0;
         for(auto& pair : entry.events)
         {
             float ms = 0;
-            // printf("event pair\n");
-            // if(!pair.first || !pair.second)
-            //     printf("BADNESS, NULL EVENT\n");
             if(pair.first && pair.second)
                 THROW_IF_HIP_ERROR(hipEventElapsedTime(&ms, pair.first, pair.second));
-                // err = hipEventElapsedTime(&ms, pair.first, pair.second);
-                // printf("error: %s\n", hipGetErrorString(err));
-            // if (err != hipSuccess)
-            //     printf("BADNESS IN ELAPSED TIME\n");
-            //     printf("error: %s\n", hipGetErrorString(err));
             entry.total_time += ms * 1000; // us
-            // Destroy events after measurement
+            // destroy events after measurement
             THROW_IF_HIP_ERROR(hipEventDestroy(pair.first));
-            // err = hipEventDestroy(pair.first);
-            // if (err != hipSuccess)
-            //     printf("BADNESS IN EVENT DESTROY\n");
-            //     printf("error: %s\n", hipGetErrorString(err));
             THROW_IF_HIP_ERROR(hipEventDestroy(pair.second));
-            // err = hipEventDestroy(pair.second);
-            // if (err != hipSuccess)
-            //     printf("BADNESS IN EVENT DESTROY 2\n");
-            //     printf("error: %s\n", hipGetErrorString(err));
         }
         entry.events.clear();
-        // Recurse
+        // recurse on internal calls
         if(entry.internal_calls)
             accumulate_times(*entry.internal_calls);
     }

--- a/library/src/common/rocsolver_logger.cpp
+++ b/library/src/common/rocsolver_logger.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -324,7 +324,7 @@ void rocsolver_logger::accumulate_times(rocsolver_profile_map& m)
             if (err != hipSuccess)
                 printf("BADNESS IN ELAPSED TIME\n");
                 printf("error: %s\n", hipGetErrorString(err));
-            entry.total_time += ms * 1000; // µs
+            entry.total_time += ms * 1000; // us
             // Destroy events after measurement
             err = hipEventDestroy(pair.first);
             if (err != hipSuccess)

--- a/library/src/common/rocsolver_logger.cpp
+++ b/library/src/common/rocsolver_logger.cpp
@@ -95,6 +95,9 @@ std::ostream* rocsolver_logger::open_log_stream(const char* environment_variable
 
 rocsolver_log_entry& rocsolver_logger::push_log_entry(rocblas_handle handle, std::string&& name)
 {
+    // Start timing logger overhead
+    double logger_start = get_time_us_no_sync();
+    
     std::vector<rocsolver_log_entry>& stack = call_stack[handle];
     stack.push_back(rocsolver_log_entry());
 
@@ -103,16 +106,11 @@ rocsolver_log_entry& rocsolver_logger::push_log_entry(rocblas_handle handle, std
     result.level = stack.size() - 1;
 
 #if ROCSOLVER_USE_ASYNC_LOGGER
-    // Track logger overhead for HIP event operations
-    double start_overhead = get_time_us_no_sync();
-
     // HIP event-based timing: create and record a start event
     hipStream_t stream = nullptr;
     rocblas_get_stream(handle, &stream);
     THROW_IF_HIP_ERROR(hipEventCreate(&result.start_evt));
     THROW_IF_HIP_ERROR(hipEventRecord(result.start_evt, stream));
-
-    result.logger_overhead_us = get_time_us_no_sync() - start_overhead;
 #else
     // Synchronous timing: record start time without sync
     result.start_time = get_time_us_no_sync();
@@ -120,6 +118,10 @@ rocsolver_log_entry& rocsolver_logger::push_log_entry(rocblas_handle handle, std
 
     for(int i = 1; i < stack.size() - 1; i++)
         result.callers.push_back(stack[i].name);
+
+    // End timing logger overhead and accumulate it
+    double logger_end = get_time_us_no_sync();
+    result.logger_overhead_us += (logger_end - logger_start);
 
     return result;
 }
@@ -133,20 +135,18 @@ rocsolver_log_entry& rocsolver_logger::peek_log_entry(rocblas_handle handle)
 
 rocsolver_log_entry rocsolver_logger::pop_log_entry(rocblas_handle handle)
 {
+    // Start timing logger overhead
+    double logger_start = get_time_us_no_sync();
+    
     std::vector<rocsolver_log_entry>& stack = call_stack[handle];
     rocsolver_log_entry result = stack.back();
 
 #if ROCSOLVER_USE_ASYNC_LOGGER
-    // Track overhead for stop event operations
-    double start_overhead = get_time_us_no_sync();
-
     // HIP event-based timing: create and record a stop event
     hipStream_t stream = nullptr;
     rocblas_get_stream(handle, &stream);
     THROW_IF_HIP_ERROR(hipEventCreate(&result.stop_evt));
     THROW_IF_HIP_ERROR(hipEventRecord(result.stop_evt, stream));
-
-    result.logger_overhead_us += get_time_us_no_sync() - start_overhead;
 #endif
     // For synchronous logger, no additional timing work needed here
 
@@ -154,6 +154,10 @@ rocsolver_log_entry rocsolver_logger::pop_log_entry(rocblas_handle handle)
 
     if(stack.empty())
         call_stack.erase(handle);
+
+    // End timing logger overhead and accumulate it
+    double logger_end = get_time_us_no_sync();
+    result.logger_overhead_us += (logger_end - logger_start);
 
     return result;
 }
@@ -280,52 +284,38 @@ rocblas_status rocsolver_log_end_impl()
 #if ROCSOLVER_USE_ASYNC_LOGGER
 void rocsolver_logger::accumulate_times(rocsolver_profile_map& m)
 {
+    // Start timing the overhead of this accumulate_times function
+    double accumulate_start = get_time_us_no_sync();
+    
     for(auto& kv : m)
     {
         rocsolver_profile_entry& entry = kv.second;
         entry.total_time = 0;
-
-        for(size_t i = 0; i < entry.events.size(); ++i)
+        for(auto& pair : entry.events)
         {
-            auto& pair = entry.events[i];
-            double logger_overhead = entry.event_overheads[i];
-
-            // Track overhead from HIP timing operations
-            double start_overhead = get_time_us_no_sync();
-
             float ms = 0;
             if(pair.first && pair.second)
                 THROW_IF_HIP_ERROR(hipEventElapsedTime(&ms, pair.first, pair.second));
-
+            entry.total_time += ms * 1000; // us
             // destroy events after measurement
             THROW_IF_HIP_ERROR(hipEventDestroy(pair.first));
             THROW_IF_HIP_ERROR(hipEventDestroy(pair.second));
-
-            double timing_overhead = get_time_us_no_sync() - start_overhead;
-
-            // Convert GPU time to microseconds and calculate total overhead
-            double gpu_time_us = ms * 1000.0;
-            double total_overhead = logger_overhead + timing_overhead;
-
-            // Ensure total overhead is not greater than or equal to GPU time
-            if(total_overhead >= gpu_time_us)
-            {
-                throw std::runtime_error(fmt::format(
-                    "Logger overhead ({:.3f} us) is greater than or equal to GPU time ({:.3f} us) for function '{}'",
-                    total_overhead, gpu_time_us, kv.first));
-            }
-
-            double corrected_time = gpu_time_us - total_overhead;
-            entry.total_time += corrected_time;
         }
-
         entry.events.clear();
-        entry.event_overheads.clear();
-
+        
+        // Subtract accumulated logger overhead from total time
+        entry.total_time -= entry.total_logger_overhead;
+        
         // recurse on internal calls
         if(entry.internal_calls)
             accumulate_times(*entry.internal_calls);
     }
+    
+    // End timing accumulate_times overhead (this overhead is not subtracted since 
+    // it occurs after function execution is complete)
+    double accumulate_end = get_time_us_no_sync();
+    // Note: We don't subtract this overhead as it happens during log_end_impl,
+    // not during the actual function execution being measured
 }
 #endif
 

--- a/library/src/common/rocsolver_logger.cpp
+++ b/library/src/common/rocsolver_logger.cpp
@@ -105,13 +105,13 @@ rocsolver_log_entry& rocsolver_logger::push_log_entry(rocblas_handle handle, std
 #if ROCSOLVER_USE_ASYNC_LOGGER
     // Track logger overhead for HIP event operations
     double start_overhead = get_time_us_no_sync();
-    
+
     // HIP event-based timing: create and record a start event
     hipStream_t stream = nullptr;
     rocblas_get_stream(handle, &stream);
     THROW_IF_HIP_ERROR(hipEventCreate(&result.start_evt));
     THROW_IF_HIP_ERROR(hipEventRecord(result.start_evt, stream));
-    
+
     result.logger_overhead_us = get_time_us_no_sync() - start_overhead;
 #else
     // Synchronous timing: record start time without sync
@@ -139,13 +139,13 @@ rocsolver_log_entry rocsolver_logger::pop_log_entry(rocblas_handle handle)
 #if ROCSOLVER_USE_ASYNC_LOGGER
     // Track overhead for stop event operations
     double start_overhead = get_time_us_no_sync();
-    
+
     // HIP event-based timing: create and record a stop event
     hipStream_t stream = nullptr;
     rocblas_get_stream(handle, &stream);
     THROW_IF_HIP_ERROR(hipEventCreate(&result.stop_evt));
     THROW_IF_HIP_ERROR(hipEventRecord(result.stop_evt, stream));
-    
+
     result.logger_overhead_us += get_time_us_no_sync() - start_overhead;
 #endif
     // For synchronous logger, no additional timing work needed here
@@ -284,29 +284,29 @@ void rocsolver_logger::accumulate_times(rocsolver_profile_map& m)
     {
         rocsolver_profile_entry& entry = kv.second;
         entry.total_time = 0;
-        
+
         for(size_t i = 0; i < entry.events.size(); ++i)
         {
             auto& pair = entry.events[i];
             double logger_overhead = entry.event_overheads[i];
-            
+
             // Track overhead from HIP timing operations
             double start_overhead = get_time_us_no_sync();
-            
+
             float ms = 0;
             if(pair.first && pair.second)
                 THROW_IF_HIP_ERROR(hipEventElapsedTime(&ms, pair.first, pair.second));
-            
+
             // destroy events after measurement
             THROW_IF_HIP_ERROR(hipEventDestroy(pair.first));
             THROW_IF_HIP_ERROR(hipEventDestroy(pair.second));
-            
+
             double timing_overhead = get_time_us_no_sync() - start_overhead;
-            
+
             // Convert GPU time to microseconds and calculate total overhead
             double gpu_time_us = ms * 1000.0;
             double total_overhead = logger_overhead + timing_overhead;
-            
+
             // Ensure total overhead is not greater than or equal to GPU time
             if(total_overhead >= gpu_time_us)
             {
@@ -314,14 +314,14 @@ void rocsolver_logger::accumulate_times(rocsolver_profile_map& m)
                     "Logger overhead ({:.3f} us) is greater than or equal to GPU time ({:.3f} us) for function '{}'",
                     total_overhead, gpu_time_us, kv.first));
             }
-            
+
             double corrected_time = gpu_time_us - total_overhead;
             entry.total_time += corrected_time;
         }
-        
+
         entry.events.clear();
         entry.event_overheads.clear();
-        
+
         // recurse on internal calls
         if(entry.internal_calls)
             accumulate_times(*entry.internal_calls);

--- a/library/src/common/rocsolver_logger.cpp
+++ b/library/src/common/rocsolver_logger.cpp
@@ -101,7 +101,6 @@ rocsolver_log_entry& rocsolver_logger::push_log_entry(rocblas_handle handle, std
     rocsolver_log_entry& result = stack.back();
     result.name = std::move(name);
     result.level = stack.size() - 1;
-    result.start_time = get_time_us_no_sync();
 
     // HIP event-based timing: create and record a start event
     hipStream_t stream = nullptr;

--- a/library/src/common/rocsolver_logger.cpp.old
+++ b/library/src/common/rocsolver_logger.cpp.old
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -101,17 +101,7 @@ rocsolver_log_entry& rocsolver_logger::push_log_entry(rocblas_handle handle, std
     rocsolver_log_entry& result = stack.back();
     result.name = std::move(name);
     result.level = stack.size() - 1;
-
-#if ROCSOLVER_USE_ASYNC_LOGGER
-    // HIP event-based timing: create and record a start event
-    hipStream_t stream = nullptr;
-    rocblas_get_stream(handle, &stream);
-    THROW_IF_HIP_ERROR(hipEventCreate(&result.start_evt));
-    THROW_IF_HIP_ERROR(hipEventRecord(result.start_evt, stream));
-#else
-    // Synchronous timing: record start time without sync
     result.start_time = get_time_us_no_sync();
-#endif
 
     for(int i = 1; i < stack.size() - 1; i++)
         result.callers.push_back(stack[i].name);
@@ -130,16 +120,6 @@ rocsolver_log_entry rocsolver_logger::pop_log_entry(rocblas_handle handle)
 {
     std::vector<rocsolver_log_entry>& stack = call_stack[handle];
     rocsolver_log_entry result = stack.back();
-
-#if ROCSOLVER_USE_ASYNC_LOGGER
-    // HIP event-based timing: create and record a stop event
-    hipStream_t stream = nullptr;
-    rocblas_get_stream(handle, &stream);
-    THROW_IF_HIP_ERROR(hipEventCreate(&result.stop_evt));
-    THROW_IF_HIP_ERROR(hipEventRecord(result.stop_evt, stream));
-#endif
-    // For synchronous logger, no additional timing work needed here
-
     stack.pop_back();
 
     if(stack.empty())
@@ -165,13 +145,13 @@ void rocsolver_logger::append_profile(std::string& str,
         int indent = shift_width * indent_level;
 
         str += fmt::format("{: <{}}{}: Calls: {}, Total Time: {:.3f} ms", "", indent, it->first,
-                           entry.calls, entry.total_time * 1e-3);
+                           entry.calls, entry.time * 1e-3);
 
         if(entry.internal_calls)
         {
             double internal_time = 0;
             for(const auto& nested : *entry.internal_calls)
-                internal_time += nested.second.total_time;
+                internal_time += nested.second.time;
 
             str += fmt::format(" (in nested functions: {:.3f} ms)\n", internal_time * 1e-3);
 
@@ -243,14 +223,6 @@ rocblas_status rocsolver_log_end_impl()
     if(!rocsolver_logger::_instance->call_stack.empty())
         return rocblas_status_internal_error;
 
-#if ROCSOLVER_USE_ASYNC_LOGGER
-    // ONE device sync prior to time collection
-    hipDeviceSynchronize();
-
-    // Recursively accumulate elapsed times for all profile entries and destroy events
-    logger->accumulate_times(logger->profile);
-#endif
-
     // print profile logging results
     if(logger->layer_mode & rocblas_layer_mode_log_profile && !logger->profile.empty())
     {
@@ -266,31 +238,6 @@ rocblas_status rocsolver_log_end_impl()
 
     return rocblas_status_success;
 }
-
-#if ROCSOLVER_USE_ASYNC_LOGGER
-void rocsolver_logger::accumulate_times(rocsolver_profile_map& m)
-{
-    for(auto& kv : m)
-    {
-        rocsolver_profile_entry& entry = kv.second;
-        entry.total_time = 0;
-        for(auto& pair : entry.events)
-        {
-            float ms = 0;
-            if(pair.first && pair.second)
-                THROW_IF_HIP_ERROR(hipEventElapsedTime(&ms, pair.first, pair.second));
-            entry.total_time += ms * 1000; // us
-            // destroy events after measurement
-            THROW_IF_HIP_ERROR(hipEventDestroy(pair.first));
-            THROW_IF_HIP_ERROR(hipEventDestroy(pair.second));
-        }
-        entry.events.clear();
-        // recurse on internal calls
-        if(entry.internal_calls)
-            accumulate_times(*entry.internal_calls);
-    }
-}
-#endif
 
 rocblas_status rocsolver_log_set_layer_mode_impl(const rocblas_layer_mode_flags layer_mode)
 {

--- a/library/src/include/rocsolver_logger.hpp
+++ b/library/src/include/rocsolver_logger.hpp
@@ -106,14 +106,12 @@ struct rocsolver_log_entry
     std::vector<std::string> callers;
     std::string name;
     int level;
-    double start_time;
 
     hipEvent_t start_evt = nullptr;
     hipEvent_t stop_evt = nullptr;
 
     rocsolver_log_entry()
         : level(0)
-        , start_time(0)
         , start_evt(nullptr)
         , stop_evt(nullptr)
     {

--- a/library/src/include/rocsolver_logger.hpp
+++ b/library/src/include/rocsolver_logger.hpp
@@ -131,11 +131,13 @@ struct rocsolver_log_entry
 #if ROCSOLVER_USE_ASYNC_LOGGER
     hipEvent_t start_evt = nullptr;
     hipEvent_t stop_evt = nullptr;
+    double logger_overhead_us = 0.0;  // Track logger overhead in microseconds
 
     rocsolver_log_entry()
         : level(0)
         , start_evt(nullptr)
         , stop_evt(nullptr)
+        , logger_overhead_us(0.0)
     {
     }
 #else
@@ -174,6 +176,9 @@ struct rocsolver_profile_entry
     int calls;
     double total_time; // stores accumulated elapsed time in microseconds
     std::vector<std::pair<hipEvent_t, hipEvent_t>> events;
+#if ROCSOLVER_USE_ASYNC_LOGGER
+    std::vector<double> event_overheads; // parallel to events vector, stores overhead per event
+#endif
     std::unique_ptr<rocsolver_profile_map> internal_calls;
 
     rocsolver_profile_entry()
@@ -312,8 +317,9 @@ private:
         from_profile.level = from_stack.level;
         from_profile.calls++;
 #if ROCSOLVER_USE_ASYNC_LOGGER
-        // store HIP event pair for later to compute time at log_end_impl.
+        // store HIP event pair and overhead for later to compute time at log_end_impl.
         from_profile.events.push_back({from_stack.start_evt, from_stack.stop_evt});
+        from_profile.event_overheads.push_back(from_stack.logger_overhead_us);
 #else
         from_profile.total_time += elapsed_time;
 #endif

--- a/library/src/include/rocsolver_logger.hpp
+++ b/library/src/include/rocsolver_logger.hpp
@@ -127,19 +127,6 @@ struct rocsolver_log_entry
     // Destroy HIP events if constructed
     ~rocsolver_log_entry()
     {
-        // Only destroy events if both are still owned here and not moved to profile_entry
-        // (once log_profile moves them, they are managed/destroyed there)
-        // So: only destroy if neither was moved (i.e., both non-zero)
-        // This reduces risk of double-destroy
-        // if(start_evt && stop_evt)
-        // {
-        //     printf("WOAH!!!!!!!!! DELETING EVENTS\n");
-        //     hipEventDestroy(start_evt);
-        //     hipEventDestroy(stop_evt);
-        // }
-        // // Null them to prevent accidental double-destruction
-        // start_evt = nullptr;
-        // stop_evt = nullptr;
     }
 };
 
@@ -175,12 +162,6 @@ struct rocsolver_profile_entry
     // Destroy HIP events when profile entry is destroyed
     ~rocsolver_profile_entry()
     {
-        // for(auto& e : events)
-        // {
-        //     printf("WOAH!!!!!!!!! DELETING EVENTS in profile\n");
-        //     if(e.first) hipEventDestroy(e.first);
-        //     if(e.second) hipEventDestroy(e.second);
-        // }
     }
 };
 
@@ -293,7 +274,7 @@ private:
         from_profile.name = from_stack.name;
         from_profile.level = from_stack.level;
         from_profile.calls++;
-        // Store HIP event pair for later to compute time at log_end_impl.
+        // store HIP event pair for later to compute time at log_end_impl.
         from_profile.events.push_back({from_stack.start_evt, from_stack.stop_evt});
     }
 

--- a/library/src/include/rocsolver_logger.hpp
+++ b/library/src/include/rocsolver_logger.hpp
@@ -37,6 +37,7 @@
 #include <tuple>
 #include <unordered_map>
 #include <vector>
+#include <hip/hip_runtime.h>
 
 #include "common_host_helpers.hpp"
 #include "lib_host_helpers.hpp"
@@ -45,6 +46,12 @@
 #include "rocsolver_logvalue.hpp"
 
 ROCSOLVER_BEGIN_NAMESPACE
+#define HIP_CHECK(...)                                         \
+    {                                                          \
+        hipError_t _status = (__VA_ARGS__);                    \
+        if(_status != hipSuccess)                              \
+            return get_rocblas_status_for_hip_status(_status); \
+    }
 
 /***************************************************************************
  * rocSOLVER logging macros
@@ -81,16 +88,13 @@ ROCSOLVER_BEGIN_NAMESPACE
             _log_token = std::make_unique<rocsolver_logger::scope_guard<T>>(false, handle);   \
         }                                                                                     \
     } while(0)
-#define ROCSOLVER_LAUNCH_KERNEL(name, ...)                                                          \
-    do                                                                                              \
-    {                                                                                               \
-        std::unique_ptr<rocsolver_logger::scope_guard<T>> _kernel_log_token;                        \
-        if(rocsolver_logger::is_logging_enabled() && rocsolver_logger::is_kernel_logging_enabled()) \
-        {                                                                                           \
-            rocsolver_logger::instance()->log_enter<T>(handle, nullptr, #name);                     \
-            _kernel_log_token = std::make_unique<rocsolver_logger::scope_guard<T>>(false, handle);  \
-        }                                                                                           \
-        hipLaunchKernelGGL((name), __VA_ARGS__);                                                    \
+#define ROCSOLVER_LAUNCH_KERNEL(name, ...) \
+    do { \
+        if (rocsolver_logger::is_logging_enabled() && rocsolver_logger::is_kernel_logging_enabled()) \
+            rocsolver_logger::instance()->log_enter<T>(handle, nullptr, #name "_kernel"); \
+        hipLaunchKernelGGL((name), __VA_ARGS__); \
+        if (rocsolver_logger::is_logging_enabled() && rocsolver_logger::is_kernel_logging_enabled()) \
+            rocsolver_logger::instance()->log_exit<T>(handle); \
     } while(0)
 
 /***************************************************************************
@@ -104,9 +108,14 @@ struct rocsolver_log_entry
     int level;
     double start_time;
 
+    hipEvent_t start_evt = nullptr;
+    hipEvent_t stop_evt = nullptr;
+
     rocsolver_log_entry()
         : level(0)
         , start_time(0)
+        , start_evt(nullptr)
+        , stop_evt(nullptr)
     {
     }
 
@@ -115,6 +124,23 @@ struct rocsolver_log_entry
 
     // Copy constructor
     rocsolver_log_entry(const rocsolver_log_entry&) = default;
+    // Destroy HIP events if constructed
+    ~rocsolver_log_entry()
+    {
+        // Only destroy events if both are still owned here and not moved to profile_entry
+        // (once log_profile moves them, they are managed/destroyed there)
+        // So: only destroy if neither was moved (i.e., both non-zero)
+        // This reduces risk of double-destroy
+        // if(start_evt && stop_evt)
+        // {
+        //     printf("WOAH!!!!!!!!! DELETING EVENTS\n");
+        //     hipEventDestroy(start_evt);
+        //     hipEventDestroy(stop_evt);
+        // }
+        // // Null them to prevent accidental double-destruction
+        // start_evt = nullptr;
+        // stop_evt = nullptr;
+    }
 };
 
 /***************************************************************************
@@ -129,13 +155,14 @@ struct rocsolver_profile_entry
     std::string name;
     int level;
     int calls;
-    double time;
+    double total_time; // now stores accumulated elapsed time in microseconds
+    std::vector<std::pair<hipEvent_t, hipEvent_t>> events;
     std::unique_ptr<rocsolver_profile_map> internal_calls;
 
     rocsolver_profile_entry()
         : level(0)
         , calls(0)
-        , time(0)
+        , total_time(0)
     {
     }
 
@@ -144,6 +171,17 @@ struct rocsolver_profile_entry
 
     // Copy constructor is deleted
     rocsolver_profile_entry(const rocsolver_profile_entry&) = delete;
+
+    // Destroy HIP events when profile entry is destroyed
+    ~rocsolver_profile_entry()
+    {
+        // for(auto& e : events)
+        // {
+        //     printf("WOAH!!!!!!!!! DELETING EVENTS in profile\n");
+        //     if(e.first) hipEventDestroy(e.first);
+        //     if(e.second) hipEventDestroy(e.second);
+        // }
+    }
 };
 
 /***************************************************************************
@@ -174,6 +212,9 @@ private:
 
     // returns a unique_ptr to a file stream or a given default stream
     std::ostream* open_log_stream(const char* environment_variable);
+
+    // recurse and accumulate HIP event timings (previously lambda in log_end_impl)
+    void accumulate_times(rocsolver_profile_map& m);
 
     // returns a log entry on the call stack
     rocsolver_log_entry& push_log_entry(rocblas_handle handle, std::string&& name);
@@ -238,17 +279,12 @@ private:
     template <typename T>
     void log_profile(rocblas_handle handle, rocsolver_log_entry& from_stack)
     {
-        hipStream_t stream;
-        rocblas_get_stream(handle, &stream);
-        double time = get_time_us_sync(stream) - from_stack.start_time;
-
         const std::lock_guard<std::mutex> lock(rocsolver_logger::_mutex);
 
         rocsolver_profile_map* map = &profile;
-        for(const std::string& caller_name : from_stack.callers)
-        {
+        for (const std::string& caller_name : from_stack.callers) {
             rocsolver_profile_entry& entry = (*map)[caller_name];
-            if(!entry.internal_calls)
+            if (!entry.internal_calls)
                 entry.internal_calls = std::make_unique<rocsolver_profile_map>();
             map = entry.internal_calls.get();
         }
@@ -257,7 +293,8 @@ private:
         from_profile.name = from_stack.name;
         from_profile.level = from_stack.level;
         from_profile.calls++;
-        from_profile.time += time;
+        // Store HIP event pair for later to compute time at log_end_impl.
+        from_profile.events.push_back({from_stack.start_evt, from_stack.stop_evt});
     }
 
     static std::unique_lock<std::mutex> acquire_lock()

--- a/library/src/include/rocsolver_logger.hpp
+++ b/library/src/include/rocsolver_logger.hpp
@@ -375,6 +375,9 @@ public:
                              const char* func_name,
                              Ts... args)
     {
+        // Start timing total template function overhead
+        double template_start = get_time_us_no_sync();
+        
         auto lock = acquire_lock();
         auto entry = push_log_entry(handle, get_func_name<T>(func_prefix, func_name));
         bool bench_enabled = layer_mode & rocblas_layer_mode_log_bench;
@@ -387,12 +390,19 @@ public:
 
         if(trace_enabled)
             trace_str += fmt::format("------- ENTER {} trace tree -------\n", entry.name);
+            
+        // End timing and add template function overhead to current log entry
+        double template_end = get_time_us_no_sync();
+        entry.logger_overhead_us += (template_end - template_start);
     }
 
     // logging function to be called before exiting a top-level (i.e. impl) function
     template <typename T>
     void log_exit_top_level(rocblas_handle handle)
     {
+        // Start timing total template function overhead
+        double template_start = get_time_us_no_sync();
+        
         auto lock = acquire_lock();
         auto entry = pop_log_entry(handle);
         bool trace_enabled = layer_mode & rocblas_layer_mode_log_trace;
@@ -406,12 +416,19 @@ public:
             trace_str.clear();
             trace_os->flush();
         }
+        
+        // End timing and add template function overhead to the popped log entry
+        double template_end = get_time_us_no_sync();
+        entry.logger_overhead_us += (template_end - template_start);
     }
 
     // logging function to be called upon entering a sub-level (i.e. template) function
     template <typename T, typename... Ts>
     void log_enter(rocblas_handle handle, const char* func_prefix, const char* func_name, Ts... args)
     {
+        // Start timing total template function overhead
+        double template_start = get_time_us_no_sync();
+        
         auto lock = acquire_lock();
         auto entry = push_log_entry(handle, get_template_name(func_prefix, func_name));
         bool trace_enabled = layer_mode & rocblas_layer_mode_log_trace && entry.level <= max_levels;
@@ -419,16 +436,27 @@ public:
 
         if(trace_enabled)
             log_trace<T>(entry.level, func_prefix, func_name, rocsolver_make_logvalue(args)...);
+            
+        // End timing and add template function overhead to current log entry
+        double template_end = get_time_us_no_sync();
+        entry.logger_overhead_us += (template_end - template_start);
     }
 
     // logging function to be called before exiting a sub-level (i.e. template) function
     template <typename T>
     void log_exit(rocblas_handle handle)
     {
+        // Start timing total template function overhead
+        double template_start = get_time_us_no_sync();
+        
         auto lock = acquire_lock();
         auto entry = pop_log_entry(handle);
         bool profile_enabled = layer_mode & rocblas_layer_mode_log_profile;
         lock.unlock();
+
+        // End timing and add template function overhead to the popped log entry
+        double template_end = get_time_us_no_sync();
+        entry.logger_overhead_us += (template_end - template_start);
 
         if(profile_enabled)
             log_profile<T>(handle, entry);

--- a/library/src/include/rocsolver_logger.hpp
+++ b/library/src/include/rocsolver_logger.hpp
@@ -91,7 +91,7 @@ ROCSOLVER_BEGIN_NAMESPACE
 #define ROCSOLVER_LAUNCH_KERNEL(name, ...) \
     do { \
         if (rocsolver_logger::is_logging_enabled() && rocsolver_logger::is_kernel_logging_enabled()) \
-            rocsolver_logger::instance()->log_enter<T>(handle, nullptr, #name "_kernel"); \
+            rocsolver_logger::instance()->log_enter<T>(handle, nullptr, #name); \
         hipLaunchKernelGGL((name), __VA_ARGS__); \
         if (rocsolver_logger::is_logging_enabled() && rocsolver_logger::is_kernel_logging_enabled()) \
             rocsolver_logger::instance()->log_exit<T>(handle); \

--- a/library/src/include/rocsolver_logger.hpp
+++ b/library/src/include/rocsolver_logger.hpp
@@ -127,7 +127,8 @@ struct rocsolver_log_entry
     std::vector<std::string> callers;
     std::string name;
     int level;
-    double logger_overhead_us; // Total overhead accumulated during this function call
+    double logger_overhead_us; // Overhead accumulated by this function's logger operations
+    double child_overhead_us; // Overhead accumulated by child functions
 
 #if ROCSOLVER_USE_ASYNC_LOGGER
     hipEvent_t start_evt = nullptr;
@@ -136,6 +137,7 @@ struct rocsolver_log_entry
     rocsolver_log_entry()
         : level(0)
         , logger_overhead_us(0)
+        , child_overhead_us(0)
         , start_evt(nullptr)
         , stop_evt(nullptr)
     {
@@ -146,6 +148,7 @@ struct rocsolver_log_entry
     rocsolver_log_entry()
         : level(0)
         , logger_overhead_us(0)
+        , child_overhead_us(0)
         , start_time(0)
     {
     }
@@ -320,17 +323,17 @@ private:
         from_profile.level = from_stack.level;
         from_profile.calls++;
         
-        // End timing logger overhead and calculate total overhead
+        // End timing logger overhead and calculate total overhead (own + children)
         double logger_end = get_time_us_no_sync();
-        double total_overhead = from_stack.logger_overhead_us + (logger_end - logger_start);
+        double total_overhead = from_stack.logger_overhead_us + from_stack.child_overhead_us + (logger_end - logger_start);
         
 #if ROCSOLVER_USE_ASYNC_LOGGER
         // store HIP event pair for later to compute time at log_end_impl.
         from_profile.events.push_back({from_stack.start_evt, from_stack.stop_evt});
-        // accumulate logger overhead for async mode
+        // accumulate total logger overhead (own + children) for async mode
         from_profile.total_logger_overhead += total_overhead;
 #else
-        // For sync mode: subtract overhead from elapsed time before accumulating
+        // For sync mode: subtract total overhead (own + children) from elapsed time
         double corrected_time = elapsed_time - total_overhead;
         from_profile.total_time += corrected_time;
         from_profile.total_logger_overhead += total_overhead;

--- a/library/src/include/rocsolver_logger.hpp
+++ b/library/src/include/rocsolver_logger.hpp
@@ -127,17 +127,17 @@ struct rocsolver_log_entry
     std::vector<std::string> callers;
     std::string name;
     int level;
+    double logger_overhead_us; // Total overhead accumulated during this function call
 
 #if ROCSOLVER_USE_ASYNC_LOGGER
     hipEvent_t start_evt = nullptr;
     hipEvent_t stop_evt = nullptr;
-    double logger_overhead_us = 0.0;  // Track logger overhead in microseconds
 
     rocsolver_log_entry()
         : level(0)
+        , logger_overhead_us(0)
         , start_evt(nullptr)
         , stop_evt(nullptr)
-        , logger_overhead_us(0.0)
     {
     }
 #else
@@ -145,6 +145,7 @@ struct rocsolver_log_entry
 
     rocsolver_log_entry()
         : level(0)
+        , logger_overhead_us(0)
         , start_time(0)
     {
     }
@@ -175,16 +176,15 @@ struct rocsolver_profile_entry
     int level;
     int calls;
     double total_time; // stores accumulated elapsed time in microseconds
+    double total_logger_overhead; // stores accumulated logger overhead in microseconds
     std::vector<std::pair<hipEvent_t, hipEvent_t>> events;
-#if ROCSOLVER_USE_ASYNC_LOGGER
-    std::vector<double> event_overheads; // parallel to events vector, stores overhead per event
-#endif
     std::unique_ptr<rocsolver_profile_map> internal_calls;
 
     rocsolver_profile_entry()
         : level(0)
         , calls(0)
         , total_time(0)
+        , total_logger_overhead(0)
     {
     }
 
@@ -297,6 +297,9 @@ private:
     template <typename T>
     void log_profile(rocblas_handle handle, rocsolver_log_entry& from_stack)
     {
+        // Start timing logger overhead for this function
+        double logger_start = get_time_us_no_sync();
+        
 #if !ROCSOLVER_USE_ASYNC_LOGGER
         hipStream_t stream;
         rocblas_get_stream(handle, &stream);
@@ -316,12 +319,21 @@ private:
         from_profile.name = from_stack.name;
         from_profile.level = from_stack.level;
         from_profile.calls++;
+        
+        // End timing logger overhead and calculate total overhead
+        double logger_end = get_time_us_no_sync();
+        double total_overhead = from_stack.logger_overhead_us + (logger_end - logger_start);
+        
 #if ROCSOLVER_USE_ASYNC_LOGGER
-        // store HIP event pair and overhead for later to compute time at log_end_impl.
+        // store HIP event pair for later to compute time at log_end_impl.
         from_profile.events.push_back({from_stack.start_evt, from_stack.stop_evt});
-        from_profile.event_overheads.push_back(from_stack.logger_overhead_us);
+        // accumulate logger overhead for async mode
+        from_profile.total_logger_overhead += total_overhead;
 #else
-        from_profile.total_time += elapsed_time;
+        // For sync mode: subtract overhead from elapsed time before accumulating
+        double corrected_time = elapsed_time - total_overhead;
+        from_profile.total_time += corrected_time;
+        from_profile.total_logger_overhead += total_overhead;
 #endif
     }
 

--- a/library/src/include/rocsolver_logger.hpp.old
+++ b/library/src/include/rocsolver_logger.hpp.old
@@ -38,14 +38,6 @@
 #include <unordered_map>
 #include <vector>
 
-#ifndef ROCSOLVER_USE_ASYNC_LOGGER
-#define ROCSOLVER_USE_ASYNC_LOGGER 1  // Default to async logger
-#endif
-
-#if ROCSOLVER_USE_ASYNC_LOGGER
-#include <hip/hip_runtime.h>
-#endif
-
 #include "common_host_helpers.hpp"
 #include "lib_host_helpers.hpp"
 #include "rocsolver/rocsolver.h"
@@ -53,12 +45,6 @@
 #include "rocsolver_logvalue.hpp"
 
 ROCSOLVER_BEGIN_NAMESPACE
-#define HIP_CHECK(...)                                         \
-    {                                                          \
-        hipError_t _status = (__VA_ARGS__);                    \
-        if(_status != hipSuccess)                              \
-            return get_rocblas_status_for_hip_status(_status); \
-    }
 
 /***************************************************************************
  * rocSOLVER logging macros
@@ -95,16 +81,6 @@ ROCSOLVER_BEGIN_NAMESPACE
             _log_token = std::make_unique<rocsolver_logger::scope_guard<T>>(false, handle);   \
         }                                                                                     \
     } while(0)
-#if ROCSOLVER_USE_ASYNC_LOGGER
-#define ROCSOLVER_LAUNCH_KERNEL(name, ...) \
-    do { \
-        if (rocsolver_logger::is_logging_enabled() && rocsolver_logger::is_kernel_logging_enabled()) \
-            rocsolver_logger::instance()->log_enter<T>(handle, nullptr, #name); \
-        hipLaunchKernelGGL((name), __VA_ARGS__); \
-        if (rocsolver_logger::is_logging_enabled() && rocsolver_logger::is_kernel_logging_enabled()) \
-            rocsolver_logger::instance()->log_exit<T>(handle); \
-    } while(0)
-#else
 #define ROCSOLVER_LAUNCH_KERNEL(name, ...)                                                          \
     do                                                                                              \
     {                                                                                               \
@@ -116,7 +92,6 @@ ROCSOLVER_BEGIN_NAMESPACE
         }                                                                                           \
         hipLaunchKernelGGL((name), __VA_ARGS__);                                                    \
     } while(0)
-#endif
 
 /***************************************************************************
  * The rocsolver_log_entry struct records function data for trace and
@@ -127,18 +102,6 @@ struct rocsolver_log_entry
     std::vector<std::string> callers;
     std::string name;
     int level;
-
-#if ROCSOLVER_USE_ASYNC_LOGGER
-    hipEvent_t start_evt = nullptr;
-    hipEvent_t stop_evt = nullptr;
-
-    rocsolver_log_entry()
-        : level(0)
-        , start_evt(nullptr)
-        , stop_evt(nullptr)
-    {
-    }
-#else
     double start_time;
 
     rocsolver_log_entry()
@@ -146,18 +109,12 @@ struct rocsolver_log_entry
         , start_time(0)
     {
     }
-#endif
 
     // Move constructor
     rocsolver_log_entry(rocsolver_log_entry&&) = default;
 
     // Copy constructor
     rocsolver_log_entry(const rocsolver_log_entry&) = default;
-
-    // Destructor
-    ~rocsolver_log_entry()
-    {
-    }
 };
 
 /***************************************************************************
@@ -172,14 +129,13 @@ struct rocsolver_profile_entry
     std::string name;
     int level;
     int calls;
-    double total_time; // stores accumulated elapsed time in microseconds
-    std::vector<std::pair<hipEvent_t, hipEvent_t>> events;
+    double time;
     std::unique_ptr<rocsolver_profile_map> internal_calls;
 
     rocsolver_profile_entry()
         : level(0)
         , calls(0)
-        , total_time(0)
+        , time(0)
     {
     }
 
@@ -188,11 +144,6 @@ struct rocsolver_profile_entry
 
     // Copy constructor is deleted
     rocsolver_profile_entry(const rocsolver_profile_entry&) = delete;
-
-    // Destructor
-    ~rocsolver_profile_entry()
-    {
-    }
 };
 
 /***************************************************************************
@@ -223,11 +174,6 @@ private:
 
     // returns a unique_ptr to a file stream or a given default stream
     std::ostream* open_log_stream(const char* environment_variable);
-
-#if ROCSOLVER_USE_ASYNC_LOGGER
-    // recurse and accumulate HIP event timings (previously lambda in log_end_impl)
-    void accumulate_times(rocsolver_profile_map& m);
-#endif
 
     // returns a log entry on the call stack
     rocsolver_log_entry& push_log_entry(rocblas_handle handle, std::string&& name);
@@ -292,17 +238,17 @@ private:
     template <typename T>
     void log_profile(rocblas_handle handle, rocsolver_log_entry& from_stack)
     {
-#if !ROCSOLVER_USE_ASYNC_LOGGER
         hipStream_t stream;
         rocblas_get_stream(handle, &stream);
-        double elapsed_time = get_time_us_sync(stream) - from_stack.start_time;
-#endif
+        double time = get_time_us_sync(stream) - from_stack.start_time;
+
         const std::lock_guard<std::mutex> lock(rocsolver_logger::_mutex);
 
         rocsolver_profile_map* map = &profile;
-        for (const std::string& caller_name : from_stack.callers) {
+        for(const std::string& caller_name : from_stack.callers)
+        {
             rocsolver_profile_entry& entry = (*map)[caller_name];
-            if (!entry.internal_calls)
+            if(!entry.internal_calls)
                 entry.internal_calls = std::make_unique<rocsolver_profile_map>();
             map = entry.internal_calls.get();
         }
@@ -311,12 +257,7 @@ private:
         from_profile.name = from_stack.name;
         from_profile.level = from_stack.level;
         from_profile.calls++;
-#if ROCSOLVER_USE_ASYNC_LOGGER
-        // store HIP event pair for later to compute time at log_end_impl.
-        from_profile.events.push_back({from_stack.start_evt, from_stack.stop_evt});
-#else
-        from_profile.total_time += elapsed_time;
-#endif
+        from_profile.time += time;
     }
 
     static std::unique_lock<std::mutex> acquire_lock()

--- a/library/src/lapack/roclapack_geqr2.hpp
+++ b/library/src/lapack/roclapack_geqr2.hpp
@@ -255,7 +255,10 @@ rocblas_status rocsolver_geqr2_template(rocblas_handle handle,
     rocblas_get_stream(handle, &stream);
 
     // get device prop
-    const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
+    int device;
+    HIP_CHECK(hipGetDevice(&device));
+    hipDeviceProp_t props;
+    HIP_CHECK(hipGetDeviceProperties(&props, device));
 
     I dim = std::min(m, n); // total number of pivots
     for(I j = 0; j < dim; ++j)
@@ -263,8 +266,8 @@ rocblas_status rocsolver_geqr2_template(rocblas_handle handle,
         I mm = m - j;
         I nn = n - j;
 
-        const size_t lmemsize = ((256 / props->warpSize) + mm + nn + 1 + mm * nn) * sizeof(T);
-        if(lmemsize <= props->sharedMemPerBlock && nn == mm)
+        const size_t lmemsize = ((256 / props.warpSize) + mm + nn + 1 + mm * nn) * sizeof(T);
+        if(lmemsize <= props.sharedMemPerBlock && nn == mm)
         {
             ROCSOLVER_LAUNCH_KERNEL((geqr2_kernel_small<256, T>), dim3(1, 1, batch_count), dim3(256),
                                     lmemsize, stream, mm, nn, A, shiftA + idx2D(j, j, lda), lda,

--- a/library/src/lapack/roclapack_geqr2.hpp
+++ b/library/src/lapack/roclapack_geqr2.hpp
@@ -255,10 +255,7 @@ rocblas_status rocsolver_geqr2_template(rocblas_handle handle,
     rocblas_get_stream(handle, &stream);
 
     // get device prop
-    int device;
-    HIP_CHECK(hipGetDevice(&device));
-    hipDeviceProp_t props;
-    HIP_CHECK(hipGetDeviceProperties(&props, device));
+    const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
 
     I dim = std::min(m, n); // total number of pivots
     for(I j = 0; j < dim; ++j)
@@ -266,8 +263,8 @@ rocblas_status rocsolver_geqr2_template(rocblas_handle handle,
         I mm = m - j;
         I nn = n - j;
 
-        const size_t lmemsize = ((256 / props.warpSize) + mm + nn + 1 + mm * nn) * sizeof(T);
-        if(lmemsize <= props.sharedMemPerBlock && nn == mm)
+        const size_t lmemsize = ((256 / props->warpSize) + mm + nn + 1 + mm * nn) * sizeof(T);
+        if(lmemsize <= props->sharedMemPerBlock && nn == mm)
         {
             ROCSOLVER_LAUNCH_KERNEL((geqr2_kernel_small<256, T>), dim3(1, 1, batch_count), dim3(256),
                                     lmemsize, stream, mm, nn, A, shiftA + idx2D(j, j, lda), lda,

--- a/library/src/lapack/roclapack_gesdd.hpp
+++ b/library/src/lapack/roclapack_gesdd.hpp
@@ -388,7 +388,10 @@ rocblas_status rocsolver_gesdd_template(rocblas_handle handle,
     T one = T(1);
     T zero = T(0);
 
-    const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
+    rocblas_int device_id;
+    HIP_CHECK(hipGetDevice(&device_id));
+    hipDeviceProp_t properties;
+    HIP_CHECK(hipGetDeviceProperties(&properties, device_id));
 
     // The general idea is as follows: Given a m by n (m >= n) matrix A, we
     // compute the eigendecomposition of A^*A with Divide-and-Conquer to obtain
@@ -437,8 +440,8 @@ rocblas_status rocsolver_gesdd_template(rocblas_handle handle,
                                                     (T*)work3, (T*)work4, (T**)workArr);
 
         rocblas_int blocks = (n - 1) / BS1 + 1;
-        blocks = std::min(blocks, props->maxGridSize[0]);
-        auto bc = std::min(batch_count, props->maxGridSize[1]);
+        blocks = std::min(blocks, properties.maxGridSize[0]);
+        auto bc = std::min(batch_count, properties.maxGridSize[1]);
         ROCSOLVER_LAUNCH_KERNEL(gesdd_flip_signs<T>, dim3(blocks, bc, 1), dim3(BS1, 1, 1), 0,
                                 stream, n, S, strideS, U_gemm, ldu_gemm, strideU_gemm, V_gemm,
                                 ldv_gemm, strideV_gemm, batch_count);
@@ -489,8 +492,8 @@ rocblas_status rocsolver_gesdd_template(rocblas_handle handle,
                                                     (T*)work3, (T*)work4, (T**)workArr);
 
         rocblas_int blocks = (m - 1) / BS1 + 1;
-        blocks = std::min(blocks, props->maxGridSize[0]);
-        auto bc = std::min(batch_count, props->maxGridSize[1]);
+        blocks = std::min(blocks, properties.maxGridSize[0]);
+        auto bc = std::min(batch_count, properties.maxGridSize[1]);
         ROCSOLVER_LAUNCH_KERNEL(gesdd_flip_signs<T>, dim3(blocks, bc, 1), dim3(BS1, 1, 1), 0,
                                 stream, m, S, strideS, V_gemm, ldv_gemm, strideV_gemm, U_gemm,
                                 ldu_gemm, strideU_gemm, batch_count);

--- a/library/src/lapack/roclapack_gesdd.hpp
+++ b/library/src/lapack/roclapack_gesdd.hpp
@@ -388,10 +388,7 @@ rocblas_status rocsolver_gesdd_template(rocblas_handle handle,
     T one = T(1);
     T zero = T(0);
 
-    rocblas_int device_id;
-    HIP_CHECK(hipGetDevice(&device_id));
-    hipDeviceProp_t properties;
-    HIP_CHECK(hipGetDeviceProperties(&properties, device_id));
+    const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
 
     // The general idea is as follows: Given a m by n (m >= n) matrix A, we
     // compute the eigendecomposition of A^*A with Divide-and-Conquer to obtain
@@ -440,8 +437,8 @@ rocblas_status rocsolver_gesdd_template(rocblas_handle handle,
                                                     (T*)work3, (T*)work4, (T**)workArr);
 
         rocblas_int blocks = (n - 1) / BS1 + 1;
-        blocks = std::min(blocks, properties.maxGridSize[0]);
-        auto bc = std::min(batch_count, properties.maxGridSize[1]);
+        blocks = std::min(blocks, props->maxGridSize[0]);
+        auto bc = std::min(batch_count, props->maxGridSize[1]);
         ROCSOLVER_LAUNCH_KERNEL(gesdd_flip_signs<T>, dim3(blocks, bc, 1), dim3(BS1, 1, 1), 0,
                                 stream, n, S, strideS, U_gemm, ldu_gemm, strideU_gemm, V_gemm,
                                 ldv_gemm, strideV_gemm, batch_count);
@@ -492,8 +489,8 @@ rocblas_status rocsolver_gesdd_template(rocblas_handle handle,
                                                     (T*)work3, (T*)work4, (T**)workArr);
 
         rocblas_int blocks = (m - 1) / BS1 + 1;
-        blocks = std::min(blocks, properties.maxGridSize[0]);
-        auto bc = std::min(batch_count, properties.maxGridSize[1]);
+        blocks = std::min(blocks, props->maxGridSize[0]);
+        auto bc = std::min(batch_count, props->maxGridSize[1]);
         ROCSOLVER_LAUNCH_KERNEL(gesdd_flip_signs<T>, dim3(blocks, bc, 1), dim3(BS1, 1, 1), 0,
                                 stream, m, S, strideS, V_gemm, ldv_gemm, strideV_gemm, U_gemm,
                                 ldu_gemm, strideU_gemm, batch_count);

--- a/library/src/lapack/roclapack_sytd2_hetd2.hpp
+++ b/library/src/lapack/roclapack_sytd2_hetd2.hpp
@@ -612,7 +612,10 @@ rocblas_status rocsolver_sytd2_hetd2_template(rocblas_handle handle,
     rocblas_stride stridet = 1; //stride for tmptau
 
     // get device prop
-    const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
+    int device;
+    HIP_CHECK(hipGetDevice(&device));
+    hipDeviceProp_t props;
+    HIP_CHECK(hipGetDeviceProperties(&props, device));
 
     if(uplo == rocblas_fill_lower)
     {
@@ -621,8 +624,8 @@ rocblas_status rocsolver_sytd2_hetd2_template(rocblas_handle handle,
         for(rocblas_int j = 0; j < n - 1; ++j)
         {
             const rocblas_int nn = n - j;
-            const size_t lmemsize = ((256 / props->warpSize) + 2 * nn + 1 + nn * nn) * sizeof(T);
-            if(lmemsize <= props->sharedMemPerBlock && nn <= xxTD2_SSKER_MAX_N)
+            const size_t lmemsize = ((256 / props.warpSize) + 2 * nn + 1 + nn * nn) * sizeof(T);
+            if(lmemsize <= props.sharedMemPerBlock && nn <= xxTD2_SSKER_MAX_N)
             {
                 ROCSOLVER_LAUNCH_KERNEL((sytd2_lower_kernel_small<256, T>), dim3(1, 1, batch_count),
                                         dim3(256), lmemsize, stream, nn, A,
@@ -668,8 +671,8 @@ rocblas_status rocsolver_sytd2_hetd2_template(rocblas_handle handle,
         for(rocblas_int j = n - 1; j > 0; --j)
         {
             const rocblas_int nn = j + 1;
-            const size_t lmemsize = ((256 / props->warpSize) + 2 * nn + 1 + nn * nn) * sizeof(T);
-            if(lmemsize <= props->sharedMemPerBlock && nn <= xxTD2_SSKER_MAX_N)
+            const size_t lmemsize = ((256 / props.warpSize) + 2 * nn + 1 + nn * nn) * sizeof(T);
+            if(lmemsize <= props.sharedMemPerBlock && nn <= xxTD2_SSKER_MAX_N)
             {
                 ROCSOLVER_LAUNCH_KERNEL((sytd2_upper_kernel_small<256, T>), dim3(1, 1, batch_count),
                                         dim3(256), lmemsize, stream, nn, A, shiftA, lda, strideA, D,

--- a/library/src/lapack/roclapack_sytd2_hetd2.hpp
+++ b/library/src/lapack/roclapack_sytd2_hetd2.hpp
@@ -612,10 +612,7 @@ rocblas_status rocsolver_sytd2_hetd2_template(rocblas_handle handle,
     rocblas_stride stridet = 1; //stride for tmptau
 
     // get device prop
-    int device;
-    HIP_CHECK(hipGetDevice(&device));
-    hipDeviceProp_t props;
-    HIP_CHECK(hipGetDeviceProperties(&props, device));
+    const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
 
     if(uplo == rocblas_fill_lower)
     {
@@ -624,8 +621,8 @@ rocblas_status rocsolver_sytd2_hetd2_template(rocblas_handle handle,
         for(rocblas_int j = 0; j < n - 1; ++j)
         {
             const rocblas_int nn = n - j;
-            const size_t lmemsize = ((256 / props.warpSize) + 2 * nn + 1 + nn * nn) * sizeof(T);
-            if(lmemsize <= props.sharedMemPerBlock && nn <= xxTD2_SSKER_MAX_N)
+            const size_t lmemsize = ((256 / props->warpSize) + 2 * nn + 1 + nn * nn) * sizeof(T);
+            if(lmemsize <= props->sharedMemPerBlock && nn <= xxTD2_SSKER_MAX_N)
             {
                 ROCSOLVER_LAUNCH_KERNEL((sytd2_lower_kernel_small<256, T>), dim3(1, 1, batch_count),
                                         dim3(256), lmemsize, stream, nn, A,
@@ -671,8 +668,8 @@ rocblas_status rocsolver_sytd2_hetd2_template(rocblas_handle handle,
         for(rocblas_int j = n - 1; j > 0; --j)
         {
             const rocblas_int nn = j + 1;
-            const size_t lmemsize = ((256 / props.warpSize) + 2 * nn + 1 + nn * nn) * sizeof(T);
-            if(lmemsize <= props.sharedMemPerBlock && nn <= xxTD2_SSKER_MAX_N)
+            const size_t lmemsize = ((256 / props->warpSize) + 2 * nn + 1 + nn * nn) * sizeof(T);
+            if(lmemsize <= props->sharedMemPerBlock && nn <= xxTD2_SSKER_MAX_N)
             {
                 ROCSOLVER_LAUNCH_KERNEL((sytd2_upper_kernel_small<256, T>), dim3(1, 1, batch_count),
                                         dim3(256), lmemsize, stream, nn, A, shiftA, lda, strideA, D,

--- a/library/src/specialized/roclapack_gemm_specialized_kernels.hpp
+++ b/library/src/specialized/roclapack_gemm_specialized_kernels.hpp
@@ -236,16 +236,19 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_gemm(rocblas_handle handle,
     rocblas_get_pointer_mode(handle, &pmode);
 
     // get warp size
-    const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
+    int device;
+    HIP_CHECK(hipGetDevice(&device));
+    hipDeviceProp_t deviceProperties;
+    HIP_CHECK(hipGetDeviceProperties(&deviceProperties, device));
 
-    std::string deviceArch(props->gcnArchName);
+    std::string deviceArch(deviceProperties.gcnArchName);
 
     if((deviceArch.find("gfx90a") != std::string::npos)
        || (deviceArch.find("gfx940") != std::string::npos)
        || (deviceArch.find("gfx941") != std::string::npos)
        || (deviceArch.find("gfx942") != std::string::npos))
     {
-        const auto warpSize = props->warpSize;
+        const auto warpSize = deviceProperties.warpSize;
 
         // launch specialized kernel
         const I numWarpsX = 4;

--- a/library/src/specialized/roclapack_gemm_specialized_kernels.hpp
+++ b/library/src/specialized/roclapack_gemm_specialized_kernels.hpp
@@ -236,19 +236,16 @@ ROCSOLVER_EXPORT rocblas_status rocsolver_gemm(rocblas_handle handle,
     rocblas_get_pointer_mode(handle, &pmode);
 
     // get warp size
-    int device;
-    HIP_CHECK(hipGetDevice(&device));
-    hipDeviceProp_t deviceProperties;
-    HIP_CHECK(hipGetDeviceProperties(&deviceProperties, device));
+    const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
 
-    std::string deviceArch(deviceProperties.gcnArchName);
+    std::string deviceArch(props->gcnArchName);
 
     if((deviceArch.find("gfx90a") != std::string::npos)
        || (deviceArch.find("gfx940") != std::string::npos)
        || (deviceArch.find("gfx941") != std::string::npos)
        || (deviceArch.find("gfx942") != std::string::npos))
     {
-        const auto warpSize = deviceProperties.warpSize;
+        const auto warpSize = props->warpSize;
 
         // launch specialized kernel
         const I numWarpsX = 4;


### PR DESCRIPTION
Currently the rocSOLVER logger used a synchronizing method after every kernel launch (when --profile or --profile-kernels is enabled in rocsolver-bench) to record the time elapsed inside the kernel. This makes the benchmarking tool slower, and provides inaccurate timing results for methods (especially those that launch a lot of kernels).

This PR uses hipEvents, and a single synchronization at the end of the top level function call. This reduces the overhead by the logger. 

Before:
```
johtyler@DOCKER-cgy-decidueye:~/code/rocSOLVER/build/release/clients/staging$ ./rocsolver-bench -f syevd --evect V -n 1024 -r s --profile 5 --profile_kernels 1
rocSOLVER version 3.31.0.e40d6537-dirty (with rocBLAS 5.0.0.ce2f7eba97)
Query device success: there are 1 devices
-------------------------------------------------------------------------------
Device ID 0 : AMD Radeon RX 6900 XT
with 17.2 GB memory, max. SCLK 2660 MHz, max. MCLK 1000 MHz, compute capability 10.3
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 32
-------------------------------------------------------------------------------

============================================
Arguments:
============================================
evect           uplo            n               lda
V               U               1024            1024

============================================
Results:
============================================
cpu_time_us     gpu_time_us
908987          129632.1

------- PROFILE -------
rocsolver_syevd_heevd_template: Calls: 10, Total Time: 1296.073 ms (in nested functions: 1295.909 ms)
    copy_mat<T>: Calls: 10, Total Time: 0.253 ms
    rocsolver_stedc_template: Calls: 10, Total Time: 71.499 ms (in nested functions: 71.160 ms)
        stedc_copyD: Calls: 10, Total Time: 0.172 ms
        (stedc_mergeUpdate_kernel<S>): Calls: 60, Total Time: 1.281 ms
        rocsolver_gemm_template: Calls: 60, Total Time: 9.171 ms (in nested functions: 9.094 ms)
            rocblas_gemm_template: Calls: 60, Total Time: 9.094 ms
        (stedc_mergePrepare_DeflateCount_kernel<S>): Calls: 60, Total Time: 1.029 ms
        init_ident<S>: Calls: 10, Total Time: 0.344 ms
        (stedc_divide_kernel<S>): Calls: 10, Total Time: 0.458 ms
        (stedc_mergePrepare_DeflateApply_kernel<S>): Calls: 60, Total Time: 1.047 ms
        stedc_reshuffleC<S>: Calls: 60, Total Time: 1.549 ms
        stedc_update_splits: Calls: 60, Total Time: 1.073 ms
        (stedc_mergePrepare_DeflateZero_kernel<S>): Calls: 60, Total Time: 1.174 ms
        stedc_copyC<T>: Calls: 10, Total Time: 0.248 ms
        (stedc_solve_kernel<S>): Calls: 10, Total Time: 2.036 ms
        (stedc_mergePrepare_SortD_kernel<S>): Calls: 60, Total Time: 1.679 ms
        (stedc_mergeValues_Rescale_kernel<S>): Calls: 60, Total Time: 3.708 ms
        reset_info: Calls: 10, Total Time: 0.165 ms
        (stedc_mergePrepare_SetCandFlags_kernel<S>): Calls: 60, Total Time: 0.990 ms
        stedc_sort<T>: Calls: 10, Total Time: 0.351 ms
        (stedc_mergeVectors_kernel<STEDC_EXTERNAL_GEMM, S>): Calls: 60, Total Time: 1.864 ms
        stedc_copyC<S>: Calls: 60, Total Time: 1.500 ms
        (stedc_mergeRotate_kernel<S>): Calls: 60, Total Time: 1.204 ms
        (stedc_mergeValues_SortDZ_kernel<S>): Calls: 60, Total Time: 1.773 ms
        (stedc_mergeValues_Solve_kernel<S>): Calls: 60, Total Time: 37.145 ms
        (stedc_mergeValues_copyD_kernel<S>): Calls: 60, Total Time: 1.199 ms
    rocsolver_sytrd_hetrd_template: Calls: 10, Total Time: 1165.915 ms (in nested functions: 1165.748 ms)
        rocsolver_sytd2_hetd2_template: Calls: 10, Total Time: 183.312 ms (in nested functions: 181.326 ms)
            set_tridiag<T>: Calls: 10, Total Time: 0.178 ms
            (sytd2_upper_kernel_small<256, T>): Calls: 10, Total Time: 7.085 ms
            rocblas_syr2_template: Calls: 1300, Total Time: 24.354 ms
            set_tau<T>: Calls: 1300, Total Time: 20.889 ms
            (latrd_dot_scale_axpy<64, T>): Calls: 1300, Total Time: 23.332 ms
            rocblas_symv_template: Calls: 1300, Total Time: 35.834 ms
            rocsolver_larfg_template: Calls: 1300, Total Time: 69.654 ms (in nested functions: 66.514 ms)
                rocblas_scal_template: Calls: 1300, Total Time: 21.727 ms
                (set_taubeta<T, I>): Calls: 1300, Total Time: 21.972 ms
                rocblas_dot_template: Calls: 1300, Total Time: 22.815 ms
        rocsolver_gemm_template: Calls: 240, Total Time: 7.915 ms (in nested functions: 7.659 ms)
            rocblas_gemm_template: Calls: 240, Total Time: 7.659 ms
        set_tridiag<T>: Calls: 10, Total Time: 0.173 ms
        rocsolver_latrd_template: Calls: 120, Total Time: 973.124 ms (in nested functions: 962.227 ms)
            (latrd_dot_scale_axpy<1024, T>): Calls: 7680, Total Time: 130.341 ms
            latrd_upper_updateW_kernel<T>: Calls: 7680, Total Time: 137.395 ms
            rocsolver_larfg_template: Calls: 7680, Total Time: 405.339 ms (in nested functions: 387.903 ms)
                rocblas_scal_template: Calls: 7680, Total Time: 127.294 ms
                (set_taubeta<T, I>): Calls: 7680, Total Time: 128.847 ms
                rocblas_dot_template: Calls: 7680, Total Time: 131.762 ms
            (latrd_upper_computeW_gemvt_kernel<NB, T>): Calls: 7680, Total Time: 155.883 ms
            latrd_upper_updateA_kernel<T>: Calls: 7680, Total Time: 133.269 ms
        (copy_trans_mat<T, T>): Calls: 10, Total Time: 1.224 ms
    rocsolver_ormtr_unmtr_template: Calls: 10, Total Time: 57.771 ms (in nested functions: 57.761 ms)
        rocsolver_ormql_unmql_template: Calls: 10, Total Time: 57.761 ms (in nested functions: 57.592 ms)
            rocsolver_larfb_inverse_template: Calls: 160, Total Time: 41.433 ms (in nested functions: 40.825 ms)
                rocsolver_gemm_template: Calls: 300, Total Time: 12.643 ms (in nested functions: 12.133 ms)
                addmatA1: Calls: 160, Total Time: 7.499 ms
                rocsolver_trsm_lower_template: Calls: 160, Total Time: 7.800 ms (in nested functions: 7.576 ms)
                rocblas_trmm_template: Calls: 320, Total Time: 9.079 ms
                copymatA1: Calls: 160, Total Time: 3.804 ms
            rocsolver_larft_inverse_template: Calls: 160, Total Time: 16.159 ms (in nested functions: 15.803 ms)
                (larft_restore_tri): Calls: 160, Total Time: 2.612 ms
                larft_set_diag: Calls: 160, Total Time: 2.680 ms
                rocsolver_gemm_template: Calls: 160, Total Time: 7.829 ms (in nested functions: 7.593 ms)
                (larft_set_tri): Calls: 160, Total Time: 2.682 ms
    reset_info: Calls: 10, Total Time: 0.471 ms
iota_n<T>: Calls: 10, Total Time: 0.168 ms
```

After:
```
johtyler@DOCKER-cgy-decidueye:~/code/rocSOLVER/build/release/clients/staging$ ./rocsolver-bench -f syevd --evect V -n 1024 -r s --profile 15 --profile_kernels 1
rocSOLVER version 3.31.0.e40d6537 (with rocBLAS 5.0.0.ce2f7eba97)
Query device success: there are 1 devices
-------------------------------------------------------------------------------
Device ID 0 : AMD Radeon RX 6900 XT
with 17.2 GB memory, max. SCLK 2660 MHz, max. MCLK 1000 MHz, compute capability 10.3
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 32
-------------------------------------------------------------------------------

============================================
Arguments:
============================================
evect           uplo            n               lda
V               U               1024            1024

============================================
Results:
============================================
cpu_time_us     gpu_time_us
904202          110882.1

------- PROFILE -------
rocsolver_syevd_heevd_template: Calls: 10, Total Time: 1108.372 ms (in nested functions: 1107.678 ms)
    copy_mat<T>: Calls: 10, Total Time: 0.168 ms
    rocsolver_stedc_template: Calls: 10, Total Time: 66.820 ms (in nested functions: 61.878 ms)
        stedc_copyD: Calls: 10, Total Time: 0.092 ms
        (stedc_mergeUpdate_kernel<S>): Calls: 60, Total Time: 0.767 ms
        rocsolver_gemm_template: Calls: 60, Total Time: 8.675 ms (in nested functions: 8.121 ms)
            rocblas_gemm_template: Calls: 60, Total Time: 8.121 ms
        (stedc_mergePrepare_DeflateCount_kernel<S>): Calls: 60, Total Time: 0.534 ms
        init_ident<S>: Calls: 10, Total Time: 0.160 ms
        (stedc_divide_kernel<S>): Calls: 10, Total Time: 0.362 ms
        (stedc_mergePrepare_DeflateApply_kernel<S>): Calls: 60, Total Time: 0.538 ms
        stedc_reshuffleC<S>: Calls: 60, Total Time: 1.011 ms
        stedc_update_splits: Calls: 60, Total Time: 0.594 ms
        (stedc_mergePrepare_DeflateZero_kernel<S>): Calls: 60, Total Time: 0.660 ms
        stedc_copyC<T>: Calls: 10, Total Time: 0.166 ms
        (stedc_solve_kernel<S>): Calls: 10, Total Time: 1.944 ms
        (stedc_mergePrepare_SortD_kernel<S>): Calls: 60, Total Time: 1.251 ms
        (stedc_mergeValues_Rescale_kernel<S>): Calls: 60, Total Time: 2.831 ms
        reset_info: Calls: 10, Total Time: 0.081 ms
        (stedc_mergePrepare_SetCandFlags_kernel<S>): Calls: 60, Total Time: 0.495 ms
        stedc_sort<T>: Calls: 10, Total Time: 0.269 ms
        (stedc_mergeVectors_kernel<STEDC_EXTERNAL_GEMM, S>): Calls: 60, Total Time: 1.318 ms
        stedc_copyC<S>: Calls: 60, Total Time: 0.963 ms
        (stedc_mergeRotate_kernel<S>): Calls: 60, Total Time: 0.683 ms
        (stedc_mergeValues_SortDZ_kernel<S>): Calls: 60, Total Time: 1.297 ms
        (stedc_mergeValues_Solve_kernel<S>): Calls: 60, Total Time: 36.519 ms
        (stedc_mergeValues_copyD_kernel<S>): Calls: 60, Total Time: 0.666 ms
    rocsolver_sytrd_hetrd_template: Calls: 10, Total Time: 984.667 ms (in nested functions: 982.796 ms)
        rocsolver_sytd2_hetd2_template: Calls: 10, Total Time: 158.080 ms (in nested functions: 126.732 ms)
            set_tridiag<T>: Calls: 10, Total Time: 0.089 ms
            (sytd2_upper_kernel_small<256, T>): Calls: 10, Total Time: 7.000 ms
            rocblas_syr2_template: Calls: 1300, Total Time: 13.256 ms
            set_tau<T>: Calls: 1300, Total Time: 10.693 ms
            (latrd_dot_scale_axpy<64, T>): Calls: 1300, Total Time: 12.558 ms
            rocblas_symv_template: Calls: 1300, Total Time: 25.007 ms
            rocsolver_larfg_template: Calls: 1300, Total Time: 58.129 ms (in nested functions: 33.155 ms)
                rocblas_scal_template: Calls: 1300, Total Time: 10.950 ms
                (set_taubeta<T, I>): Calls: 1300, Total Time: 11.151 ms
                rocblas_dot_template: Calls: 1300, Total Time: 11.054 ms
        rocsolver_gemm_template: Calls: 240, Total Time: 6.420 ms (in nested functions: 4.172 ms)
            rocblas_gemm_template: Calls: 240, Total Time: 4.172 ms
        set_tridiag<T>: Calls: 10, Total Time: 0.090 ms
        rocsolver_latrd_template: Calls: 120, Total Time: 817.062 ms (in nested functions: 636.445 ms)
            (latrd_dot_scale_axpy<1024, T>): Calls: 7680, Total Time: 66.671 ms
            latrd_upper_updateW_kernel<T>: Calls: 7680, Total Time: 71.004 ms
            rocsolver_larfg_template: Calls: 7680, Total Time: 336.354 ms (in nested functions: 192.328 ms)
                rocblas_scal_template: Calls: 7680, Total Time: 63.471 ms
                (set_taubeta<T, I>): Calls: 7680, Total Time: 64.289 ms
                rocblas_dot_template: Calls: 7680, Total Time: 64.568 ms
            (latrd_upper_computeW_gemvt_kernel<NB, T>): Calls: 7680, Total Time: 92.295 ms
            latrd_upper_updateA_kernel<T>: Calls: 7680, Total Time: 70.123 ms
        (copy_trans_mat<T, T>): Calls: 10, Total Time: 1.144 ms
    rocsolver_ormtr_unmtr_template: Calls: 10, Total Time: 55.944 ms (in nested functions: 55.851 ms)
        rocsolver_ormql_unmql_template: Calls: 10, Total Time: 55.851 ms (in nested functions: 54.284 ms)
            rocsolver_larfb_inverse_template: Calls: 160, Total Time: 39.484 ms (in nested functions: 33.509 ms)
                rocsolver_gemm_template: Calls: 300, Total Time: 11.120 ms (in nested functions: 8.270 ms)
                    rocblas_gemm_template: Calls: 300, Total Time: 8.270 ms
                addmatA1: Calls: 160, Total Time: 6.040 ms
                rocsolver_trsm_lower_template: Calls: 160, Total Time: 7.671 ms (in nested functions: 6.156 ms)
                    nonunit_forward_substitution_kernel<T>: Calls: 160, Total Time: 6.156 ms
                rocblas_trmm_template: Calls: 320, Total Time: 6.194 ms
                copymatA1: Calls: 160, Total Time: 2.484 ms
            rocsolver_larft_inverse_template: Calls: 160, Total Time: 14.800 ms (in nested functions: 10.989 ms)
                (larft_restore_tri): Calls: 160, Total Time: 1.330 ms
                larft_set_diag: Calls: 160, Total Time: 1.312 ms
                rocsolver_gemm_template: Calls: 160, Total Time: 7.008 ms (in nested functions: 5.491 ms)
                    rocblas_gemm_template: Calls: 160, Total Time: 5.491 ms
                (larft_set_tri): Calls: 160, Total Time: 1.340 ms
    reset_info: Calls: 10, Total Time: 0.078 ms
iota_n<T>: Calls: 10, Total Time: 0.080 ms

```

However, for larger matrix sizes, the difference does not seem to be as large:
Before:
```
johtyler@DOCKER-cgy-decidueye:~/code/rocSOLVER/build/release/clients/staging$ ./rocsolver-bench -f syevd --evect V -n 8192 -r s --profile 5 --profile_kernels 1
rocSOLVER version 3.31.0.e40d6537-dirty (with rocBLAS 5.0.0.ce2f7eba97)
Query device success: there are 1 devices
-------------------------------------------------------------------------------
Device ID 0 : AMD Radeon RX 6900 XT
with 17.2 GB memory, max. SCLK 2660 MHz, max. MCLK 1000 MHz, compute capability 10.3
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 32
-------------------------------------------------------------------------------

============================================
Arguments:
============================================
evect           uplo            n               lda
V               U               8192            8192

============================================
Results:
============================================
cpu_time_us     gpu_time_us
446644674       3395728.1

------- PROFILE -------
rocsolver_syevd_heevd_template: Calls: 10, Total Time: 33956.892 ms (in nested functions: 33956.608 ms)
    copy_mat<T>: Calls: 10, Total Time: 15.541 ms
    rocsolver_stedc_template: Calls: 10, Total Time: 2383.470 ms (in nested functions: 2382.838 ms)
        stedc_copyD: Calls: 10, Total Time: 0.192 ms
        (stedc_mergeUpdate_kernel<S>): Calls: 90, Total Time: 22.789 ms
        rocsolver_gemm_template: Calls: 90, Total Time: 738.724 ms (in nested functions: 738.625 ms)
            rocblas_gemm_template: Calls: 90, Total Time: 738.625 ms
        (stedc_mergePrepare_DeflateCount_kernel<S>): Calls: 90, Total Time: 1.619 ms
        init_ident<S>: Calls: 10, Total Time: 22.444 ms
        (stedc_divide_kernel<S>): Calls: 10, Total Time: 2.104 ms
        (stedc_mergePrepare_DeflateApply_kernel<S>): Calls: 90, Total Time: 1.681 ms
        stedc_reshuffleC<S>: Calls: 90, Total Time: 125.818 ms
        stedc_update_splits: Calls: 90, Total Time: 2.388 ms
        (stedc_mergePrepare_DeflateZero_kernel<S>): Calls: 90, Total Time: 3.599 ms
        stedc_copyC<T>: Calls: 10, Total Time: 13.534 ms
        (stedc_solve_kernel<S>): Calls: 10, Total Time: 2.507 ms
        (stedc_mergePrepare_SortD_kernel<S>): Calls: 90, Total Time: 10.748 ms
        (stedc_mergeValues_Rescale_kernel<S>): Calls: 90, Total Time: 308.987 ms
        reset_info: Calls: 10, Total Time: 0.178 ms
        (stedc_mergePrepare_SetCandFlags_kernel<S>): Calls: 90, Total Time: 1.534 ms
        stedc_sort<T>: Calls: 10, Total Time: 13.548 ms
        (stedc_mergeVectors_kernel<STEDC_EXTERNAL_GEMM, S>): Calls: 90, Total Time: 64.841 ms
        stedc_copyC<S>: Calls: 90, Total Time: 143.988 ms
        (stedc_mergeRotate_kernel<S>): Calls: 90, Total Time: 4.818 ms
        (stedc_mergeValues_SortDZ_kernel<S>): Calls: 90, Total Time: 11.464 ms
        (stedc_mergeValues_Solve_kernel<S>): Calls: 90, Total Time: 869.310 ms
        (stedc_mergeValues_copyD_kernel<S>): Calls: 90, Total Time: 16.023 ms
    rocsolver_sytrd_hetrd_template: Calls: 10, Total Time: 26257.438 ms (in nested functions: 26255.980 ms)
        rocsolver_sytd2_hetd2_template: Calls: 10, Total Time: 189.785 ms (in nested functions: 187.988 ms)
            set_tridiag<T>: Calls: 10, Total Time: 0.184 ms
            (sytd2_upper_kernel_small<256, T>): Calls: 10, Total Time: 7.149 ms
            rocblas_syr2_template: Calls: 1300, Total Time: 24.910 ms
            set_tau<T>: Calls: 1300, Total Time: 21.162 ms
            (latrd_dot_scale_axpy<64, T>): Calls: 1300, Total Time: 24.077 ms
            rocblas_symv_template: Calls: 1300, Total Time: 37.615 ms
            rocsolver_larfg_template: Calls: 1300, Total Time: 72.891 ms (in nested functions: 70.156 ms)
                rocblas_scal_template: Calls: 1300, Total Time: 22.670 ms
                (set_taubeta<T, I>): Calls: 1300, Total Time: 23.637 ms
                rocblas_dot_template: Calls: 1300, Total Time: 23.849 ms
        rocsolver_gemm_template: Calls: 2480, Total Time: 1037.996 ms (in nested functions: 1035.631 ms)
            rocblas_gemm_template: Calls: 2480, Total Time: 1035.631 ms
        set_tridiag<T>: Calls: 10, Total Time: 0.206 ms
        rocsolver_latrd_template: Calls: 1240, Total Time: 24255.211 ms (in nested functions: 24146.721 ms)
            (latrd_dot_scale_axpy<1024, T>): Calls: 79360, Total Time: 1435.602 ms
            latrd_upper_updateW_kernel<T>: Calls: 79360, Total Time: 1558.961 ms
            rocsolver_larfg_template: Calls: 79360, Total Time: 4273.121 ms (in nested functions: 4099.070 ms)
                rocblas_scal_template: Calls: 79360, Total Time: 1305.078 ms
                (set_taubeta<T, I>): Calls: 79360, Total Time: 1393.120 ms
                rocblas_dot_template: Calls: 79360, Total Time: 1400.872 ms
            (latrd_upper_computeW_gemvt_kernel<NB, T>): Calls: 79360, Total Time: 15429.843 ms
            latrd_upper_updateA_kernel<T>: Calls: 79360, Total Time: 1449.194 ms
        (copy_trans_mat<T, T>): Calls: 10, Total Time: 772.782 ms
    rocsolver_ormtr_unmtr_template: Calls: 10, Total Time: 5275.564 ms (in nested functions: 5275.557 ms)
        rocsolver_ormql_unmql_template: Calls: 10, Total Time: 5275.557 ms (in nested functions: 5274.601 ms)
            rocsolver_larfb_inverse_template: Calls: 1280, Total Time: 4869.016 ms (in nested functions: 4864.104 ms)
                rocsolver_gemm_template: Calls: 2540, Total Time: 3737.417 ms (in nested functions: 3733.820 ms)
                addmatA1: Calls: 1280, Total Time: 505.159 ms
                rocsolver_trsm_lower_template: Calls: 1280, Total Time: 253.087 ms (in nested functions: 249.506 ms)
                rocblas_trmm_template: Calls: 2560, Total Time: 159.810 ms
                copymatA1: Calls: 1280, Total Time: 208.631 ms
            rocsolver_larft_inverse_template: Calls: 1280, Total Time: 405.585 ms (in nested functions: 402.618 ms)
                (larft_restore_tri): Calls: 1280, Total Time: 21.990 ms
                larft_set_diag: Calls: 1280, Total Time: 21.910 ms
                rocsolver_gemm_template: Calls: 1280, Total Time: 336.110 ms (in nested functions: 334.354 ms)
                (larft_set_tri): Calls: 1280, Total Time: 22.608 ms
    reset_info: Calls: 10, Total Time: 24.595 ms
iota_n<T>: Calls: 10, Total Time: 0.177 ms
```

After:
```
johtyler@DOCKER-cgy-decidueye:~/code/rocSOLVER/build/release/clients/staging$ ./rocsolver-bench -f syevd --evect V -n 8192 -r s --profile 15 --profile_kernels 1
rocSOLVER version 3.31.0.e40d6537 (with rocBLAS 5.0.0.ce2f7eba97)
Query device success: there are 1 devices
-------------------------------------------------------------------------------
Device ID 0 : AMD Radeon RX 6900 XT
with 17.2 GB memory, max. SCLK 2660 MHz, max. MCLK 1000 MHz, compute capability 10.3
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 32
-------------------------------------------------------------------------------

============================================
Arguments:
============================================
evect           uplo            n               lda
V               U               8192            8192

============================================
Results:
============================================
cpu_time_us     gpu_time_us
448462629       3174500.1

------- PROFILE -------
rocsolver_syevd_heevd_template: Calls: 10, Total Time: 31744.231 ms (in nested functions: 31719.157 ms)
    copy_mat<T>: Calls: 10, Total Time: 15.376 ms
    rocsolver_stedc_template: Calls: 10, Total Time: 2371.521 ms (in nested functions: 2272.890 ms)
        stedc_copyD: Calls: 10, Total Time: 0.103 ms
        (stedc_mergeUpdate_kernel<S>): Calls: 90, Total Time: 22.409 ms
        rocsolver_gemm_template: Calls: 90, Total Time: 660.492 ms (in nested functions: 659.651 ms)
            rocblas_gemm_template: Calls: 90, Total Time: 659.651 ms
        (stedc_mergePrepare_DeflateCount_kernel<S>): Calls: 90, Total Time: 0.881 ms
        init_ident<S>: Calls: 10, Total Time: 6.463 ms
        (stedc_divide_kernel<S>): Calls: 10, Total Time: 2.021 ms
        (stedc_mergePrepare_DeflateApply_kernel<S>): Calls: 90, Total Time: 0.932 ms
        stedc_reshuffleC<S>: Calls: 90, Total Time: 124.856 ms
        stedc_update_splits: Calls: 90, Total Time: 1.657 ms
        (stedc_mergePrepare_DeflateZero_kernel<S>): Calls: 90, Total Time: 2.694 ms
        stedc_copyC<T>: Calls: 10, Total Time: 13.391 ms
        (stedc_solve_kernel<S>): Calls: 10, Total Time: 2.424 ms
        (stedc_mergePrepare_SortD_kernel<S>): Calls: 90, Total Time: 10.016 ms
        (stedc_mergeValues_Rescale_kernel<S>): Calls: 90, Total Time: 309.691 ms
        reset_info: Calls: 10, Total Time: 0.090 ms
        (stedc_mergePrepare_SetCandFlags_kernel<S>): Calls: 90, Total Time: 0.787 ms
        stedc_sort<T>: Calls: 10, Total Time: 13.463 ms
        (stedc_mergeVectors_kernel<STEDC_EXTERNAL_GEMM, S>): Calls: 90, Total Time: 64.029 ms
        stedc_copyC<S>: Calls: 90, Total Time: 143.922 ms
        (stedc_mergeRotate_kernel<S>): Calls: 90, Total Time: 3.909 ms
        (stedc_mergeValues_SortDZ_kernel<S>): Calls: 90, Total Time: 10.728 ms
        (stedc_mergeValues_Solve_kernel<S>): Calls: 90, Total Time: 861.936 ms
        (stedc_mergeValues_copyD_kernel<S>): Calls: 90, Total Time: 15.995 ms
    rocsolver_sytrd_hetrd_template: Calls: 10, Total Time: 24394.410 ms (in nested functions: 24377.060 ms)
        rocsolver_sytd2_hetd2_template: Calls: 10, Total Time: 164.324 ms (in nested functions: 131.618 ms)
            set_tridiag<T>: Calls: 10, Total Time: 0.097 ms
            (sytd2_upper_kernel_small<256, T>): Calls: 10, Total Time: 7.053 ms
            rocblas_syr2_template: Calls: 1300, Total Time: 13.919 ms
            set_tau<T>: Calls: 1300, Total Time: 11.055 ms
            (latrd_dot_scale_axpy<64, T>): Calls: 1300, Total Time: 12.923 ms
            rocblas_symv_template: Calls: 1300, Total Time: 26.143 ms
            rocsolver_larfg_template: Calls: 1300, Total Time: 60.426 ms (in nested functions: 34.446 ms)
                rocblas_scal_template: Calls: 1300, Total Time: 11.409 ms
                (set_taubeta<T, I>): Calls: 1300, Total Time: 11.463 ms
                rocblas_dot_template: Calls: 1300, Total Time: 11.574 ms
        rocsolver_gemm_template: Calls: 2480, Total Time: 1017.445 ms (in nested functions: 994.607 ms)
            rocblas_gemm_template: Calls: 2480, Total Time: 994.607 ms
        set_tridiag<T>: Calls: 10, Total Time: 0.116 ms
        rocsolver_latrd_template: Calls: 1240, Total Time: 22424.065 ms (in nested functions: 20588.215 ms)
            (latrd_dot_scale_axpy<1024, T>): Calls: 79360, Total Time: 785.334 ms
            latrd_upper_updateW_kernel<T>: Calls: 79360, Total Time: 792.529 ms
            rocsolver_larfg_template: Calls: 79360, Total Time: 3494.921 ms (in nested functions: 2029.937 ms)
                rocblas_scal_template: Calls: 79360, Total Time: 650.843 ms
                (set_taubeta<T, I>): Calls: 79360, Total Time: 664.624 ms
                rocblas_dot_template: Calls: 79360, Total Time: 714.470 ms
            (latrd_upper_computeW_gemvt_kernel<NB, T>): Calls: 79360, Total Time: 14729.567 ms
            latrd_upper_updateA_kernel<T>: Calls: 79360, Total Time: 785.865 ms
        (copy_trans_mat<T, T>): Calls: 10, Total Time: 771.110 ms
    rocsolver_ormtr_unmtr_template: Calls: 10, Total Time: 4937.768 ms (in nested functions: 4937.674 ms)
        rocsolver_ormql_unmql_template: Calls: 10, Total Time: 4937.674 ms (in nested functions: 4925.650 ms)
            rocsolver_larfb_inverse_template: Calls: 1280, Total Time: 4547.306 ms (in nested functions: 4499.103 ms)
                rocsolver_gemm_template: Calls: 2540, Total Time: 3447.974 ms (in nested functions: 3423.896 ms)
                    rocblas_gemm_template: Calls: 2540, Total Time: 3423.896 ms
                addmatA1: Calls: 1280, Total Time: 485.808 ms
                rocsolver_trsm_lower_template: Calls: 1280, Total Time: 230.963 ms (in nested functions: 194.465 ms)
                    rocsolver_gemm_template: Calls: 2560, Total Time: 68.341 ms (in nested functions: 44.009 ms)
                        rocblas_gemm_template: Calls: 2560, Total Time: 44.009 ms
                    nonunit_forward_substitution_kernel<T>: Calls: 3840, Total Time: 126.124 ms
                rocblas_trmm_template: Calls: 2560, Total Time: 134.843 ms
                copymatA1: Calls: 1280, Total Time: 199.514 ms
            rocsolver_larft_inverse_template: Calls: 1280, Total Time: 378.344 ms (in nested functions: 348.399 ms)
                (larft_restore_tri): Calls: 1280, Total Time: 11.056 ms
                larft_set_diag: Calls: 1280, Total Time: 10.806 ms
                rocsolver_gemm_template: Calls: 1280, Total Time: 314.758 ms (in nested functions: 302.792 ms)
                    rocblas_gemm_template: Calls: 1280, Total Time: 302.792 ms
                (larft_set_tri): Calls: 1280, Total Time: 11.779 ms
    reset_info: Calls: 10, Total Time: 0.083 ms
iota_n<T>: Calls: 10, Total Time: 0.094 ms
```

Take a look at the usage of THROW_IF_HIP_ERROR. Should this be replaced with CHECK_HIP_ERROR?
